### PR TITLE
Receive payjoin progress screens + Receive Routing fixes

### DIFF
--- a/lib/core/bitcoin/data/datasources/bitcoin_blockchain_datasource.dart
+++ b/lib/core/bitcoin/data/datasources/bitcoin_blockchain_datasource.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:bb_mobile/core/electrum/data/models/electrum_server_model.dart';
 import 'package:bdk_flutter/bdk_flutter.dart' as bdk;
 
@@ -29,6 +31,12 @@ class BitcoinBlockchainDatasource {
   Future<String> broadcastPsbt(String finalizedPsbt) async {
     final psbt = await bdk.PartiallySignedTransaction.fromString(finalizedPsbt);
     final tx = psbt.extractTx();
+    final txId = await _blockchain.broadcast(transaction: tx);
+    return txId;
+  }
+
+  Future<String> broadcastTransaction(Uint8List transaction) async {
+    final tx = await bdk.Transaction.fromBytes(transactionBytes: transaction);
     final txId = await _blockchain.broadcast(transaction: tx);
     return txId;
   }

--- a/lib/core/bitcoin/data/repository/bdk_wallet_repository_impl.dart
+++ b/lib/core/bitcoin/data/repository/bdk_wallet_repository_impl.dart
@@ -385,7 +385,7 @@ class BdkWalletRepositoryImpl
       final fees = tx.fee;
       final confirmationDateTime = tx.confirmationTime?.timestamp.toInt() ?? 0;
       final walletTx = BaseWalletTransaction(
-        txid: txid!,
+        txid: txid,
         type: type,
         amount: amount,
         fees: fees?.toInt(),

--- a/lib/core/locator/core_locator_services.dart
+++ b/lib/core/locator/core_locator_services.dart
@@ -1,4 +1,3 @@
-
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/payjoin/data/services/payjoin_watcher_service_impl.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
@@ -6,7 +5,6 @@ import 'package:bb_mobile/core/payjoin/domain/services/payjoin_watcher_service.d
 import 'package:bb_mobile/core/seed/data/services/mnemonic_seed_factory_impl.dart';
 import 'package:bb_mobile/core/seed/domain/repositories/seed_repository.dart';
 import 'package:bb_mobile/core/seed/domain/services/mnemonic_seed_factory.dart';
-import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository_impl.dart';
 import 'package:bb_mobile/core/swaps/data/services/swap_watcher_impl.dart';
 import 'package:bb_mobile/core/swaps/domain/repositories/swap_repository.dart';
@@ -58,7 +56,6 @@ Future<void> registerServices() async {
     () => PayjoinWatcherServiceImpl(
       payjoinRepository: locator<PayjoinRepository>(),
       electrumServerRepository: locator<ElectrumServerRepository>(),
-      settingsRepository: locator<SettingsRepository>(),
       walletManagerService: locator<WalletManagerService>(),
     ),
   );

--- a/lib/core/locator/core_locator_usecases.dart
+++ b/lib/core/locator/core_locator_usecases.dart
@@ -1,8 +1,10 @@
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/exchange/data/datasources/bitcoin_price_datasource.dart';
 import 'package:bb_mobile/core/exchange/data/repository/exchange_rate_repository_impl.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/services/payjoin_watcher_service.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/broadcast_original_transaction_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
@@ -179,6 +181,13 @@ Future<void> registerUsecases() async {
   locator.registerFactory<GetWalletTransactionsUsecase>(
     () => GetWalletTransactionsUsecase(
       walletManager: locator<WalletManagerService>(),
+    ),
+  );
+  locator.registerFactory<BroadcastOriginalTransactionUsecase>(
+    () => BroadcastOriginalTransactionUsecase(
+      electrumServerRepository: locator<ElectrumServerRepository>(),
+      walletMetadataRepository: locator<WalletMetadataRepository>(),
+      payjoinRepository: locator<PayjoinRepository>(),
     ),
   );
 }

--- a/lib/core/payjoin/data/datasources/payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/payjoin_datasource.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:isolate';
 
-
 import 'package:bb_mobile/core/payjoin/data/models/payjoin_input_pair_model.dart';
 import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
@@ -319,6 +318,25 @@ class PayjoinDatasource {
     required String txId,
   }) async {
     final model = await get(uri) as PayjoinSenderModel?;
+
+    if (model == null) {
+      throw Exception('No model found');
+    }
+
+    final updatedModel = model.copyWith(
+      txId: txId,
+      isCompleted: true, // Nothing more to do from the sender side
+    );
+    await _store(updatedModel);
+
+    return updatedModel;
+  }
+
+  Future<PayjoinReceiverModel> completeReceiver(
+    String id, {
+    required String txId,
+  }) async {
+    final model = await get(id) as PayjoinReceiverModel?;
 
     if (model == null) {
       throw Exception('No model found');
@@ -730,8 +748,6 @@ class PayjoinDatasource {
     }
   }
 }
-
-
 
 class PayjoinNotFoundException implements Exception {
   final String message;

--- a/lib/core/payjoin/data/models/payjoin_model.dart
+++ b/lib/core/payjoin/data/models/payjoin_model.dart
@@ -17,6 +17,7 @@ sealed class PayjoinModel with _$PayjoinModel {
     required BigInt maxFeeRateSatPerVb,
     @Uint8ListJsonConverter() Uint8List? originalTxBytes,
     String? proposalPsbt,
+    String? txId,
     @Default(false) bool isExpired,
     @Default(false) bool isCompleted,
   }) = PayjoinReceiverModel;
@@ -52,6 +53,7 @@ sealed class PayjoinModel with _$PayjoinModel {
         walletId: model.walletId,
         originalTxBytes: model.originalTxBytes,
         proposalPsbt: model.proposalPsbt,
+        txId: model.txId,
       ),
       sender: (model) => Payjoin.sender(
         status: isCompleted

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-
 import 'package:bb_mobile/core/bitcoin/data/datasources/bitcoin_blockchain_datasource.dart';
 import 'package:bb_mobile/core/electrum/data/models/electrum_server_model.dart';
 import 'package:bb_mobile/core/electrum/domain/entity/electrum_server.dart';
@@ -191,6 +190,26 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     );
 
     return model.toEntity() as PayjoinSender;
+  }
+
+  @override
+  Future<PayjoinReceiver> broadcastOriginalTransaction({
+    required String payjoinId,
+    required Uint8List originalTxBytes,
+    required ElectrumServer electrumServer,
+  }) async {
+    final blockchain = await BitcoinBlockchainDatasource.fromElectrumServer(
+      ElectrumServerModel.fromEntity(electrumServer),
+    );
+
+    final txId = await blockchain.broadcastTransaction(originalTxBytes);
+
+    final model = await _source.completeReceiver(
+      payjoinId,
+      txId: txId,
+    );
+
+    return model.toEntity() as PayjoinReceiver;
   }
 }
 

--- a/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
+++ b/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
@@ -83,11 +83,16 @@ class PayjoinWatcherServiceImpl implements PayjoinWatcherService {
   Future<void> _processPayjoinProposal(PayjoinSender payjoin) async {
     final walletId = payjoin.walletId;
     final proposalPsbt = payjoin.proposalPsbt;
-    final environment = await _settings.getEnvironment();
-    final network = Network.fromEnvironment(
-      isTestnet: environment.isTestnet,
-      isLiquid: false,
-    );
+    // Get the correct network from the wallet metadata using the walletId from
+    //  the payjoin to be able to get the correct Electrum server to broadcast
+    //  the transaction.
+    final wallet = await _walletManager.getWallet(walletId);
+    if (wallet == null) {
+      debugPrint('Wallet not found for id: $walletId');
+      // TODO: Mark the payjoin as failed
+      return;
+    }
+    final network = wallet.network;
     final electrumServer =
         await _electrumServer.getElectrumServer(network: network);
 

--- a/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
+++ b/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
@@ -29,11 +28,16 @@ class PayjoinWatcherServiceImpl implements PayjoinWatcherService {
         _walletManager = walletManagerService,
         _payjoinStreamController = StreamController<Payjoin>.broadcast() {
     // Listen to payjoin events from the repository and process them
-    _payjoin.requestsForReceivers.listen(
-      (payjoin) => _processPayjoinRequest(
+    _payjoin.requestsForReceivers.listen((payjoin) async {
+      debugPrint('Received payjoin request: ${payjoin.id}');
+      // Add the payjoin with request status to the stream so listeners can know
+      //  that a payjoin request was received.
+      _payjoinStreamController.add(payjoin);
+      // Process the payjoin request
+      await _processPayjoinRequest(
         payjoin,
-      ),
-    );
+      );
+    });
     _payjoin.proposalsForSenders
         .listen((payjoin) => _processPayjoinProposal(payjoin));
   }
@@ -48,26 +52,32 @@ class PayjoinWatcherServiceImpl implements PayjoinWatcherService {
     final unspentUtxos =
         await _walletManager.getUnspentUtxos(walletId: walletId);
 
-    final processedPayjoin = await _payjoin.processRequest(
-      id: payjoin.id,
-      hasOwnedInputs: (inputScript) => _walletManager.isOwnedByWallet(
-        walletId: walletId,
-        scriptBytes: inputScript,
-      ),
-      hasReceiverOutput: (outputScript) => _walletManager.isOwnedByWallet(
-        walletId: walletId,
-        scriptBytes: outputScript,
-      ),
-      unspentUtxos: unspentUtxos,
-      processPsbt: (psbt) async {
-        final tx = await Transaction.fromPsbtBase64(psbt);
-        final signedPsbt =
-            await _walletManager.sign(walletId: walletId, tx: tx);
-        return signedPsbt.toPsbtBase64();
-      },
-    );
-
-    _payjoinStreamController.add(processedPayjoin);
+    try {
+      final processedPayjoin = await _payjoin.processRequest(
+        id: payjoin.id,
+        hasOwnedInputs: (inputScript) => _walletManager.isOwnedByWallet(
+          walletId: walletId,
+          scriptBytes: inputScript,
+        ),
+        hasReceiverOutput: (outputScript) => _walletManager.isOwnedByWallet(
+          walletId: walletId,
+          scriptBytes: outputScript,
+        ),
+        unspentUtxos: unspentUtxos,
+        processPsbt: (psbt) async {
+          final tx = await Transaction.fromPsbtBase64(psbt);
+          final signedPsbt =
+              await _walletManager.sign(walletId: walletId, tx: tx);
+          return signedPsbt.toPsbtBase64();
+        },
+      );
+      _payjoinStreamController.add(processedPayjoin);
+    } catch (e) {
+      debugPrint('Error processing payjoin request: $e');
+      // The payjoin request was not processed correctly, so we need to broadcast
+      // the original transaction instead.
+      _broadcastOriginalTransaction(payjoin);
+    }
   }
 
   Future<void> _processPayjoinProposal(PayjoinSender payjoin) async {
@@ -101,6 +111,44 @@ class PayjoinWatcherServiceImpl implements PayjoinWatcherService {
     } catch (e) {
       // TODO: Handle this, maybe by sending the original transaction instead
       debugPrint('Error broadcasting payjoin: $e');
+    }
+  }
+
+  Future<void> _broadcastOriginalTransaction(PayjoinReceiver payjoin) async {
+    try {
+      debugPrint(
+        'Broadcasting original transaction for payjoin: ${payjoin.id}',
+      );
+      // Get the correct network from the wallet metadata using the walletId from
+      //  the payjoin to be able to get the correct Electrum server to broadcast
+      //  the transaction.
+      final wallet = await _walletManager.getWallet(payjoin.walletId);
+      if (wallet == null) {
+        debugPrint('Wallet not found for id: ${payjoin.walletId}');
+        // TODO: Mark the payjoin as failed
+        return;
+      }
+      final network = wallet.network;
+      final electrumServer =
+          await _electrumServer.getElectrumServer(network: network);
+
+      // Broadcast the original transaction using the Electrum server
+      if (payjoin.originalTxBytes == null) {
+        debugPrint(
+            'No original transaction bytes to broadcast found for payjoin:'
+            ' ${payjoin.id}');
+        return;
+      }
+      final processedPayjoin = await _payjoin.broadcastOriginalTransaction(
+        payjoinId: payjoin.id,
+        originalTxBytes: payjoin.originalTxBytes!,
+        electrumServer: electrumServer,
+      );
+      _payjoinStreamController.add(processedPayjoin);
+    } catch (e) {
+      debugPrint('Error broadcasting original transaction: $e');
+      // TODO: mark the payjoin as failed
+      return;
     }
   }
 }

--- a/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
+++ b/lib/core/payjoin/data/services/payjoin_watcher_service_impl.dart
@@ -4,27 +4,22 @@ import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repo
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/services/payjoin_watcher_service.dart';
-import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entity/transaction.dart';
-import 'package:bb_mobile/core/wallet/domain/entity/wallet_metadata.dart';
 import 'package:bb_mobile/core/wallet/domain/services/wallet_manager_service.dart';
 import 'package:flutter/material.dart';
 
 class PayjoinWatcherServiceImpl implements PayjoinWatcherService {
   final PayjoinRepository _payjoin;
   final ElectrumServerRepository _electrumServer;
-  final SettingsRepository _settings;
   final WalletManagerService _walletManager;
   final StreamController<Payjoin> _payjoinStreamController;
 
   PayjoinWatcherServiceImpl({
     required PayjoinRepository payjoinRepository,
     required ElectrumServerRepository electrumServerRepository,
-    required SettingsRepository settingsRepository,
     required WalletManagerService walletManagerService,
   })  : _payjoin = payjoinRepository,
         _electrumServer = electrumServerRepository,
-        _settings = settingsRepository,
         _walletManager = walletManagerService,
         _payjoinStreamController = StreamController<Payjoin>.broadcast() {
     // Listen to payjoin events from the repository and process them

--- a/lib/core/payjoin/domain/entity/payjoin.dart
+++ b/lib/core/payjoin/domain/entity/payjoin.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:bb_mobile/core/utils/transaction_parsing.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'payjoin.freezed.dart';
@@ -15,6 +16,7 @@ sealed class Payjoin with _$Payjoin {
     required String pjUri,
     Uint8List? originalTxBytes,
     String? proposalPsbt,
+    String? txId,
   }) = PayjoinReceiver;
   const factory Payjoin.sender({
     @Default(PayjoinStatus.requested) PayjoinStatus status,
@@ -27,9 +29,58 @@ sealed class Payjoin with _$Payjoin {
   const Payjoin._();
 
   String get id => when(
-        receiver: (_, id, __, ___, ____, _____) => id,
+        receiver: (_, id, __, ___, ____, _____, ______) => id,
         sender: (_, uri, __, ___, ____, _____) => uri,
       );
+
+  Future<bool> get isOriginalTxBroadcasted async {
+    if (txId == null) {
+      return false;
+    }
+
+    String originalTxId;
+    switch (this) {
+      case final PayjoinReceiver receiver:
+        if (receiver.originalTxBytes == null) {
+          return false;
+        }
+        originalTxId = await TransactionParsing.getTxIdFromTransactionBytes(
+          receiver.originalTxBytes!,
+        );
+      case final PayjoinSender sender:
+        originalTxId = await TransactionParsing.getTxIdFromPsbt(
+          sender.originalPsbt,
+        );
+    }
+
+    return txId == originalTxId;
+  }
+
+  Future<bool> get isPayjoinTxBroadcasted async {
+    if (txId == null) {
+      return false;
+    }
+
+    String payjoinTxId;
+    switch (this) {
+      case final PayjoinReceiver receiver:
+        if (receiver.proposalPsbt == null) {
+          return false;
+        }
+        payjoinTxId = await TransactionParsing.getTxIdFromPsbt(
+          receiver.proposalPsbt!,
+        );
+      case final PayjoinSender sender:
+        if (sender.proposalPsbt == null) {
+          return false;
+        }
+        payjoinTxId = await TransactionParsing.getTxIdFromPsbt(
+          sender.proposalPsbt!,
+        );
+    }
+
+    return txId == payjoinTxId;
+  }
 
   bool get isCompleted => status == PayjoinStatus.completed;
   bool get isExpired => status == PayjoinStatus.expired;

--- a/lib/core/payjoin/domain/repositories/payjoin_repository.dart
+++ b/lib/core/payjoin/domain/repositories/payjoin_repository.dart
@@ -6,7 +6,6 @@ import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/wallet/domain/entity/tx_input.dart';
 import 'package:bb_mobile/core/wallet/domain/entity/utxo.dart';
 
-
 abstract class PayjoinRepository {
   Stream<PayjoinReceiver> get requestsForReceivers;
   Stream<PayjoinSender> get proposalsForSenders;
@@ -35,6 +34,11 @@ abstract class PayjoinRepository {
   Future<PayjoinSender> broadcastPsbt({
     required String payjoinId,
     required String finalizedPsbt,
+    required ElectrumServer electrumServer,
+  });
+  Future<PayjoinReceiver> broadcastOriginalTransaction({
+    required String payjoinId,
+    required Uint8List originalTxBytes,
     required ElectrumServer electrumServer,
   });
 }

--- a/lib/core/payjoin/domain/usecases/broadcast_original_transaction_usecase.dart
+++ b/lib/core/payjoin/domain/usecases/broadcast_original_transaction_usecase.dart
@@ -1,0 +1,62 @@
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_metadata_repository.dart';
+
+class BroadcastOriginalTransactionUsecase {
+  final PayjoinRepository _payjoin;
+  final ElectrumServerRepository _electrumServerRepository;
+  final WalletMetadataRepository _walletMetadataRepository;
+
+  BroadcastOriginalTransactionUsecase({
+    required PayjoinRepository payjoinRepository,
+    required ElectrumServerRepository electrumServerRepository,
+    required WalletMetadataRepository walletMetadataRepository,
+  })  : _payjoin = payjoinRepository,
+        _electrumServerRepository = electrumServerRepository,
+        _walletMetadataRepository = walletMetadataRepository;
+
+  Future<PayjoinReceiver> execute(PayjoinReceiver payjoin) async {
+    try {
+      if (payjoin.originalTxBytes == null) {
+        throw BroadcastOriginalTransactionException(
+          'No original transaction bytes to broadcast found for payjoin:'
+          ' ${payjoin.id}',
+        );
+      }
+
+      // Get the network from the wallet metadata using the walletId from the
+      //  payjoin to be able to get the correct Electrum server to broadcast the
+      //  transaction.
+      final walletMetadata = await _walletMetadataRepository.get(
+        payjoin.walletId,
+      );
+
+      if (walletMetadata == null) {
+        throw BroadcastOriginalTransactionException(
+          'Wallet metadata not found for walletId: ${payjoin.walletId}',
+        );
+      }
+
+      final network = walletMetadata.network;
+      final electrumServer = await _electrumServerRepository.getElectrumServer(
+        network: network,
+      );
+
+      // Broadcast the original transaction using the Electrum server
+      return await _payjoin.broadcastOriginalTransaction(
+        payjoinId: payjoin.id,
+        originalTxBytes: payjoin.originalTxBytes!,
+        electrumServer: electrumServer,
+      );
+    } catch (e) {
+      throw BroadcastOriginalTransactionException('$e');
+    }
+  }
+}
+
+class BroadcastOriginalTransactionException implements Exception {
+  final String message;
+
+  BroadcastOriginalTransactionException(this.message);
+}

--- a/lib/core/seed/data/repository/seed_repository_impl.dart
+++ b/lib/core/seed/data/repository/seed_repository_impl.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';

--- a/lib/core/utils/transaction_parsing.dart
+++ b/lib/core/utils/transaction_parsing.dart
@@ -22,4 +22,12 @@ class TransactionParsing {
     final tx = await bdk.PartiallySignedTransaction.fromString(psbt);
     return tx.extractTx().txid();
   }
+
+  static Future<String> getTxIdFromTransactionBytes(
+      Uint8List transactionBytes) async {
+    final tx = await bdk.Transaction.fromBytes(
+      transactionBytes: transactionBytes,
+    );
+    return tx.txid();
+  }
 }

--- a/lib/core/utils/transaction_parsing.dart
+++ b/lib/core/utils/transaction_parsing.dart
@@ -24,7 +24,8 @@ class TransactionParsing {
   }
 
   static Future<String> getTxIdFromTransactionBytes(
-      Uint8List transactionBytes) async {
+    Uint8List transactionBytes,
+  ) async {
     final tx = await bdk.Transaction.fromBytes(
       transactionBytes: transactionBytes,
     );

--- a/lib/core/wallet/data/services/wallet_manager_service_impl.dart
+++ b/lib/core/wallet/data/services/wallet_manager_service_impl.dart
@@ -614,23 +614,27 @@ class WalletManagerServiceImpl implements WalletManagerService {
     for (final tx in transactions) {
       switch (tx.type) {
         case TxType.send:
-          walletTxs.add(SendTransactionDetail(
-            amount: tx.amount,
-            fees: tx.fees!,
-            txId: tx.txid,
-            walletId: walletId,
-            network: network!,
-            confirmationTime: tx.confirmationTime,
-          ));
+          walletTxs.add(
+            SendTransactionDetail(
+              amount: tx.amount,
+              fees: tx.fees!,
+              txId: tx.txid,
+              walletId: walletId,
+              network: network!,
+              confirmationTime: tx.confirmationTime,
+            ),
+          );
         case TxType.receive:
-          walletTxs.add(ReceiveTransactionDetail(
-            amount: tx.amount,
-            fees: tx.fees,
-            txId: tx.txid,
-            walletId: walletId,
-            network: network!,
-            confirmationTime: tx.confirmationTime,
-          ));
+          walletTxs.add(
+            ReceiveTransactionDetail(
+              amount: tx.amount,
+              fees: tx.fees,
+              txId: tx.txid,
+              walletId: walletId,
+              network: network!,
+              confirmationTime: tx.confirmationTime,
+            ),
+          );
         case TxType.self:
           // TODO: Handle this case.
           throw UnimplementedError();

--- a/lib/features/receive/presentation/bloc/receive_event.dart
+++ b/lib/features/receive/presentation/bloc/receive_event.dart
@@ -19,6 +19,8 @@ class ReceiveEvent with _$ReceiveEvent {
       ReceiveNewAddressGenerated;
   const factory ReceiveEvent.receivePayjoinUpdated(PayjoinReceiver payjoin) =
       ReceivePayjoinUpdated;
+  const factory ReceiveEvent.receivePayjoinOriginalTxBroadcasted() =
+      ReceivePayjoinOriginalTxBroadcasted;
   const factory ReceiveEvent.receiveLightningSwapUpdated(LnReceiveSwap swap) =
       ReceiveLightningSwapUpdated;
 }

--- a/lib/features/receive/presentation/bloc/receive_event.dart
+++ b/lib/features/receive/presentation/bloc/receive_event.dart
@@ -17,6 +17,8 @@ class ReceiveEvent with _$ReceiveEvent {
       ReceiveAddressOnlyToggled;
   const factory ReceiveEvent.receiveNewAddressGenerated() =
       ReceiveNewAddressGenerated;
+  const factory ReceiveEvent.receivePayjoinUpdated(PayjoinReceiver payjoin) =
+      ReceivePayjoinUpdated;
   const factory ReceiveEvent.receiveLightningSwapUpdated(LnReceiveSwap swap) =
       ReceiveLightningSwapUpdated;
 }

--- a/lib/features/receive/receive_locator.dart
+++ b/lib/features/receive/receive_locator.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/broadcast_original_transaction_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/core/seed/domain/repositories/seed_repository.dart';
@@ -51,6 +52,8 @@ class ReceiveLocator {
         getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
         createReceiveSwapUsecase: locator<CreateReceiveSwapUsecase>(),
         receiveWithPayjoinUsecase: locator<ReceiveWithPayjoinUsecase>(),
+        broadcastOriginalTransactionUsecase:
+            locator<BroadcastOriginalTransactionUsecase>(),
         watchPayjoinUsecase: locator<WatchPayjoinUsecase>(),
         watchSwapUsecase: locator<WatchSwapUsecase>(),
         wallet: wallet,

--- a/lib/features/receive/ui/receive_router.dart
+++ b/lib/features/receive/ui/receive_router.dart
@@ -31,174 +31,92 @@ enum ReceiveRoute {
 }
 
 class ReceiveRouter {
-  static final GlobalKey<NavigatorState> shellNavigatorKey =
+  static final GlobalKey<NavigatorState> _shellNavigatorKey =
       GlobalKey<NavigatorState>();
 
   static final route = ShellRoute(
-    navigatorKey: shellNavigatorKey,
+    navigatorKey: _shellNavigatorKey,
     builder: (context, state, child) {
-      // Pass a preselected wallet to the receive bloc if one is set in the URI
-      //  of the incoming route
-      final wallet = state.uri.queryParameters['wallet'] as Wallet?;
-
-      return BlocProvider<ReceiveBloc>(
-        create: (_) => locator<ReceiveBloc>(param1: wallet),
-        child: MultiBlocListener(
-          listeners: [
-            BlocListener<ReceiveBloc, ReceiveState>(
-              listenWhen: (previous, current) =>
-                  // makes sure it doesn't go from payment received to payment in progress again
-                  previous.isPaymentReceived != true &&
-                  previous.isPaymentInProgress != true &&
-                  current.isPaymentInProgress == true,
-              listener: (context, receiveState) {
-                if (receiveState is BitcoinReceiveState &&
-                    receiveState.payjoin?.status == PayjoinStatus.requested) {
-                  // For a Payjoin receive, show the payment in progress screen
-                  //  when the payment/swap is completed.
-                  context.go(
-                    '${state.matchedLocation}/${ReceiveRoute.payjoinInProgress.path}',
-                    extra: receiveState,
-                  );
-                  return;
-                } else if (receiveState is LightningReceiveState) {
-                  context.go(
-                    '${state.matchedLocation}/${ReceiveRoute.paymentInProgress.path}',
-                    extra: receiveState,
-                  );
-                }
-              },
-            ),
-            BlocListener<ReceiveBloc, ReceiveState>(
-              listenWhen: (previous, current) =>
-                  previous.isPaymentReceived != true &&
-                  current.isPaymentReceived == true,
-              listener: (context, receiveState) {
-                if (receiveState is LightningReceiveState) {
-                  // For a Lightning receive, show the payment received screen
-                  //  when the payment/swap is completed.
-                  context.go(
-                    '${state.matchedLocation}/${ReceiveRoute.paymentReceived.path}',
-                    extra: receiveState,
-                  );
-                } else {
-                  // For Bitcoin and Liquid receives, it goes directly to the details screen
-                  context.go(
-                    '${state.matchedLocation}/${ReceiveRoute.details.path}',
-                    extra: receiveState,
-                  );
-                }
-              },
-            ),
-          ],
-          child: ReceiveScaffold(
-            child: child,
-          ),
-        ),
-      );
+      return ReceiveScaffold(child: child);
     },
     routes: [
-      GoRoute(
-        name: ReceiveRoute.receiveBitcoin.name,
-        path: ReceiveRoute.receiveBitcoin.path,
-        pageBuilder: (context, state) {
-          // Entry route, start a bitcoin receive if not already there
-          final bloc = context.read<ReceiveBloc>();
-          if (bloc.state is! BitcoinReceiveState) {
-            bloc.add(const ReceiveBitcoinStarted());
-          }
-          return const NoTransitionPage(child: ReceiveQrPage());
-        },
-        routes: [
-          GoRoute(
-            path: ReceiveRoute.amount.path,
-            pageBuilder: (context, state) =>
-                const NoTransitionPage(child: ReceiveAmountScreen()),
-          ),
-          GoRoute(
-            path: ReceiveRoute.payjoinInProgress.path,
-            parentNavigatorKey: AppRouter.rootNavigatorKey,
-            builder: (context, state) {
-              final receiveState = state.extra! as BitcoinReceiveState;
-
-              return ReceivePayjoinInProgressScreen(
-                receiveState: receiveState,
-              );
-            },
-            routes: [
-              GoRoute(
-                path: ReceiveRoute.details.path,
-                parentNavigatorKey: AppRouter.rootNavigatorKey,
-                builder: (context, state) {
-                  final receiveState = state.extra! as BitcoinReceiveState;
-
-                  return ReceiveDetailsScreen(
-                    receiveState: receiveState,
-                  );
-                },
-              ),
-            ],
-          ),
-          GoRoute(
-            path: ReceiveRoute.details.path,
-            parentNavigatorKey: AppRouter.rootNavigatorKey,
-            builder: (context, state) {
-              final receiveState = state.extra! as BitcoinReceiveState;
-
-              return ReceiveDetailsScreen(
-                receiveState: receiveState,
-              );
-            },
-          ),
-        ],
-      ),
-      GoRoute(
-        name: ReceiveRoute.receiveLightning.name,
-        path: ReceiveRoute.receiveLightning.path,
-        pageBuilder: (context, state) {
-          // Entry route, go to lightning receive state if not already there
-          final bloc = context.read<ReceiveBloc>();
-          if (bloc.state is! LightningReceiveState) {
-            bloc.add(const ReceiveLightningStarted());
-          }
-          return NoTransitionPage(
-            child: ReceiveAmountScreen(
-              onContinueNavigation: () => context.push(
-                '${state.matchedLocation}/${ReceiveRoute.qr.path}',
-              ),
+      // Bitcoin Receive
+      ShellRoute(
+        builder: (context, state, child) {
+          // Pass a preselected wallet to the receive bloc if one is set in the URI
+          //  of the incoming route
+          final wallet = state.uri.queryParameters['wallet'] as Wallet?;
+          return BlocProvider<ReceiveBloc>(
+            create: (_) => locator<ReceiveBloc>(param1: wallet)
+              ..add(const ReceiveBitcoinStarted()),
+            child: MultiBlocListener(
+              listeners: [
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      // makes sure it doesn't go from payment received to payment in progress again
+                      previous.isPaymentReceived != true &&
+                      previous.isPaymentInProgress != true &&
+                      current.isPaymentInProgress == true,
+                  listener: (context, receiveState) {
+                    if (receiveState is BitcoinReceiveState &&
+                        receiveState.payjoin?.status ==
+                            PayjoinStatus.requested) {
+                      // For a Payjoin receive, show the payment in progress screen
+                      //  when the payment/swap is completed.
+                      // Since the payment in progress route is outside of the ShellRoute,
+                      // it uses the root navigator and so doesn't have the ReceiveBloc
+                      //  in the context. We need to pass it as an extra parameter.
+                      context.go(
+                        '${state.matchedLocation}/${ReceiveRoute.payjoinInProgress.path}',
+                        extra: context.read<ReceiveBloc>(),
+                      );
+                      return;
+                    }
+                  },
+                ),
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      previous.isPaymentReceived != true &&
+                      current.isPaymentReceived == true,
+                  listener: (context, receiveState) {
+                    // Navigate directly to the details screen for a Bitcoin receive
+                    // Since the details route is outside of the ShellRoute,
+                    // it uses the root navigator and so doesn't have the ReceiveBloc
+                    //  in the context. We need to pass it as an extra parameter.
+                    context.go(
+                      '${state.matchedLocation}/${ReceiveRoute.details.path}',
+                      extra: context.read<ReceiveBloc>(),
+                    );
+                  },
+                ),
+              ],
+              child: child,
             ),
           );
         },
         routes: [
+          // Entry route for a Bitcoin receive
           GoRoute(
-            path: ReceiveRoute.qr.path,
-            pageBuilder: (context, state) =>
-                const NoTransitionPage(child: ReceiveQrPage()),
-          ),
-          GoRoute(
-            path: ReceiveRoute.amount.path,
-            pageBuilder: (context, state) =>
-                const NoTransitionPage(child: ReceiveAmountScreen()),
-          ),
-          GoRoute(
-            path: ReceiveRoute.paymentInProgress.path,
-            parentNavigatorKey: AppRouter.rootNavigatorKey,
-            builder: (context, state) {
-              final receiveState = state.extra! as LightningReceiveState;
-
-              return ReceivePaymentInProgressScreen(
-                receiveState: receiveState,
-              );
+            name: ReceiveRoute.receiveBitcoin.name,
+            path: ReceiveRoute.receiveBitcoin.path,
+            pageBuilder: (context, state) {
+              return const NoTransitionPage(child: ReceiveQrPage());
             },
             routes: [
               GoRoute(
-                path: ReceiveRoute.paymentReceived.path,
+                path: ReceiveRoute.amount.path,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: ReceiveAmountScreen()),
+              ),
+              GoRoute(
+                path: ReceiveRoute.payjoinInProgress.path,
                 parentNavigatorKey: AppRouter.rootNavigatorKey,
                 builder: (context, state) {
-                  final receiveState = state.extra! as LightningReceiveState;
+                  final bloc = state.extra! as ReceiveBloc;
 
-                  return ReceivePaymentReceivedScreen(
-                    receiveState: receiveState,
+                  return BlocProvider.value(
+                    value: bloc,
+                    child: const ReceivePayjoinInProgressScreen(),
                   );
                 },
                 routes: [
@@ -206,13 +124,147 @@ class ReceiveRouter {
                     path: ReceiveRoute.details.path,
                     parentNavigatorKey: AppRouter.rootNavigatorKey,
                     builder: (context, state) {
-                      final receiveState =
-                          state.extra! as LightningReceiveState;
+                      final bloc = state.extra! as ReceiveBloc;
 
-                      return ReceiveDetailsScreen(
-                        receiveState: receiveState,
+                      return BlocProvider.value(
+                        value: bloc,
+                        child: const ReceiveDetailsScreen(),
                       );
                     },
+                  ),
+                ],
+              ),
+              GoRoute(
+                path: ReceiveRoute.details.path,
+                parentNavigatorKey: AppRouter.rootNavigatorKey,
+                builder: (context, state) {
+                  final bloc = state.extra! as ReceiveBloc;
+
+                  return BlocProvider.value(
+                    value: bloc,
+                    child: const ReceiveDetailsScreen(),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+      // Lightning receive
+      ShellRoute(
+        builder: (context, state, child) {
+          final wallet = state.uri.queryParameters['wallet'] as Wallet?;
+          return BlocProvider<ReceiveBloc>(
+            create: (_) => locator<ReceiveBloc>(param1: wallet)
+              ..add(const ReceiveLightningStarted()),
+            child: MultiBlocListener(
+              listeners: [
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      // makes sure it doesn't go from payment received to payment in progress again
+                      previous.isPaymentReceived != true &&
+                      previous.isPaymentInProgress != true &&
+                      current.isPaymentInProgress == true,
+                  listener: (context, receiveState) {
+                    if (receiveState is LightningReceiveState) {
+                      // Since the payment in progress route is outside of the ShellRoute,
+                      // it uses the root navigator and so doesn't have the ReceiveBloc
+                      //  in the context. We need to pass it as an extra parameter.
+                      context.go(
+                        '${state.matchedLocation}/${ReceiveRoute.paymentInProgress.path}',
+                        extra: context.read<ReceiveBloc>(),
+                      );
+                    }
+                  },
+                ),
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      previous.isPaymentReceived != true &&
+                      current.isPaymentReceived == true,
+                  listener: (context, receiveState) {
+                    if (receiveState is LightningReceiveState) {
+                      // For a Lightning receive, show the payment received screen
+                      //  when the payment/swap is completed.
+                      // Since the payment received route is outside of the ShellRoute,
+                      // it uses the root navigator and so doesn't have the ReceiveBloc
+                      //  in the context. We need to pass it as an extra parameter.
+                      context.go(
+                        '${state.matchedLocation}/${ReceiveRoute.paymentReceived.path}',
+                        extra: context.read<ReceiveBloc>(),
+                      );
+                    }
+                  },
+                ),
+              ],
+              child: child,
+            ),
+          );
+        },
+        routes: [
+          // Entry route for a Lightning receive
+          GoRoute(
+            name: ReceiveRoute.receiveLightning.name,
+            path: ReceiveRoute.receiveLightning.path,
+            pageBuilder: (context, state) {
+              return NoTransitionPage(
+                child: ReceiveAmountScreen(
+                  onContinueNavigation: () => context.push(
+                    '${state.matchedLocation}/${ReceiveRoute.qr.path}',
+                  ),
+                ),
+              );
+            },
+            routes: [
+              GoRoute(
+                path: ReceiveRoute.qr.path,
+                pageBuilder: (context, state) {
+                  return const NoTransitionPage(
+                    child: ReceiveQrPage(),
+                  );
+                },
+              ),
+              GoRoute(
+                path: ReceiveRoute.amount.path,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: ReceiveAmountScreen()),
+              ),
+              GoRoute(
+                path: ReceiveRoute.paymentInProgress.path,
+                parentNavigatorKey: AppRouter.rootNavigatorKey,
+                builder: (context, state) {
+                  final bloc = state.extra! as ReceiveBloc;
+
+                  return BlocProvider.value(
+                    value: bloc,
+                    child: const ReceivePaymentInProgressScreen(),
+                  );
+                },
+                routes: [
+                  GoRoute(
+                    path: ReceiveRoute.paymentReceived.path,
+                    parentNavigatorKey: AppRouter.rootNavigatorKey,
+                    builder: (context, state) {
+                      final bloc = state.extra! as ReceiveBloc;
+
+                      return BlocProvider.value(
+                        value: bloc,
+                        child: const ReceivePaymentReceivedScreen(),
+                      );
+                    },
+                    routes: [
+                      GoRoute(
+                        path: ReceiveRoute.details.path,
+                        parentNavigatorKey: AppRouter.rootNavigatorKey,
+                        builder: (context, state) {
+                          final bloc = state.extra! as ReceiveBloc;
+
+                          return BlocProvider.value(
+                            value: bloc,
+                            child: const ReceiveDetailsScreen(),
+                          );
+                        },
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -220,33 +272,74 @@ class ReceiveRouter {
           ),
         ],
       ),
-      GoRoute(
-        name: ReceiveRoute.receiveLiquid.name,
-        path: ReceiveRoute.receiveLiquid.path,
-        pageBuilder: (context, state) {
-          // Entry route, go to liquid receive state if not already there
-          final bloc = context.read<ReceiveBloc>();
-          if (bloc.state is! LiquidReceiveState) {
-            bloc.add(const ReceiveLiquidStarted());
-          }
-          return const NoTransitionPage(child: ReceiveQrPage());
+      // Liquid receive
+      ShellRoute(
+        builder: (context, state, child) {
+          // Pass a preselected wallet to the receive bloc if one is set in the URI
+          //  of the incoming route
+          final wallet = state.uri.queryParameters['wallet'] as Wallet?;
+          return BlocProvider<ReceiveBloc>(
+            create: (_) => locator<ReceiveBloc>(param1: wallet)
+              ..add(const ReceiveLiquidStarted()),
+            child: MultiBlocListener(
+              listeners: [
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      // makes sure it doesn't go from payment received to payment in progress again
+                      previous.isPaymentReceived != true &&
+                      previous.isPaymentInProgress != true &&
+                      current.isPaymentInProgress == true,
+                  listener: (context, receiveState) {
+                    // TODO: Navigate to Liquid payment in progress if needed
+                  },
+                ),
+                BlocListener<ReceiveBloc, ReceiveState>(
+                  listenWhen: (previous, current) =>
+                      previous.isPaymentReceived != true &&
+                      current.isPaymentReceived == true,
+                  listener: (context, receiveState) {
+                    // Go directly to the details screen for a Liquid receive
+                    // Since the details route is outside of the ShellRoute,
+                    // it uses the root navigator and so doesn't have the ReceiveBloc
+                    //  in the context. We need to pass it as an extra parameter.
+                    context.go(
+                      '${state.matchedLocation}/${ReceiveRoute.details.path}',
+                      extra: context.read<ReceiveBloc>(),
+                    );
+                  },
+                ),
+              ],
+              child: child,
+            ),
+          );
         },
         routes: [
+          // Entry route for a Liquid receive
           GoRoute(
-            path: ReceiveRoute.amount.path,
-            pageBuilder: (context, state) =>
-                const NoTransitionPage(child: ReceiveAmountScreen()),
-          ),
-          GoRoute(
-            path: ReceiveRoute.details.path,
-            parentNavigatorKey: AppRouter.rootNavigatorKey,
-            builder: (context, state) {
-              final receiveState = state.extra! as LiquidReceiveState;
-
-              return ReceiveDetailsScreen(
-                receiveState: receiveState,
-              );
+            name: ReceiveRoute.receiveLiquid.name,
+            path: ReceiveRoute.receiveLiquid.path,
+            pageBuilder: (context, state) {
+              return const NoTransitionPage(child: ReceiveQrPage());
             },
+            routes: [
+              GoRoute(
+                path: ReceiveRoute.amount.path,
+                pageBuilder: (context, state) =>
+                    const NoTransitionPage(child: ReceiveAmountScreen()),
+              ),
+              GoRoute(
+                path: ReceiveRoute.details.path,
+                parentNavigatorKey: AppRouter.rootNavigatorKey,
+                builder: (context, state) {
+                  final bloc = state.extra! as ReceiveBloc;
+
+                  return BlocProvider.value(
+                    value: bloc,
+                    child: const ReceiveDetailsScreen(),
+                  );
+                },
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/features/receive/ui/screens/receive_details_screen.dart
+++ b/lib/features/receive/ui/screens/receive_details_screen.dart
@@ -4,16 +4,12 @@ import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
 class ReceiveDetailsScreen extends StatelessWidget {
-  const ReceiveDetailsScreen({
-    super.key,
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const ReceiveDetailsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +32,7 @@ class ReceiveDetailsScreen extends StatelessWidget {
             },
           ),
         ),
-        body: DetailsPage(
-          receiveState: receiveState,
-        ),
+        body: const DetailsPage(),
         // child: AmountPage(),
       ),
     );
@@ -46,14 +40,17 @@ class ReceiveDetailsScreen extends StatelessWidget {
 }
 
 class DetailsPage extends StatelessWidget {
-  const DetailsPage({
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const DetailsPage();
 
   @override
   Widget build(BuildContext context) {
+    // Using read instead of select or watch is ok here,
+    //  since the amounts can not be changed at this point anymore.
+    final amountBitcoin =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountBitcoin;
+    final amountFiat =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountFiat;
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -68,12 +65,12 @@ class DetailsPage extends StatelessWidget {
           ),
           const Gap(16),
           BBText(
-            receiveState.formattedConfirmedAmountBitcoin,
+            amountBitcoin,
             style: context.font.headlineLarge,
           ),
           const Gap(4),
           BBText(
-            '~${receiveState.formattedConfirmedAmountFiat}',
+            '~$amountFiat',
             style: context.font.bodyLarge,
             color: context.colour.surface,
           ),

--- a/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
-class ReceivePaymentReceivedScreen extends StatelessWidget {
-  const ReceivePaymentReceivedScreen({
+class ReceivePayjoinInProgressScreen extends StatelessWidget {
+  const ReceivePayjoinInProgressScreen({
     super.key,
     required this.receiveState,
   });
@@ -38,7 +38,7 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
             },
           ),
         ),
-        body: PaymentReceivedPage(
+        body: PayjoinInProgressPage(
           receiveState: receiveState,
         ),
         // child: AmountPage(),
@@ -47,9 +47,8 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
   }
 }
 
-class PaymentReceivedPage extends StatelessWidget {
-  const PaymentReceivedPage({
-    super.key,
+class PayjoinInProgressPage extends StatelessWidget {
+  const PayjoinInProgressPage({
     required this.receiveState,
   });
 
@@ -63,13 +62,17 @@ class PaymentReceivedPage extends StatelessWidget {
         children: [
           const Spacer(),
           BBText(
-            'Payment received',
+            'Payjoin in progress',
             style: context.font.headlineLarge,
           ),
-          const Gap(24),
+          BBText(
+            'Wait for the sender to finish the payjoin transaction',
+            style: context.font.headlineMedium,
+          ),
+          const Gap(16),
           BBText(
             receiveState.formattedConfirmedAmountBitcoin,
-            style: context.font.displaySmall,
+            style: context.font.headlineLarge,
           ),
           const Gap(4),
           BBText(
@@ -78,7 +81,11 @@ class PaymentReceivedPage extends StatelessWidget {
             color: context.colour.surface,
           ),
           const Spacer(),
-          ReceiveDetailsButton(
+          BBText(
+            "No time to wait or did the payjoin fail on the sender's side?",
+            style: context.font.bodyLarge,
+          ),
+          ReceiveBroadcastPayjoinButton(
             receiveState: receiveState,
           ),
           const Gap(16),
@@ -88,8 +95,8 @@ class PaymentReceivedPage extends StatelessWidget {
   }
 }
 
-class ReceiveDetailsButton extends StatelessWidget {
-  const ReceiveDetailsButton({super.key, required this.receiveState});
+class ReceiveBroadcastPayjoinButton extends StatelessWidget {
+  const ReceiveBroadcastPayjoinButton({super.key, required this.receiveState});
 
   final ReceiveState receiveState;
 
@@ -98,8 +105,10 @@ class ReceiveDetailsButton extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: BBButton.big(
-        label: 'Details',
+        label: 'Receive payment normally',
         onPressed: () {
+          // Todo: broadcast the payjoin transaction
+          // context.read<ReceiveBloc>().add(const ReceivePayjoinBroadcasted());
           context.go(ReceiveRoute.details.path, extra: receiveState);
         },
         bgColor: context.colour.secondary,

--- a/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
@@ -1,21 +1,18 @@
 import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
-import 'package:bb_mobile/features/receive/ui/receive_router.dart';
 import 'package:bb_mobile/router.dart';
 import 'package:bb_mobile/ui/components/buttons/button.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
 class ReceivePayjoinInProgressScreen extends StatelessWidget {
   const ReceivePayjoinInProgressScreen({
     super.key,
-    required this.receiveState,
   });
-
-  final ReceiveState receiveState;
 
   @override
   Widget build(BuildContext context) {
@@ -38,57 +35,49 @@ class ReceivePayjoinInProgressScreen extends StatelessWidget {
             },
           ),
         ),
-        body: PayjoinInProgressPage(
-          receiveState: receiveState,
-        ),
-        // child: AmountPage(),
+        body: const PayjoinInProgressPage(),
       ),
     );
   }
 }
 
 class PayjoinInProgressPage extends StatelessWidget {
-  const PayjoinInProgressPage({
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const PayjoinInProgressPage();
 
   @override
   Widget build(BuildContext context) {
+    // Using read instead of select or watch is ok here,
+    //  since the amounts can not be changed at this point anymore.
+    final amountBitcoin =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountBitcoin;
+    final amountFiat =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountFiat;
+
     return Center(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Spacer(),
           BBText(
             'Payjoin in progress',
             style: context.font.headlineLarge,
           ),
           BBText(
             'Wait for the sender to finish the payjoin transaction',
-            style: context.font.headlineMedium,
+            style: context.font.bodyMedium,
           ),
           const Gap(16),
           BBText(
-            receiveState.formattedConfirmedAmountBitcoin,
+            amountBitcoin,
             style: context.font.headlineLarge,
           ),
           const Gap(4),
           BBText(
-            '~${receiveState.formattedConfirmedAmountFiat}',
+            '~$amountFiat',
             style: context.font.bodyLarge,
             color: context.colour.surface,
           ),
-          const Spacer(),
-          BBText(
-            "No time to wait or did the payjoin fail on the sender's side?",
-            style: context.font.bodyLarge,
-          ),
-          ReceiveBroadcastPayjoinButton(
-            receiveState: receiveState,
-          ),
-          const Gap(16),
+          const Gap(84),
+          const ReceiveBroadcastPayjoinButton(),
         ],
       ),
     );
@@ -96,23 +85,33 @@ class PayjoinInProgressPage extends StatelessWidget {
 }
 
 class ReceiveBroadcastPayjoinButton extends StatelessWidget {
-  const ReceiveBroadcastPayjoinButton({super.key, required this.receiveState});
-
-  final ReceiveState receiveState;
+  const ReceiveBroadcastPayjoinButton({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: BBButton.big(
-        label: 'Receive payment normally',
-        onPressed: () {
-          // Todo: broadcast the payjoin transaction
-          // context.read<ReceiveBloc>().add(const ReceivePayjoinBroadcasted());
-          context.go(ReceiveRoute.details.path, extra: receiveState);
-        },
-        bgColor: context.colour.secondary,
-        textColor: context.colour.onSecondary,
+      child: Column(
+        children: [
+          BBText(
+            "No time to wait or did the payjoin fail on the sender's side?",
+            style: context.font.titleMedium,
+            textAlign: TextAlign.center,
+            maxLines: 2,
+          ),
+          const Gap(16),
+          BBButton.big(
+            label: 'Receive payment normally',
+            onPressed: () {
+              debugPrint('Receive payment normally');
+              context.read<ReceiveBloc>().add(
+                    const ReceivePayjoinOriginalTxBroadcasted(),
+                  );
+            },
+            bgColor: context.colour.secondary,
+            textColor: context.colour.onSecondary,
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
@@ -4,16 +4,12 @@ import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
 class ReceivePaymentInProgressScreen extends StatelessWidget {
-  const ReceivePaymentInProgressScreen({
-    super.key,
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const ReceivePaymentInProgressScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +32,7 @@ class ReceivePaymentInProgressScreen extends StatelessWidget {
             },
           ),
         ),
-        body: PaymentInProgressPage(
-          receiveState: receiveState,
-        ),
+        body: const PaymentInProgressPage(),
         // child: AmountPage(),
       ),
     );
@@ -46,14 +40,17 @@ class ReceivePaymentInProgressScreen extends StatelessWidget {
 }
 
 class PaymentInProgressPage extends StatelessWidget {
-  const PaymentInProgressPage({
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const PaymentInProgressPage();
 
   @override
   Widget build(BuildContext context) {
+    // Using read instead of select or watch is ok here,
+    //  since the amounts can not be changed at this point anymore.
+    final amountBitcoin =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountBitcoin;
+    final amountFiat =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountFiat;
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -68,12 +65,12 @@ class PaymentInProgressPage extends StatelessWidget {
           ),
           const Gap(16),
           BBText(
-            receiveState.formattedConfirmedAmountBitcoin,
+            amountBitcoin,
             style: context.font.headlineLarge,
           ),
           const Gap(4),
           BBText(
-            '~${receiveState.formattedConfirmedAmountFiat}',
+            '~$amountFiat',
             style: context.font.bodyLarge,
             color: context.colour.surface,
           ),

--- a/lib/features/receive/ui/screens/receive_payment_received_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_received_screen.dart
@@ -6,16 +6,12 @@ import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
 class ReceivePaymentReceivedScreen extends StatelessWidget {
-  const ReceivePaymentReceivedScreen({
-    super.key,
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const ReceivePaymentReceivedScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -38,9 +34,7 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
             },
           ),
         ),
-        body: PaymentReceivedPage(
-          receiveState: receiveState,
-        ),
+        body: const PaymentReceivedPage(),
         // child: AmountPage(),
       ),
     );
@@ -48,15 +42,17 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
 }
 
 class PaymentReceivedPage extends StatelessWidget {
-  const PaymentReceivedPage({
-    super.key,
-    required this.receiveState,
-  });
-
-  final ReceiveState receiveState;
+  const PaymentReceivedPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    // Using read instead of select or watch is ok here,
+    //  since the amounts can not be changed at this point anymore.
+    final amountBitcoin =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountBitcoin;
+    final amountFiat =
+        context.read<ReceiveBloc>().state.formattedConfirmedAmountFiat;
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.end,
@@ -68,19 +64,17 @@ class PaymentReceivedPage extends StatelessWidget {
           ),
           const Gap(24),
           BBText(
-            receiveState.formattedConfirmedAmountBitcoin,
+            amountBitcoin,
             style: context.font.displaySmall,
           ),
           const Gap(4),
           BBText(
-            '~${receiveState.formattedConfirmedAmountFiat}',
+            '~$amountFiat',
             style: context.font.bodyLarge,
             color: context.colour.surface,
           ),
           const Spacer(),
-          ReceiveDetailsButton(
-            receiveState: receiveState,
-          ),
+          const ReceiveDetailsButton(),
           const Gap(16),
         ],
       ),
@@ -89,9 +83,7 @@ class PaymentReceivedPage extends StatelessWidget {
 }
 
 class ReceiveDetailsButton extends StatelessWidget {
-  const ReceiveDetailsButton({super.key, required this.receiveState});
-
-  final ReceiveState receiveState;
+  const ReceiveDetailsButton({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -100,7 +92,12 @@ class ReceiveDetailsButton extends StatelessWidget {
       child: BBButton.big(
         label: 'Details',
         onPressed: () {
-          context.go(ReceiveRoute.details.path, extra: receiveState);
+          // We need to pass the bloc to the details screen since it is outside
+          // of the Shellroute where the bloc is created.
+          context.go(
+            '${GoRouterState.of(context).matchedLocation}/${ReceiveRoute.details.path}',
+            extra: context.read<ReceiveBloc>(),
+          );
         },
         bgColor: context.colour.secondary,
         textColor: context.colour.onSecondary,

--- a/lib/features/receive/ui/widgets/receive_payment_received_details.dart
+++ b/lib/features/receive/ui/widgets/receive_payment_received_details.dart
@@ -1,18 +1,12 @@
-import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:flutter/material.dart';
 
 class ReceivePaymentReceivedDetails extends StatelessWidget {
-  final ReceiveState receiveState;
-
   const ReceivePaymentReceivedDetails({
     super.key,
-    required this.receiveState,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Text('ReceivePaymentReceivedDetailsTable'),
-    );
+    return const Text('ReceivePaymentReceivedDetailsTable');
   }
 }


### PR DESCRIPTION
This PR adds the payjoin in progress screen when a payjoin request is made and permits the receiver to broadcast the original tx if waiting for the sender is not an option or the payjoin failed on the sender's side.

It also improves the routing and fixes the bug that overwrites fields when switching networks.