### PR TITLE
show spinner while loading payjoin address

### DIFF
--- a/lib/receive/bloc/receive_cubit.dart
+++ b/lib/receive/bloc/receive_cubit.dart
@@ -62,17 +62,17 @@ class ReceiveCubit extends Cubit<ReceiveState> {
     await isPayjoinEnabled();
     await loadAddress();
 
-    payjoinInit();
+    await payjoinInit();
   }
 
-  void payjoinInit() {
+  Future<void> payjoinInit() async {
     final baseType = state.walletBloc!.state.wallet!.baseWalletType;
 
     if (state.paymentNetwork == PaymentNetwork.bitcoin &&
         state.defaultAddress != null &&
         state.isPayjoin &&
         baseType == BaseWalletType.Bitcoin) {
-      receivePayjoin(
+      await receivePayjoin(
         state.walletBloc!.state.wallet!.isTestnet(),
         state.defaultAddress!.address,
       );
@@ -203,7 +203,8 @@ class ReceiveCubit extends Cubit<ReceiveState> {
 
     emit(
       state.copyWith(
-        loadingAddress: false,
+        loadingAddress: state
+            .isPayjoin, // Keep loading while the payjoin receiver is being initialized, if it's enabled.
         errLoadingAddress: '',
       ),
     );
@@ -357,7 +358,13 @@ class ReceiveCubit extends Cubit<ReceiveState> {
 
   Future<void> receivePayjoin(bool isTestnet, String address) async {
     final receiver = await _payjoinManager.initReceiver(isTestnet, address);
-    emit(state.copyWith(payjoinReceiver: receiver));
+    emit(
+      state.copyWith(
+        payjoinReceiver: receiver,
+        loadingAddress:
+            false, // Stop loading now that the receiver is initialized.
+      ),
+    );
     _payjoinManager.spawnNewReceiver(
       isTestnet: isTestnet,
       receiver: receiver,

--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -143,6 +143,8 @@ class _Screen extends StatelessWidget {
     final showQR = context.select(
       (ReceiveCubit x) => x.state.showQR(swapTx, isChainSwap: isChainSwap),
     );
+    final loadingAddress =
+        context.select((ReceiveCubit x) => x.state.loadingAddress);
 
     final watchOnly =
         context.select((WalletBloc x) => x.state.wallet!.watchOnly());
@@ -222,12 +224,19 @@ class _Screen extends StatelessWidget {
               const SwapFeesDetails(),
             ],
             if (isChainSwap == false && showQR) ...[
-              const ReceiveQR(),
-              const Gap(8),
-              ReceiveAddress(
-                swapTx: swapTx,
-                addressQr: addressQr,
-              ),
+              if (loadingAddress)
+                const Center(child: CircularProgressIndicator())
+              else
+                Column(
+                  children: [
+                    const ReceiveQR(),
+                    const Gap(8),
+                    ReceiveAddress(
+                      swapTx: swapTx,
+                      addressQr: addressQr,
+                    ),
+                  ],
+                ),
               const Gap(8),
               if (shouldShowForm) const BitcoinReceiveForm(),
               if (paymentNetwork == PaymentNetwork.lightning || formSubmitted)


### PR DESCRIPTION
This PR makes sure that loadingAddress is still true when payjoin is enabled and the payjoin receiver is still being initialized.
It then uses the loadingAddress state to show a spinner instead of the QR and addresses as long as it is true, effectively showing the address only when the payjoin uri is also constructed.