### PR TITLE
Disabled coin selection if selecting sweep balance

### DIFF
--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -19,7 +19,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:pattern_formatter/pattern_formatter.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 class ReceiveScreen extends StatelessWidget {
@@ -332,18 +334,18 @@ class CreateInvoice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final amount = context.select((ReceiveCubit _) => _.state.invoiceAmount);
+    //final amount = context.select((ReceiveCubit _) => _.state.invoiceAmount);
     final description = context.select((ReceiveCubit _) => _.state.description);
 
-    final amtStr = context.select(
-      (SettingsCubit cubit) => cubit.state.getAmountInUnits(
-        amount,
-        removeText: true,
-        hideZero: true,
-        removeEndZeros: true,
-        isSats: true,
-      ),
-    );
+    // final amtStr = context.select(
+    //   (SettingsCubit cubit) => cubit.state.getAmountInUnits(
+    //     amount,
+    //     removeText: true,
+    //     hideZero: true,
+    //     removeEndZeros: true,
+    //     isSats: true,
+    //   ),
+    // );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -351,19 +353,20 @@ class CreateInvoice extends StatelessWidget {
         const BBHeader.popUpCenteredText(text: 'Request a Payment'),
         const Gap(40),
         const BBText.title('Amount'),
-        BBAmountInput(
-          btcFormatting: true,
-          value: amtStr,
-          onRightTap: () {},
-          disabled: false,
-          isSats: false,
-          hint: 'Enter Amount',
-          onChanged: (txt) {
-            final clean = txt.replaceAll(',', '').replaceAll(' ', '');
-            final amt = context.read<SettingsCubit>().state.getSatsAmount(clean, false);
-            context.read<ReceiveCubit>().updateAmount(amt);
-          },
-        ),
+        // BBAmountInput(
+        //   btcFormatting: true,
+        //   value: amtStr,
+        //   onRightTap: () {},
+        //   disabled: false,
+        //   isSats: false,
+        //   hint: 'Enter Amount',
+        //   onChanged: (txt) {
+        //     final clean = txt.replaceAll(',', '').replaceAll(' ', '');
+        //     final amt = context.read<SettingsCubit>().state.getSatsAmount(clean, false);
+        //     context.read<ReceiveCubit>().updateAmount(amt);
+        //   },
+        // ),
+        const InvoiceAmountField(),
         const Gap(16),
         const BBText.title('Public description'),
         BBTextInput.big(
@@ -647,123 +650,124 @@ class RenameLabel extends StatelessWidget {
 //   }
 // }
 
-// class InvoiceAmountField extends StatefulWidget {
-//   const InvoiceAmountField({super.key});
+class InvoiceAmountField extends StatefulWidget {
+  const InvoiceAmountField({super.key});
 
-//   @override
-//   State<InvoiceAmountField> createState() => _InvoiceAmountFieldState();
-// }
+  @override
+  State<InvoiceAmountField> createState() => _InvoiceAmountFieldState();
+}
 
-// class _InvoiceAmountFieldState extends State<InvoiceAmountField> {
-//   final _controller = TextEditingController();
-//   final FocusNode _focusNode = FocusNode();
+class _InvoiceAmountFieldState extends State<InvoiceAmountField> {
+  final _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
 
-//   @override
-//   void dispose() {
-//     _focusNode.dispose();
-//     _controller.dispose();
-//     super.dispose();
-//   }
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
 
-//   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
-//     final delete = event.logicalKey == LogicalKeyboardKey.backspace;
-//     if (delete) context.read<ReceiveCubit>().updateAmount(0);
-//     return KeyEventResult.ignored;
-//   }
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    final delete = event.logicalKey == LogicalKeyboardKey.backspace;
+    if (delete) context.read<ReceiveCubit>().updateAmount(0);
+    return KeyEventResult.ignored;
+  }
 
-//   @override
-//   Widget build(BuildContext context) {
-//     final isSats = context.select((SettingsCubit cubit) => cubit.state.unitsInSats);
-//     final amount = context.select((ReceiveCubit cubit) => cubit.state.invoiceAmount);
-//     final amountStr = context.select(
-//       (SettingsCubit cubit) => cubit.state.getAmountInUnits(
-//         amount,
-//         removeText: true,
-//         hideZero: true,
-//         removeEndZeros: true,
-//       ),
-//     );
+  @override
+  Widget build(BuildContext context) {
+    final isSats = context.select((SettingsCubit cubit) => cubit.state.unitsInSats);
+    final amount = context.select((ReceiveCubit cubit) => cubit.state.invoiceAmount);
+    final amountStr = context.select(
+      (SettingsCubit cubit) => cubit.state.getAmountInUnits(
+        amount,
+        removeText: true,
+        hideZero: true,
+        removeEndZeros: true,
+      ),
+    );
 
-//     if (_controller.text != amountStr) {
-//       _controller.text = amountStr;
+    if (_controller.text != amountStr) {
+      _controller.text = amountStr;
 
-//       if (isSats)
-//         _controller.selection = TextSelection.fromPosition(
-//           TextPosition(
-//             offset: amountStr.length,
-//           ),
-//         );
-//       else
-//         _controller.selection = TextSelection.fromPosition(
-//           TextPosition(
-//             offset: _controller.text.length,
-//           ),
-//         );
-//     }
+      if (isSats)
+        _controller.selection = TextSelection.fromPosition(
+          TextPosition(
+            offset: amountStr.length,
+          ),
+        );
+      else
+        _controller.selection = TextSelection.fromPosition(
+          TextPosition(
+            offset: _controller.text.length,
+          ),
+        );
+    }
 
-//     return Focus(
-//       focusNode: _focusNode,
-//       onKeyEvent: (n, e) {
-//         return _handleKeyEvent(n, e);
-//       },
-//       child: TextField(
-//         controller: _controller,
-//         decoration: InputDecoration(
-//           border: OutlineInputBorder(
-//             borderRadius: BorderRadius.circular(80.0),
-//           ),
-//           filled: true,
-//           fillColor: context.colour.onPrimary,
-//           contentPadding: const EdgeInsets.only(left: 24),
-//           hintText: 'Enter amount',
-//           suffixIcon: isSats
-//               ? IconButton(
-//                   color: context.colour.secondary,
-//                   onPressed: () {
-//                     context.read<SettingsCubit>().toggleUnitsInSats();
-//                   },
-//                   icon: const FaIcon(
-//                     FontAwesomeIcons.coins,
-//                   ),
-//                 )
-//               : IconButton(
-//                   color: context.colour.secondary,
-//                   onPressed: () {
-//                     context.read<SettingsCubit>().toggleUnitsInSats();
-//                   },
-//                   icon: const FaIcon(
-//                     FontAwesomeIcons.bitcoin,
-//                   ),
-//                 ),
-//         ),
-//         keyboardType: const TextInputType.numberWithOptions(
-//           decimal: true,
-//         ),
-//         onChanged: (txt) {
-//           final aLen = _controller.text.length;
-//           final tLen = txt.length;
-//           if (aLen > tLen || (aLen - tLen).abs() > 2) {
-//             context.read<ReceiveCubit>().updateAmount(0);
-//             return;
-//           }
-//           final clean = txt.replaceAll(',', '');
-//           final amt = context.read<SettingsCubit>().state.getSatsAmount(clean, null);
-//           context.read<ReceiveCubit>().updateAmount(amt);
-//         },
-//         inputFormatters: [
-//           if (!isSats)
-//             ThousandsFormatter(
-//               formatter: NumberFormat()
-//                 ..maximumFractionDigits = 8
-//                 ..minimumFractionDigits = 8
-//                 ..turnOffGrouping(),
-//               allowFraction: true,
-//             ),
-//         ],
-//       ),
-//     );
-//   }
-// }
+    return Focus(
+      focusNode: _focusNode,
+      onKeyEvent: (n, e) {
+        return _handleKeyEvent(n, e);
+      },
+      child: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(80.0),
+          ),
+          filled: true,
+          fillColor: context.colour.onPrimary,
+          contentPadding: const EdgeInsets.only(left: 24),
+          hintText: 'Enter amount',
+          suffixText: isSats ? 'sats' : 'BTC',
+          suffixIcon: isSats
+              ? IconButton(
+                  color: context.colour.secondary,
+                  onPressed: () {
+                    context.read<SettingsCubit>().toggleUnitsInSats();
+                  },
+                  icon: const FaIcon(
+                    FontAwesomeIcons.coins,
+                  ),
+                )
+              : IconButton(
+                  color: context.colour.secondary,
+                  onPressed: () {
+                    context.read<SettingsCubit>().toggleUnitsInSats();
+                  },
+                  icon: const FaIcon(
+                    FontAwesomeIcons.bitcoin,
+                  ),
+                ),
+        ),
+        keyboardType: const TextInputType.numberWithOptions(
+          decimal: true,
+        ),
+        onChanged: (txt) {
+          final aLen = _controller.text.length;
+          final tLen = txt.length;
+          if (aLen > tLen || (aLen - tLen).abs() > 2) {
+            context.read<ReceiveCubit>().updateAmount(0);
+            return;
+          }
+          final clean = txt.replaceAll(',', '');
+          final amt = context.read<SettingsCubit>().state.getSatsAmount(clean, null);
+          context.read<ReceiveCubit>().updateAmount(amt);
+        },
+        inputFormatters: [
+          if (!isSats)
+            ThousandsFormatter(
+              formatter: NumberFormat()
+                ..maximumFractionDigits = 8
+                ..minimumFractionDigits = 8
+                ..turnOffGrouping(),
+              allowFraction: true,
+            ),
+        ],
+      ),
+    );
+  }
+}
 
 // class InvoiceDescriptionField extends StatefulWidget {
 //   const InvoiceDescriptionField({super.key});

--- a/lib/send/advanced.dart
+++ b/lib/send/advanced.dart
@@ -32,6 +32,8 @@ class AdvancedOptionsPopUp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final sendAll = context.select((SendCubit x) => x.state.sendAllCoin);
+
     return PopUpBorder(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -63,16 +65,17 @@ class AdvancedOptionsPopUp extends StatelessWidget {
             //   ],
             // ),
             const Gap(32),
-            CenterLeft(
-              child: BBButton.text(
-                // style: TextButton.styleFrom(padding: EdgeInsets.zero),
-                onPressed: () {
-                  AddressSelectionPopUp.openPopup(context);
-                },
-                label: 'Manual coin selection',
-                // child: const BBText.body('Manual coin selection'),
+            if (!sendAll)
+              CenterLeft(
+                child: BBButton.text(
+                  // style: TextButton.styleFrom(padding: EdgeInsets.zero),
+                  onPressed: () {
+                    AddressSelectionPopUp.openPopup(context);
+                  },
+                  label: 'Manual coin selection',
+                  // child: const BBText.body('Manual coin selection'),
+                ),
               ),
-            ),
             // const EnableRBFOption(),
             const Gap(8),
             const SendAllOption(),

--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -1,7 +1,6 @@
 import 'package:bb_mobile/_pkg/barcode.dart';
 import 'package:bb_mobile/_pkg/bull_bitcoin_api.dart';
 import 'package:bb_mobile/_pkg/file_storage.dart';
-import 'package:bb_mobile/_pkg/launcher.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/storage/secure_storage.dart';
@@ -429,7 +428,7 @@ class TxSuccess extends StatelessWidget {
   Widget build(BuildContext context) {
     final amount = context.select((SendCubit cubit) => cubit.state.amount);
     final amtStr = context.select((SettingsCubit cubit) => cubit.state.getAmountInUnits(amount));
-    final txid = context.select((SendCubit cubit) => cubit.state.tx);
+    //final txid = context.select((SendCubit cubit) => cubit.state.tx);
     return AnnotatedRegion(
       value: const SystemUiOverlayStyle(statusBarColor: Colors.green),
       child: Column(
@@ -452,13 +451,12 @@ class TxSuccess extends StatelessWidget {
           const Gap(15),
           GestureDetector(
             onTap: () {
-              final url = context.read<SettingsCubit>().state.explorerTxUrl(txid!.txid);
-              locator<Launcher>().launchApp(url);
+              // final url = context.read<SettingsCubit>().state.explorerTxUrl(txid!.txid);
+              // locator<Launcher>().launchApp(url);
             },
             child: const BBText.body(
               'View Transaction details ->',
               textAlign: TextAlign.center,
-              isBlue: true,
             ),
           ),
           const Gap(200),


### PR DESCRIPTION
Fixed issues

- coin selection should not be allowed if send full wallet balance is selected.

- In recieve - create invoice, if my chosen unit is btc i should be able to set the amount in BTC, right now it only allows setting amount in sats.