### PR TITLE
Structure routing with entry routes and subroutes to fix bad state bug

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -231,40 +231,40 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
-  bip85: 3059e217a3a606a100dd244f21d2fc61b0a1aa83
+  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  bip85: f656a7e6b23afda4960efb11c87d51d68e8be3db
   boltz: 6388ec2412f3753b63a9e65c97f87ea26f43bddc
-  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
+  camera_avfoundation: adb0207d868b2d873e895371d88448399ab78d87
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  document_file_save_plus: 47b52a647efb29f7d431af45a856ce1a841f32fc
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  document_file_save_plus: 913d440d8b611ae19add4522ed578e3ed1483a2f
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_file_dialog: ca8d7fbd1772d4f0c2777b4ab20a7787ef4e7dd8
-  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
-  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
+  flutter_file_dialog: 4c014a45b105709a27391e266c277d7e588e9299
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
+  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   lwk: 22e06bc5664247d6b2dac91cfe209b63b70dd580
-  no_screenshot: 6d183496405a3ab709a67a54e5cd0f639e94729e
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  no_screenshot: 67d110f12466f4913b488803d4e498d03ef2889e
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   payjoin_flutter: 6397d7b698cdad6453be4949ab6aca1863f6c5e5
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   ScreenProtectorKit: 83a6281b02c7a5902ee6eac4f5045f674e902ae4
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
-  sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
+  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  tor: 767208930250ef7be241963b75568c55c0a81890
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  webview_cookie_manager: d63a76cabdf42a7ea3d92768ac67d4853a1367f8
-  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
+  tor: 662a9f5b980b5c86decb8ba611de9bcd4c8286eb
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  webview_cookie_manager: eaf920722b493bd0f7611b5484771ca53fed03f7
+  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
 
 PODFILE CHECKSUM: 38934b16624b4fa72035a092e777e96d352e7058
 

--- a/lib/features/app_startup/ui/app_startup_widget.dart
+++ b/lib/features/app_startup/ui/app_startup_widget.dart
@@ -1,4 +1,6 @@
 import 'package:bb_mobile/features/app_startup/presentation/bloc/app_startup_bloc.dart';
+import 'package:bb_mobile/features/app_unlock/ui/app_unlock_router.dart';
+import 'package:bb_mobile/features/onboarding/ui/onboarding_router.dart';
 import 'package:bb_mobile/features/onboarding/ui/screens/onboarding_splash.dart';
 import 'package:bb_mobile/router.dart';
 import 'package:flutter/material.dart';
@@ -24,9 +26,7 @@ class _AppStartupWidgetState extends State<AppStartupWidget> {
             if (state is AppStartupInitial) {
               return const OnboardingSplash(loading: true);
             } else if (state is AppStartupLoadingInProgress) {
-              return const OnboardingSplash(
-                loading: true,
-              );
+              return const OnboardingSplash(loading: true);
             } else if (state is AppStartupSuccess) {
               // if (!state.hasDefaultWallets) return const OnboardingScreen();
               // if (state.isPinCodeSet) return const PinCodeUnlockScreen();
@@ -56,15 +56,16 @@ class AppStartupListener extends StatelessWidget {
     return MultiBlocListener(
       listeners: [
         BlocListener<AppStartupBloc, AppStartupState>(
-          listenWhen: (previous, current) =>
-              current is AppStartupSuccess && previous != current,
+          listenWhen:
+              (previous, current) =>
+                  current is AppStartupSuccess && previous != current,
           listener: (context, state) {
             if (state is AppStartupSuccess && state.isPinCodeSet) {
-              AppRouter.router.go(AppRoute.appUnlock.path);
+              AppRouter.router.go(AppUnlockRoute.appUnlock.path);
             }
 
             if (state is AppStartupSuccess && !state.hasDefaultWallets) {
-              AppRouter.router.go(AppRoute.onboarding.path);
+              AppRouter.router.go(OnboardingRoute.onboarding.path);
             }
           },
         ),

--- a/lib/features/app_unlock/ui/app_unlock_router.dart
+++ b/lib/features/app_unlock/ui/app_unlock_router.dart
@@ -1,0 +1,24 @@
+import 'dart:ui';
+
+import 'package:bb_mobile/features/app_unlock/ui/pin_code_unlock_screen.dart';
+import 'package:go_router/go_router.dart';
+
+enum AppUnlockRoute {
+  appUnlock('/app-unlock');
+
+  final String path;
+
+  const AppUnlockRoute(this.path);
+}
+
+class AppUnlockRouter {
+  static final route = GoRoute(
+    name: AppUnlockRoute.appUnlock.name,
+    path: AppUnlockRoute.appUnlock.path,
+    builder: (context, state) {
+      final onSuccess = state.extra as VoidCallback?;
+
+      return PinCodeUnlockScreen(onSuccess: onSuccess);
+    },
+  );
+}

--- a/lib/features/backup_wallet/ui/screens/choose_encrypted_vault_provider_screen.dart
+++ b/lib/features/backup_wallet/ui/screens/choose_encrypted_vault_provider_screen.dart
@@ -6,8 +6,8 @@ import 'package:bb_mobile/core/recoverbull/domain/entity/key_server.dart'
     show CurrentKeyServerFlow;
 import 'package:bb_mobile/features/backup_wallet/presentation/bloc/backup_wallet_bloc.dart';
 import 'package:bb_mobile/features/backup_wallet/ui/widgets/how_to_decide.dart';
+import 'package:bb_mobile/features/key_server/ui/key_server_router.dart';
 import 'package:bb_mobile/locator.dart';
-import 'package:bb_mobile/router.dart' show AppRoute;
 import 'package:bb_mobile/ui/components/loading/progress_screen.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
@@ -59,8 +59,8 @@ class _Screen extends StatelessWidget {
           context.read<BackupWalletBloc>().add(const StartTransitioning());
           final bloc = context.read<BackupWalletBloc>();
           context
-              .pushNamed(
-                AppRoute.keyServerFlow.name,
+              .push(
+                KeyServerRoute.keyServerFlow.path,
                 extra: (
                   state.backupFile,
                   CurrentKeyServerFlow.enter.toString(),

--- a/lib/features/buy/ui/buy_router.dart
+++ b/lib/features/buy/ui/buy_router.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/features/buy/ui/buy_screen.dart';
+import 'package:go_router/go_router.dart';
+
+enum BuyRoute {
+  buy('buy');
+
+  final String path;
+
+  const BuyRoute(this.path);
+}
+
+class BuyRouter {
+  static final route = GoRoute(
+    name: BuyRoute.buy.name,
+    path: BuyRoute.buy.path,
+    builder: (context, state) => const BuyScreen(),
+  );
+}

--- a/lib/features/home/home_locator.dart
+++ b/lib/features/home/home_locator.dart
@@ -16,7 +16,7 @@ import 'package:bb_mobile/locator.dart';
 class HomeLocator {
   static void setup() {
     // Bloc
-    locator.registerLazySingleton<HomeBloc>(
+    locator.registerFactory<HomeBloc>(
       () => HomeBloc(
         getWalletsUsecase: locator<GetWalletsUsecase>(),
         checkWalletSyncingUsecase: locator<CheckWalletSyncingUsecase>(),

--- a/lib/features/home/presentation/blocs/home_bloc.dart
+++ b/lib/features/home/presentation/blocs/home_bloc.dart
@@ -17,7 +17,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_started_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/features/home/domain/entity/warning.dart';
-import 'package:bb_mobile/router.dart';
+import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -280,7 +280,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       return HomeWarning(
         title: title,
         description: 'Click to configure electrum server settings',
-        actionRoute: AppRoute.settings.name,
+        actionRoute: SettingsRoute.settings.name,
         type: WarningType.error,
       );
     }
@@ -293,7 +293,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       return HomeWarning(
         title: 'Payjoin Service Unreachable',
         description: 'Contact support for assistance',
-        actionRoute: AppRoute.settings.name,
+        actionRoute: SettingsRoute.settings.name,
         type: WarningType.error,
       );
     }
@@ -313,7 +313,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       return HomeWarning(
         title: 'Boltz Server Unreachable',
         description: 'Contact support for assistance',
-        actionRoute: AppRoute.settings.name,
+        actionRoute: SettingsRoute.settings.name,
         type: WarningType.error,
       );
     }

--- a/lib/features/home/ui/widgets/exchange_top_section.dart
+++ b/lib/features/home/ui/widgets/exchange_top_section.dart
@@ -2,9 +2,9 @@ import 'package:bb_mobile/features/bitcoin_price/presentation/bloc/bitcoin_price
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/home/presentation/blocs/home_bloc.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
-import 'package:bb_mobile/router.dart';
 import 'package:bb_mobile/ui/components/cards/action_card.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
@@ -221,7 +221,7 @@ class _TopNav extends StatelessWidget {
         const Gap(8),
 
         InkWell(
-          onTap: () => context.pushNamed(AppRoute.settings.name),
+          onTap: () => context.pushNamed(SettingsRoute.settings.name),
           child: Image.asset(
             Assets.icons.settingsLine.path,
             width: 24,

--- a/lib/features/home/ui/widgets/home_app_bar.dart
+++ b/lib/features/home/ui/widgets/home_app_bar.dart
@@ -60,7 +60,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
 //       ),
 //       actions: [
 //         IconButton(
-//           onPressed: () => context.pushNamed(AppRoute.settings.name),
+//           onPressed: () => context.pushNamed(SettingsRoute.settings.name),
 //           icon: const Icon(Icons.settings),
 //         ),
 //         const IconButton(onPressed: null, icon: Icon(Icons.person)),

--- a/lib/features/home/ui/widgets/home_bottom_buttons.dart
+++ b/lib/features/home/ui/widgets/home_bottom_buttons.dart
@@ -25,12 +25,12 @@ class HomeBottomButtons extends StatelessWidget {
             onPressed: () {
               // Lightning is the default receive method if no specific wallet is selected
               if (wallet == null) {
-                context.pushNamed(ReceiveRoute.receiveLightning.name);
+                context.push(ReceiveRoute.receiveLightning.path);
               } else {
-                context.pushNamed(
+                context.push(
                   wallet!.isLiquid
-                      ? ReceiveRoute.receiveLiquid.name
-                      : ReceiveRoute.receiveBitcoin.name,
+                      ? ReceiveRoute.receiveLiquid.path
+                      : ReceiveRoute.receiveBitcoin.path,
                   extra: wallet,
                 );
               }
@@ -46,7 +46,7 @@ class HomeBottomButtons extends StatelessWidget {
             label: 'Send',
             iconFirst: true,
             onPressed: () {
-              context.pushNamed(SendRoute.send.name, extra: wallet);
+              context.push(SendRoute.send.path, extra: wallet);
             },
             bgColor: context.colour.secondary,
             textColor: context.colour.onPrimary,

--- a/lib/features/home/ui/widgets/top_section.dart
+++ b/lib/features/home/ui/widgets/top_section.dart
@@ -2,9 +2,9 @@ import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/home/presentation/blocs/home_bloc.dart';
 import 'package:bb_mobile/features/home/ui/widgets/eye_toggle.dart';
 import 'package:bb_mobile/features/home/ui/widgets/home_fiat_balance.dart';
+import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
-import 'package:bb_mobile/router.dart';
 import 'package:bb_mobile/ui/components/cards/action_card.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
@@ -171,7 +171,7 @@ class _TopNav extends StatelessWidget {
         const Gap(8),
 
         InkWell(
-          onTap: () => context.pushNamed(AppRoute.settings.name),
+          onTap: () => context.pushNamed(SettingsRoute.settings.name),
           child: Image.asset(
             Assets.icons.settingsLine.path,
             width: 24,

--- a/lib/features/home/ui/widgets/wallet_cards.dart
+++ b/lib/features/home/ui/widgets/wallet_cards.dart
@@ -46,7 +46,6 @@ class HomeWalletCards extends StatelessWidget {
                 context.goNamed(
                   HomeRoute.walletHome.name,
                   pathParameters: {'walletId': w.id},
-                  extra: context.read<HomeBloc>(),
                 );
               },
             ),

--- a/lib/features/key_server/ui/key_server_flow.dart
+++ b/lib/features/key_server/ui/key_server_flow.dart
@@ -240,7 +240,7 @@ class _KeyServerFlowState extends State<KeyServerFlow> {
     OnboardingState state,
   ) {
     if (state.onboardingStepStatus == OnboardingStepStatus.success) {
-      context.goNamed(OnboardingSubroute.recoverSuccess.name);
+      context.goNamed(OnboardingRoute.recoverSuccess.name);
     }
   }
 

--- a/lib/features/key_server/ui/key_server_router.dart
+++ b/lib/features/key_server/ui/key_server_router.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/features/key_server/ui/key_server_flow.dart';
+import 'package:go_router/go_router.dart';
+
+enum KeyServerRoute {
+  keyServerFlow('key-server-flow');
+
+  final String path;
+
+  const KeyServerRoute(this.path);
+}
+
+class KeyServerRouter {
+  static final route = GoRoute(
+    path: KeyServerRoute.keyServerFlow.path,
+    builder: (context, state) {
+      final (String? backupFile, String? flow, bool fromOnboarding) =
+          state.extra! as (String?, String?, bool);
+      return KeyServerFlow(
+        backupFile: backupFile,
+        currentFlow: flow,
+        fromOnboarding: fromOnboarding,
+      );
+    },
+  );
+}

--- a/lib/features/onboarding/ui/onboarding_router.dart
+++ b/lib/features/onboarding/ui/onboarding_router.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/recoverbull/domain/entity/backup_info.dart';
 import 'package:bb_mobile/features/home/ui/home_router.dart';
+import 'package:bb_mobile/features/key_server/ui/key_server_router.dart';
 import 'package:bb_mobile/features/onboarding/presentation/bloc/onboarding_bloc.dart';
 import 'package:bb_mobile/features/onboarding/ui/screens/choose_encrypted_vault_provider_screen.dart';
 import 'package:bb_mobile/features/onboarding/ui/screens/fetched_backup_info_screen.dart';
@@ -8,12 +9,12 @@ import 'package:bb_mobile/features/onboarding/ui/screens/onboarding_recovery_suc
 import 'package:bb_mobile/features/onboarding/ui/screens/onboarding_splash.dart';
 import 'package:bb_mobile/features/onboarding/ui/screens/recover_options.dart';
 import 'package:bb_mobile/locator.dart';
-import 'package:bb_mobile/router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
-enum OnboardingSubroute {
+enum OnboardingRoute {
+  onboarding('/onboarding'),
   splash('splash'),
   recoverOptions('recover-options'),
   chooseRecoverProvider('choose-recover-provider'),
@@ -24,7 +25,7 @@ enum OnboardingSubroute {
 
   final String path;
 
-  const OnboardingSubroute(this.path);
+  const OnboardingRoute(this.path);
 }
 
 class OnboardingRouter {
@@ -60,47 +61,49 @@ class OnboardingRouter {
             ),
         routes: [
           GoRoute(
-            name: AppRoute.onboarding.name,
-            path: AppRoute.onboarding.path,
+            name: OnboardingRoute.onboarding.name,
+            path: OnboardingRoute.onboarding.path,
             parentNavigatorKey: shellNavigatorKey,
             builder: (context, state) => const OnboardingSplash(),
             routes: [
               GoRoute(
-                name: OnboardingSubroute.splash.name,
-                path: OnboardingSubroute.splash.path,
+                name: OnboardingRoute.splash.name,
+                path: OnboardingRoute.splash.path,
                 builder: (context, state) => const OnboardingSplash(),
               ),
               GoRoute(
-                name: OnboardingSubroute.recoverFromPhysical.name,
-                path: OnboardingSubroute.recoverFromPhysical.path,
+                name: OnboardingRoute.recoverFromPhysical.name,
+                path: OnboardingRoute.recoverFromPhysical.path,
                 builder: (context, state) => const OnboardingPhysicalRecovery(),
               ),
               GoRoute(
-                name: OnboardingSubroute.recoverFromEncrypted.name,
-                path: OnboardingSubroute.recoverFromEncrypted.path,
+                name: OnboardingRoute.recoverFromEncrypted.name,
+                path: OnboardingRoute.recoverFromEncrypted.path,
                 builder: (context, state) => const OnboardingPhysicalRecovery(),
               ),
               GoRoute(
-                name: OnboardingSubroute.recoverOptions.name,
-                path: OnboardingSubroute.recoverOptions.path,
+                name: OnboardingRoute.recoverOptions.name,
+                path: OnboardingRoute.recoverOptions.path,
                 builder: (context, state) => const OnboardingRecoverOptions(),
               ),
               GoRoute(
-                name: OnboardingSubroute.retrievedBackupInfo.name,
-                path: OnboardingSubroute.retrievedBackupInfo.path,
+                name: OnboardingRoute.retrievedBackupInfo.name,
+                path: OnboardingRoute.retrievedBackupInfo.path,
                 builder: (context, state) {
                   final backupInfo = state.extra! as BackupInfo;
                   return FetchedBackupInfoScreen(encryptedInfo: backupInfo);
                 },
+                routes: [KeyServerRouter.route],
               ),
               GoRoute(
-                name: OnboardingSubroute.chooseRecoverProvider.name,
-                path: OnboardingSubroute.chooseRecoverProvider.path,
+                name: OnboardingRoute.chooseRecoverProvider.name,
+                path: OnboardingRoute.chooseRecoverProvider.path,
                 builder: (context, state) => const ChooseVaultProviderScreen(),
+                routes: [KeyServerRouter.route],
               ),
               GoRoute(
-                name: OnboardingSubroute.recoverSuccess.name,
-                path: OnboardingSubroute.recoverSuccess.path,
+                name: OnboardingRoute.recoverSuccess.name,
+                path: OnboardingRoute.recoverSuccess.path,
                 builder: (context, state) => const OnboardingRecoverySuccess(),
               ),
             ],

--- a/lib/features/onboarding/ui/screens/choose_encrypted_vault_provider_screen.dart
+++ b/lib/features/onboarding/ui/screens/choose_encrypted_vault_provider_screen.dart
@@ -41,9 +41,9 @@ class _ScreenState extends State<_Screen> {
   void _handleProviderTap(BuildContext context, BackupProviderEntity provider) {
     if (provider == backupProviders[0]) {
       context.read<OnboardingBloc>().add(const SelectGoogleDriveRecovery());
-    } else if (provider == backupProviders[2]) {
+    } else if (provider == backupProviders[1]) {
       context.read<OnboardingBloc>().add(const SelectFileSystemRecovery());
-    } else if (provider == backupProviders[3]) {
+    } else if (provider == backupProviders[2]) {
       debugPrint('Selected provider: ${provider.name}, not supported yet');
     }
   }

--- a/lib/features/onboarding/ui/screens/choose_encrypted_vault_provider_screen.dart
+++ b/lib/features/onboarding/ui/screens/choose_encrypted_vault_provider_screen.dart
@@ -13,9 +13,7 @@ import 'package:flutter_bloc/flutter_bloc.dart'
 import 'package:go_router/go_router.dart';
 
 class ChooseVaultProviderScreen extends StatefulWidget {
-  const ChooseVaultProviderScreen({
-    super.key,
-  });
+  const ChooseVaultProviderScreen({super.key});
 
   @override
   State<ChooseVaultProviderScreen> createState() =>
@@ -53,8 +51,9 @@ class _ScreenState extends State<_Screen> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<OnboardingBloc, OnboardingState>(
-      listenWhen: (previous, current) =>
-          current.onboardingStepStatus != previous.onboardingStepStatus,
+      listenWhen:
+          (previous, current) =>
+              current.onboardingStepStatus != previous.onboardingStepStatus,
       listener: (context, state) {
         if (state.onboardingStepStatus == OnboardingStepStatus.success &&
             !state.backupInfo.isCorrupted) {
@@ -66,21 +65,22 @@ class _ScreenState extends State<_Screen> {
 
           context
               .pushNamed(
-            OnboardingSubroute.retrievedBackupInfo.name,
-            extra: state.backupInfo,
-          )
+                OnboardingRoute.retrievedBackupInfo.name,
+                extra: state.backupInfo,
+              )
               .then((_) {
-            // When we return from the route, end the navigation state
-            if (mounted) {
-              bloc.add(const EndTransitioning());
-            }
-          });
+                // When we return from the route, end the navigation state
+                if (mounted) {
+                  bloc.add(const EndTransitioning());
+                }
+              });
         }
       },
       child: BlocBuilder<OnboardingBloc, OnboardingState>(
-        buildWhen: (previous, current) =>
-            current.onboardingStepStatus != previous.onboardingStepStatus ||
-            current.transitioning != previous.transitioning,
+        buildWhen:
+            (previous, current) =>
+                current.onboardingStepStatus != previous.onboardingStepStatus ||
+                current.transitioning != previous.transitioning,
         builder: (context, state) {
           // Show loading screen during loading OR navigation to avoid flickers
           if (state.onboardingStepStatus == OnboardingStepStatus.loading ||
@@ -88,48 +88,51 @@ class _ScreenState extends State<_Screen> {
             return Scaffold(
               backgroundColor: context.colour.onSecondary,
               body: ProgressScreen(
-                title: (state.vaultProvider is GoogleDrive)
-                    ? "You will need to sign-in to Google Drive"
-                    : "Fetching from your device.",
-                description: (state.vaultProvider is GoogleDrive)
-                    ? "Google will ask you to share personal information with this app."
-                    : "",
+                title:
+                    (state.vaultProvider is GoogleDrive)
+                        ? "You will need to sign-in to Google Drive"
+                        : "Fetching from your device.",
+                description:
+                    (state.vaultProvider is GoogleDrive)
+                        ? "Google will ask you to share personal information with this app."
+                        : "",
                 isLoading: true,
-                extras: (state.vaultProvider is GoogleDrive)
-                    ? [
-                        Text.rich(
-                          TextSpan(
-                            children: [
-                              TextSpan(
-                                text: "This information ",
-                                style: context.font.headlineMedium,
-                              ),
-                              TextSpan(
-                                text: "will not ",
-                                style: context.font.headlineLarge?.copyWith(
-                                  fontWeight: FontWeight.bold,
+                extras:
+                    (state.vaultProvider is GoogleDrive)
+                        ? [
+                          Text.rich(
+                            TextSpan(
+                              children: [
+                                TextSpan(
+                                  text: "This information ",
+                                  style: context.font.headlineMedium,
                                 ),
-                              ),
-                              TextSpan(
-                                text: "leave your phone and is ",
-                                style: context.font.headlineMedium,
-                              ),
-                              TextSpan(
-                                text: "never ",
-                                style: context.font.headlineLarge?.copyWith(
-                                  fontWeight: FontWeight.bold,
+                                TextSpan(
+                                  text: "will not ",
+                                  style: context.font.headlineLarge?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
-                              ),
-                              TextSpan(
-                                text: "shared with Bull Bitcoin.",
-                                style: context.font.headlineMedium,
-                              ),
-                            ],
+                                TextSpan(
+                                  text: "leave your phone and is ",
+                                  style: context.font.headlineMedium,
+                                ),
+                                TextSpan(
+                                  text: "never ",
+                                  style: context.font.headlineLarge?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                TextSpan(
+                                  text: "shared with Bull Bitcoin.",
+                                  style: context.font.headlineMedium,
+                                ),
+                              ],
+                            ),
+                            textAlign: TextAlign.center,
                           ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ]
-                    : [],
+                        ]
+                        : [],
               ),
             );
           }
@@ -153,8 +156,8 @@ class _ScreenState extends State<_Screen> {
       body: Padding(
         padding: const EdgeInsets.all(20),
         child: VaultLocations(
-          onProviderSelected: (provider) =>
-              _handleProviderTap(context, provider),
+          onProviderSelected:
+              (provider) => _handleProviderTap(context, provider),
         ),
       ),
     );

--- a/lib/features/onboarding/ui/screens/fetched_backup_info_screen.dart
+++ b/lib/features/onboarding/ui/screens/fetched_backup_info_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/recoverbull/domain/entity/backup_info.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/key_server.dart';
-import 'package:bb_mobile/router.dart';
+import 'package:bb_mobile/features/key_server/ui/key_server_router.dart';
 import 'package:bb_mobile/ui/components/buttons/button.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
@@ -12,10 +12,7 @@ import 'package:intl/intl.dart';
 
 class FetchedBackupInfoScreen extends StatelessWidget {
   final BackupInfo encryptedInfo;
-  const FetchedBackupInfoScreen({
-    super.key,
-    required this.encryptedInfo,
-  });
+  const FetchedBackupInfoScreen({super.key, required this.encryptedInfo});
 
   @override
   Widget build(BuildContext context) {
@@ -48,15 +45,13 @@ class FetchedBackupInfoScreen extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _KeyValueRow(
-                    label: 'Backup ID:',
-                    value: encryptedInfo.id,
-                  ),
+                  _KeyValueRow(label: 'Backup ID:', value: encryptedInfo.id),
                   const Gap(8),
                   _KeyValueRow(
                     label: 'Created at:',
-                    value: DateFormat("yyyy-MMM-dd, HH:mm:ss")
-                        .format(encryptedInfo.createdAt.toLocal()),
+                    value: DateFormat(
+                      "yyyy-MMM-dd, HH:mm:ss",
+                    ).format(encryptedInfo.createdAt.toLocal()),
                   ),
                 ],
               ),
@@ -65,14 +60,15 @@ class FetchedBackupInfoScreen extends StatelessWidget {
             Center(
               child: BBButton.big(
                 label: 'Enter Backup key manually >>',
-                onPressed: () => context.pushNamed(
-                  AppRoute.keyServerFlow.name,
-                  extra: (
-                    encryptedInfo.backupFile,
-                    CurrentKeyServerFlow.recoveryWithBackupKey.name,
-                    true
-                  ),
-                ),
+                onPressed:
+                    () => context.push(
+                      KeyServerRoute.keyServerFlow.path,
+                      extra: (
+                        encryptedInfo.backupFile,
+                        CurrentKeyServerFlow.recoveryWithBackupKey.name,
+                        true,
+                      ),
+                    ),
                 bgColor: Colors.transparent,
                 textStyle: context.font.bodySmall,
                 textColor: context.colour.inversePrimary,
@@ -81,14 +77,15 @@ class FetchedBackupInfoScreen extends StatelessWidget {
             const Gap(16),
             BBButton.big(
               label: 'Decrypt vault',
-              onPressed: () => context.pushNamed(
-                AppRoute.keyServerFlow.name,
-                extra: (
-                  encryptedInfo.backupFile,
-                  CurrentKeyServerFlow.recovery.name,
-                  true
-                ),
-              ),
+              onPressed:
+                  () => context.push(
+                    KeyServerRoute.keyServerFlow.path,
+                    extra: (
+                      encryptedInfo.backupFile,
+                      CurrentKeyServerFlow.recovery.name,
+                      true,
+                    ),
+                  ),
               bgColor: context.colour.secondary,
               textColor: context.colour.onSecondary,
             ),
@@ -110,17 +107,10 @@ class _KeyValueRow extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        BBText(
-          label,
-          style: context.font.bodyMedium,
-        ),
+        BBText(label, style: context.font.bodyMedium),
         const SizedBox(width: 8),
         Expanded(
-          child: BBText(
-            value,
-            style: context.font.bodyLarge,
-            maxLines: 3,
-          ),
+          child: BBText(value, style: context.font.bodyLarge, maxLines: 3),
         ),
       ],
     );

--- a/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
@@ -22,7 +22,7 @@ class OnboardingPhysicalRecovery extends StatelessWidget {
       listener: (context, state) {
         if (state.step == OnboardingStep.recover &&
             state.onboardingStepStatus == OnboardingStepStatus.success) {
-          context.goNamed(OnboardingSubroute.recoverSuccess.name);
+          context.goNamed(OnboardingRoute.recoverSuccess.name);
         }
       },
       child: const Scaffold(

--- a/lib/features/onboarding/ui/screens/recover_options.dart
+++ b/lib/features/onboarding/ui/screens/recover_options.dart
@@ -59,14 +59,16 @@ class _OnboardingRecoverOptionsState extends State<OnboardingRecoverOptions> {
                       description:
                           'Anonymous backup with strong encryption using your cloud.',
                       tag: 'Easy and simple (1 minute)',
-                      onTap: () => {
-                        context.read<KeyServerCubit>().checkConnection(),
-                        context.pushNamed(
-                          OnboardingSubroute.chooseRecoverProvider
-                              .name, // ChooseVaultProviderScreen
-                          extra: true,
-                        ),
-                      },
+                      onTap:
+                          () => {
+                            context.read<KeyServerCubit>().checkConnection(),
+                            context.pushNamed(
+                              OnboardingRoute
+                                  .chooseRecoverProvider
+                                  .name, // ChooseVaultProviderScreen
+                              extra: true,
+                            ),
+                          },
                     ),
                     const Gap(16),
                     BackupOptionCard(
@@ -80,9 +82,10 @@ class _OnboardingRecoverOptionsState extends State<OnboardingRecoverOptions> {
                       description:
                           'Write down 12 words on a piece of paper. Keep them safe and make sure not to lose them.',
                       tag: 'Trustless (take your time)',
-                      onTap: () => context.pushNamed(
-                        OnboardingSubroute.recoverFromPhysical.name,
-                      ),
+                      onTap:
+                          () => context.pushNamed(
+                            OnboardingRoute.recoverFromPhysical.name,
+                          ),
                     ),
                   ],
                 ),
@@ -135,20 +138,13 @@ class BackupOptionCard extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  SizedBox(
-                    width: 36,
-                    height: 45,
-                    child: icon,
-                  ),
+                  SizedBox(width: 36, height: 45, child: icon),
                   const Gap(12),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        BBText(
-                          title,
-                          style: context.font.headlineMedium,
-                        ),
+                        BBText(title, style: context.font.headlineMedium),
                         const Gap(10),
                         BBText(
                           description,

--- a/lib/features/onboarding/ui/widgets/recover_backup_button.dart
+++ b/lib/features/onboarding/ui/widgets/recover_backup_button.dart
@@ -5,9 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 class RecoverWalletButton extends StatelessWidget {
-  const RecoverWalletButton({
-    super.key,
-  });
+  const RecoverWalletButton({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +16,7 @@ class RecoverWalletButton extends StatelessWidget {
       iconData: Icons.history_edu,
       outlined: true,
       onPressed: () {
-        context.goNamed(OnboardingSubroute.recoverOptions.name);
+        context.goNamed(OnboardingRoute.recoverOptions.name);
       },
     );
   }

--- a/lib/features/receive/ui/receive_router.dart
+++ b/lib/features/receive/ui/receive_router.dart
@@ -58,21 +58,8 @@ class ReceiveRouter {
                         current.isPaymentInProgress == true,
                 listener: (context, state) {
                   final bloc = context.read<ReceiveBloc>();
-                  final matched = GoRouterState.of(context).matchedLocation;
                   final type = state.type;
-
-                  // Pop the current route if it's not one of the main receive routes
-                  // This is to prevent the user from going back to the previous screen
-                  // when they select a different network
-                  // and then pressing the back button.
-                  // TODO: this is a temporary fix, we should handle this better in the future
-                  // with proper stateful nested navigation.
                   final location = GoRouter.of(context).state.matchedLocation;
-                  if (location != ReceiveRoute.receiveBitcoin.path &&
-                      location != ReceiveRoute.receiveLightning.path &&
-                      location != ReceiveRoute.receiveLiquid.path) {
-                    context.pop();
-                  }
 
                   // For a Payjoin or Lightning receive, show the payment in progress screen
                   //  when the payjoin is requested or swap is claimable.
@@ -81,13 +68,13 @@ class ReceiveRouter {
                   //  in the context. We need to pass it as an extra parameter.
                   if (type == ReceiveType.bitcoin &&
                       state.payjoin?.status == PayjoinStatus.requested) {
-                    context.pushReplacement(
-                      '$matched/${ReceiveRoute.payjoinInProgress.path}',
+                    context.go(
+                      '$location/${ReceiveRoute.payjoinInProgress.path}',
                       extra: bloc,
                     );
                   } else if (type == ReceiveType.lightning) {
-                    context.pushReplacement(
-                      '$matched/${ReceiveRoute.paymentInProgress.path}',
+                    context.go(
+                      '$location/${ReceiveRoute.paymentInProgress.path}',
                       extra: bloc,
                     );
                   }
@@ -100,7 +87,7 @@ class ReceiveRouter {
                         current.isPaymentReceived == true,
                 listener: (context, state) {
                   final bloc = context.read<ReceiveBloc>();
-                  final matched = GoRouterState.of(context).matchedLocation;
+                  final matched = GoRouter.of(context).state.matchedLocation;
                   final type = state.type;
 
                   final path = switch (type) {
@@ -109,20 +96,7 @@ class ReceiveRouter {
                     _ => '$matched/${ReceiveRoute.details.path}',
                   };
 
-                  // Pop the current route if it's not one of the main receive routes
-                  // This is to prevent the user from going back to the previous screen
-                  // when they select a different network
-                  // and then pressing the back button.
-                  // TODO: this is a temporary fix, we should handle this better in the future
-                  // with proper stateful nested navigation.
-                  final location = GoRouter.of(context).state.matchedLocation;
-                  if (location != ReceiveRoute.receiveBitcoin.path &&
-                      location != ReceiveRoute.receiveLightning.path &&
-                      location != ReceiveRoute.receiveLiquid.path) {
-                    context.pop();
-                  }
-
-                  context.pushReplacement(path, extra: bloc);
+                  context.go(path, extra: bloc);
                 },
               ),
             ],
@@ -134,7 +108,6 @@ class ReceiveRouter {
     routes: [
       // Bitcoin Receive
       GoRoute(
-        name: ReceiveRoute.receiveBitcoin.name,
         path: ReceiveRoute.receiveBitcoin.path,
         pageBuilder: (context, state) {
           // This is the entry route for the bitcoin receive flow when coming from
@@ -197,7 +170,6 @@ class ReceiveRouter {
       ),
       // Lightning receive
       GoRoute(
-        name: ReceiveRoute.receiveLightning.name,
         path: ReceiveRoute.receiveLightning.path,
         pageBuilder: (context, state) {
           // This is the entry route for the lightning receive flow.
@@ -226,48 +198,50 @@ class ReceiveRouter {
                   state.extra is Wallet ? state.extra! as Wallet : null;
               return NoTransitionPage(child: ReceiveQrPage(wallet: wallet));
             },
-          ),
-          GoRoute(
-            path: ReceiveRoute.amount.path,
-            pageBuilder:
-                (context, state) =>
-                    const NoTransitionPage(child: ReceiveAmountScreen()),
-          ),
-          GoRoute(
-            path: ReceiveRoute.paymentInProgress.path,
-            parentNavigatorKey: AppRouter.rootNavigatorKey,
-            builder: (context, state) {
-              final bloc = state.extra! as ReceiveBloc;
-
-              return BlocProvider.value(
-                value: bloc,
-                child: const ReceivePaymentInProgressScreen(),
-              );
-            },
             routes: [
               GoRoute(
-                path: ReceiveRoute.paymentReceived.path,
+                path: ReceiveRoute.amount.path,
+                pageBuilder:
+                    (context, state) =>
+                        const NoTransitionPage(child: ReceiveAmountScreen()),
+              ),
+              GoRoute(
+                path: ReceiveRoute.paymentInProgress.path,
                 parentNavigatorKey: AppRouter.rootNavigatorKey,
                 builder: (context, state) {
                   final bloc = state.extra! as ReceiveBloc;
 
                   return BlocProvider.value(
                     value: bloc,
-                    child: const ReceivePaymentReceivedScreen(),
+                    child: const ReceivePaymentInProgressScreen(),
                   );
                 },
                 routes: [
                   GoRoute(
-                    path: ReceiveRoute.details.path,
+                    path: ReceiveRoute.paymentReceived.path,
                     parentNavigatorKey: AppRouter.rootNavigatorKey,
                     builder: (context, state) {
                       final bloc = state.extra! as ReceiveBloc;
 
                       return BlocProvider.value(
                         value: bloc,
-                        child: const ReceiveDetailsScreen(),
+                        child: const ReceivePaymentReceivedScreen(),
                       );
                     },
+                    routes: [
+                      GoRoute(
+                        path: ReceiveRoute.details.path,
+                        parentNavigatorKey: AppRouter.rootNavigatorKey,
+                        builder: (context, state) {
+                          final bloc = state.extra! as ReceiveBloc;
+
+                          return BlocProvider.value(
+                            value: bloc,
+                            child: const ReceiveDetailsScreen(),
+                          );
+                        },
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -277,7 +251,6 @@ class ReceiveRouter {
       ),
       // Liquid receive
       GoRoute(
-        name: ReceiveRoute.receiveLiquid.name,
         path: ReceiveRoute.receiveLiquid.path,
         pageBuilder: (context, state) {
           // This is the entry route for the liquid receive flow when coming from
@@ -315,4 +288,164 @@ class ReceiveRouter {
       ),
     ],
   );
+
+  // Test example for stateful navigation with independent blocs as we should
+  // have in the future for the receive flow.
+  /*
+  static final statefulTestRoute = StatefulShellRoute.indexedStack(
+    builder: (context, state, shell) => ScaffoldWithNavBar(shell: shell),
+    branches: [
+      // Branch A with Bloc scoped using ShellRoute
+      StatefulShellBranch(
+        initialLocation: '/a',
+        routes: [
+          ShellRoute(
+            builder: (context, state, child) {
+              return BlocProvider(create: (_) => CounterBloc(), child: child);
+            },
+            routes: [
+              GoRoute(
+                path: '/a',
+                builder: (context, state) => const TabAScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'details',
+                    builder: (context, state) => const TabADetailsScreen(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+
+      // Branch B with separate Bloc
+      StatefulShellBranch(
+        routes: [
+          ShellRoute(
+            builder: (context, state, child) {
+              return BlocProvider(create: (_) => CounterBloc(), child: child);
+            },
+            routes: [
+              GoRoute(
+                path: '/b',
+                builder: (context, state) => const TabBScreen(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );*/
 }
+
+/*
+// Components for the stateful test route
+class TabAScreen extends StatelessWidget {
+  const TabAScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.watch<CounterBloc>().state;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tab A')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Counter A: $count', style: const TextStyle(fontSize: 24)),
+            ElevatedButton(
+              onPressed: () => context.read<CounterBloc>().increment(),
+              child: const Text('Increment A'),
+            ),
+            ElevatedButton(
+              onPressed: () => context.push('/a/details'),
+              child: const Text('Go to A Details'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TabADetailsScreen extends StatelessWidget {
+  const TabADetailsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.watch<CounterBloc>().state;
+    return Scaffold(
+      appBar: AppBar(title: const Text('A Details')),
+      body: Center(child: Text('Counter A (in details): $count')),
+    );
+  }
+}
+
+class TabBScreen extends StatelessWidget {
+  const TabBScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.watch<CounterBloc>().state;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tab B')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Counter B: $count', style: const TextStyle(fontSize: 24)),
+            ElevatedButton(
+              onPressed: () => context.read<CounterBloc>().increment(),
+              child: const Text('Increment B'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CounterBloc extends Cubit<int> {
+  CounterBloc() : super(0);
+
+  void increment() => emit(state + 1);
+}
+
+class ScaffoldWithNavBar extends StatelessWidget {
+  final StatefulNavigationShell shell;
+  const ScaffoldWithNavBar({super.key, required this.shell});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Shell Navigation Example'),
+        automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_left),
+          onPressed: () {
+            GoRouter.of(context).state.matchedLocation == '/a' ||
+                    GoRouter.of(context).state.matchedLocation == '/b'
+                ? context.pop()
+                : GoRouter.of(
+                  shell.shellRouteContext.navigatorKey.currentContext!,
+                ).pop();
+          },
+        ),
+      ),
+      body: shell,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: shell.currentIndex,
+        onTap: shell.goBranch,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.looks_one), label: 'Tab A'),
+          BottomNavigationBarItem(icon: Icon(Icons.looks_two), label: 'Tab B'),
+        ],
+      ),
+    );
+  }
+}
+*/

--- a/lib/features/receive/ui/screens/receive_details_screen.dart
+++ b/lib/features/receive/ui/screens/receive_details_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/utils/amount_formatting.dart';
+import 'package:bb_mobile/features/home/ui/home_router.dart';
 import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/features/receive/ui/widgets/receive_transaction_details_table.dart';
 import 'package:bb_mobile/ui/components/badges/transaction_direction_badge.dart';
@@ -29,7 +30,7 @@ class ReceiveDetailsScreen extends StatelessWidget {
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return; // Don't allow back navigation
 
-        context.pop();
+        context.go(HomeRoute.home.path);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -38,7 +39,7 @@ class ReceiveDetailsScreen extends StatelessWidget {
           flexibleSpace: TopBar(
             title: 'Receive',
             actionIcon: Icons.close,
-            onAction: context.pop,
+            onAction: () => context.go(HomeRoute.home.path),
           ),
         ),
         body: SafeArea(
@@ -72,7 +73,9 @@ class ReceiveDetailsScreen extends StatelessWidget {
                   const Gap(16),
                   BBButton.big(
                     label: 'Done',
-                    onPressed: context.pop,
+                    onPressed: () {
+                      context.go(HomeRoute.home.path);
+                    },
                     bgColor: theme.colorScheme.secondary,
                     textColor: theme.colorScheme.onPrimary,
                   ),

--- a/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/utils/amount_formatting.dart';
+import 'package:bb_mobile/features/home/ui/home_router.dart';
 import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/ui/components/buttons/button.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
@@ -20,7 +21,7 @@ class ReceivePayjoinInProgressScreen extends StatelessWidget {
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return; // Don't allow back navigation
 
-        context.pop();
+        context.go(HomeRoute.home.path);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -29,7 +30,7 @@ class ReceivePayjoinInProgressScreen extends StatelessWidget {
           flexibleSpace: TopBar(
             title: 'Receive',
             actionIcon: Icons.close,
-            onAction: context.pop,
+            onAction: () => context.go(HomeRoute.home.path),
           ),
         ),
         body: const PayjoinInProgressPage(),

--- a/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/home/ui/home_router.dart';
 import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
@@ -17,7 +18,7 @@ class ReceivePaymentInProgressScreen extends StatelessWidget {
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return; // Don't allow back navigation
 
-        context.pop();
+        context.go(HomeRoute.home.path);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -26,7 +27,7 @@ class ReceivePaymentInProgressScreen extends StatelessWidget {
           flexibleSpace: TopBar(
             title: 'Receive',
             actionIcon: Icons.close,
-            onAction: context.pop,
+            onAction: () => context.go(HomeRoute.home.path),
           ),
         ),
         body: const PaymentInProgressPage(),

--- a/lib/features/receive/ui/screens/receive_payment_received_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_received_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/home/ui/home_router.dart';
 import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/features/receive/ui/receive_router.dart';
 import 'package:bb_mobile/ui/components/buttons/button.dart';
@@ -18,7 +19,7 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return; // Don't allow back navigation
-        context.pop();
+        context.go(HomeRoute.home.path);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -27,7 +28,7 @@ class ReceivePaymentReceivedScreen extends StatelessWidget {
           flexibleSpace: TopBar(
             title: 'Receive',
             actionIcon: Icons.close,
-            onAction: context.pop,
+            onAction: () => context.go(HomeRoute.home.path),
           ),
         ),
         body: const PaymentReceivedPage(),
@@ -84,7 +85,7 @@ class ReceiveDetailsButton extends StatelessWidget {
         onPressed: () {
           // We need to pass the bloc to the details screen since it is outside
           // of the Shellroute where the bloc is created.
-          context.pushReplacement(
+          context.go(
             '${GoRouterState.of(context).matchedLocation}/${ReceiveRoute.details.path}',
             extra: context.read<ReceiveBloc>(),
           );

--- a/lib/features/receive/ui/screens/receive_scaffold.dart
+++ b/lib/features/receive/ui/screens/receive_scaffold.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/home/ui/home_router.dart';
 import 'package:bb_mobile/features/receive/ui/widgets/receive_network_selection.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:flutter/material.dart';
@@ -23,7 +24,16 @@ class ReceiveScaffold extends StatelessWidget {
         appBar: AppBar(
           forceMaterialTransparency: true,
           automaticallyImplyLeading: false,
-          flexibleSpace: TopBar(title: 'Receive', onBack: context.pop),
+          flexibleSpace: TopBar(
+            title: 'Receive',
+            onBack: () {
+              if (context.canPop()) {
+                context.pop();
+              } else {
+                context.goNamed(HomeRoute.home.name);
+              }
+            },
+          ),
         ),
         body: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/receive/ui/widgets/receive_network_selection.dart
+++ b/lib/features/receive/ui/widgets/receive_network_selection.dart
@@ -21,33 +21,12 @@ class ReceiveNetworkSelection extends StatelessWidget {
                 ? const {'Lightning', 'Liquid'}
                 : const {'Bitcoin', 'Lightning'},
         onSelected: (c) {
-          // Pop the current route if it's not one of the main receive routes
-          // This is to prevent the user from going back to the previous screen
-          // when they select a different network
-          // and then pressing the back button.
-          // TODO: this is a temporary fix, we should handle this better in the future
-          // with proper stateful nested navigation.
-          final location = GoRouter.of(context).state.matchedLocation;
-          if (location != ReceiveRoute.receiveBitcoin.path &&
-              location != ReceiveRoute.receiveLightning.path &&
-              location != ReceiveRoute.receiveLiquid.path) {
-            context.pop();
-          }
           if (c == 'Bitcoin') {
-            context.pushReplacementNamed(
-              ReceiveRoute.receiveBitcoin.name,
-              extra: wallet,
-            );
+            context.go(ReceiveRoute.receiveBitcoin.path, extra: wallet);
           } else if (c == 'Lightning') {
-            context.pushReplacementNamed(
-              ReceiveRoute.receiveLightning.name,
-              extra: wallet,
-            );
+            context.go(ReceiveRoute.receiveLightning.path, extra: wallet);
           } else if (c == 'Liquid') {
-            context.pushReplacementNamed(
-              ReceiveRoute.receiveLiquid.name,
-              extra: wallet,
-            );
+            context.go(ReceiveRoute.receiveLiquid.path, extra: wallet);
           }
         },
         initialValue:

--- a/lib/features/sell/ui/sell_router.dart
+++ b/lib/features/sell/ui/sell_router.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/features/sell/ui/sell_screen.dart';
+import 'package:go_router/go_router.dart';
+
+enum SellRoute {
+  sell('sell');
+
+  final String path;
+
+  const SellRoute(this.path);
+}
+
+class SellRouter {
+  static final route = GoRoute(
+    name: SellRoute.sell.name,
+    path: SellRoute.sell.path,
+    builder: (context, state) => const SellScreen(),
+  );
+}

--- a/lib/features/send/ui/send_router.dart
+++ b/lib/features/send/ui/send_router.dart
@@ -15,7 +15,6 @@ enum SendRoute {
 
 class SendRouter {
   static final route = GoRoute(
-    name: SendRoute.send.name,
     path: SendRoute.send.path,
     builder: (context, state) {
       // Pass a preselected wallet to the send bloc if one is set in the URI

--- a/lib/features/settings/ui/screens/settings_screen.dart
+++ b/lib/features/settings/ui/screens/settings_screen.dart
@@ -29,7 +29,7 @@ class SettingsScreen extends StatelessWidget {
               ListTile(
                 title: Text(context.loc.backupSettingsLabel),
                 onTap: () {
-                  context.pushNamed(SettingsSubroute.backupSettings.name);
+                  context.pushNamed(SettingsRoute.backupSettings.name);
                 },
                 trailing: const Icon(Icons.chevron_right),
               ),
@@ -43,7 +43,7 @@ class SettingsScreen extends StatelessWidget {
               ListTile(
                 title: Text(context.loc.pinCodeSettingsLabel),
                 onTap: () {
-                  context.pushNamed(SettingsSubroute.pinCode.name);
+                  context.pushNamed(SettingsRoute.pinCode.name);
                 },
                 trailing: const Icon(Icons.chevron_right),
               ),

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -3,10 +3,12 @@ import 'package:bb_mobile/features/backup_settings/ui/screens/backup_settings_sc
 import 'package:bb_mobile/features/backup_wallet/ui/backup_wallet_router.dart';
 import 'package:bb_mobile/features/pin_code/ui/pin_code_setting_flow.dart';
 import 'package:bb_mobile/features/settings/ui/screens/language_settings_screen.dart';
+import 'package:bb_mobile/features/settings/ui/screens/settings_screen.dart';
 import 'package:bb_mobile/features/test_wallet_backup/ui/test_wallet_backup_router.dart';
 import 'package:go_router/go_router.dart';
 
-enum SettingsSubroute {
+enum SettingsRoute {
+  settings('settings'),
   pinCode('pin-code'),
   language('language'),
   currency('currency'),
@@ -14,40 +16,45 @@ enum SettingsSubroute {
 
   final String path;
 
-  const SettingsSubroute(this.path);
+  const SettingsRoute(this.path);
 }
 
 class SettingsRouter {
-  static final routes = [
-    GoRoute(
-      name: SettingsSubroute.language.name,
-      path: SettingsSubroute.language.path,
-      builder: (context, state) => const LanguageSettingsScreen(),
-    ),
-    GoRoute(
-      path: SettingsSubroute.pinCode.path,
-      name: SettingsSubroute.pinCode.name,
-      builder: (context, state) => const PinCodeSettingFlow(),
-    ),
-    GoRoute(
-      path: SettingsSubroute.backupSettings.path,
-      name: SettingsSubroute.backupSettings.name,
-      builder: (context, state) => const BackupSettingsScreen(),
-      routes: [
-        ...BackupSettingsSettingsRouter.routes,
-        ...BackupWalletRouter.routes,
-        ...TestWalletBackupRouter.routes,
-      ],
-    ),
+  static final route = GoRoute(
+    name: SettingsRoute.settings.name,
+    path: SettingsRoute.settings.path,
+    builder: (context, state) => const SettingsScreen(),
+    routes: [
+      GoRoute(
+        name: SettingsRoute.language.name,
+        path: SettingsRoute.language.path,
+        builder: (context, state) => const LanguageSettingsScreen(),
+      ),
+      GoRoute(
+        path: SettingsRoute.pinCode.path,
+        name: SettingsRoute.pinCode.name,
+        builder: (context, state) => const PinCodeSettingFlow(),
+      ),
+      GoRoute(
+        path: SettingsRoute.backupSettings.path,
+        name: SettingsRoute.backupSettings.name,
+        builder: (context, state) => const BackupSettingsScreen(),
+        routes: [
+          ...BackupSettingsSettingsRouter.routes,
+          ...BackupWalletRouter.routes,
+          ...TestWalletBackupRouter.routes,
+        ],
+      ),
 
-    /** TODO: Implement CurrencySettingsScreen
+      /** TODO: Implement CurrencySettingsScreen
      * Add the `BitcoinPriceCurrencyChanged` event to the `BitcoinPriceBloc` when the currency is changed successfully on the settings screen
      *  This way the `BitcoinPriceBloc` can fetch the bitcoin price with the new currency and the whole app will be updated with the new currency
      * The global BitcoinPriceBloc can also be used to obtain the available fiat currencies and show them in the CurrencySettingsScreen
     GoRoute(
-      path: SettingsSubroute.currency.path,
-      name: SettingsSubroute.currency.name,
+      path: SettingsRoute.currency.path,
+      name: SettingsRoute.currency.name,
       builder: (context, state) => const CurrencySettingsScreen(),
     ),*/
-  ];
+    ],
+  );
 }

--- a/lib/features/swap/ui/swap_router.dart
+++ b/lib/features/swap/ui/swap_router.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/features/swap/ui/swap_page.dart';
+import 'package:go_router/go_router.dart';
+
+enum SwapRoute {
+  swap('swap');
+
+  final String path;
+
+  const SwapRoute(this.path);
+}
+
+class SwapRouter {
+  static final route = GoRoute(
+    name: SwapRoute.swap.name,
+    path: SwapRoute.swap.path,
+    builder: (context, state) => const SwapFlow(),
+  );
+}

--- a/lib/features/test_wallet_backup/ui/screens/fetched_backup_info_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/fetched_backup_info_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/recoverbull/domain/entity/backup_info.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/key_server.dart';
-import 'package:bb_mobile/router.dart';
+import 'package:bb_mobile/features/key_server/ui/key_server_router.dart';
 import 'package:bb_mobile/ui/components/buttons/button.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
@@ -12,10 +12,7 @@ import 'package:intl/intl.dart';
 
 class FetchedBackupInfoScreen extends StatelessWidget {
   final BackupInfo encryptedInfo;
-  const FetchedBackupInfoScreen({
-    super.key,
-    required this.encryptedInfo,
-  });
+  const FetchedBackupInfoScreen({super.key, required this.encryptedInfo});
 
   @override
   Widget build(BuildContext context) {
@@ -48,15 +45,13 @@ class FetchedBackupInfoScreen extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _KeyValueRow(
-                    label: 'Backup ID:',
-                    value: encryptedInfo.id,
-                  ),
+                  _KeyValueRow(label: 'Backup ID:', value: encryptedInfo.id),
                   const Gap(8),
                   _KeyValueRow(
                     label: 'Created at:',
-                    value: DateFormat("yyyy-MMM-dd, HH:mm:ss")
-                        .format(encryptedInfo.createdAt.toLocal()),
+                    value: DateFormat(
+                      "yyyy-MMM-dd, HH:mm:ss",
+                    ).format(encryptedInfo.createdAt.toLocal()),
                   ),
                 ],
               ),
@@ -65,14 +60,15 @@ class FetchedBackupInfoScreen extends StatelessWidget {
             Center(
               child: BBButton.big(
                 label: 'Enter Backup key manually >>',
-                onPressed: () => context.pushNamed(
-                  AppRoute.keyServerFlow.name,
-                  extra: (
-                    encryptedInfo.backupFile,
-                    CurrentKeyServerFlow.recoveryWithBackupKey.name,
-                    false
-                  ),
-                ),
+                onPressed:
+                    () => context.push(
+                      KeyServerRoute.keyServerFlow.path,
+                      extra: (
+                        encryptedInfo.backupFile,
+                        CurrentKeyServerFlow.recoveryWithBackupKey.name,
+                        false,
+                      ),
+                    ),
                 bgColor: Colors.transparent,
                 textStyle: context.font.bodySmall,
                 textColor: context.colour.inversePrimary,
@@ -81,14 +77,15 @@ class FetchedBackupInfoScreen extends StatelessWidget {
             const Gap(16),
             BBButton.big(
               label: 'Decrypt vault',
-              onPressed: () => context.pushNamed(
-                AppRoute.keyServerFlow.name,
-                extra: (
-                  encryptedInfo.backupFile,
-                  CurrentKeyServerFlow.recovery.name,
-                  false
-                ),
-              ),
+              onPressed:
+                  () => context.push(
+                    KeyServerRoute.keyServerFlow.path,
+                    extra: (
+                      encryptedInfo.backupFile,
+                      CurrentKeyServerFlow.recovery.name,
+                      false,
+                    ),
+                  ),
               bgColor: context.colour.secondary,
               textColor: context.colour.onSecondary,
             ),
@@ -110,17 +107,10 @@ class _KeyValueRow extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        BBText(
-          label,
-          style: context.font.bodyMedium,
-        ),
+        BBText(label, style: context.font.bodyMedium),
         const SizedBox(width: 8),
         Expanded(
-          child: BBText(
-            value,
-            style: context.font.bodyLarge,
-            maxLines: 3,
-          ),
+          child: BBText(value, style: context.font.bodyLarge, maxLines: 3),
         ),
       ],
     );

--- a/lib/features/transactions/ui/transactions_router.dart
+++ b/lib/features/transactions/ui/transactions_router.dart
@@ -9,7 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 enum TransactionsRoute {
-  transactions('/transactions'),
+  transactions('transactions'),
   transactionDetails('details'),
   payjoinDetails('payjoin-details');
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,59 +1,12 @@
-import 'package:bb_mobile/features/app_unlock/ui/pin_code_unlock_screen.dart';
-import 'package:bb_mobile/features/buy/ui/buy_screen.dart';
+import 'package:bb_mobile/features/app_unlock/ui/app_unlock_router.dart';
 import 'package:bb_mobile/features/home/ui/home_router.dart';
-import 'package:bb_mobile/features/key_server/ui/key_server_flow.dart'
-    show KeyServerFlow;
 import 'package:bb_mobile/features/onboarding/ui/onboarding_router.dart';
-import 'package:bb_mobile/features/receive/ui/receive_router.dart';
-import 'package:bb_mobile/features/sell/ui/sell_screen.dart';
-import 'package:bb_mobile/features/send/ui/send_router.dart';
-import 'package:bb_mobile/features/settings/ui/screens/settings_screen.dart';
-import 'package:bb_mobile/features/settings/ui/settings_router.dart';
-import 'package:bb_mobile/features/swap/ui/swap_page.dart';
-import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
-import 'package:bb_mobile/ui/screens/dev_page.dart';
 import 'package:bb_mobile/ui/screens/route_error_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-// These are the main routes of the app, the ones that are not nested in other
-//  routes and so are reachable from anywhere in the app.
-enum AppRoute {
-  onboarding('/onboarding'),
-  appUnlock('/app-unlock'),
-  //todo; move to settings router
-  recoverWallet('/recover-wallet'),
-  recoverImportWallet('/recover-wallet-import'),
-  keyServerFlow('/key-server-flow'),
-  settings('/settings'),
-
-  sell('/sell'),
-  buy('/buy'),
-  swap('/swap'),
-
-  devStart('/dev-start'),
-  devReceive('/dev-receive'),
-  devSend('/dev-send'),
-  devSettings('/dev-settings'),
-  devHome('/dev-home'),
-  devRecover('/dev-recover'),
-  devCreate('/dev-create'),
-  devUnlock('/dev-unlock'),
-  devSwap('/dev-swap'),
-  devSettingsBitcoin('/dev-settings-bitcoin'),
-  devSettingsSecurityPin('/dev-settings-security-pin'),
-  devSettingsLanguage('/dev-settings-language'),
-  devSettingsCurrency('/dev-settings-currency'),
-  devBackup('/dev-backup'),
-  devSettingsSwapHistory('/dev-settings-swap-history'),
-  devSettingsBackup('/dev-settings-backup'),
-  devSettingsTestBackup('/dev-settings-test-backup');
-
-  final String path;
-
-  const AppRoute(this.path);
-}
-
+/// The main router of the app. It is the root of the routing tree and contains
+/// all the entry-level routes.
 class AppRouter {
   static final GlobalKey<NavigatorState> rootNavigatorKey =
       GlobalKey<NavigatorState>();
@@ -61,125 +14,7 @@ class AppRouter {
   static final router = GoRouter(
     navigatorKey: rootNavigatorKey,
     initialLocation: HomeRoute.home.path,
-    routes: [
-      HomeRouter.route,
-      // GoRoute(
-      //   name: AppRoute.onboarding.name,
-      //   path: AppRoute.onboarding.path,
-      //   builder: (context, state) {
-      //     return const OnboardingScreen();
-      //   },
-      // ),
-      GoRoute(
-        name: AppRoute.keyServerFlow.name,
-        path: AppRoute.keyServerFlow.path,
-        builder: (context, state) {
-          final (String? backupFile, String? flow, bool fromOnboarding) =
-              state.extra! as (String?, String?, bool);
-          return KeyServerFlow(
-            backupFile: backupFile,
-            currentFlow: flow,
-            fromOnboarding: fromOnboarding,
-          );
-        },
-      ),
-      GoRoute(
-        name: AppRoute.appUnlock.name,
-        path: AppRoute.appUnlock.path,
-        builder: (context, state) {
-          final onSuccess = state.extra as VoidCallback?;
-
-          return PinCodeUnlockScreen(onSuccess: onSuccess);
-        },
-      ),
-
-      GoRoute(
-        name: AppRoute.settings.name,
-        path: AppRoute.settings.path,
-        builder: (context, state) => const SettingsScreen(),
-        routes: SettingsRouter.routes,
-      ),
-
-      GoRoute(
-        name: AppRoute.sell.name,
-        path: AppRoute.sell.path,
-        builder: (context, state) => const SellScreen(),
-      ),
-      GoRoute(
-        name: AppRoute.buy.name,
-        path: AppRoute.buy.path,
-        builder: (context, state) => const BuyScreen(),
-      ),
-      GoRoute(
-        name: AppRoute.swap.name,
-        path: AppRoute.swap.path,
-        builder: (context, state) => const SwapFlow(),
-      ),
-      TransactionsRouter.route,
-      ReceiveRouter.route,
-      SendRouter.route,
-      DevPages.devStart,
-      OnboardingRouter.route,
-    ],
+    routes: [OnboardingRouter.route, AppUnlockRouter.route, HomeRouter.route],
     errorBuilder: (context, state) => const RouteErrorScreen(),
-  );
-}
-
-class DevPages {
-  static final devStart = GoRoute(
-    name: AppRoute.devStart.name,
-    path: AppRoute.devStart.path,
-    builder:
-        (context, state) => DevPage(
-          title: 'Dev',
-          pages: [
-            DevPageData(route: HomeRoute.home.name, title: 'Home', done: true),
-            DevPageData(
-              route: AppRoute.recoverWallet.name,
-              title: 'Recover',
-              done: true,
-            ),
-            DevPageData(
-              route: AppRoute.onboarding.name,
-              title: 'Onboarding',
-              done: true,
-            ),
-            DevPageData(route: AppRoute.devReceive.name, title: 'Receive'),
-            DevPageData(route: AppRoute.devCreate.name, title: 'Create'),
-            DevPageData(route: AppRoute.devSend.name, title: 'Send'),
-            DevPageData(route: AppRoute.devSettings.name, title: 'Settings'),
-            DevPageData(route: AppRoute.devUnlock.name, title: 'Unlock'),
-            DevPageData(route: AppRoute.devSwap.name, title: 'Swap'),
-            DevPageData(route: AppRoute.devBackup.name, title: 'Backup'),
-            DevPageData(
-              route: AppRoute.devSettingsBitcoin.name,
-              title: 'Settings Bitcoin',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsSecurityPin.name,
-              title: 'Settings Security Pin',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsLanguage.name,
-              title: 'Settings Language',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsCurrency.name,
-              title: 'Settings Currency',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsSwapHistory.name,
-              title: 'Settings Swap History',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsBackup.name,
-              title: 'Settings Backup',
-            ),
-            DevPageData(
-              route: AppRoute.devSettingsTestBackup.name,
-              title: 'Settings Test Backup',
-            ),
-          ],
-        ),
   );
 }

--- a/lib/ui/components/cards/action_card.dart
+++ b/lib/ui/components/cards/action_card.dart
@@ -1,5 +1,5 @@
+import 'package:bb_mobile/features/swap/ui/swap_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
-import 'package:bb_mobile/router.dart';
 import 'package:bb_mobile/ui/components/text/text.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
 import 'package:flutter/material.dart';
@@ -78,7 +78,7 @@ class _ActionRow extends StatelessWidget {
               icon: Assets.icons.swap.path,
               label: 'Swap',
               onPressed: () {
-                context.pushNamed(AppRoute.swap.name);
+                context.pushNamed(SwapRoute.swap.name);
               },
               position: _ButtonPosition.last,
               disabled: false,


### PR DESCRIPTION
- This PR makes sure there is a difference between entry routes and subroutes. Subroutes, that were entry routes as well before this PR, can now be pushed onto entry routes without causing problems like rebuilding of the underlying routes and blocs.
- Makes the HomeBloc locator a factory again, blocs should always use a factory, since they should be closed when out of scope. Using a singleton makes it impossible for the lifecycle management to be done well.
- Clean up of AppRouter and make the subroutes easily reusable. For example the receive and send routes are added easily as subroutes of the home as the selected wallet view.