### PR TITLE
fix: check balance on amount change

### DIFF
--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -257,9 +257,6 @@ class SendCubit extends Cubit<SendState> {
     if (changeWallet == true) {
       selectWallets();
     }
-    if (_currencyCubit.state.amount != 0) {
-      _checkBalance();
-    }
   }
 
   void selectWallets({bool fromStart = false}) {
@@ -356,7 +353,7 @@ class SendCubit extends Cubit<SendState> {
       if (amt == 0) {
         emit(state.copyWith(showSendButton: false));
       } else {
-        _checkBalance();
+        checkBalance();
       }
       // emit(state.copyWith(showSendButton: true));
 
@@ -399,7 +396,7 @@ class SendCubit extends Cubit<SendState> {
     if (amt == 0) {
       emit(state.copyWith(showSendButton: false));
     } else {
-      _checkBalance();
+      checkBalance();
     }
 
     // emit(state.copyWith(showSendButton: true));
@@ -447,7 +444,7 @@ class SendCubit extends Cubit<SendState> {
     if (amount == 0) {
       emit(state.copyWith(showSendButton: false));
     } else {
-      _checkBalance();
+      checkBalance();
     }
 
     // emit(state.copyWith(showSendButton: true));
@@ -483,14 +480,19 @@ class SendCubit extends Cubit<SendState> {
     if (amount == 0) {
       emit(state.copyWith(showSendButton: false));
     } else {
-      _checkBalance();
+      checkBalance();
     }
     // emit(state.copyWith(showSendButton: true));
   }
 
-  void _checkBalance() {
+  void checkBalance() {
     final balance = state.selectedWalletBloc?.state.balanceSats() ?? 0;
     final amount = _currencyCubit.state.amount;
+
+    if (amount == 0) {
+      emit(state.copyWith(showSendButton: false));
+      return;
+    }
 
     if (balance < amount) {
       emit(
@@ -535,7 +537,7 @@ class SendCubit extends Cubit<SendState> {
   void updateWalletBloc(WalletBloc walletBloc) {
     emit(state.copyWith(selectedWalletBloc: walletBloc));
     sendAllCoin(false);
-    _checkBalance();
+    checkBalance();
   }
 
   void disabledDropdownClicked() {
@@ -592,7 +594,7 @@ class SendCubit extends Cubit<SendState> {
     _currencyCubit.updateAmountDirect(amount);
     _currencyCubit.updateAmount(amount == 0 ? '' : amount.toString());
 
-    _checkBalance();
+    checkBalance();
   }
 
   void togglePayjoin(bool toggle) {

--- a/lib/send/listeners.dart
+++ b/lib/send/listeners.dart
@@ -23,6 +23,12 @@ class SendListeners extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiBlocListener(
       listeners: [
+        BlocListener<CurrencyCubit, CurrencyState>(
+          listenWhen: (previous, current) => previous.amount != current.amount,
+          listener: (context, state) {
+            context.read<SendCubit>().checkBalance();
+          },
+        ),
         BlocListener<CreateSwapCubit, SwapState>(
           listenWhen: (previous, current) => previous.swapTx != current.swapTx,
           listener: (context, state) async {


### PR DESCRIPTION
This PR exposes the checkBalance function of the SendCubit so it can be called again on amount change with a CurrencyCubit listener, which was previously done by calling the updateAddress function with null and false parameters but caused bugs when entering bip21 URI's.
This fix makes sure the checkBalance is called, triggering enabling or disabling the send button, without the other side effects of calling the updateAddress again.