### PR TITLE
use streams to get updates in wallet services and WalletServiceData

### DIFF
--- a/lib/_repository/app_wallets_repository.dart
+++ b/lib/_repository/app_wallets_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/_model/swap.dart';
 import 'package:bb_mobile/_model/transaction.dart';
 import 'package:bb_mobile/_model/wallet.dart';
@@ -11,6 +13,11 @@ class AppWalletsRepository {
   final WalletsStorageRepository _walletsStorageRepository;
 
   final List<WalletService> _walletServices = [];
+  final StreamController<List<WalletService>> _walletsController =
+      StreamController.broadcast();
+
+  Stream<List<WalletService>> get wallets =>
+      _walletsController.stream.asBroadcastStream();
 
   Future<void> getWalletsFromStorage() async {
     final (wallets, err) = await _walletsStorageRepository.readAllWallets();
@@ -28,6 +35,7 @@ class AppWalletsRepository {
           .map((_) => createWalletService(wallet: _, fromStorage: true))
           .toList(),
     );
+    _walletsController.add(_walletServices);
   }
 
   List<Wallet> get allWallets => _walletServices.map((_) => _.wallet).toList();
@@ -46,6 +54,7 @@ class AppWalletsRepository {
 
   void deleteWallet(String id) {
     _walletServices.removeWhere((_) => _.wallet.id == id);
+    _walletsController.add(_walletServices);
   }
 
   List<WalletService> walletServiceFromNetwork(BBNetwork network) =>

--- a/lib/home/bloc/home_event.dart
+++ b/lib/home/bloc/home_event.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/_model/wallet.dart';
+import 'package:bb_mobile/_repository/wallet_service.dart';
 
 class HomeEvent {}
 
@@ -23,8 +24,13 @@ class LoadWalletsForNetwork extends HomeEvent {
 }
 
 class WalletUpdated extends HomeEvent {
-  WalletUpdated(this.wallet);
-  final Wallet wallet;
+  WalletUpdated(this.walletData);
+  final WalletServiceData walletData;
+}
+
+class WalletServicesUpdated extends HomeEvent {
+  WalletServicesUpdated(this.walletServices);
+  final List<WalletService> walletServices;
 }
 
 class WalletsSubscribe extends HomeEvent {}

--- a/lib/home/bloc/home_state.dart
+++ b/lib/home/bloc/home_state.dart
@@ -24,6 +24,8 @@ class HomeState with _$HomeState {
   }) = _HomeState;
   const HomeState._();
 
+  bool syncingAny() => wallets.any((_) => _.syncing);
+
   bool hasWallets() => !loadingWallets && wallets.isNotEmpty;
 
   // List<Wallet> walletsFromNetwork(BBNetwork network) =>

--- a/lib/home/bloc/home_state.dart
+++ b/lib/home/bloc/home_state.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/_model/swap.dart';
 import 'package:bb_mobile/_model/transaction.dart';
 import 'package:bb_mobile/_model/wallet.dart';
+import 'package:bb_mobile/_repository/wallet_service.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'home_state.freezed.dart';
@@ -8,7 +9,7 @@ part 'home_state.freezed.dart';
 @freezed
 class HomeState with _$HomeState {
   const factory HomeState({
-    @Default([]) List<Wallet> wallets,
+    @Default([]) List<WalletServiceData> wallets,
     // List<Wallet>? tempwallets,
     // List<Wallet>? wallets,
     @Default(true) bool loadingWallets,
@@ -23,49 +24,44 @@ class HomeState with _$HomeState {
   }) = _HomeState;
   const HomeState._();
 
-  bool hasWallets() =>
-      !loadingWallets && wallets != null && wallets!.isNotEmpty;
+  bool hasWallets() => !loadingWallets && wallets.isNotEmpty;
 
   // List<Wallet> walletsFromNetwork(BBNetwork network) =>
   //     wallets?.where((wallet) => wallet.network == network).toList().reversed.toList() ?? [];
 
-  bool hasMainWallets() => wallets?.any((_) => _.mainWallet) ?? false;
+  bool hasMainWallets() => wallets.any((_) => _.wallet.mainWallet);
 
   List<Wallet> walletsFromNetwork(BBNetwork network) {
-    final blocs = wallets
-            ?.where((_) => _.network == network)
-            //.toList()
-            //.reversed
-            .toList() ??
-        [];
+    final walletsData = wallets
+        .where((_) => _.wallet.network == network)
+        //.toList()
+        //.reversed
+        .toList();
 
-    return blocs;
+    return walletsData.map((e) => e.wallet).toList();
   }
 
   List<Wallet> walletsFromNetworkExcludeWatchOnly(BBNetwork network) {
-    final blocs = wallets
-            ?.where(
-              (walletBloc) =>
-                  walletBloc.network == network &&
-                  walletBloc.watchOnly() == false,
-            )
-            .toList() ??
-        [];
+    final data = wallets
+        .where(
+          (d) => d.wallet.network == network && d.wallet.watchOnly() == false,
+        )
+        .toList();
 
-    return blocs;
+    return data.map((e) => e.wallet).toList();
   }
 
   List<Wallet> walletsNotMainFromNetwork(BBNetwork network) {
     final blocs = wallets
-            ?.where(
-              (wallet) => wallet.network == network && !wallet.mainWallet,
-            )
-            .toList()
-            .reversed
-            .toList() ??
-        [];
+        .where(
+          (wallet) =>
+              wallet.wallet.network == network && !wallet.wallet.mainWallet,
+        )
+        .toList()
+        .reversed
+        .toList();
 
-    return blocs;
+    return blocs.map((e) => e.wallet).toList();
   }
 
   int lenWalletsFromNetwork(BBNetwork network) =>
@@ -113,12 +109,11 @@ class HomeState with _$HomeState {
   }
 
   Wallet? getWalletFromTx(Transaction tx) {
-    if (wallets == null) return null;
-
-    for (final walletBloc in wallets!) {
+    for (final walletBloc in wallets) {
       final wallet = walletBloc;
-      if (wallet.transactions.indexWhere((t) => t.txid == tx.txid) != -1) {
-        return walletBloc;
+      if (wallet.wallet.transactions.indexWhere((t) => t.txid == tx.txid) !=
+          -1) {
+        return walletBloc.wallet;
       }
     }
 
@@ -126,15 +121,13 @@ class HomeState with _$HomeState {
   }
 
   Wallet? getWalletFromSwapTx(SwapTx swaptx) {
-    if (wallets == null) return null;
-
-    for (final walletBloc in wallets!) {
+    for (final walletBloc in wallets) {
       final wallet = walletBloc;
-      if (wallet.transactions.indexWhere(
+      if (wallet.wallet.transactions.indexWhere(
             (t) => t.swapTx?.id == swaptx.id,
           ) !=
           -1) {
-        return walletBloc;
+        return walletBloc.wallet;
       }
     }
 
@@ -162,9 +155,9 @@ class HomeState with _$HomeState {
     // if (walletIdx == -1) return null;
     // final wallet = wallets![walletIdx];
     // final wallets = walletsFromNetwork(wallet.network);
-    final idx = wallets?.indexWhere((w) => id == w.id);
-    if (idx == -1 || idx == null) return null;
-    return wallets![idx];
+    final idx = wallets.indexWhere((w) => id == w.wallet.id);
+    if (idx == -1) return null;
+    return wallets[idx].wallet;
   }
 
   Wallet? getFirstWithSpendableAndBalance(BBNetwork network, {int amt = 0}) {
@@ -182,18 +175,19 @@ class HomeState with _$HomeState {
   }
 
   SwapTx? getSwapTxById(String id) {
-    for (final walletBloc in wallets!) {
+    for (final walletBloc in wallets) {
       final wallet = walletBloc;
-      if (wallet.swaps.isEmpty) continue;
-      final idx = wallet.swaps.indexWhere((_) => _.id == id);
-      if (idx != -1) return wallet.swaps[idx];
+      if (wallet.wallet.swaps.isEmpty) continue;
+      final idx = wallet.wallet.swaps.indexWhere((_) => _.id == id);
+      if (idx != -1) return wallet.wallet.swaps[idx];
     }
 
-    for (final walletBloc in wallets!) {
+    for (final walletBloc in wallets) {
       final wallet = walletBloc;
-      if (wallet.transactions.isEmpty) continue;
-      final idx = wallet.transactions.indexWhere((_) => _.swapTx?.id == id);
-      if (idx != -1) return wallet.transactions[idx].swapTx;
+      if (wallet.wallet.transactions.isEmpty) continue;
+      final idx =
+          wallet.wallet.transactions.indexWhere((_) => _.swapTx?.id == id);
+      if (idx != -1) return wallet.wallet.transactions[idx].swapTx;
     }
 
     return null;
@@ -440,10 +434,12 @@ class HomeState with _$HomeState {
   }
 
   Wallet? findWalletWithSameFngr(Wallet wallet) {
-    for (final wb in wallets!) {
+    for (final wb in wallets) {
       final w = wb;
-      if (w.id == wallet.id) continue;
-      if (w.sourceFingerprint == wallet.sourceFingerprint) return wb;
+      if (w.wallet.id == wallet.id) continue;
+      if (w.wallet.sourceFingerprint == wallet.sourceFingerprint) {
+        return wb.wallet;
+      }
     }
     return null;
   }

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -48,12 +48,7 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: HomeLoadingCubit(),
-      child: const HomeWalletLoadingListeners(
-        child: _Screen(),
-      ),
-    );
+    return const _Screen();
   }
 }
 
@@ -879,13 +874,8 @@ class HomeLoadingTxsIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<HomeLoadingCubit, Map<String, bool>>(
-      buildWhen: (previous, current) => previous.values != current.values,
-      builder: (context, state) {
-        final isLoading = state.values.contains(true);
-        return _Loading(loading: isLoading);
-      },
-    );
+    final isSyncing = context.select((HomeBloc x) => x.state.syncingAny());
+    return _Loading(loading: isSyncing);
   }
 }
 

--- a/lib/home/listeners.dart
+++ b/lib/home/listeners.dart
@@ -5,9 +5,7 @@ import 'package:bb_mobile/home/bloc/home_bloc.dart';
 import 'package:bb_mobile/home/bloc/home_state.dart';
 import 'package:bb_mobile/home/home_page.dart';
 import 'package:bb_mobile/locator.dart';
-import 'package:bb_mobile/wallet/bloc/state.dart';
 import 'package:bb_mobile/wallet/bloc/wallet_bloc.dart';
-import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -122,89 +120,6 @@ class WalletBlocListeners extends StatelessWidget {
     if (blocs.isEmpty) return walletChild;
 
     return walletChild;
-  }
-}
-
-class HomeLoadingEvent {}
-
-class SetLoading extends HomeLoadingEvent {
-  SetLoading(this.id, this.loading);
-  final String id;
-  final bool loading;
-}
-
-class HomeLoadingCubit extends Bloc<HomeLoadingEvent, Map<String, bool>> {
-  HomeLoadingCubit() : super({}) {
-    on<SetLoading>(
-      (event, emit) {
-        final map = state;
-        map[event.id] = event.loading;
-        emit({});
-        emit(map);
-      },
-      transformer: droppable(),
-    );
-  }
-}
-
-class HomeWalletLoadingListeners extends StatefulWidget {
-  const HomeWalletLoadingListeners({super.key, required this.child});
-
-  final Widget child;
-
-  @override
-  State<HomeWalletLoadingListeners> createState() =>
-      _HomeWalletLoadingListenersState();
-}
-
-class _HomeWalletLoadingListenersState
-    extends State<HomeWalletLoadingListeners> {
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  void _setup() {
-    if (!context.mounted) return;
-    final blocs = context.read<AppWalletBlocs>().state;
-
-    for (final bloc in blocs) {
-      context
-          .read<HomeLoadingCubit>()
-          .add(SetLoading(bloc.state.wallet.id, bloc.state.syncing));
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final walletBlocs = context.select((AppWalletBlocs x) => x.state);
-
-    if (walletBlocs.isEmpty) return widget.child;
-
-    _setup();
-    // TODO: cleanup
-    return MultiBlocListener(
-      listeners: [
-        for (final walletBloc in walletBlocs)
-          BlocListener<WalletBloc, WalletState>(
-            bloc: walletBloc,
-            listenWhen: (previous, current) =>
-                previous.syncing != current.syncing,
-            listener: (context, state) {
-              if (state.syncing) {
-                context
-                    .read<HomeLoadingCubit>()
-                    .add(SetLoading(state.wallet.id, true));
-              } else {
-                context
-                    .read<HomeLoadingCubit>()
-                    .add(SetLoading(state.wallet.id, false));
-              }
-            },
-          ),
-      ],
-      child: widget.child,
-    );
   }
 }
 


### PR DESCRIPTION
This PR:

- creates a stream to get updates about the available wallet services
- subscribes to the wallet services stream and subscribes to the data stream of every wallet service
- changes HomeState to use WalletServiceData instead of Wallet
- Removes the Home Loading Cubit and listeners that were only used to toggle the syncing indicator and just uses a getter from the HomeState instead.