### PR TITLE
Fix TxSuccess conditional

### DIFF
--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -174,13 +174,6 @@ class _Screen extends StatelessWidget {
     if (showWarning && !walletIsLiquid && potentialonchainSwap == false)
       return const _Warnings();
 
-    if (signed && !isLn) {
-      if (!sent)
-        return const TxDetailsScreen();
-      else
-        return const TxSuccess();
-    }
-
     return ColoredBox(
       color: context.colour.primaryContainer,
       child: SingleChildScrollView(


### PR DESCRIPTION
This relies exclusively on two simple if conditionals in _Screen rather than a complex nested one later on. I missed committing this in #341 but it is necessary in order to fix the Confirm TxDetailsScreen