### PR TITLE
fix: core.init() for startup resume + remove await + complete and clean up sessions

### DIFF
--- a/lib/_pkg/payjoin/event.dart
+++ b/lib/_pkg/payjoin/event.dart
@@ -30,8 +30,9 @@ class PayjoinBroadcastEvent extends PayjoinEvent {
 }
 
 class PayjoinSenderPostMessageASuccessEvent extends PayjoinEvent {
-  // TODO: add to relate the event to a specific send transaction/payjoin session
-  PayjoinSenderPostMessageASuccessEvent();
+  final String pjUri;
+
+  PayjoinSenderPostMessageASuccessEvent({required this.pjUri});
 }
 
 class PayjoinFailureEvent extends PayjoinEvent {

--- a/lib/_pkg/payjoin/storage.dart
+++ b/lib/_pkg/payjoin/storage.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:bb_mobile/_pkg/error.dart';
 import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/storage/hive.dart';
+import 'package:flutter/material.dart';
 import 'package:payjoin_flutter/receive.dart';
 import 'package:payjoin_flutter/send.dart';
 
@@ -86,6 +87,7 @@ class PayjoinStorage {
             receivers.add(RecvSession.fromJson(obj));
           } catch (e) {
             // Skip invalid entries
+            debugPrint('Error: $e');
           }
         }
       });
@@ -150,6 +152,7 @@ class PayjoinStorage {
             senders.add(SendSession.fromJson(obj));
           } catch (e) {
             // Skip invalid entries
+            debugPrint('Error: $e');
           }
         }
       });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,12 +27,15 @@ import 'package:go_router/go_router.dart';
 import 'package:lwk_dart/lwk_dart.dart';
 import 'package:oktoast/oktoast.dart';
 
+import 'package:payjoin_flutter/src/generated/frb_generated.dart';
+
 Future main({bool fromTest = false}) async {
   FlutterError.onError = (err) =>
       log('Flutter Error:' + err.toString(minLevel: DiagnosticLevel.debug));
 
   runZonedGuarded(() async {
     if (!fromTest) WidgetsFlutterBinding.ensureInitialized();
+    await core.init();
     await LibLwk.init();
     await LibBoltz.init();
     await dotenv.load(isOptional: true);

--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/_model/swap.dart';
 import 'package:bb_mobile/_model/wallet.dart';
+import 'package:bb_mobile/_pkg/logger.dart';
 import 'package:bb_mobile/_pkg/payjoin/manager.dart';
 import 'package:bb_mobile/_pkg/wallet/address.dart';
 import 'package:bb_mobile/_pkg/wallet/repository/storage.dart';


### PR DESCRIPTION
This PR fixes some of the problems with resuming sessions at startup and with the sessions and isolates in general, namely:

- core.init() was needed in main to be able to reinitiate persisted sessions fromJson
- the resumeSessions now spawns all in parallel since otherwise another stored session couldn't be spawned before the previous was completed. Since it is unsure when a session will complete, it was not good to let all other sessions wait for the previous to complete.
- The completer of the spawnReceiver was never completed and the sessions were never cleaned, so isolates just kept piling up over time.
- The spawnSender didn't complete everywhere I think is necessary either, neither did the clean up work, this is now fixed by using the pjUrl as an identifier to store the isolates and clean them up.
- A parameter is added to the PostMessageASuccessEvent to be able to only progress the send flow for a post of that particular send and not because of another session emitting this event at the same time.
- Removed the setting of the state to `sent` in payjoinSend, as well as syncing and the delay, since they are not useful here. A payjoin shouldn't go to the success screen, so shouldn't come on `sent: true`, neither should it have a delay and then sync, since at this stage the tx is not broadcasted yet, only the original psbt is posted to the pj directory.