### PR TITLE
Keep the Bitcoin or Liquid address when toggling networks to receive instead of generating a new every time

### DIFF
--- a/lib/features/receive/presentation/bloc/receive_state.dart
+++ b/lib/features/receive/presentation/bloc/receive_state.dart
@@ -71,7 +71,9 @@ class ReceiveState with _$ReceiveState {
   String get qrData {
     switch (type) {
       case ReceiveType.bitcoin:
-        if (bitcoinAddress.isEmpty) {
+        if (bitcoinAddress.isEmpty || isPayjoinLoading) {
+          // Wait for the address and also for the payjoin in case not only the
+          // address should be shown.
           return '';
         }
         if (isAddressOnly ||


### PR DESCRIPTION
This PR now uses only one BLoC for all receive networks + only fetches async data if not in the state yet.