### PR TITLE
Pj send events

### DIFF
--- a/lib/_pkg/payjoin/event.dart
+++ b/lib/_pkg/payjoin/event.dart
@@ -34,6 +34,11 @@ class PayjoinSenderPostMessageASuccessEvent extends PayjoinEvent {
   PayjoinSenderPostMessageASuccessEvent();
 }
 
+class PayjoinFailureEvent extends PayjoinEvent {
+  final Object? error;
+  PayjoinFailureEvent({this.error});
+}
+
 class PayjoinEventListener extends StatefulWidget {
   const PayjoinEventListener({required this.child, super.key});
   final Widget child;

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -72,6 +72,13 @@ class SendCubit extends Cubit<SendState> {
         emit(state.copyWith(
           isPayjoinPostSuccess: true,
         ));
+      } else if (event is PayjoinFailureEvent) {
+        emit(
+          state.copyWith(
+            errSending: event.error.toString(),
+            sending: false,
+          ),
+        );
       }
     });
   }

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -69,9 +69,11 @@ class SendCubit extends Cubit<SendState> {
     // Subscribe to payjoin events to update the send state
     _pjEventSubscription = PayjoinEventBus().stream.listen((event) {
       if (event is PayjoinSenderPostMessageASuccessEvent) {
-        emit(state.copyWith(
-          isPayjoinPostSuccess: true,
-        ));
+        emit(
+          state.copyWith(
+            isPayjoinPostSuccess: true,
+          ),
+        );
       } else if (event is PayjoinFailureEvent) {
         emit(
           state.copyWith(


### PR DESCRIPTION
- Moves the request_posted message emission till after validating the response from the pj directory.
- Adds a failure event to the PayjoinEventBus and process this in the SendCubit too.