### PR TITLE
fix: remove duplicate payjoin code in getAddressWithAmountAndLabel

### DIFF
--- a/lib/receive/bloc/state.dart
+++ b/lib/receive/bloc/state.dart
@@ -49,16 +49,6 @@ class ReceiveState with _$ReceiveState {
     if (paymentNetwork == PaymentNetwork.lightning ||
         (amount == 0 && description.isEmpty && payjoinReceiver == null)) {
       finalAddress = address;
-    } else if (payjoinReceiver != null) {
-      // Receiver session is active: build a payjoin URI
-      var pjUrl = payjoinReceiver!.pjUriBuilder();
-      if (amount > 0) {
-        pjUrl = pjUrl.amountSats(amount: BigInt.from(amount * 100000000));
-      }
-      if (description.isNotEmpty) {
-        pjUrl = pjUrl.label(label: description);
-      }
-      finalAddress = pjUrl.build().asString();
     } else {
       if (isLiquid) {
         // Refer spec: https://github.com/ElementsProject/elements/issues/805


### PR DESCRIPTION
This PR removes some code that is executed when payjoinReceiver != null that was present two times in the same function, one time before checking `isLiquid` and one time after checking `isLiquid`. The code before the Liquid check was causing the issue and so I removed it, since if not Liquid, it will still be executed after this check.

A more elaborate fix would also make sure the payjoinReceiver gets reset when isLiquid, but I think a bigger refactoring can eliminate this problem completely, so for now just removing the duplicate code before the check works as a quick fix.