### PR TITLE
Reset errImporting, to allow correcting mistakes in Recovery word input

### DIFF
--- a/lib/import/bloc/import_cubit.dart
+++ b/lib/import/bloc/import_cubit.dart
@@ -303,14 +303,12 @@ class ImportWalletCubit extends Cubit<ImportState> {
   }
 
   void recoverWalletClicked() async {
+    emit(state.copyWith(importType: ImportTypes.words, errImporting: ''));
     for (final word in state.words)
       if (word.isEmpty) {
         emit(state.copyWith(errImporting: 'Please fill all words'));
         return;
       }
-
-    emit(state.copyWith(importType: ImportTypes.words));
-
     await _updateWalletDetailsForSelection();
     if (state.errImporting.isNotEmpty) return;
 

--- a/lib/import/bloc/import_state.dart
+++ b/lib/import/bloc/import_state.dart
@@ -13,16 +13,12 @@ enum ImportSteps {
   selectImportType,
   importWords,
   importXpub,
-
   scanningNFC,
   scanningWallets,
-
   advancedOptions,
-
   // selectColdCard,
   // coldcardFile,
   // coldcardNFC,
-
   selectWalletType,
 }
 


### PR DESCRIPTION
Fixed second point in : https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/32

Regarding allowing user to correct wrong inputs.

Required resetting cubit errImporting field every time recover is clicked. 

Noticed this pattern required in other projects too where err states need to be set to emptyString every time an attempt is made, especially if logic involves err.emtpyString checks.