### PR TITLE
Fixed coldcard descriptor bug

### DIFF
--- a/lib/_model/wallet.dart
+++ b/lib/_model/wallet.dart
@@ -92,7 +92,8 @@ class Wallet with _$Wallet {
       if (err3 != null) errs.add(err3.message);
       wallets.add(wallet44!);
 
-      if (wallets.isEmpty) throw 'Unable to create a wallet:\n ${errs.join(', ')}';
+      if (wallets.isEmpty)
+        throw 'Unable to create a wallet:\n ${errs.join(', ')}';
 
       return (wallets, null);
     } catch (e) {
@@ -132,7 +133,8 @@ class Wallet with _$Wallet {
       if (err3 != null) errs.add(err3.message);
       wallets.add(wallet44!);
 
-      if (wallets.isEmpty) throw 'Unable to create a wallet:\n ${errs.join(', ')}';
+      if (wallets.isEmpty)
+        throw 'Unable to create a wallet:\n ${errs.join(', ')}';
 
       return (wallets, null);
     } catch (e) {
@@ -187,7 +189,8 @@ class Wallet with _$Wallet {
       if (err3 != null) errs.add(err3.message);
       wallets.add(wallet44!);
 
-      if (wallets.isEmpty) throw 'Unable to create a wallet:\n ${errs.join(', ')}';
+      if (wallets.isEmpty)
+        throw 'Unable to create a wallet:\n ${errs.join(', ')}';
       return (wallets, null);
     } catch (e) {
       return (null, Err(e.toString()));
@@ -264,7 +267,8 @@ class Wallet with _$Wallet {
       if (err3 != null) errs.add(err3.message);
       wallets.add(wallet44!);
 
-      if (wallets.isEmpty) throw 'Unable to create a wallet:\n ${errs.join(', ')}';
+      if (wallets.isEmpty)
+        throw 'Unable to create a wallet:\n ${errs.join(', ')}';
       return (wallets, null);
     } catch (e) {
       return (null, Err(e.toString()));
@@ -318,7 +322,8 @@ class Wallet with _$Wallet {
       if (err3 != null) errs.add(err3.message);
       wallets.add(wallet44!);
 
-      if (wallets.isEmpty) throw 'Unable to create a wallet:\n ${errs.join(', ')}';
+      if (wallets.isEmpty)
+        throw 'Unable to create a wallet:\n ${errs.join(', ')}';
       return (wallets, null);
     } catch (e) {
       return (null, Err(e.toString()));
@@ -338,7 +343,8 @@ class Wallet with _$Wallet {
     try {
       final bbNetwork = isTestNet ? BBNetwork.Testnet : BBNetwork.Mainnet;
       if (bbWalletType == BBWalletType.descriptors) {
-        if (descriptor == null || descriptor.isEmpty) throw 'No descriptor provided';
+        if (descriptor == null || descriptor.isEmpty)
+          throw 'No descriptor provided';
         if (changeDescriptor == null || changeDescriptor.isEmpty)
           throw 'No change descriptor provided';
 
@@ -396,7 +402,7 @@ class Wallet with _$Wallet {
         case WalletType.bip44:
           coldWallet = coldCard.bip44!;
       }
-      path = coldWallet.deriv!.replaceAll("'", '');
+      path = coldWallet.deriv!;
       final fingerprint = coldCard.xfp!;
 
       final wallet = Wallet(
@@ -405,7 +411,7 @@ class Wallet with _$Wallet {
         walletType: walletType,
         fingerprint: fingerprint,
         path: path,
-        xpub: coldCard.xpub,
+        xpub: coldWallet.xpub,
         backupTested: true,
       );
 
@@ -446,7 +452,8 @@ class Wallet with _$Wallet {
   }
 
   String cleanFingerprint() {
-    if (network == BBNetwork.Testnet) return fingerprint.replaceFirst('tn::', '');
+    if (network == BBNetwork.Testnet)
+      return fingerprint.replaceFirst('tn::', '');
     return fingerprint;
   }
 
@@ -477,14 +484,19 @@ class Wallet with _$Wallet {
   }
 
   List<Address> addressesWithBalance() {
-    return addresses?.where((addr) => addr.calculateBalance() > 0).toList() ?? [];
+    return addresses?.where((addr) => addr.calculateBalance() > 0).toList() ??
+        [];
   }
 
   List<Address> addressesWithoutBalance({bool isUsed = false}) {
     if (!isUsed)
-      return addresses?.where((addr) => addr.calculateBalance() == 0).toList() ?? [];
+      return addresses
+              ?.where((addr) => addr.calculateBalance() == 0)
+              .toList() ??
+          [];
     else
-      return addresses?.where((addr) => addr.hasSpentAndNoBalance()).toList() ?? [];
+      return addresses?.where((addr) => addr.hasSpentAndNoBalance()).toList() ??
+          [];
   }
 
   List<String> mne() {
@@ -565,7 +577,9 @@ class Wallet with _$Wallet {
   }
 
   List<Transaction> getPendingTxs() {
-    return (transactions?.where((tx) => tx.timestamp == 0).toList().reversed ?? []).toList();
+    return (transactions?.where((tx) => tx.timestamp == 0).toList().reversed ??
+            [])
+        .toList();
   }
 
   List<Transaction> getConfirmedTxs() {

--- a/lib/_pkg/wallet/create.dart
+++ b/lib/_pkg/wallet/create.dart
@@ -74,8 +74,9 @@ class WalletCreate {
     bool fromStorage = true,
   }) async {
     try {
-      final network =
-          wallet.network == BBNetwork.Testnet ? bdk.Network.Testnet : bdk.Network.Bitcoin;
+      final network = wallet.network == BBNetwork.Testnet
+          ? bdk.Network.Testnet
+          : bdk.Network.Bitcoin;
       final walletType = wallet.walletType;
       // final eternalDescr = wallet.externalDescriptor;
       // String? iDesc;
@@ -95,7 +96,8 @@ class WalletCreate {
           );
 
           if (wallet.path != null) {
-            final derivation = await bdk.DerivationPath.create(path: wallet.path!);
+            final derivation =
+                await bdk.DerivationPath.create(path: wallet.path!);
             descriptor = await descriptor.derive(derivation);
           }
 
@@ -139,6 +141,57 @@ class WalletCreate {
           }
 
         case BBWalletType.coldcard:
+          final fngr = wallet.fingerprint;
+
+          final pubKey = await bdk.DescriptorPublicKey.fromString(wallet.xpub!);
+
+          // final internalDescriptor =
+          //     await bdk.DescriptorPublicKey.fromString(wallet.internalDescriptor);
+
+          switch (walletType) {
+            case WalletType.bip84:
+              internal = await bdk.Descriptor.newBip84Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.Internal,
+              );
+
+              external = await bdk.Descriptor.newBip84Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.External,
+              );
+            case WalletType.bip49:
+              internal = await bdk.Descriptor.newBip49Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.Internal,
+              );
+
+              external = await bdk.Descriptor.newBip49Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.External,
+              );
+            case WalletType.bip44:
+              internal = await bdk.Descriptor.newBip44Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.Internal,
+              );
+
+              external = await bdk.Descriptor.newBip44Public(
+                fingerPrint: fngr,
+                publicKey: pubKey,
+                network: network,
+                keychain: bdk.KeychainKind.External,
+              );
+          }
         case BBWalletType.xpub:
           // final fngr = fingerPrintFromDescr(
           //   eternalDescr,
@@ -155,7 +208,8 @@ class WalletCreate {
           //     await bdk.DescriptorPublicKey.fromString(wallet.internalDescriptor);
 
           if (wallet.path != null) {
-            final derivation = await bdk.DerivationPath.create(path: wallet.path!);
+            final derivation =
+                await bdk.DerivationPath.create(path: wallet.path!);
             pubKey = await pubKey.derive(derivation);
           }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,8 @@ class BullBitcoinWalletApp extends StatelessWidget {
         value: locator<SettingsCubit>(),
         child: BlocListener<SettingsCubit, SettingsState>(
           listener: (context, state) {
-            if (state.language != localizationDelegate.currentLocale.languageCode)
+            if (state.language !=
+                localizationDelegate.currentLocale.languageCode)
               localizationDelegate.changeLocale(Locale(state.language ?? 'en'));
           },
           child: DeepLinker(
@@ -55,7 +56,8 @@ class BullBitcoinWalletApp extends StatelessWidget {
               locale: localizationDelegate.currentLocale,
               builder: (context, child) {
                 SystemChrome.setSystemUIOverlayStyle(
-                  SystemUiOverlayStyle(statusBarColor: context.colour.background),
+                  SystemUiOverlayStyle(
+                      statusBarColor: context.colour.background),
                 );
                 if (child == null) return Container();
                 return GestureDetector(

--- a/lib/wallet/bloc/wallet_cubit.dart
+++ b/lib/wallet/bloc/wallet_cubit.dart
@@ -58,7 +58,8 @@ class WalletCubit extends Cubit<WalletState> {
     emit(state.copyWith(wallet: wallet));
 
     if (state.bdkWallet == null) {
-      final (wallets, err) = await walletCreate.loadBdkWallet(wallet, fromStorage: fromStorage);
+      final (wallets, err) =
+          await walletCreate.loadBdkWallet(wallet, fromStorage: fromStorage);
       if (err != null) {
         emit(
           state.copyWith(
@@ -313,7 +314,8 @@ class WalletCubit extends Cubit<WalletState> {
   void getFirstAddress() async {
     if (state.bdkWallet == null) return;
 
-    final (address, err) = await walletUpdate.getAddressAtIdx(state.bdkWallet!, 0);
+    final (address, err) =
+        await walletUpdate.getAddressAtIdx(state.bdkWallet!, 0);
     if (err != null) {
       emit(state.copyWith(errSyncingAddresses: err.toString()));
       return;


### PR DESCRIPTION
The source of this issue was in the `_pkg/wallet/create/loadBdkWallet` function, in which cold card wallets were following the same case as xpub. 

- Added a new case for cold card wallets which do not need to further derive keys.

There were few other issues I noticed along the way, which we can consider fixing as part of this PR: 

- [ ] In some derivation paths the hardened paths are being removed because of errors using the apostrophe `'` character. It will be better to use the letter `h` character consistently across the codebase which is less prone to stringification errors and it also works reliably with bdk.
- [ ] Broadcast page shows scan xpub; instead it must show scan signed psbt or tx hex.
- [ ] Broadcast does not work for a signed psbt