### PR TITLE
feat: send flow pj success screen

### DIFF
--- a/lib/_pkg/payjoin/event.dart
+++ b/lib/_pkg/payjoin/event.dart
@@ -22,14 +22,16 @@ class PayjoinEventBus {
   }
 }
 
-abstract class PayjoinEvent {
-  final String txid;
-
-  PayjoinEvent({required this.txid});
-}
+abstract class PayjoinEvent {}
 
 class PayjoinBroadcastEvent extends PayjoinEvent {
-  PayjoinBroadcastEvent({required super.txid});
+  final String txid;
+  PayjoinBroadcastEvent({required this.txid});
+}
+
+class PayjoinSenderPostMessageASuccessEvent extends PayjoinEvent {
+  // TODO: add to relate the event to a specific send transaction/payjoin session
+  PayjoinSenderPostMessageASuccessEvent();
 }
 
 class PayjoinEventListener extends StatefulWidget {

--- a/lib/send/bloc/send_state.dart
+++ b/lib/send/bloc/send_state.dart
@@ -41,6 +41,7 @@ class SendState with _$SendState {
     Uri? payjoinEndpoint,
     Sender? payjoinSender,
     @Default(true) bool togglePayjoin,
+    @Default(false) bool isPayjoinPostSuccess,
     @Default(false) bool sendAllCoin,
     @Default([]) List<UTXO> selectedUtxos,
     @Default('') String errAddresses,

--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -158,6 +158,9 @@ class _Screen extends StatelessWidget {
     final sent = context.select((SendCubit cubit) => cubit.state.sent);
     final isLn = context.select((SendCubit cubit) => cubit.state.isLnInvoice());
     final isPj = context.select((SendCubit cubit) => cubit.state.hasPjParam());
+    final isPayjoinPostSuccess = context.select(
+      (SendCubit cubit) => cubit.state.isPayjoinPostSuccess,
+    );
 
     final showWarning =
         context.select((CreateSwapCubit x) => x.state.showWarning());
@@ -167,6 +170,7 @@ class _Screen extends StatelessWidget {
           x.state.selectedWalletBloc?.state.wallet?.isLiquid() ?? false,
     );
 
+    if (isPayjoinPostSuccess) return const PjSuccess();
     if (sent && isLn) return const SendingLnTx();
     if (sent) return const TxSuccess();
 
@@ -682,6 +686,52 @@ class TxDetailsScreen extends StatelessWidget {
           '~ $feeFiat $fiatCurrency',
         ),
         const Gap(32),
+      ],
+    );
+  }
+}
+
+class PjSuccess extends StatelessWidget {
+  const PjSuccess({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final amount = context.select((CurrencyCubit cubit) => cubit.state.amount);
+    final amtStr = context.select(
+      (CurrencyCubit cubit) => cubit.state.getAmountInUnits(
+        amount,
+      ),
+    );
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const SizedBox(
+          width: double.infinity,
+          height: 80,
+        ),
+        const BBText.body(
+          'Payjoin requested',
+          textAlign: TextAlign.center,
+        ),
+        const Gap(16),
+        const Icon(Icons.pending_rounded, size: 100, color: Colors.orange),
+        const BBText.bodySmall(
+          "Waiting for recipient's response to broadcast.",
+          textAlign: TextAlign.center,
+        ),
+        const Gap(16),
+        BBText.body(
+          amtStr,
+          textAlign: TextAlign.center,
+        ),
+        const Gap(40),
+        BBButton.big(
+          label: 'Back to home',
+          onPressed: () {
+            context.pop();
+          },
+        ),
       ],
     );
   }


### PR DESCRIPTION
This PR adds and propogate the necessary events in the sender isolate and `PayjoinEventBus` to know when a payjoin request is successfully posted.
It also uses that event to progress the send flow and show a payjoin success screen.

In this version the cubit doesn't check if the event stems from the send in progress or from another payjoin isolate, since the event doesn't have any data fields yet. So it assumes the event is from the transaction the user is sending at that moment.
In a later version this can be handled by adding some data to the event to check against the send state. 