### PR TITLE
Mark unrecoverable errors so they don't spawn

### DIFF
--- a/lib/_pkg/payjoin/storage.dart
+++ b/lib/_pkg/payjoin/storage.dart
@@ -186,6 +186,29 @@ class PayjoinStorage {
     }
   }
 
+  Future<Err?> markSenderSessionUnrecoverable(String pjUri) async {
+    try {
+      final (session, err) = await readSenderSession(pjUri);
+      if (err != null) return err;
+
+      final updatedSession = SendSession(
+        session!.isTestnet,
+        session.sender,
+        session.walletId,
+        session.pjUri,
+        PayjoinSessionStatus.unrecoverable,
+      );
+
+      await _hiveStorage.saveValue(
+        key: senderPrefix + pjUri,
+        value: jsonEncode(updatedSession.toJson()),
+      );
+      return null;
+    } catch (e) {
+      return Err(e.toString());
+    }
+  }
+
   Future<(List<SendSession>, Err?)> readAllSenders() async {
     try {
       final (allData, err) = await _hiveStorage.getAll();

--- a/lib/_pkg/payjoin/storage.dart
+++ b/lib/_pkg/payjoin/storage.dart
@@ -96,6 +96,28 @@ class PayjoinStorage {
     }
   }
 
+  Future<Err?> markReceiverSessionUnrecoverable(String id) async {
+    try {
+      final (session, err) = await readReceiverSession(id);
+      if (err != null) return err;
+
+      final updatedSession = RecvSession(
+        session!.isTestnet,
+        session.receiver,
+        session.walletId,
+        PayjoinSessionStatus.unrecoverable,
+      );
+
+      await _hiveStorage.saveValue(
+        key: receiverPrefix + id,
+        value: jsonEncode(updatedSession.toJson()),
+      );
+      return null;
+    } catch (e) {
+      return Err(e.toString());
+    }
+  }
+
   Future<(List<RecvSession>, Err?)> readAllReceivers() async {
     //deleteAllSessions();
     try {


### PR DESCRIPTION
Mark unrecoverable errors in storage so that they no longer spawn isolates.

Spawning isolates and failing them immediately uses more resources than necessary. This is therefore a performance improvement for the stability of the app.

In the medium term we should switch on errors from payjoin-flutter, but those errors are not yet available to switch on. This will reduce the amount of error definition and handling we have to manually implement, but since this is a potential immediate performance issue I'm addressing it straight away.
