### PR TITLE
Select first utxo for payjoin contribution

### DIFF
--- a/lib/_pkg/payjoin/manager.dart
+++ b/lib/_pkg/payjoin/manager.dart
@@ -577,12 +577,9 @@ Future<void> _isolateReceiver(List<dynamic> args) async {
         sendPort,
       );
       final unspent = listUnspent as List<bdk.LocalUtxo>;
-      final candidateInputs = await Future.wait(
-        unspent.map((utxo) => _inputPairFromUtxo(utxo, true)),
-      );
-      final selectedUtxo = await pj5.tryPreservingPrivacy(
-        candidateInputs: candidateInputs,
-      );
+      if (unspent.isEmpty) throw Exception('No unspent outputs available');
+
+      final selectedUtxo = await _inputPairFromUtxo(unspent[0], true);
       final pj6 = await pj5.contributeInputs(replacementInputs: [selectedUtxo]);
       final pj7 = await pj6.commitInputs();
 


### PR DESCRIPTION
The tryPreservingPrivacy function avoids some varieties of Unnecessary Input Heuristic but sometimes finds no available selection. We always want to contribute an input for the sake of demonstration, and the resulting transaction can't be worse for privacy than a naive transaction, it just might be identifiable as a payjoin.

In the future, we definitely want more sophisticated coin selection, but for now, this makes more payjoins so we get more feedback from testing to make a more reliable, legible product.