### PR TITLE
Update dependencies to build on macOS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
 
     defaultConfig {
         applicationId 'com.bullbitcoin.mobile'
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Update minSdkVersion to 24
Update kotlin [gradle plugin] version to 1.9.0

---

Without these changes, I was getting all sorts of errors building like the following that suggested an upgrade would fix it:

```
> Task :app:compileDebugKotlin FAILED

> Task :app:mergeExtDexDebug
ERROR:D8: com.android.tools.r8.kotlin.H
ERROR:D8: com.android.tools.r8.kotlin.H

> Task :app:mergeExtDexDebug FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:mergeExtDexDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform annotation-jvm-1.9.1.jar (androidx.annotation:annotation-jvm:1.9.1) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.jvm.environment=standard-jvm, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime, org.jetbrains.kotlin.platform.type=jvm}.le-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.jvm.environment=standard-jvm, org.gradle
      > Execution failed for DexingWithClasspathTransform: /Users/dan/.gradle/caches/transforms-3/b0c0d67866dec39418d2eab670abb092/transformed/jetified-annotation-jvm-1.9.1.jar.rains.kotlin.platform.type=jvm}.
         > Error while dexing.
   > Failed to transform kotlin-stdlib-1.9.24.jar (org.jetbrains.kotlin:kotlin-stdlib:1.9.24) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.jvm.environment=standard-jvm, org.gradle.libraryelements=jar, org.gradle.status=release, orgble-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.category=library, org.gradle.jvm.environment=standard-jvm, org.gradl.gradle.usage=java-runtime, org.jetbrains.kotlin.platform.type=jvm}.brains.kotlin.platform.type=jvm}.
      > Execution failed for DexingWithClasspathTransform: /Users/dan/.gradle/caches/transforms-3/838a01eb57f3f113ab61b72ac0b3cbb3/transformed/jetified-kotlin-stdlib-1.9.24.jar.
         > Error while dexing.
```