### PR TITLE
fix: amended-commit-ref

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1066,8 +1066,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "28642ec548278d7e3d724a7518042b816ffd5dae"
-      resolved-ref: "28642ec548278d7e3d724a7518042b816ffd5dae"
+      ref: "0-22"
+      resolved-ref: "2c7fec23efc12a071e1a3f7a979c455ee15a26fa"
       url: "https://github.com/DanGould/payjoin-flutter"
     source: git
     version: "0.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   payjoin_flutter:
     git:
       url: https://github.com/DanGould/payjoin-flutter
-      ref: 28642ec548278d7e3d724a7518042b816ffd5dae
+      ref: 0-22
   carousel_slider: ^4.2.1
   qr_flutter: ^4.1.0
   flutter_translate: ^4.0.3


### PR DESCRIPTION
`DanGould/payjoin-flutter` commit `28642ec548278d7e3d724a7518042b816ffd5dae` doesn't exist anymore, probably amended.

Since developers have cached it locally in `.pub-cache`, we can still build without issues, but this wouldn't work for someone which haven't cached it.

Replacing by last active branch `0-22`