### PR TITLE
fix: custom manual fee not used in Send

### DIFF
--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -95,7 +95,7 @@ class _SendPageState extends State<SendPage> {
       defaultRBF: locator<SettingsCubit>().state.defaultRBF,
       fileStorage: locator<FileStorage>(),
       networkCubit: locator<NetworkCubit>(),
-      networkFeesCubit: locator<NetworkFeesCubit>(),
+      networkFeesCubit: networkFees,
       homeCubit: locator<HomeCubit>(),
       swapBoltz: locator<SwapBoltz>(),
       currencyCubit: currency,


### PR DESCRIPTION
Two different NetworkFeesCubit instances where used between the SendPage and the SendCubit: the SendPage components used a local NetworkFeesCubit to store the fee state, but the global default NetworkFeesCubit was injected in the SendCubit and was used to get the fees on confirmation from, not having the locally set state.

This fixes https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/331.