### PR TITLE
Reset pj state for new addresses

### DIFF
--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -119,7 +119,13 @@ class SendCubit extends Cubit<SendState> {
       return;
     }
 
-    emit(state.copyWith(paymentNetwork: paymentNetwork));
+    emit(
+      state.copyWith(
+        paymentNetwork: paymentNetwork,
+        payjoinEndpoint: null, // Reset payjoin endpoint for not pj addresses
+        payjoinSender: null, // Reset payjoin sender for not pj addresses
+      ),
+    );
 
     switch (paymentNetwork) {
       case AddressNetwork.bip21Bitcoin:
@@ -233,7 +239,8 @@ class SendCubit extends Cubit<SendState> {
     emit(state.copyWith(scanningAddress: false));
     if (changeWallet == true) {
       selectWallets();
-    } else {
+    }
+    if (_currencyCubit.state.amount != 0) {
       _checkBalance();
     }
   }

--- a/lib/send/listeners.dart
+++ b/lib/send/listeners.dart
@@ -28,7 +28,6 @@ class SendListeners extends StatelessWidget {
           listener: (context, state) {
             final isLn = context.read<SendCubit>().state.isLnInvoice();
             if (isLn) return;
-            context.read<SendCubit>().updateAddress(null, changeWallet: false);
             // context.read<SendCubit>().selectWallets();
           },
         ),


### PR DESCRIPTION
This small fix hides the 'Send payjoin' switch again if another address without payjoin params is pasted after one that had these params.

When resetting the pj state on a new address, and pasting a pj uri with amount, the currency cubit executed the updateAddress a second time but without the uri, just the address, not setting back the pj params after resetting.
The only reason I can think of that the currency cubit did this was to trigger a _checkBalance, so I changed the condition to check a balance and removed the updateAddress from the currency cubit listener. Now the update address is only executed once, the time with the pj params present.