### PR TITLE
DRAFT push payjoin details to transaction model

### DIFF
--- a/lib/_model/transaction.dart
+++ b/lib/_model/transaction.dart
@@ -46,6 +46,7 @@ class Transaction with _$Transaction {
     bdk.TransactionDetails? bdkTx,
     // Wallet? wallet,
     @Default(false) bool isSwap,
+    @Default(false) bool isPayjoin,
     SwapTx? swapTx,
     @Default(false) bool isLiquid,
     @Default('') String unblindedUrl,

--- a/lib/_pkg/payjoin/manager.dart
+++ b/lib/_pkg/payjoin/manager.dart
@@ -229,13 +229,6 @@ class PayjoinManager {
     );
   }
 
-  Future<List<bdk.LocalUtxo>> _listUnspent(
-    Wallet wallet,
-    bool isTestnet,
-  ) async {
-    return await _walletTx.listUnspent(wallet: wallet);
-  }
-
   Future<String> _processPsbt({
     required String psbt,
     required Wallet wallet,

--- a/lib/_pkg/wallet/bdk/transaction.dart
+++ b/lib/_pkg/wallet/bdk/transaction.dart
@@ -439,6 +439,7 @@ class BDKTransactions {
     required List<UTXO> selectedUtxos,
     int? absFee,
     String? note,
+    bool isPayjoin = false,
   }) async {
     try {
       final isMainnet = wallet.network == BBNetwork.Mainnet;
@@ -569,9 +570,10 @@ class BDKTransactions {
         label: (note == null || note == '')
             ? labelsString
             : note, // for now we just take the first label
-        toAddress: address,
+        toAddress: isPayjoin ? null : address,
         outAddrs: outAddrs,
         psbt: base64Encode(psbtStr),
+        isPayjoin: isPayjoin,
       );
       return ((tx, feeAmt?.toInt(), base64Encode(psbtStr)), null);
     } on Exception catch (e) {

--- a/lib/transaction/transaction_page.dart
+++ b/lib/transaction/transaction_page.dart
@@ -285,6 +285,11 @@ class _TxDetails extends StatelessWidget {
             const Gap(4),
             AmountValue(isReceived: isReceived, amtStr: amtStr, units: units),
             const Gap(24),
+            if (tx.isPayjoin) ...[
+              const Gap(24),
+              const BBText.title('Payjoin'),
+              const Gap(4),
+            ],
             if (!isSwapPending) ...[
               const BBText.title('Transaction ID'),
               const Gap(4),


### PR DESCRIPTION
This is a draft attempt (IDEK WHAT I'M DOING IN FLUTTER) to move data from some of these isolated processes into the main wallet history data structures.

I don't it make sense to push completed transactions to the success screen, because payjoin is async. A sender should have the originalPsbt to pass to the success screen before entering spawnSender, and it will await a response from the sender with a payjoinPsbt to tupdate the transaction with.

A receiver should have an *unsigned* payjoinPsbt that it can listen for in mempool.

the transaction from an isolate is going to have to be passed as an event. That should propagate into the Transaction model and history. Then the network fees of each contributor can be calculated by taking the difference between originalPsbt and payjoinPsbt

