### PR TITLE
fix: remove address toLowerCase

### DIFF
--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -119,7 +119,7 @@ class SendCubit extends Cubit<SendState> {
 
     switch (paymentNetwork) {
       case AddressNetwork.bip21Bitcoin:
-        final bip21Obj = bip21.decode(address.toLowerCase());
+        final bip21Obj = bip21.decode(address);
         final newAddress = bip21Obj.address;
         emit(state.copyWith(address: newAddress));
         final amount = bip21Obj.options['amount'] as num?;


### PR DESCRIPTION
For bip49 it is important to retain letters in lower and uppercase. Removing the toLowerCase() in the correct place makes sure it is and bip49 addresses are correctly scanned and passed to the Send input.

This fixes https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/334.