### PR TITLE
use list of ohttp relays in case one is failing

### DIFF
--- a/lib/_core/data/datasources/payjoin_datasource.dart
+++ b/lib/_core/data/datasources/payjoin_datasource.dart
@@ -135,14 +135,14 @@ class PdkPayjoinDatasourceImpl implements PayjoinDatasource {
       OhttpKeys? ohttpKeys;
       for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrls) {
         try {
-          ohttpRelay = await Url.fromStr(ohttpRelayUrl);
+          final relay = await Url.fromStr(ohttpRelayUrl);
           ohttpKeys = await fetchOhttpKeys(
-            ohttpRelay: ohttpRelay,
+            ohttpRelay: relay,
             payjoinDirectory: payjoinDirectory,
           );
+          ohttpRelay = relay;
           break;
         } catch (e) {
-          ohttpRelay = null;
           continue;
         }
       }

--- a/lib/_core/data/datasources/payjoin_datasource.dart
+++ b/lib/_core/data/datasources/payjoin_datasource.dart
@@ -130,11 +130,26 @@ class PdkPayjoinDatasourceImpl implements PayjoinDatasource {
   }) async {
     try {
       final payjoinDirectory = await Url.fromStr(_payjoinDirectoryUrl);
-      final ohttpRelay = await Url.fromStr(PayjoinConstants.ohttpRelayUrl);
-      final ohttpKeys = await fetchOhttpKeys(
-        ohttpRelay: ohttpRelay,
-        payjoinDirectory: payjoinDirectory,
-      );
+
+      Url? ohttpRelay;
+      OhttpKeys? ohttpKeys;
+      for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrls) {
+        try {
+          ohttpRelay = await Url.fromStr(ohttpRelayUrl);
+          ohttpKeys = await fetchOhttpKeys(
+            ohttpRelay: ohttpRelay,
+            payjoinDirectory: payjoinDirectory,
+          );
+          break;
+        } catch (e) {
+          ohttpRelay = null;
+          continue;
+        }
+      }
+
+      if (ohttpRelay == null || ohttpKeys == null) {
+        throw Exception('All OHTTP relays failed');
+      }
 
       final receiver = await Receiver.create(
         address: address,
@@ -645,9 +660,25 @@ class PdkPayjoinDatasourceImpl implements PayjoinDatasource {
     required Sender sender,
     required Dio dio,
   }) async {
-    final (req, context) = await sender.extractV2(
-      ohttpProxyUrl: await Url.fromStr(PayjoinConstants.ohttpRelayUrl),
-    );
+    (Request, V2PostContext)? result;
+
+    for (final ohttpProxyUrl in PayjoinConstants.ohttpRelayUrls) {
+      try {
+        result = await sender.extractV2(
+          ohttpProxyUrl: await Url.fromStr(ohttpProxyUrl),
+        );
+        break;
+      } catch (e) {
+        log('request exception: $e');
+        continue;
+      }
+    }
+
+    if (result == null) {
+      throw Exception('All OHTTP relays failed');
+    }
+
+    final (req, context) = result;
 
     final res = await dio.post(
       req.url.asString(),
@@ -672,9 +703,25 @@ class PdkPayjoinDatasourceImpl implements PayjoinDatasource {
     required Dio dio,
   }) async {
     try {
-      final (req, reqCtx) = await context.extractReq(
-        ohttpRelay: await Url.fromStr(PayjoinConstants.ohttpRelayUrl),
-      );
+      (Request, ClientResponse)? result;
+
+      for (final ohttpRelay in PayjoinConstants.ohttpRelayUrls) {
+        try {
+          result = await context.extractReq(
+            ohttpRelay: await Url.fromStr(ohttpRelay),
+          );
+          break;
+        } catch (e) {
+          log('extract request exception: $e');
+          continue;
+        }
+      }
+
+      if (result == null) {
+        throw Exception('All OHTTP relays failed');
+      }
+
+      final (req, reqCtx) = result;
 
       final res = await dio.post(
         req.url.asString(),

--- a/lib/_utils/constants.dart
+++ b/lib/_utils/constants.dart
@@ -22,7 +22,10 @@ class HiveBoxNameConstants {
 }
 
 class PayjoinConstants {
-  static const String ohttpRelayUrl = 'https://pj.bobspacebkk.com';
+  static const List<String> ohttpRelayUrls = [
+    'https://ohttp.achow101.com',
+    'https://pj.bobspacebkk.com',
+  ];
   static const String directoryUrl = 'https://payjo.in';
   static const directoryPollingInterval = 5;
 }


### PR DESCRIPTION
Integration tests were failing and there seems to be a problem with the ohttp relay of bobspace: 'https://pj.bobspacebkk.com'. This PR changes this single relay to a list of relays which now also contains achow's ohttp relay. This makes the integration tests and payjoin work again.