### PR TITLE
Error handler dialog & Fix for #136

### DIFF
--- a/lib/_ui/components/alert.dart
+++ b/lib/_ui/components/alert.dart
@@ -1,0 +1,67 @@
+import 'package:bb_mobile/styles.dart';
+import 'package:flutter/material.dart';
+
+class AlertData {
+  const AlertData({
+    this.title,
+    required this.text,
+    this.actionButtonsBuilder,
+  });
+
+  final String text;
+  final String? title;
+  final List<Widget> Function(BuildContext)? actionButtonsBuilder;
+}
+
+class Alert extends StatelessWidget {
+  const Alert({this.title, required this.text, required this.buttons});
+
+  static Future openPopUp(BuildContext context, AlertData alertData) {
+    return showGeneralDialog(
+      barrierLabel: 'showGeneralDialog',
+      barrierDismissible: false,
+      transitionDuration: const Duration(milliseconds: 200),
+      context: context,
+      pageBuilder: (context, _, __) {
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: Alert(
+            title: alertData.title,
+            text: alertData.text,
+            buttons: alertData.actionButtonsBuilder != null
+                ? alertData.actionButtonsBuilder!(context)
+                : [],
+          ),
+        );
+      },
+      transitionBuilder: (context, anim1, anim2, child) {
+        return SlideTransition(
+          position: Tween(begin: const Offset(0, 1), end: Offset.zero).animate(anim1),
+          child: child,
+        );
+      },
+    );
+  }
+
+  final String? title;
+  final String text;
+  final List<Widget> buttons;
+
+  @override
+  Widget build(BuildContext context) {
+    final double width = MediaQuery.of(context).size.width;
+
+    return IntrinsicHeight(
+      child: SizedBox(
+        width: width * (95 / 100),
+        child: AlertDialog(
+          backgroundColor: context.colour.onPrimary,
+          title: title != null ? Text(title ?? '') : Container(),
+          content: Text(text),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+          actions: buttons,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/_ui/components/text_input.dart
+++ b/lib/_ui/components/text_input.dart
@@ -19,6 +19,8 @@ class BBTextInput extends StatefulWidget {
     this.focusNode,
     this.hint,
     this.controller,
+    this.onSubmitted,
+    this.textInputAction,
   })  : type = _TextInputType.multiLine,
         onEnter = null;
 
@@ -29,6 +31,8 @@ class BBTextInput extends StatefulWidget {
     this.focusNode,
     this.hint,
     this.controller,
+    this.onSubmitted,
+    this.textInputAction,
   })  : type = _TextInputType.big,
         rightIcon = null,
         onRightTap = null,
@@ -43,6 +47,8 @@ class BBTextInput extends StatefulWidget {
     required this.onRightTap,
     this.hint,
     this.controller,
+    this.onSubmitted,
+    this.textInputAction,
   })  : type = _TextInputType.bigWithIcon,
         onEnter = null;
 
@@ -54,6 +60,8 @@ class BBTextInput extends StatefulWidget {
     this.hint,
     this.controller,
     this.onEnter,
+    this.onSubmitted,
+    this.textInputAction,
   })  : type = _TextInputType.small,
         rightIcon = null,
         onRightTap = null;
@@ -69,6 +77,8 @@ class BBTextInput extends StatefulWidget {
   final bool disabled;
   final FocusNode? focusNode;
   final Function? onEnter;
+  final Function(String)? onSubmitted;
+  final TextInputAction? textInputAction;
 
   @override
   State<BBTextInput> createState() => _BBTextInputState();
@@ -197,9 +207,11 @@ class _BBTextInputState extends State<BBTextInput> {
             focusNode: widget.focusNode,
             enabled: !widget.disabled,
             onChanged: widget.onChanged,
+            onSubmitted: (value) => widget.onSubmitted?.call(value),
             controller: _editingController,
             onTap: () => widget.onEnter!(),
             enableIMEPersonalizedLearning: false,
+            textInputAction: widget.textInputAction,
             decoration: InputDecoration(
               hintText: widget.hint,
               border: OutlineInputBorder(

--- a/lib/_ui/components/utils.dart
+++ b/lib/_ui/components/utils.dart
@@ -1,0 +1,33 @@
+import 'package:bb_mobile/_ui/components/alert.dart';
+import 'package:bb_mobile/_ui/components/button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:go_router/go_router.dart';
+
+// TODO: How to make 3rd param as Cubit and still call clearErrors()
+Function showErrorAlert = (BuildContext context, String err, dynamic cubit) {
+  SchedulerBinding.instance.addPostFrameCallback((_) {
+    Alert.openPopUp(
+      context,
+      AlertData(
+        title: 'Error',
+        text: err,
+        actionButtonsBuilder: (context) {
+          return [
+            SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: BBButton.bigBlack(
+                label: 'Okay',
+                filled: true,
+                onPressed: () {
+                  cubit.clearErrors();
+                  context.pop();
+                },
+              ),
+            ),
+          ];
+        },
+      ),
+    );
+  });
+};

--- a/lib/address/bloc/address_cubit.dart
+++ b/lib/address/bloc/address_cubit.dart
@@ -134,4 +134,13 @@ class AddressCubit extends Cubit<AddressState> {
     await Future.delayed(const Duration(seconds: 3));
     emit(state.copyWith(savedAddressName: false));
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errSavingAddressName: '',
+        errFreezingAddress: '',
+      ),
+    );
+  }
 }

--- a/lib/address/pop_up.dart
+++ b/lib/address/pop_up.dart
@@ -6,6 +6,7 @@ import 'package:bb_mobile/_pkg/wallet/repository.dart';
 import 'package:bb_mobile/_pkg/wallet/sync.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/inline_label.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
@@ -391,10 +392,15 @@ class _AddressLabelTextFieldState extends State<AddressLabelTextField> {
   final _controller = TextEditingController();
   @override
   Widget build(BuildContext context) {
+    final AddressCubit cubit = context.select((AddressCubit cubit) => cubit);
     final saving = context.select((AddressCubit cubit) => cubit.state.savingAddressName);
     final err = context.select((AddressCubit cubit) => cubit.state.errSavingAddressName);
     final saved = context.select((AddressCubit cubit) => cubit.state.savedAddressName);
     final _ = widget.address.label ?? 'Enter Label';
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     if (saved) const Center(child: BBText.body('Saved!')).animate(delay: 300.ms).fadeIn();
     return Column(
@@ -406,12 +412,6 @@ class _AddressLabelTextFieldState extends State<AddressLabelTextField> {
           ),
         ),
         const Gap(60),
-        if (err.isNotEmpty) ...[
-          BBText.body(
-            err,
-          ),
-          const Gap(16),
-        ],
         Center(
           child: SizedBox(
             width: 250,

--- a/lib/import/recover.dart
+++ b/lib/import/recover.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/import/bloc/import_cubit.dart';
 import 'package:bb_mobile/import/bloc/import_state.dart';
 import 'package:bb_mobile/import/bloc/words_cubit.dart';
@@ -225,6 +226,22 @@ class _ImportWordTextFieldState extends State<ImportWordTextField> {
     );
   }
 
+  void onSubmit(String value) {
+    final suggestions = context.read<WordsCubit>().state.findWords(value);
+    hideOverlay();
+    if (suggestions.isNotEmpty && suggestions.contains(value)) {
+      context.read<ImportWalletCubit>().wordChanged12(widget.index, value, true);
+      setState(() {
+        tapped = true;
+      });
+    } else {
+      context.read<ImportWalletCubit>().wordChanged12(widget.index, '', false);
+      controller.clear();
+    }
+    widget.focusNode.unfocus();
+    widget.returnClicked(widget.index);
+  }
+
   @override
   Widget build(BuildContext context) {
     final word = context.select(
@@ -274,6 +291,8 @@ class _ImportWordTextFieldState extends State<ImportWordTextField> {
                       });
                     },
                     value: word.word,
+                    textInputAction: TextInputAction.go,
+                    onSubmitted: (String value) => onSubmit(value),
                   ),
                 ),
               ),
@@ -327,8 +346,14 @@ class _ImportWordsRecoverButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ImportWalletCubit cubit = context.select((ImportWalletCubit cubit) => cubit);
     final recovering = context.select((ImportWalletCubit cubit) => cubit.state.importing);
     final err = context.select((ImportWalletCubit cubit) => cubit.state.errImporting);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32),
       child: Column(
@@ -343,12 +368,6 @@ class _ImportWordsRecoverButton extends StatelessWidget {
               disabled: recovering,
             ),
           ),
-          if (err.isNotEmpty) ...[
-            const Gap(8),
-            BBText.error(
-              err,
-            ),
-          ],
         ],
       ),
     );

--- a/lib/import/xpub.dart
+++ b/lib/import/xpub.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/indicators.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
 import 'package:bb_mobile/_ui/toast.dart';
@@ -70,11 +71,16 @@ class ColdCardSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ImportWalletCubit cubit = context.select((ImportWalletCubit cubit) => cubit);
     final loading = context.select((ImportWalletCubit cubit) => cubit.state.loadingFile);
     final scanning = context
         .select((ImportWalletCubit cubit) => cubit.state.importStep == ImportSteps.scanningNFC);
 
     final err = context.select((ImportWalletCubit cubit) => cubit.state.errLoadingFile);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     if (loading)
       return const Center(child: CircularProgressIndicator()).animate(delay: 300.ms).fadeIn();
@@ -112,10 +118,6 @@ class ColdCardSection extends StatelessWidget {
             loadingText: 'Stop Scanning',
           ),
           const Gap(24),
-          if (err.isNotEmpty)
-            BBText.error(
-              err,
-            ),
           const Opacity(opacity: 0.3, child: Divider()),
         ],
       ),
@@ -193,7 +195,12 @@ class _ImportExtra extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ImportWalletCubit cubit = context.select((ImportWalletCubit cubit) => cubit);
     final err = context.select((ImportWalletCubit cubit) => cubit.state.errImporting);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -217,7 +224,6 @@ class _ImportExtra extends StatelessWidget {
             },
           ),
           const Gap(8),
-          if (err.isNotEmpty) BBText.error(err, textAlign: TextAlign.center),
         ],
       ),
     );
@@ -270,6 +276,7 @@ class AdvancedOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ImportWalletCubit cubit = context.select((ImportWalletCubit cubit) => cubit);
     final xpub = context.select((ImportWalletCubit cubit) => cubit.state.xpub);
     final path = context.select((ImportWalletCubit x) => x.state.customDerivation);
     final fingerprint = context.select((ImportWalletCubit x) => x.state.fingerprint);
@@ -280,6 +287,10 @@ class AdvancedOptions extends StatelessWidget {
         context.select((ImportWalletCubit x) => x.state.manualCombinedPublicDescriptor ?? '');
 
     final err = context.select((ImportWalletCubit cubit) => cubit.state.errImporting);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     return Padding(
       padding: const EdgeInsets.only(
@@ -361,8 +372,6 @@ class AdvancedOptions extends StatelessWidget {
               context.read<ImportWalletCubit>().xpubSaveClicked();
             },
           ),
-          const Gap(16),
-          if (err.isNotEmpty) BBText.error(err, textAlign: TextAlign.center),
           const Gap(80),
         ],
       ),

--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -363,4 +363,14 @@ class ReceiveCubit extends Cubit<ReceiveState> {
   }
 
   void shareClicked() {}
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errCreatingInvoice: '',
+        errLoadingAddress: '',
+        errSavingLabel: '',
+      ),
+    );
+  }
 }

--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/_pkg/wallet/repository.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
 import 'package:bb_mobile/locator.dart';
@@ -185,8 +186,13 @@ class Actions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ReceiveCubit cubit = context.select((ReceiveCubit x) => x);
     final showRequestButton = context.select((ReceiveCubit x) => x.state.showNewRequestButton());
     final errLoadingAddress = context.select((ReceiveCubit x) => x.state.errLoadingAddress);
+
+    if (errLoadingAddress.isNotEmpty) {
+      showErrorAlert(context, errLoadingAddress, cubit);
+    }
 
     return Column(
       children: [
@@ -203,7 +209,6 @@ class Actions extends StatelessWidget {
             context.read<ReceiveCubit>().generateNewAddress();
           },
         ),
-        BBText.errorSmall(errLoadingAddress),
       ],
     );
   }

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -518,4 +518,16 @@ class SendCubit extends Cubit<SendState> {
 
     emit(state.copyWith(sending: false, sent: true));
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errAddresses: '',
+        errDownloadingFile: '',
+        errLoadingFees: '',
+        errScanningAddress: '',
+        errSending: '',
+      ),
+    );
+  }
 }

--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/_pkg/wallet/transaction.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/fees.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/send/advanced.dart';
@@ -264,11 +265,15 @@ class SendButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final watchOnly = context.select((WalletBloc cubit) => cubit.state.wallet!.watchOnly());
 
+    final SendCubit cubit = context.select((SendCubit cubit) => cubit);
     final sending = context.select((SendCubit cubit) => cubit.state.sending);
     final showSend = context.select((SendCubit cubit) => cubit.state.showSendButton);
     final err = context.select((SendCubit cubit) => cubit.state.errSending);
-
     final signed = context.select((SendCubit cubit) => cubit.state.signed);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -303,12 +308,6 @@ class SendButton extends StatelessWidget {
           ),
         ),
         const Gap(8),
-        if (err.isNotEmpty)
-          Center(
-            child: BBText.body(
-              err,
-            ),
-          ),
       ],
     );
   }

--- a/lib/settings/bloc/broadcasttx_cubit.dart
+++ b/lib/settings/bloc/broadcasttx_cubit.dart
@@ -384,4 +384,16 @@ class BroadcastTxCubit extends Cubit<BroadcastTxState> {
     await Future.delayed(const Duration(seconds: 4));
     emit(state.copyWith(downloaded: false));
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errExtractingTx: '',
+        errLoadingFile: '',
+        errPSBT: '',
+        errBroadcastingTx: '',
+        errDownloadingFile: '',
+      ),
+    );
+  }
 }

--- a/lib/settings/bloc/settings_cubit.dart
+++ b/lib/settings/bloc/settings_cubit.dart
@@ -319,4 +319,15 @@ class SettingsCubit extends Cubit<SettingsState> {
         return null;
     }
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errLoadingCurrency: '',
+        errLoadingFees: '',
+        errLoadingLanguage: '',
+        errLoadingNetworks: '',
+      ),
+    );
+  }
 }

--- a/lib/settings/broadcast.dart
+++ b/lib/settings/broadcast.dart
@@ -6,6 +6,7 @@ import 'package:bb_mobile/_ui/app_bar.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
 import 'package:bb_mobile/home/bloc/home_cubit.dart';
@@ -269,9 +270,14 @@ class SendButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final BroadcastTxCubit cubit = context.select((BroadcastTxCubit cubit) => cubit);
     final step = context.select((BroadcastTxCubit cubit) => cubit.state.step);
     final hasErr = context.select((BroadcastTxCubit cubit) => cubit.state.hasErr());
     final err = context.select((BroadcastTxCubit cubit) => cubit.state.getErrors());
+
+    if (hasErr) {
+      showErrorAlert(context, err, cubit);
+    }
 
     final broadcasting = context.select((BroadcastTxCubit cubit) => cubit.state.broadcastingTx);
     final extractingTx = context.select((BroadcastTxCubit cubit) => cubit.state.extractingTx);
@@ -289,12 +295,6 @@ class SendButton extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (hasErr) ...[
-          BBText.error(
-            err,
-          ),
-          const Gap(16),
-        ],
         Center(
           child: SizedBox(
             width: 300,
@@ -435,7 +435,9 @@ class TxInfo extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 BBText.bodySmall(address.miniString()),
-                BBText.bodyBold(sState.getAmountInUnits(address.highestPreviousBalance)),
+                BBText.bodyBold(
+                  sState.getAmountInUnits(address.highestPreviousBalance),
+                ),
               ],
             ),
             const Gap(8),

--- a/lib/settings/electrum.dart
+++ b/lib/settings/electrum.dart
@@ -3,6 +3,7 @@ import 'package:bb_mobile/_pkg/consts/keys.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
 import 'package:bb_mobile/settings/bloc/settings_cubit.dart';
@@ -45,9 +46,14 @@ class NetworkButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final SettingsCubit cubit = context.select((SettingsCubit x) => x);
     final selectedNetwork = context.select((SettingsCubit x) => x.state.getNetwork());
     if (selectedNetwork == null) return const SizedBox.shrink();
     final err = context.select((SettingsCubit x) => x.state.errLoadingNetworks);
+
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
 
     return Column(
       children: [
@@ -78,10 +84,6 @@ class NetworkButton extends StatelessWidget {
         //     ],
         //   ),
         // ),
-        if (err.isNotEmpty)
-          BBText.errorSmall(
-            err,
-          ),
       ],
     );
   }
@@ -147,11 +149,16 @@ class NetworkStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final SettingsCubit cubit = context.select((SettingsCubit x) => x);
     final networkConnected = context.select((SettingsCubit x) => x.state.networkConnected);
     final errLoadingNetwork = context.select((SettingsCubit x) => x.state.errLoadingNetworks);
     final isTestnet = context.select((SettingsCubit x) => x.state.testnet);
     final network =
         context.select((SettingsCubit x) => x.state.getNetwork()?.getNetworkUrl(isTestnet) ?? '');
+
+    if (errLoadingNetwork.isNotEmpty) {
+      showErrorAlert(context, errLoadingNetwork, cubit);
+    }
 
     return Column(
       children: [
@@ -169,10 +176,6 @@ class NetworkStatus extends StatelessWidget {
             BBText.body(network),
           ],
         ),
-        if (errLoadingNetwork.isNotEmpty) ...[
-          const Gap(8),
-          BBText.errorSmall(errLoadingNetwork),
-        ],
       ],
     );
   }

--- a/lib/transaction/bloc/transaction_cubit.dart
+++ b/lib/transaction/bloc/transaction_cubit.dart
@@ -307,4 +307,15 @@ class TransactionCubit extends Cubit<TransactionState> {
   void cancelTx() {
     emit(state.copyWith(updatedTx: null));
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errBuildingTx: '',
+        errLoadingAddresses: '',
+        errSavingLabel: '',
+        errSendingTx: '',
+      ),
+    );
+  }
 }

--- a/lib/transaction/transaction_page.dart
+++ b/lib/transaction/transaction_page.dart
@@ -17,6 +17,7 @@ import 'package:bb_mobile/_ui/app_bar.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/_ui/popup_border.dart';
 import 'package:bb_mobile/_ui/templates/headers.dart';
 import 'package:bb_mobile/home/bloc/home_cubit.dart';
@@ -98,11 +99,16 @@ class _Screen extends StatelessWidget {
       body: BlocBuilder<TransactionCubit, TransactionState>(
         // buildWhen: (previous, current) => previous.tx != current.tx,
         builder: (context, state) {
+          final cubit = context.select((TransactionCubit cubit) => cubit);
           final tx = context.select((TransactionCubit cubit) => cubit.state.tx);
 
           // final toAddresses = tx.outAddresses ?? [];
 
           final err = context.select((TransactionCubit cubit) => cubit.state.errLoadingAddresses);
+
+          if (err.isNotEmpty) {
+            showErrorAlert(context, err, cubit);
+          }
 
           final txid = tx.txid;
           final amt = tx.getAmount().abs();
@@ -261,13 +267,6 @@ class _Screen extends StatelessWidget {
                     ),
                     const Gap(4),
                     const TxLabelTextField(),
-                    const Gap(24),
-                    if (err.isNotEmpty) ...[
-                      const Gap(32),
-                      BBText.errorSmall(
-                        err,
-                      ),
-                    ],
                     const Gap(100),
                   ],
                 ),
@@ -385,10 +384,15 @@ class BumpFeesPopup extends StatelessWidget {
     final built = context.select((TransactionCubit x) => x.state.updatedTx != null);
     final sending = context.select((TransactionCubit x) => x.state.sendingTx);
 
+    final cubit = context.select((TransactionCubit x) => x);
     final er = context.select((TransactionCubit x) => x.state.errSendingTx);
     final err = context.select((TransactionCubit x) => x.state.errBuildingTx);
 
     final errr = err.isNotEmpty ? err : er;
+
+    if (errr.isNotEmpty) {
+      showErrorAlert(context, errr, cubit);
+    }
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -412,8 +416,6 @@ class BumpFeesPopup extends StatelessWidget {
             value: amt,
           ),
           const Gap(32),
-          if (errr.isNotEmpty) BBText.errorSmall(errr),
-          const Gap(8),
           BBButton.bigRed(
             label: built ? 'Send Transaction' : 'Build Transaction',
             loading: sending,

--- a/lib/wallet_settings/bloc/wallet_settings_cubit.dart
+++ b/lib/wallet_settings/bloc/wallet_settings_cubit.dart
@@ -429,6 +429,18 @@ class WalletSettingsCubit extends Cubit<WalletSettingsState> {
       ),
     );
   }
+
+  void clearErrors() async {
+    emit(
+      state.copyWith(
+        errDeleting: '',
+        errGettingAddresses: '',
+        errSavingFile: '',
+        errSavingName: '',
+        errTestingBackup: '',
+      ),
+    );
+  }
 }
 
 const mn1 = [

--- a/lib/wallet_settings/test-backup.dart
+++ b/lib/wallet_settings/test-backup.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/_ui/app_bar.dart';
 import 'package:bb_mobile/_ui/components/button.dart';
 import 'package:bb_mobile/_ui/components/text.dart';
 import 'package:bb_mobile/_ui/components/text_input.dart';
+import 'package:bb_mobile/_ui/components/utils.dart';
 import 'package:bb_mobile/styles.dart';
 import 'package:bb_mobile/wallet/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/wallet_settings/bloc/wallet_settings_cubit.dart';
@@ -259,22 +260,17 @@ class TestBackupConfirmButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cubit = context.select((WalletSettingsCubit cubit) => cubit);
     final testing = context.select((WalletSettingsCubit cubit) => cubit.state.testingBackup);
     final err = context.select((WalletSettingsCubit cubit) => cubit.state.errTestingBackup);
     final tested = context.select((WalletSettingsCubit cubit) => cubit.state.backupTested);
 
+    if (err.isNotEmpty) {
+      showErrorAlert(context, err, cubit);
+    }
+
     return Column(
       children: [
-        if (err.isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Center(
-              child: BBText.error(
-                err,
-              ).animate().fadeIn(),
-            ),
-          ),
-        const Gap(40),
         if (tested)
           Center(
             child: Padding(


### PR DESCRIPTION
1. Added a generic ErrorAlert component and converted all error message code to make use of this.
 - The red bg shade is coming from the theme.
 - RIght now, we got error in the states as strings. Ideally error variable in the states should of some Error class, with fields like type, message, code, stacktrace, etc.,
 - I thought of writing some logic to convert the technical error messages to user friendly error messages. But don't want to do that with the current structure.

2. Fix for [ #136](https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/136)