### PR TITLE
Send Payjoin

### DIFF
--- a/lib/_pkg/payjoin/manager.dart
+++ b/lib/_pkg/payjoin/manager.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:dio/dio.dart';
+import 'package:payjoin_flutter/common.dart';
+import 'package:payjoin_flutter/send.dart';
+import 'package:payjoin_flutter/uri.dart' as pj_uri;
+
+const List<String> _ohttpRelayUrls = [
+  'https://pj.bobspacebkk.com',
+  'https://ohttp.achow101.com',
+];
+
+class PayjoinManager {
+  Future<Sender> initSender(
+    String pjUriString,
+    int networkFeesSatPerVb,
+    String originalPsbt,
+  ) async {
+    try {
+      // TODO this is a super ugly hack because of ugliness in the bip21 module.
+      // Fix that and get rid of this.
+      final pjSubstring = pjUriString.substring(pjUriString.indexOf('pj=') + 3);
+      final capitalizedPjSubstring = pjSubstring.toUpperCase();
+      final pjUriStringWithCapitalizedPj =
+          pjUriString.substring(0, pjUriString.indexOf('pj=') + 3) +
+              capitalizedPjSubstring;
+      // This should already be done before letting payjoin be enabled for sending
+      final pjUri = (await pj_uri.Uri.fromStr(pjUriStringWithCapitalizedPj))
+          .checkPjSupported();
+      final minFeeRateSatPerKwu = BigInt.from(networkFeesSatPerVb * 250);
+      final senderBuilder = await SenderBuilder.fromPsbtAndUri(
+        psbtBase64: originalPsbt,
+        pjUri: pjUri,
+      );
+      final sender = await senderBuilder.buildRecommended(
+        minFeeRate: minFeeRateSatPerKwu,
+      );
+      return sender;
+    } catch (e) {
+      throw Exception('Error initializing payjoin Sender: $e');
+    }
+  }
+
+  /// Sends a payjoin using the v2 protocol given an initialized Sender.
+  /// V2 protocol first attempts a v2 request, but if one cannot be extracted
+  /// from the given bitcoin URI, it will attempt to send a v1 request.
+  Future<String?> runSender(Sender sender) async {
+    Request postReq;
+    V2PostContext postReqCtx;
+    final dio = Dio();
+
+    try {
+      final result =
+          await sender.extractV2(ohttpProxyUrl: await _randomOhttpRelayUrl());
+      postReq = result.$1;
+      postReqCtx = result.$2;
+    } catch (e) {
+      // extract v2 failed, attempt to send v1
+      return await _runSenderV1(sender, dio);
+    }
+
+    try {
+      final postRes = await _postRequest(dio, postReq);
+      final getCtx = await postReqCtx.processResponse(
+        response: postRes.data as List<int>,
+      );
+      while (true) {
+        try {
+          final (getRequest, getReqCtx) = await getCtx.extractReq(
+            ohttpRelay: await _randomOhttpRelayUrl(),
+          );
+          final getRes = await _postRequest(dio, getRequest);
+          return await getCtx.processResponse(
+            response: getRes.data as List<int>,
+            ohttpCtx: getReqCtx,
+          );
+        } catch (e) {
+          // loop
+        }
+      }
+    } catch (e) {
+      throw Exception('Error polling payjoin sender: $e');
+    }
+  }
+
+  /// Returns a random OHTTP proxy URL from the list of available URLs.
+  /// Random proxying makes it more difficult for a single ohttp relay or
+  /// payjoin directory to conduct attacks based on timing metadata.
+  Future<pj_uri.Url> _randomOhttpRelayUrl() async {
+    return await pj_uri.Url.fromStr(
+      _ohttpRelayUrls[Random.secure().nextInt(_ohttpRelayUrls.length)],
+    );
+  }
+
+  // Attempt to send a payjoin using the v1 protocol as fallback.
+  Future<String> _runSenderV1(Sender sender, Dio dio) async {
+    try {
+      final (req, v1Ctx) = await sender.extractV1();
+      final response = await _postRequest(dio, req);
+      final proposalPsbt =
+          await v1Ctx.processResponse(response: response.data as List<int>);
+      return proposalPsbt;
+    } catch (e) {
+      throw Exception('Send V1 payjoin error: $e');
+    }
+  }
+
+  /// Take a Request from the payjoin sender and post it over OHTTP.
+  Future<Response<dynamic>> _postRequest(Dio dio, Request req) async {
+    return await dio.post(
+      req.url.asString(),
+      options: Options(
+        headers: {
+          'Content-Type': req.contentType,
+        },
+        responseType: ResponseType.bytes,
+      ),
+      data: req.body,
+    );
+  }
+}

--- a/lib/_pkg/payjoin/manager.dart
+++ b/lib/_pkg/payjoin/manager.dart
@@ -1,9 +1,15 @@
 import 'dart:async';
+import 'dart:isolate';
 import 'dart:math';
 
+import 'package:bb_mobile/_model/transaction.dart';
+import 'package:bb_mobile/_model/wallet.dart';
+import 'package:bb_mobile/_pkg/error.dart';
+import 'package:bb_mobile/_pkg/wallet/transaction.dart';
 import 'package:dio/dio.dart';
 import 'package:payjoin_flutter/common.dart';
 import 'package:payjoin_flutter/send.dart';
+import 'package:payjoin_flutter/src/generated/frb_generated.dart';
 import 'package:payjoin_flutter/uri.dart' as pj_uri;
 
 const List<String> _ohttpRelayUrls = [
@@ -12,6 +18,11 @@ const List<String> _ohttpRelayUrls = [
 ];
 
 class PayjoinManager {
+  PayjoinManager(this._walletTx);
+  final WalletTx _walletTx;
+  final Map<String, Isolate> _activePollers = {};
+  final Map<String, ReceivePort> _activePorts = {};
+
   Future<Sender> initSender(
     String pjUriString,
     int networkFeesSatPerVb,
@@ -42,81 +53,154 @@ class PayjoinManager {
     }
   }
 
-  /// Sends a payjoin using the v2 protocol given an initialized Sender.
-  /// V2 protocol first attempts a v2 request, but if one cannot be extracted
-  /// from the given bitcoin URI, it will attempt to send a v1 request.
-  Future<String?> runSender(Sender sender) async {
-    Request postReq;
-    V2PostContext postReqCtx;
-    final dio = Dio();
-
+  Future<Err?> spawnSender({
+    required bool isTestnet,
+    required Sender sender,
+    required Wallet wallet,
+  }) async {
     try {
-      final result =
-          await sender.extractV2(ohttpProxyUrl: await _randomOhttpRelayUrl());
-      postReq = result.$1;
-      postReqCtx = result.$2;
-    } catch (e) {
-      // extract v2 failed, attempt to send v1
-      return await _runSenderV1(sender, dio);
-    }
+      final completer = Completer<Err?>();
+      final receivePort = ReceivePort();
 
-    try {
-      final postRes = await _postRequest(dio, postReq);
-      final getCtx = await postReqCtx.processResponse(
-        response: postRes.data as List<int>,
-      );
-      while (true) {
-        try {
-          final (getRequest, getReqCtx) = await getCtx.extractReq(
-            ohttpRelay: await _randomOhttpRelayUrl(),
-          );
-          final getRes = await _postRequest(dio, getRequest);
-          return await getCtx.processResponse(
-            response: getRes.data as List<int>,
-            ohttpCtx: getReqCtx,
-          );
-        } catch (e) {
-          // loop
+      // TODO Create unique ID for this payjoin session
+      const sessionId = 'TODO_SENDER_ENDPOINT';
+
+      receivePort.listen((message) async {
+        if (message is Map<String, dynamic>) {
+          if (message['type'] == 'psbt_to_sign') {
+            final proposalPsbt = message['psbt'] as String;
+            final (wtxid, err) = await _walletTx.signAndBroadcastPsbt(
+              psbt: proposalPsbt,
+              wallet: wallet,
+            );
+            if (err != null) {
+              completer.complete(err);
+              return;
+            }
+            await _cleanupSession(sessionId);
+          } else if (message is Err) {
+            // TODO propagate this error to the UI
+            await _cleanupSession(sessionId);
+          }
         }
+      });
+
+      final args = [
+        receivePort.sendPort,
+        sender.toJson(),
+      ];
+
+      final isolate = await Isolate.spawn(
+        _isolateSender,
+        args,
+      );
+      _activePollers[sessionId] = isolate;
+      _activePorts[sessionId] = receivePort;
+      return completer.future;
+    } catch (e) {
+      return Err(e.toString());
+    }
+  }
+
+  Future<void> _cleanupSession(String sessionId) async {
+    _activePollers[sessionId]?.kill();
+    _activePollers.remove(sessionId);
+    _activePorts[sessionId]?.close();
+    _activePorts.remove(sessionId);
+  }
+}
+
+// Top-level function to generate random OHTTP relay URL
+Future<pj_uri.Url> _randomOhttpRelayUrl() async {
+  return await pj_uri.Url.fromStr(
+    _ohttpRelayUrls[Random.secure().nextInt(_ohttpRelayUrls.length)],
+  );
+}
+
+/// Top-level function that runs inside the isolate.
+/// It should not reference instance-specific variables or methods.
+Future<void> _isolateSender(List<dynamic> args) async {
+  // Initialize any core dependencies here if required
+  await core.init();
+
+  final sendPort = args[0] as SendPort;
+  final senderJson = args[1] as String;
+
+  // Reconstruct the Sender from the JSON
+  final sender = Sender.fromJson(senderJson);
+
+  // Run the sender logic inside the isolate
+  try {
+    final proposalPsbt = await _runSender(sender);
+    sendPort.send({
+      'type': 'psbt_to_sign',
+      'psbt': proposalPsbt,
+    });
+  } catch (e) {
+    sendPort.send(Err(e.toString()));
+  }
+}
+
+/// Top-level function that attempts to run payjoin sender (V2 protocol first, fallback to V1).
+Future<String?> _runSender(Sender sender) async {
+  final dio = Dio();
+
+  try {
+    final result = await sender.extractV2(
+      ohttpProxyUrl: await _randomOhttpRelayUrl(),
+    );
+    final postReq = result.$1;
+    final postReqCtx = result.$2;
+
+    // Attempt V2
+    final postRes = await _postRequest(dio, postReq);
+    final getCtx = await postReqCtx.processResponse(
+      response: postRes.data as List<int>,
+    );
+
+    while (true) {
+      try {
+        final (getRequest, getReqCtx) = await getCtx.extractReq(
+          ohttpRelay: await _randomOhttpRelayUrl(),
+        );
+        final getRes = await _postRequest(dio, getRequest);
+        return await getCtx.processResponse(
+          response: getRes.data as List<int>,
+          ohttpCtx: getReqCtx,
+        );
+      } catch (e) {
+        // Loop until a valid response is found
       }
-    } catch (e) {
-      throw Exception('Error polling payjoin sender: $e');
     }
+  } catch (e) {
+    // If V2 fails, attempt V1
+    return await _runSenderV1(sender, dio);
   }
+}
 
-  /// Returns a random OHTTP proxy URL from the list of available URLs.
-  /// Random proxying makes it more difficult for a single ohttp relay or
-  /// payjoin directory to conduct attacks based on timing metadata.
-  Future<pj_uri.Url> _randomOhttpRelayUrl() async {
-    return await pj_uri.Url.fromStr(
-      _ohttpRelayUrls[Random.secure().nextInt(_ohttpRelayUrls.length)],
-    );
+/// Attempt to send payjoin using the V1 protocol.
+Future<String> _runSenderV1(Sender sender, Dio dio) async {
+  try {
+    final (req, v1Ctx) = await sender.extractV1();
+    final response = await _postRequest(dio, req);
+    final proposalPsbt =
+        await v1Ctx.processResponse(response: response.data as List<int>);
+    return proposalPsbt;
+  } catch (e) {
+    throw Exception('Send V1 payjoin error: $e');
   }
+}
 
-  // Attempt to send a payjoin using the v1 protocol as fallback.
-  Future<String> _runSenderV1(Sender sender, Dio dio) async {
-    try {
-      final (req, v1Ctx) = await sender.extractV1();
-      final response = await _postRequest(dio, req);
-      final proposalPsbt =
-          await v1Ctx.processResponse(response: response.data as List<int>);
-      return proposalPsbt;
-    } catch (e) {
-      throw Exception('Send V1 payjoin error: $e');
-    }
-  }
-
-  /// Take a Request from the payjoin sender and post it over OHTTP.
-  Future<Response<dynamic>> _postRequest(Dio dio, Request req) async {
-    return await dio.post(
-      req.url.asString(),
-      options: Options(
-        headers: {
-          'Content-Type': req.contentType,
-        },
-        responseType: ResponseType.bytes,
-      ),
-      data: req.body,
-    );
-  }
+/// Posts a request via dio and returns the response.
+Future<Response<dynamic>> _postRequest(Dio dio, Request req) async {
+  return await dio.post(
+    req.url.asString(),
+    options: Options(
+      headers: {
+        'Content-Type': req.contentType,
+      },
+      responseType: ResponseType.bytes,
+    ),
+    data: req.body,
+  );
 }

--- a/lib/_pkg/wallet/bdk/sensitive_create.dart
+++ b/lib/_pkg/wallet/bdk/sensitive_create.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/_pkg/wallet/create.dart';
 import 'package:bb_mobile/_pkg/wallet/repository/wallets.dart';
 import 'package:bb_mobile/_pkg/wallet/utils.dart';
 import 'package:bdk_flutter/bdk_flutter.dart' as bdk;
+import 'package:path_provider/path_provider.dart';
 
 class BDKSensitiveCreate {
   BDKSensitiveCreate({
@@ -449,7 +450,13 @@ class BDKSensitiveCreate {
           );
       }
 
-      const dbConfig = bdk.DatabaseConfig.memory();
+      final appDocDir = await getApplicationDocumentsDirectory();
+      final String dbDir =
+          '${appDocDir.path}/${wallet.getWalletStorageString()}';
+
+      final dbConfig = bdk.DatabaseConfig.sqlite(
+        config: bdk.SqliteDbConfiguration(path: dbDir),
+      );
 
       final bdkWallet = await bdk.Wallet.create(
         descriptor: external,

--- a/lib/_pkg/wallet/bdk/transaction.dart
+++ b/lib/_pkg/wallet/bdk/transaction.dart
@@ -591,15 +591,16 @@ class BDKTransactions {
     // required bdk.Blockchain blockchain,
     required bdk.Wallet bdkWallet,
     // required String address,
+    bool trustWitnessUtxo = false,
   }) async {
     try {
       final psbtStruct = await bdk.PartiallySignedTransaction.fromString(psbt);
       final tx = psbtStruct.extractTx();
       final _ = await bdkWallet.sign(
         psbt: psbtStruct,
-        signOptions: const bdk.SignOptions(
+        signOptions: bdk.SignOptions(
           // multiSig: false,
-          trustWitnessUtxo: false,
+          trustWitnessUtxo: trustWitnessUtxo,
           allowAllSighashes: false,
           removePartialSigs: true,
           tryFinalize: true,
@@ -620,6 +621,25 @@ class BDKTransactions {
           solution: 'Please try again.',
         )
       );
+    }
+  }
+
+  /// Broadcast a PSBT and return the txid
+  Future<(String?, Err?)> broadcastPsbt({
+    required String psbt,
+    required bdk.Blockchain blockchain,
+  }) async {
+    // FIXME does this need to handle Transaction model accounting?
+    try {
+      final psbtStruct = await bdk.PartiallySignedTransaction.fromString(psbt);
+      final tx = psbtStruct.extractTx();
+
+      await blockchain.broadcast(transaction: tx);
+      final txid = psbtStruct.txid();
+
+      return (txid, null);
+    } on Exception catch (e) {
+      return (null, Err(e.message));
     }
   }
 

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -261,7 +261,7 @@ Future _setupBlocs() async {
   );
 
   locator.registerSingleton<PayjoinManager>(
-    PayjoinManager(),
+    PayjoinManager(locator<WalletTx>()),
   );
 
   locator.registerSingleton<NetworkFeesCubit>(

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/_pkg/launcher.dart';
 import 'package:bb_mobile/_pkg/logger.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
 import 'package:bb_mobile/_pkg/nfc.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/storage/secure_storage.dart';
 import 'package:bb_mobile/_pkg/storage/storage.dart';
@@ -257,6 +258,10 @@ Future _setupBlocs() async {
       hiveStorage: locator<HiveStorage>(),
       walletNetwork: locator<WalletNetwork>(),
     ),
+  );
+
+  locator.registerSingleton<PayjoinManager>(
+    PayjoinManager(),
   );
 
   locator.registerSingleton<NetworkFeesCubit>(

--- a/lib/send/advanced.dart
+++ b/lib/send/advanced.dart
@@ -129,6 +129,28 @@ class SendAllOption extends StatelessWidget {
   }
 }
 
+class SendPayjoinOption extends StatelessWidget {
+  const SendPayjoinOption({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final togglePayjoin =
+        context.select((SendCubit x) => x.state.togglePayjoin);
+    return Row(
+      children: [
+        const BBText.title('Send payjoin'),
+        const Spacer(),
+        BBSwitch(
+          value: togglePayjoin,
+          onChanged: (e) {
+            context.read<SendCubit>().togglePayjoin(e);
+          },
+        ),
+      ],
+    );
+  }
+}
+
 class EnableRBFOption extends StatelessWidget {
   const EnableRBFOption({super.key});
 

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -133,6 +133,16 @@ class SendCubit extends Cubit<SendState> {
         if (label != null) {
           emit(state.copyWith(note: label));
         }
+        final pjParam = bip21Obj.options['pj'] as String?;
+        if (pjParam != null) {
+          // FIXME: this is an ugly hack because of ugliness in the bip21 module.
+          // Dart's URI encoding is not the same as the one used by the bip21 module.
+          final parsedPjParam = Uri.parse(pjParam);
+          final partialEncodedPjParam =
+              parsedPjParam.toString().replaceAll('#', '%23');
+          final encodedPjParam = partialEncodedPjParam.replaceAll('%20', '+');
+          emit(state.copyWith(payjoinEndpoint: Uri.parse(encodedPjParam)));
+        }
       case AddressNetwork.bip21Liquid:
         final bip21Obj = bip21.decode(
           address.startsWith('liquidnetwork:')

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -571,6 +571,10 @@ class SendCubit extends Cubit<SendState> {
     _checkBalance();
   }
 
+  void togglePayjoin(bool toggle) {
+    emit(state.copyWith(togglePayjoin: toggle));
+  }
+
   void utxoSelected(UTXO utxo) {
     var selectedUtxos = state.selectedUtxos.toList();
 

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -954,34 +954,11 @@ class SendCubit extends Cubit<SendState> {
     // TODO copy originalPsbt.extractTx() to state.tx
     // emit(state.copyWith(tx: originalPsbtTxWithId));
     emit(state.copyWith(sending: true, sent: false));
-    final proposalPsbt = await _payjoinManager.runSender(
-      state.payjoinSender!,
-    );
-    final (wtxid, errSignBroadcast) = await _walletTx.signAndBroadcastPsbt(
+    await _payjoinManager.spawnSender(
+      isTestnet: _networkCubit.state.testnet,
+      sender: state.payjoinSender!,
       wallet: wallet,
-      psbt: proposalPsbt!,
     );
-    if (errSignBroadcast != null) {
-      emit(state.copyWith(
-          errSending: errSignBroadcast.toString(), sending: false));
-      return;
-    }
-
-    final txWithId = state.tx?.copyWith(txid: wtxid?.$2 ?? '');
-    emit(state.copyWith(tx: txWithId));
-
-    final (updatedWallet, _) = wtxid!;
-    state.selectedWalletBloc!.add(
-      UpdateWallet(
-        updatedWallet,
-        updateTypes: [
-          UpdateWalletTypes.addresses,
-          UpdateWalletTypes.transactions,
-          UpdateWalletTypes.swaps,
-        ],
-      ),
-    );
-
     Future.delayed(150.ms);
     state.selectedWalletBloc!.add(SyncWallet());
 

--- a/lib/send/bloc/send_state.dart
+++ b/lib/send/bloc/send_state.dart
@@ -37,6 +37,7 @@ class SendState with _$SendState {
     @Default('') String errDownloadingFile,
     @Default(false) bool downloaded,
     @Default(false) bool disableRBF,
+    Uri? payjoinEndpoint,
     @Default(false) bool sendAllCoin,
     @Default([]) List<UTXO> selectedUtxos,
     @Default('') String errAddresses,

--- a/lib/send/bloc/send_state.dart
+++ b/lib/send/bloc/send_state.dart
@@ -40,6 +40,7 @@ class SendState with _$SendState {
     @Default(false) bool disableRBF,
     Uri? payjoinEndpoint,
     Sender? payjoinSender,
+    @Default(true) bool togglePayjoin,
     @Default(false) bool sendAllCoin,
     @Default([]) List<UTXO> selectedUtxos,
     @Default('') String errAddresses,
@@ -257,7 +258,9 @@ class SendState with _$SendState {
                 ? payjoinSender != null
                     ? 'Payjoining'
                     : 'Broadcasting'
-                : 'Confirm'
+                : payjoinSender != null
+                    ? 'Confirm Payjoin'
+                    : 'Confirm'
             : sending
                 ? 'Building Tx'
                 : !isLn

--- a/lib/send/bloc/send_state.dart
+++ b/lib/send/bloc/send_state.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/_pkg/utils.dart';
 import 'package:bb_mobile/wallet/bloc/wallet_bloc.dart';
 import 'package:bdk_flutter/bdk_flutter.dart' as bdk;
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:payjoin_flutter/send.dart';
 
 part 'send_state.freezed.dart';
 
@@ -38,6 +39,7 @@ class SendState with _$SendState {
     @Default(false) bool downloaded,
     @Default(false) bool disableRBF,
     Uri? payjoinEndpoint,
+    Sender? payjoinSender,
     @Default(false) bool sendAllCoin,
     @Default([]) List<UTXO> selectedUtxos,
     @Default('') String errAddresses,
@@ -60,6 +62,8 @@ class SendState with _$SendState {
   bool isWatchOnly() => selectedWalletBloc?.state.wallet?.watchOnly() ?? false;
 
   bool isLnInvoice() => invoice != null;
+
+  bool hasPjParam() => payjoinEndpoint != null;
 
   // String getAddressFromInvoiceOrAddress() {
   //   // if (invoice != null) return invoice!.;
@@ -250,7 +254,9 @@ class SendState with _$SendState {
         ? 'Generate PSBT'
         : signed
             ? sending
-                ? 'Broadcasting'
+                ? payjoinSender != null
+                    ? 'Payjoining'
+                    : 'Broadcasting'
                 : 'Confirm'
             : sending
                 ? 'Building Tx'

--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -157,6 +157,7 @@ class _Screen extends StatelessWidget {
     final signed = context.select((SendCubit cubit) => cubit.state.signed);
     final sent = context.select((SendCubit cubit) => cubit.state.sent);
     final isLn = context.select((SendCubit cubit) => cubit.state.isLnInvoice());
+    final isPj = context.select((SendCubit cubit) => cubit.state.hasPjParam());
 
     final showWarning =
         context.select((CreateSwapCubit x) => x.state.showWarning());
@@ -200,6 +201,8 @@ class _Screen extends StatelessWidget {
                 const Gap(24),
                 const AmountField(),
                 if (!isLn) const SendAllOption(),
+                const Gap(24),
+                if (isPj) const SendPayjoinOption(),
                 const Gap(24),
                 const DescriptionField(),
                 if (!isLn) ...[

--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/_pkg/bull_bitcoin_api.dart';
 import 'package:bb_mobile/_pkg/clipboard.dart';
 import 'package:bb_mobile/_pkg/file_storage.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/wallet/repository/sensitive_storage.dart';
 import 'package:bb_mobile/_pkg/wallet/transaction.dart';
@@ -97,6 +98,7 @@ class _SendPageState extends State<SendPage> {
       networkCubit: locator<NetworkCubit>(),
       networkFeesCubit: locator<NetworkFeesCubit>(),
       homeCubit: locator<HomeCubit>(),
+      payjoinManager: locator<PayjoinManager>(),
       swapBoltz: locator<SwapBoltz>(),
       currencyCubit: currency,
       openScanner: widget.openScanner,

--- a/lib/swap/swap_page.dart
+++ b/lib/swap/swap_page.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/_pkg/boltz/swap.dart';
 import 'package:bb_mobile/_pkg/bull_bitcoin_api.dart';
 import 'package:bb_mobile/_pkg/file_storage.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/wallet/repository/sensitive_storage.dart';
 import 'package:bb_mobile/_pkg/wallet/transaction.dart';
@@ -77,6 +78,7 @@ class _SwapPageState extends State<SwapPage> {
       networkCubit: locator<NetworkCubit>(),
       networkFeesCubit: locator<NetworkFeesCubit>(),
       homeCubit: locator<HomeCubit>(),
+      payjoinManager: locator<PayjoinManager>(),
       swapBoltz: locator<SwapBoltz>(),
       currencyCubit: currency,
       openScanner: false,

--- a/lib/transaction/bump_fees.dart
+++ b/lib/transaction/bump_fees.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/_pkg/bull_bitcoin_api.dart';
 import 'package:bb_mobile/_pkg/file_storage.dart';
 import 'package:bb_mobile/_pkg/launcher.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/wallet/address.dart';
 import 'package:bb_mobile/_pkg/wallet/bdk/sensitive_create.dart';
@@ -164,6 +165,7 @@ class _BumpFeesPageState extends State<BumpFeesPage> {
       networkCubit: locator<NetworkCubit>(),
       networkFeesCubit: locator<NetworkFeesCubit>(),
       homeCubit: locator<HomeCubit>(),
+      payjoinManager: locator<PayjoinManager>(),
       swapBoltz: locator<SwapBoltz>(),
       currencyCubit: currency,
       openScanner: false,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,7 +256,7 @@ packages:
     source: hosted
     version: "1.18.0"
   convert:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
@@ -280,7 +280,7 @@ packages:
     source: hosted
     version: "0.3.4+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
@@ -644,7 +644,7 @@ packages:
     source: hosted
     version: "2.5.7"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
@@ -1062,6 +1062,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  payjoin_flutter:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: "0124ef669eb3b8e130e4584a534e9eb51a06bdec"
+      resolved-ref: "0124ef669eb3b8e130e4584a534e9eb51a06bdec"
+      url: "https://github.com/LtbLightning/payjoin-flutter"
+    source: git
+    version: "0.21.0"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,10 @@ dependencies:
   modal_bottom_sheet: ^3.0.0-pre
   font_awesome_flutter: ^10.3.0
   path_provider: ^2.0.15
+  payjoin_flutter:
+    git:
+      url: https://github.com/LtbLightning/payjoin-flutter
+      ref: 0124ef669eb3b8e130e4584a534e9eb51a06bdec
   carousel_slider: ^4.2.1
   qr_flutter: ^4.1.0
   flutter_translate: ^4.0.3


### PR DESCRIPTION
This is a basic sender implementation that may be merged so we can build off of it. It does not include any isolate behavior or do accounting properly. I would like help getting the accounting right by taking data from a signed payjoin and pushing it into the Transaction model @ethicnology.

This separates the signing and "confirmed" stages and marshals successful payjoins to the final screen. I don't think a new payjoin handshake screen is merited until the isolates can allow that behavior to happen outside of the send cubit.

Please see the commit log for hacks taken to get this working. 

For a payjoin send:

- [x] when a payjoin address is pasted the UI should mention that the transaction is a payjoin on the build tx page (3rd commit)
- [x] the build process should be separated from the confirm process and we should have a screen to confirm the details (2nd commit)
- [ ] after confirm there should be a status page for the payjoin (similar to swaps) - there is an option to exit and go to the transaction detail page or go back home
- [ ] there should be a toast that notifies the user when a payjoin broadcasts
- [ ] uri & address copy / paste should be separate

I ask reviewers to confirm errors are handled appropriately, since this flutter paradigm is new to me.