### PR TITLE
fix: only init payjoin when payment network is bitcoin

### DIFF
--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -53,6 +53,7 @@ class ReceiveCubit extends Cubit<ReceiveState> {
 
     if (state.paymentNetwork == PaymentNetwork.lightning) {
       emit(state.copyWith(defaultAddress: null));
+      return;
     }
 
     if (!walletBloc.state.wallet!.mainWallet) {
@@ -63,7 +64,9 @@ class ReceiveCubit extends Cubit<ReceiveState> {
     // if (watchOnly)
     //   emit(state.copyWith(paymentNetwork: ReceivePaymentNetwork.bitcoin));
     await loadAddress();
-    if (state.defaultAddress != null) {
+
+    if (state.paymentNetwork == PaymentNetwork.bitcoin &&
+        state.defaultAddress != null) {
       receivePayjoin(
         state.walletBloc!.state.wallet!.isTestnet(),
         state.defaultAddress!.address,


### PR DESCRIPTION
The first receive tab and network that seems to be loaded initially is Lightning. For this an amount has to be entered and no default invoice should be generated, so returning immediately in the updateWalletBloc function is added for Lightning.
And then this PR also adds a check to make sure to only init payjoin for the bitcoin network, this way we avoid the liquid address being used to init the payjoin.