### PR TITLE
Fix untrack-generated-files

### DIFF
--- a/lib/_pkg/wallet/lwk/sync.dart
+++ b/lib/_pkg/wallet/lwk/sync.dart
@@ -9,7 +9,7 @@ void _syncLwkIsolate(List<dynamic> args) async {
   final lwkWallet = args[1] as lwk.Wallet;
   final blockChain = args[2] as String;
   try {
-    await lwkWallet.sync(electrumUrl: blockChain, validateDomain: true);
+    await lwkWallet.sync(electrumUrl: blockChain);
     sendPort.send(lwkWallet);
   } catch (e) {
     sendPort.send(
@@ -64,7 +64,7 @@ class LWKSync {
     required String blockChain,
   }) async {
     try {
-      await lwkWallet.sync(electrumUrl: blockChain, validateDomain: true);
+      await lwkWallet.sync(electrumUrl: blockChain);
       return (lwkWallet, null);
     } on Exception catch (e) {
       return (

--- a/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
+++ b/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
@@ -1,12 +1,11 @@
 // This is a generated file; do not edit or check into version control.
-FLUTTER_ROOT=/Users/ishi/Software/flutter
-FLUTTER_APPLICATION_PATH=/Users/ishi/Code/wallet/bullbitcoin-mobile
+FLUTTER_ROOT=/opt/homebrew/Caskroom/flutter/3.24.4/flutter
+FLUTTER_APPLICATION_PATH=/Users/dan/f/dev/bullbitcoin-mobile
 COCOAPODS_PARALLEL_CODE_SIGN=true
-FLUTTER_TARGET=/Users/ishi/Code/wallet/bullbitcoin-mobile/lib/main.dart
 FLUTTER_BUILD_DIR=build
 FLUTTER_BUILD_NAME=0.3.2
 FLUTTER_BUILD_NUMBER=23
 DART_OBFUSCATION=false
 TRACK_WIDGET_CREATION=true
 TREE_SHAKE_ICONS=false
-PACKAGE_CONFIG=/Users/ishi/Code/wallet/bullbitcoin-mobile/.dart_tool/package_config.json
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/macos/Flutter/ephemeral/flutter_export_environment.sh
+++ b/macos/Flutter/ephemeral/flutter_export_environment.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/Users/ishi/Software/flutter"
-export "FLUTTER_APPLICATION_PATH=/Users/ishi/Code/wallet/bullbitcoin-mobile"
+export "FLUTTER_ROOT=/opt/homebrew/Caskroom/flutter/3.24.4/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/dan/f/dev/bullbitcoin-mobile"
 export "COCOAPODS_PARALLEL_CODE_SIGN=true"
-export "FLUTTER_TARGET=/Users/ishi/Code/wallet/bullbitcoin-mobile/lib/main.dart"
 export "FLUTTER_BUILD_DIR=build"
 export "FLUTTER_BUILD_NAME=0.3.2"
 export "FLUTTER_BUILD_NUMBER=23"
 export "DART_OBFUSCATION=false"
 export "TRACK_WIDGET_CREATION=true"
 export "TREE_SHAKE_ICONS=false"
-export "PACKAGE_CONFIG=/Users/ishi/Code/wallet/bullbitcoin-mobile/.dart_tool/package_config.json"
+export "PACKAGE_CONFIG=.dart_tool/package_config.json"


### PR DESCRIPTION
lwkWallet.sync no longer takes a validateDomain parameter

I was unable to build 0acf3e4669ce8a11b6d5a712c397a7bd611951d5 without this change

Unclear to me whether or not this was a lock file or freeze change that overlooked a breaking change in that library, but this fixes it.