### PR TITLE
Unnecessary killing and starting of isolates when app is backgrounded

### DIFF
--- a/lib/_pkg/payjoin/listeners.dart
+++ b/lib/_pkg/payjoin/listeners.dart
@@ -37,24 +37,5 @@ class _PayjoinLifecycleManagerState extends State<PayjoinLifecycleManager>
   }
 
   @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    final inBg = state == AppLifecycleState.inactive ||
-        state == AppLifecycleState.paused ||
-        state == AppLifecycleState.hidden ||
-        state == AppLifecycleState.detached;
-
-    if (!inBackground && inBg) {
-      // App going to background
-      widget.payjoinManager.pauseAllSessions();
-    } else if (inBackground && !inBg) {
-      // App coming to foreground
-      widget.payjoinManager.resumeSessions(widget.wallet);
-    }
-
-    inBackground = inBg;
-    super.didChangeAppLifecycleState(state);
-  }
-
-  @override
   Widget build(BuildContext context) => widget.child;
 }


### PR DESCRIPTION
As far as I know, isolates are backgrounded and resumed together with the main app thread, so I think it is not necessary to kill and resume them explicitly ourselves. Normally they will be paused when the app is backgrounded and resumed when it is foregrounded again.

