### PR TITLE
feat: add copying of address only to receive with payjoin

### DIFF
--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -71,6 +71,13 @@ class ReceiveCubit extends Cubit<ReceiveState> {
         state.walletBloc!.state.wallet!.isTestnet(),
         state.defaultAddress!.address,
       );
+    } else {
+      // Clear payjoin receiver
+      emit(
+        state.copyWith(
+          payjoinReceiver: null,
+        ),
+      );
     }
   }
 

--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -806,7 +806,6 @@ class CreateLightningInvoice extends StatelessWidget {
         const Gap(48),
         Center(
           child: BBButton.big(
-            // leftIcon: FontAwesomeIcons.receipt,
             leftSvgAsset: 'assets/request-payment.svg',
             buttonKey: UIKeys.receiveSavePaymentButton,
             loading: creatingInv,
@@ -939,21 +938,6 @@ class SwapFeesDetails extends StatelessWidget {
         ],
       ),
     );
-
-    // return BBText.bodySmall(
-    //   'Lightning Network payments are converted instantly to Liquid Network Bitcoin (L-BTC). A swap fee of $fees $units will be deducted',
-    // );
-
-    /*
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const BBText.body('Total fees:'),
-        BBText.bodyBold('$fees $units'),
-        const Gap(16),
-      ],
-    );
-    */
   }
 }
 
@@ -995,10 +979,6 @@ class ReceiveQRDisplay extends StatelessWidget {
           if (locator.isRegistered<Clippboard>()) {
             await locator<Clippboard>().copy(address);
           }
-
-          // ScaffoldMessenger.of(context).showSnackBar(
-          //   const SnackBar(content: Text('Copied to clipboard')),
-          // );
         },
         child: Column(
           children: [
@@ -1137,41 +1117,65 @@ class _ReceiveDisplayAddressState extends State<ReceiveDisplayAddress> {
         context.select((ReceiveCubit x) => x.state.payjoinReceiver);
 
     return AnimatedSwitcher(
-        duration: const Duration(milliseconds: 350),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            BBText.body(receiveAddressLabel),
+      duration: const Duration(milliseconds: 350),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          BBText.body(receiveAddressLabel),
+          Row(
+            children: [
+              Expanded(
+                child: GestureDetector(
+                  onTap: () async {
+                    if (locator.isRegistered<Clippboard>()) {
+                      await locator<Clippboard>().copy(addr);
+                    }
+                  },
+                  child: BBText.bodySmall(
+                    addr,
+                    isBlue: true,
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () async {
+                  if (locator.isRegistered<Clippboard>()) {
+                    await locator<Clippboard>().copy(addr);
+                  }
+                },
+                iconSize: 24,
+                color: Colors.blue,
+                icon: const Icon(Icons.copy),
+              ),
+            ],
+          ),
+          if (isPjReceiver != null)
             Row(
               children: [
                 Expanded(
                   child: GestureDetector(
                     onTap: () async {
                       if (locator.isRegistered<Clippboard>()) {
-                        await locator<Clippboard>().copy(addr);
+                        await locator<Clippboard>().copy(addrOnly);
                       }
-
-                      // ScaffoldMessenger.of(context).showSnackBar(
-                      //   const SnackBar(
-                      //     content: Text('Copied to clipboard'),
-                      //   ),
-                      // );
                     },
-                    child: BBText.bodySmall(
-                      addr,
-                      isBlue: true,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const BBText.bodySmall('Address only:'),
+                        BBText.bodySmall(
+                          addrOnly,
+                          isBlue: true,
+                        ),
+                      ],
                     ),
                   ),
                 ),
                 IconButton(
                   onPressed: () async {
                     if (locator.isRegistered<Clippboard>()) {
-                      await locator<Clippboard>().copy(addr);
+                      await locator<Clippboard>().copy(addrOnly);
                     }
-
-                    // ScaffoldMessenger.of(context).showSnackBar(
-                    //   const SnackBar(content: Text('Copied to clipboard')),
-                    // );
                   },
                   iconSize: 24,
                   color: Colors.blue,
@@ -1179,126 +1183,11 @@ class _ReceiveDisplayAddressState extends State<ReceiveDisplayAddress> {
                 ),
               ],
             ),
-            if (isPjReceiver != null)
-              Row(
-                children: [
-                  Expanded(
-                    child: GestureDetector(
-                      onTap: () async {
-                        if (locator.isRegistered<Clippboard>()) {
-                          await locator<Clippboard>().copy(addrOnly);
-                        }
-                      },
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const BBText.bodySmall('Address only:'),
-                          BBText.bodySmall(
-                            addrOnly,
-                            isBlue: true,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  IconButton(
-                    onPressed: () async {
-                      if (locator.isRegistered<Clippboard>()) {
-                        await locator<Clippboard>().copy(addrOnly);
-                      }
-
-                      // ScaffoldMessenger.of(context).showSnackBar(
-                      //   const SnackBar(content: Text('Copied to clipboard')),
-                      // );
-                    },
-                    iconSize: 24,
-                    color: Colors.blue,
-                    icon: const Icon(Icons.copy),
-                  ),
-                ],
-              ),
-          ],
-        ));
+        ],
+      ),
+    );
   }
 }
-
-// class CreateInvoice extends StatelessWidget {
-//   const CreateInvoice({super.key});
-
-//   static Future openPopUp(BuildContext context) async {
-//     final receiveCubit = context.read<ReceiveCubit>();
-//     final currencyCubit = context.read<CurrencyCubit>();
-
-//     if (currencyCubit.state.amount > 0)
-//       currencyCubit.convertAmtOnCurrencyChange();
-
-//     return showBBBottomSheet(
-//       context: context,
-//       child: BlocProvider.value(
-//         value: receiveCubit,
-//         child: BlocProvider.value(
-//           value: currencyCubit,
-//           child: BlocListener<ReceiveCubit, ReceiveState>(
-//             listenWhen: (previous, current) =>
-//                 previous.savedInvoiceAmount != current.savedInvoiceAmount ||
-//                 previous.savedDescription != current.savedDescription,
-//             listener: (context, state) {
-//               context.pop();
-//             },
-//             child: const Padding(
-//               padding: EdgeInsets.all(30),
-//               child: CreateInvoice(),
-//             ),
-//           ),
-//         ),
-//       ),
-//     );
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final description = context.select((ReceiveCubit _) => _.state.description);
-
-//     return Column(
-//       crossAxisAlignment: CrossAxisAlignment.stretch,
-//       children: [
-//         BBHeader.popUpCenteredText(
-//           text: 'Request a Payment',
-//           onBack: () {
-//             context.read<ReceiveCubit>().clearInvoiceFields();
-//             context.read<CurrencyCubit>().reset();
-
-//             context.pop();
-//           },
-//         ),
-//         const Gap(40),
-//         const Gap(4),
-//         const EnterAmount(uiKey: UIKeys.receiveAmountField),
-//         const Gap(24),
-//         const BBText.title('   Public description'),
-//         const Gap(4),
-//         BBTextInput.big(
-//           uiKey: UIKeys.receiveDescriptionField,
-//           value: description,
-//           hint: 'Enter description',
-//           onChanged: (txt) {
-//             context.read<ReceiveCubit>().descriptionChanged(txt);
-//           },
-//         ),
-//         const Gap(40),
-//         BBButton.big(
-//           buttonKey: UIKeys.receiveSavePaymentButton,
-//           label: 'Save',
-//           onPressed: () {
-//             final amt = context.read<CurrencyCubit>().state.amount;
-//             context.read<ReceiveCubit>().saveFinalInvoiceClicked(amt);
-//           },
-//         ),
-//         const Gap(40),
-//       ],
-//     );
-//   }
-// }
 
 class CheckForPaymentsButton extends StatelessWidget {
   const CheckForPaymentsButton({super.key});
@@ -1313,72 +1202,3 @@ class CheckForPaymentsButton extends StatelessWidget {
     );
   }
 }
-
-// class AddLabelButton extends StatelessWidget {
-//   const AddLabelButton({super.key});
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return BBButton.big(
-//       label: 'Add address label',
-//       // leftIcon: FontAwesomeIcons.penToSquare,
-//       leftSvgAsset: 'assets/edit.svg',
-//       onPressed: () {
-//         AddLabelPopUp.openPopUp(context);
-//       },
-//     );
-//   }
-// }
-
-// class AddLabelPopUp extends StatelessWidget {
-//   const AddLabelPopUp({super.key});
-
-//   static Future openPopUp(BuildContext context) async {
-//     final receive = context.read<ReceiveCubit>();
-//     return showBBBottomSheet(
-//       context: context,
-//       child: BlocProvider.value(
-//         value: receive,
-//         child: const Padding(
-//           padding: EdgeInsets.all(30),
-//           child: AddLabelPopUp(),
-//         ),
-//       ),
-//     );
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final value = context.select((ReceiveCubit x) => x.state.description);
-//     return Column(
-//       crossAxisAlignment: CrossAxisAlignment.stretch,
-//       children: [
-//         BBHeader.popUpCenteredText(
-//           text: 'Add Label',
-//           isLeft: true,
-//           onBack: () {
-//             context.pop();
-//           },
-//         ),
-//         const Gap(24),
-//         BBTextInput.big(
-//           hint: 'Enter label',
-//           value: value,
-//           onChanged: (txt) {
-//             context.read<ReceiveCubit>().descriptionChanged(txt);
-//           },
-//         ),
-//         const Gap(40),
-//         Center(
-//           child: BBButton.big(
-//             label: 'Save',
-//             onPressed: () {
-//               context.read<ReceiveCubit>().saveAddrressLabel();
-//             },
-//           ),
-//         ),
-//         const Gap(40),
-//       ],
-//     );
-//   }
-// }

--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -1132,58 +1132,93 @@ class _ReceiveDisplayAddressState extends State<ReceiveDisplayAddress> {
     );
 
     final addr = bip21Address.isNotEmpty ? bip21Address : widget.addressQr;
+    final addrOnly = widget.addressQr;
+    final isPjReceiver =
+        context.select((ReceiveCubit x) => x.state.payjoinReceiver);
 
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 350),
-      child: !showToast
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+        duration: const Duration(milliseconds: 350),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            BBText.body(receiveAddressLabel),
+            Row(
               children: [
-                BBText.body(receiveAddressLabel),
-                Row(
-                  children: [
-                    Expanded(
-                      child: GestureDetector(
-                        onTap: () async {
-                          if (locator.isRegistered<Clippboard>()) {
-                            await locator<Clippboard>().copy(addr);
-                          }
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () async {
+                      if (locator.isRegistered<Clippboard>()) {
+                        await locator<Clippboard>().copy(addr);
+                      }
 
-                          // ScaffoldMessenger.of(context).showSnackBar(
-                          //   const SnackBar(
-                          //     content: Text('Copied to clipboard'),
-                          //   ),
-                          // );
-                        },
-                        child: BBText.bodySmall(
-                          addr,
-                          isBlue: true,
-                        ),
-                      ),
+                      // ScaffoldMessenger.of(context).showSnackBar(
+                      //   const SnackBar(
+                      //     content: Text('Copied to clipboard'),
+                      //   ),
+                      // );
+                    },
+                    child: BBText.bodySmall(
+                      addr,
+                      isBlue: true,
                     ),
-                    IconButton(
-                      onPressed: () async {
-                        if (locator.isRegistered<Clippboard>()) {
-                          await locator<Clippboard>().copy(addr);
-                        }
+                  ),
+                ),
+                IconButton(
+                  onPressed: () async {
+                    if (locator.isRegistered<Clippboard>()) {
+                      await locator<Clippboard>().copy(addr);
+                    }
 
-                        // ScaffoldMessenger.of(context).showSnackBar(
-                        //   const SnackBar(content: Text('Copied to clipboard')),
-                        // );
-                      },
-                      iconSize: 24,
-                      color: Colors.blue,
-                      icon: const Icon(Icons.copy),
-                    ),
-                  ],
+                    // ScaffoldMessenger.of(context).showSnackBar(
+                    //   const SnackBar(content: Text('Copied to clipboard')),
+                    // );
+                  },
+                  iconSize: 24,
+                  color: Colors.blue,
+                  icon: const Icon(Icons.copy),
                 ),
               ],
-            )
-          : const Padding(
-              padding: EdgeInsets.symmetric(vertical: 16),
-              child: BBText.body('Address copied to clipboard'),
             ),
-    );
+            if (isPjReceiver != null)
+              Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () async {
+                        if (locator.isRegistered<Clippboard>()) {
+                          await locator<Clippboard>().copy(addrOnly);
+                        }
+                      },
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const BBText.bodySmall('Address only:'),
+                          BBText.bodySmall(
+                            addrOnly,
+                            isBlue: true,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () async {
+                      if (locator.isRegistered<Clippboard>()) {
+                        await locator<Clippboard>().copy(addrOnly);
+                      }
+
+                      // ScaffoldMessenger.of(context).showSnackBar(
+                      //   const SnackBar(content: Text('Copied to clipboard')),
+                      // );
+                    },
+                    iconSize: 24,
+                    color: Colors.blue,
+                    icon: const Icon(Icons.copy),
+                  ),
+                ],
+              ),
+          ],
+        ));
   }
 }
 


### PR DESCRIPTION
This PR adds the address only without bip21 scheme and parameters underneath the bip21 uri for users to copy for bip21 incompatible wallets.