### PR TITLE
fix: remove repeated updateAddress call without pj uri

### DIFF
--- a/lib/send/listeners.dart
+++ b/lib/send/listeners.dart
@@ -23,20 +23,6 @@ class SendListeners extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiBlocListener(
       listeners: [
-        BlocListener<CurrencyCubit, CurrencyState>(
-          listenWhen: (previous, current) => previous.amount != current.amount,
-          listener: (context, state) {
-            final isLn = context.read<SendCubit>().state.isLnInvoice();
-            if (isLn) return;
-            // context.read<SendCubit>().selectWallets();
-          },
-        ),
-        BlocListener<CurrencyCubit, CurrencyState>(
-          listenWhen: (previous, current) => previous.amount != current.amount,
-          listener: (context, state) {
-            context.read<SendCubit>().updateAddress(null, changeWallet: false);
-          },
-        ),
         BlocListener<CreateSwapCubit, SwapState>(
           listenWhen: (previous, current) => previous.swapTx != current.swapTx,
           listener: (context, state) async {


### PR DESCRIPTION
The `updateAddress` with only the address, when a pj uri was entered, was removed in a previous fix already since it was replaced with the following in the `updateAddress` function:

```
if (_currencyCubit.state.amount != 0) {
  _checkBalance();
}
```

Executing the _checkBalance function was the only effect calling the updateAddress from the CurrencyCubit listener had, so it got replaced with a check for the amount in the state since it had the undesired side effects of overwriting the address without the bip21 uri scheme, thus not setting the payjoin.

Therefore it got removed again in this PR. As well as the previous CurrencyCubit listener above it that didn't had any useful code anymore.