### PR TITLE
Update to payjoin 0.23.0

### DIFF
--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -19,7 +19,6 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:flutter/foundation.dart';
-import 'package:payjoin_flutter/uri.dart' show Url;
 import 'package:synchronized/synchronized.dart';
 
 class PayjoinRepositoryImpl implements PayjoinRepository {
@@ -104,9 +103,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
   @override
   Future<bool> checkOhttpRelayHealth() async {
-    final directory = await Url.fromStr(PayjoinConstants.directoryUrl);
     final (ohttpKeys, ohttpRelay) = await _pdkPayjoinDatasource
-        .fetchOhttpKeyAndRelay(payjoinDirectory: directory);
+        .fetchOhttpKeyAndRelay(payjoinDirectory: PayjoinConstants.directoryUrl);
     return ohttpKeys != null && ohttpRelay != null;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1333,11 +1333,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "release/v0.23.0-dev.1"
-      resolved-ref: ee7418e85af103317493365f956de92b6a98dee8
-      url: "https://github.com/LtbLightning/payjoin-flutter"
+      ref: deps-for-bb
+      resolved-ref: "322b61b9074be2c0170e44e589f6552917e58a2e"
+      url: "https://github.com/DanGould/payjoin-flutter"
     source: git
-    version: "0.23.0-dev.1"
+    version: "0.23.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -1732,10 +1732,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: "054cedf68706bb142839ba0ae6b135f6b68039f0b8301cbe8784ae653d5ff8de"
+      sha256: b05159406a97e1cbb2b9ee4faa9fb096fe0e2dfcd8b08fcd2a00553450d3422e
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.7.1"
   timing:
     dependency: transitive
     description:
@@ -1982,10 +1982,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.13.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
   path_provider: ^2.0.15
   payjoin_flutter:
     git:
-      url: https://github.com/LtbLightning/payjoin-flutter
-      ref: release/v0.23.0-dev.1
+      url: https://github.com/DanGould/payjoin-flutter
+      ref: deps-for-bb
   carousel_slider: ^4.2.1
   qr_flutter: ^4.1.0
   flutter_translate: ^4.0.3
@@ -191,3 +191,4 @@ flutter_launcher_icons:
   min_sdk_android: 21 # android min sdk min:16, default 21
   adaptive_icon_background: "#FBFBFB"
   adaptive_icon_foreground: "assets/iconnew-red.png"
+


### PR DESCRIPTION
via payjoin-flutter @ DanGould/deps-for-bb

The persistence API changed but is incomplete, and so not worth moving to on this commit. Instead, I use an in-memory persister as a hack to bridge this release to the next one when the real API is available.

I am had some issues running the test, but I guess it's from my environment needing java21 (where an emulator is running) and not bb-mobile's setup. Copying the .env.template verbatim into .env also worked (Though for some reason mere `touch .env` did not)