### PR TITLE
Async Payjoin send and receives

### DIFF
--- a/lib/_pkg/payjoin/listeners.dart
+++ b/lib/_pkg/payjoin/listeners.dart
@@ -1,0 +1,60 @@
+import 'package:bb_mobile/_model/wallet.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
+import 'package:flutter/material.dart';
+
+class PayjoinLifecycleManager extends StatefulWidget {
+  const PayjoinLifecycleManager({
+    required this.child,
+    required this.payjoinManager,
+    required this.wallet,
+    super.key,
+  });
+
+  final Widget child;
+  final PayjoinManager payjoinManager;
+  final Wallet wallet;
+  @override
+  State<PayjoinLifecycleManager> createState() =>
+      _PayjoinLifecycleManagerState();
+}
+
+class _PayjoinLifecycleManagerState extends State<PayjoinLifecycleManager>
+    with WidgetsBindingObserver {
+  bool inBackground = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // Resume any stored sessions on app start
+    widget.payjoinManager.resumeSessions(widget.wallet);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final inBg = state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.detached;
+
+    if (!inBackground && inBg) {
+      // App going to background
+      widget.payjoinManager.pauseAllSessions();
+    } else if (inBackground && !inBg) {
+      // App coming to foreground
+      widget.payjoinManager.resumeSessions(widget.wallet);
+    }
+
+    inBackground = inBg;
+    super.didChangeAppLifecycleState(state);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/_pkg/payjoin/storage.dart
+++ b/lib/_pkg/payjoin/storage.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/_pkg/error.dart';
+import 'package:bb_mobile/_pkg/payjoin/manager.dart';
+import 'package:bb_mobile/_pkg/storage/hive.dart';
+import 'package:payjoin_flutter/receive.dart';
+import 'package:payjoin_flutter/send.dart';
+
+class PayjoinStorage {
+  PayjoinStorage({required HiveStorage hiveStorage})
+      : _hiveStorage = hiveStorage;
+  final HiveStorage _hiveStorage;
+
+  static const String receiverPrefix = 'pj_recv_';
+  static const String senderPrefix = 'pj_send_';
+
+  // Future<Err?> deleteAllSessions() async {
+  //   try {
+  //     final (allData, err) = await _hiveStorage.getAll();
+  //     if (err != null) return err;
+
+  //     for (final key in allData!.keys) {
+  //       if (key.startsWith(receiverPrefix) || key.startsWith(senderPrefix)) {
+  //         final delErr = await _hiveStorage.deleteValue(key);
+  //         if (delErr != null) return delErr;
+  //       }
+  //     }
+  //     return null;
+  //   } catch (e) {
+  //     return Err(e.toString());
+  //   }
+  // }
+
+  Future<Err?> insertReceiverSession(
+    bool isTestnet,
+    Receiver receiver,
+    String walletId,
+  ) async {
+    try {
+      final recvSession = RecvSession(
+        isTestnet,
+        receiver,
+        walletId,
+      );
+
+      await _hiveStorage.saveValue(
+        key: receiverPrefix + receiver.id(),
+        value: jsonEncode(recvSession.toJson()),
+      );
+      return null;
+    } catch (e) {
+      return Err(e.toString());
+    }
+  }
+
+  Future<(RecvSession?, Err?)> readReceiverSession(String sessionId) async {
+    try {
+      final (jsn, err) =
+          await _hiveStorage.getValue(receiverPrefix + sessionId);
+      if (err != null) throw err;
+      final obj = jsonDecode(jsn!) as Map<String, dynamic>;
+      final session = RecvSession.fromJson(obj);
+      return (session, null);
+    } catch (e) {
+      return (
+        null,
+        Err(
+          e.toString(),
+          expected: e.toString() == 'No Receiver with id $sessionId',
+        )
+      );
+    }
+  }
+
+  Future<(List<RecvSession>, Err?)> readAllReceivers() async {
+    //deleteAllSessions();
+    try {
+      final (allData, err) = await _hiveStorage.getAll();
+      if (err != null) return (List<RecvSession>.empty(), err);
+
+      final List<RecvSession> receivers = [];
+      allData!.forEach((key, value) {
+        if (key.startsWith(receiverPrefix)) {
+          try {
+            final obj = jsonDecode(value) as Map<String, dynamic>;
+            receivers.add(RecvSession.fromJson(obj));
+          } catch (e) {
+            // Skip invalid entries
+          }
+        }
+      });
+      return (receivers, null);
+    } catch (e) {
+      return (List<RecvSession>.empty(), Err(e.toString()));
+    }
+  }
+
+  Future<Err?> insertSenderSession(
+    Sender sender,
+    String pjUrl,
+    String walletId,
+    bool isTestnet,
+  ) async {
+    try {
+      final sendSession = SendSession(
+        isTestnet,
+        sender,
+        walletId,
+        pjUrl,
+      );
+
+      await _hiveStorage.saveValue(
+        key: senderPrefix + pjUrl,
+        value: jsonEncode(sendSession.toJson()),
+      );
+      return null;
+    } catch (e) {
+      return Err(e.toString());
+    }
+  }
+
+  Future<(SendSession?, Err?)> readSenderSession(String pjUrl) async {
+    try {
+      final (jsn, err) = await _hiveStorage.getValue(senderPrefix + pjUrl);
+      if (err != null) throw err;
+      final obj = jsonDecode(jsn!) as Map<String, dynamic>;
+      final session = SendSession.fromJson(obj);
+      return (session, null);
+    } catch (e) {
+      return (
+        null,
+        Err(
+          e.toString(),
+          expected: e.toString() == 'No Sender with id $pjUrl',
+        )
+      );
+    }
+  }
+
+  Future<(List<SendSession>, Err?)> readAllSenders() async {
+    try {
+      final (allData, err) = await _hiveStorage.getAll();
+      if (err != null) return (List<SendSession>.empty(), err);
+
+      final List<SendSession> senders = [];
+      allData!.forEach((key, value) {
+        if (key.startsWith(senderPrefix)) {
+          try {
+            final obj = jsonDecode(value) as Map<String, dynamic>;
+            senders.add(SendSession.fromJson(obj));
+          } catch (e) {
+            // Skip invalid entries
+          }
+        }
+      });
+      return (senders, null);
+    } catch (e) {
+      return (List<SendSession>.empty(), Err(e.toString()));
+    }
+  }
+}

--- a/lib/_pkg/storage/storage.dart
+++ b/lib/_pkg/storage/storage.dart
@@ -19,6 +19,7 @@ class StorageKeys {
   static const swapTxSensitive = 'swapTxSensitive';
   static const hiveEncryption = 'hiveEncryptionKey';
   static const version = 'version';
+  static const payjoin = 'payjoin';
 }
 
 abstract class IStorage {

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -10,6 +10,7 @@ import 'package:bb_mobile/_pkg/logger.dart';
 import 'package:bb_mobile/_pkg/mempool_api.dart';
 import 'package:bb_mobile/_pkg/nfc.dart';
 import 'package:bb_mobile/_pkg/payjoin/manager.dart';
+import 'package:bb_mobile/_pkg/payjoin/storage.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
 import 'package:bb_mobile/_pkg/storage/secure_storage.dart';
 import 'package:bb_mobile/_pkg/storage/storage.dart';
@@ -109,6 +110,11 @@ Future _setupAppServices() async {
   locator.registerSingleton<DeepLink>(deepLink);
   locator.registerSingleton<Lighting>(
     Lighting(
+      hiveStorage: locator<HiveStorage>(),
+    ),
+  );
+  locator.registerSingleton<PayjoinStorage>(
+    PayjoinStorage(
       hiveStorage: locator<HiveStorage>(),
     ),
   );
@@ -261,7 +267,10 @@ Future _setupBlocs() async {
   );
 
   locator.registerSingleton<PayjoinManager>(
-    PayjoinManager(locator<WalletTx>()),
+    PayjoinManager(
+      locator<WalletTx>(),
+      locator<PayjoinStorage>(),
+    ),
   );
 
   locator.registerSingleton<NetworkFeesCubit>(

--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -383,7 +383,7 @@ class ReceiveCubit extends Cubit<ReceiveState> {
   Future<void> receivePayjoin(bool isTestnet, String address) async {
     final receiver = await _payjoinManager.initReceiver(isTestnet, address);
     emit(state.copyWith(payjoinReceiver: receiver));
-    _payjoinManager.spawnReceiver(
+    _payjoinManager.spawnNewReceiver(
       isTestnet: isTestnet,
       receiver: receiver,
       wallet: state.walletBloc!.state.wallet!,

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -954,10 +954,11 @@ class SendCubit extends Cubit<SendState> {
     // TODO copy originalPsbt.extractTx() to state.tx
     // emit(state.copyWith(tx: originalPsbtTxWithId));
     emit(state.copyWith(sending: true, sent: false));
-    await _payjoinManager.spawnSender(
+    await _payjoinManager.spawnNewSender(
       isTestnet: _networkCubit.state.testnet,
       sender: state.payjoinSender!,
       wallet: wallet,
+      pjUrl: state.payjoinEndpoint!.toString(),
     );
     Future.delayed(150.ms);
     state.selectedWalletBloc!.add(SyncWallet());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1066,11 +1066,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0124ef669eb3b8e130e4584a534e9eb51a06bdec"
-      resolved-ref: "0124ef669eb3b8e130e4584a534e9eb51a06bdec"
-      url: "https://github.com/LtbLightning/payjoin-flutter"
+      ref: "28642ec548278d7e3d724a7518042b816ffd5dae"
+      resolved-ref: "28642ec548278d7e3d724a7518042b816ffd5dae"
+      url: "https://github.com/DanGould/payjoin-flutter"
     source: git
-    version: "0.21.0"
+    version: "0.22.0"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,8 +41,8 @@ dependencies:
   path_provider: ^2.0.15
   payjoin_flutter:
     git:
-      url: https://github.com/LtbLightning/payjoin-flutter
-      ref: 0124ef669eb3b8e130e4584a534e9eb51a06bdec
+      url: https://github.com/DanGould/payjoin-flutter
+      ref: 28642ec548278d7e3d724a7518042b816ffd5dae
   carousel_slider: ^4.2.1
   qr_flutter: ^4.1.0
   flutter_translate: ^4.0.3


### PR DESCRIPTION
The whole point of Payoin V2 is to save the state of a payjoin and resume it whenever you have internet. Our first implementation doesn't do that since the logic is limited to the Send or Receive UI context where it's created and it disappears when the app goes out of memory.

This change persists that information in HiveStorage, pauses sessions on app background, and resumes sessions on app foregroudn, allowing async payjoin to happen.

There was a bug where Sender's didn't persist information sent in their first request, so once they were persisted and resumed they were out of sync with receivers. This has been fixed in an upcoming release of payjoin-flutter and so requires that update in order to function.

In order to test, start a receiver, background that app, then start a sender to that receiver, then background that app, then resume the receiver, then stop it, then resume the sender. The payjoin should flow good as ever as long as there's enough time to send the first payjoin message before stopping at each stage.