### PR TITLE
Don't display txid in toast

### DIFF
--- a/lib/_pkg/payjoin/event.dart
+++ b/lib/_pkg/payjoin/event.dart
@@ -51,7 +51,7 @@ class _PayjoinEventListenerState extends State<PayjoinEventListener> {
       if (event is PayjoinBroadcastEvent) {
         showToastWidget(
           position: ToastPosition.top,
-          AlertUI(text: 'Payjoin transaction broadcast: ${event.txid}'),
+          const AlertUI(text: 'Payjoin transaction detected'),
           animationCurve: Curves.decelerate,
         );
       }


### PR DESCRIPTION
While we should create a success screen to display the Payjoin Success with a link to mempool.space, I'm not comfortable linking directly from the alert, since some people might not want to reveal their IP addres to the explorer, and making a stopgap payjoin success screen seems like an unnecessary hack when we plan to follow up with a proper payjoin history.

So this just gets rid of the txid that renders for now.