### PR TITLE
fix: only show error for current send pj session

### DIFF
--- a/lib/_pkg/payjoin/event.dart
+++ b/lib/_pkg/payjoin/event.dart
@@ -35,9 +35,10 @@ class PayjoinSenderPostMessageASuccessEvent extends PayjoinEvent {
   PayjoinSenderPostMessageASuccessEvent({required this.pjUri});
 }
 
-class PayjoinFailureEvent extends PayjoinEvent {
+class PayjoinSendFailureEvent extends PayjoinEvent {
+  final String pjUri;
   final Object? error;
-  PayjoinFailureEvent({this.error});
+  PayjoinSendFailureEvent({required this.pjUri, this.error});
 }
 
 class PayjoinEventListener extends StatefulWidget {

--- a/lib/_pkg/payjoin/manager.dart
+++ b/lib/_pkg/payjoin/manager.dart
@@ -123,7 +123,7 @@ class PayjoinManager {
           }
         } else if (message is Err) {
           PayjoinEventBus().emit(
-            PayjoinFailureEvent(error: message),
+            PayjoinSendFailureEvent(pjUri: pjUri, error: message),
           );
           await _cleanupSession(pjUri);
           completer.complete(message);

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -77,7 +77,8 @@ class SendCubit extends Cubit<SendState> {
         );
       } else if (event is PayjoinBroadcastEvent) {
         state.selectedWalletBloc!.add(SyncWallet());
-      } else if (event is PayjoinFailureEvent) {
+      } else if (event is PayjoinSendFailureEvent &&
+          event.pjUri == state.payjoinEndpoint.toString()) {
         emit(
           state.copyWith(
             errSending: event.error.toString(),


### PR DESCRIPTION
Sometimes a payjoin error was shown on the send page because of another pj session emitting a `PayjoinFailureEvent` at that time. This PR fixes that by adding a `pjUri` to the event and checking for the same one as the `SendCubit`'s `pjUri`.