### PR TITLE
feat: Mnemonic Translator

### DIFF
--- a/lib/features/experimental/experimental_router.dart
+++ b/lib/features/experimental/experimental_router.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/features/experimental/import_watch_only_wallet/import_watch_only_router.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_router.dart';
 import 'package:bb_mobile/features/experimental/psbt_flow/psbt_router.dart';
 import 'package:bb_mobile/features/experimental/scan_signed_tx/scan_signed_tx_router.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,7 @@ class ExperimentalRouterConfig {
       ImportWatchOnlyRouterConfig.route,
       PsbtRouterConfig.route,
       ScanSignedTxRouterConfig.route,
+      MnemonicTranslateRouterConfig.route,
     ],
   );
 }

--- a/lib/features/experimental/mnemonic_translate/domain/usecases/get_default_mnemonic_usecase.dart
+++ b/lib/features/experimental/mnemonic_translate/domain/usecases/get_default_mnemonic_usecase.dart
@@ -1,0 +1,50 @@
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_repository.dart';
+
+class GetDefaultMnemonicUsecase {
+  final WalletRepository _walletRepository;
+  final SeedRepository _seedRepository;
+
+  GetDefaultMnemonicUsecase({
+    required WalletRepository walletRepository,
+    required SeedRepository seedRepository,
+  }) : _walletRepository = walletRepository,
+       _seedRepository = seedRepository;
+
+  Future<(List<String>, String?)> execute() async {
+    try {
+      final defaultWallets = await _walletRepository.getWallets(
+        onlyDefaults: true,
+        onlyBitcoin: true,
+        environment: Environment.mainnet,
+      );
+
+      if (defaultWallets.isEmpty) throw 'No default wallet found';
+
+      final defaultWallet = defaultWallets.first;
+      final defaultFingerprint = defaultWallet.masterFingerprint;
+      final defaultSeed = await _seedRepository.get(defaultFingerprint);
+
+      final defaultSeedModel = SeedModel.fromEntity(defaultSeed);
+      final (mnemonicWords, passphrase) = switch (defaultSeedModel) {
+        MnemonicSeedModel(:final mnemonicWords, :final passphrase) => (
+          mnemonicWords,
+          passphrase,
+        ),
+        _ => throw 'Default seed is not a mnemonic seed',
+      };
+
+      return (mnemonicWords, passphrase);
+    } catch (e) {
+      throw GetDefaultMnemonicException(e.toString());
+    }
+  }
+}
+
+class GetDefaultMnemonicException implements Exception {
+  final String message;
+
+  GetDefaultMnemonicException(this.message);
+}

--- a/lib/features/experimental/mnemonic_translate/mnemonic_translate_cubit.dart
+++ b/lib/features/experimental/mnemonic_translate/mnemonic_translate_cubit.dart
@@ -1,0 +1,58 @@
+import 'package:bb_mobile/features/experimental/mnemonic_translate/domain/usecases/get_default_mnemonic_usecase.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_state.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MnemonicTranslateCubit extends Cubit<MnemonicTranslateState> {
+  final GetDefaultMnemonicUsecase _getDefaultMnemonicUsecase;
+
+  MnemonicTranslateCubit({
+    required GetDefaultMnemonicUsecase getDefaultMnemonicUsecase,
+  }) : _getDefaultMnemonicUsecase = getDefaultMnemonicUsecase,
+       super(const MnemonicTranslateState()) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      final (mnemonic, passphrase) = await _getDefaultMnemonicUsecase.execute();
+      emit(state.copyWith(defaultMnemonic: mnemonic, passphrase: passphrase));
+      translate();
+    } catch (e) {
+      emit(state.copyWith(error: e.toString()));
+    }
+  }
+
+  void translate() {
+    try {
+      final defaultMnemonic = bip39.Mnemonic.fromWords(
+        words: state.defaultMnemonic,
+      );
+
+      final translatedMnemonic = bip39.Mnemonic(
+        defaultMnemonic.entropy,
+        state.selectedLanguage,
+      );
+
+      emit(
+        state.copyWith(
+          translatedMnemonic: translatedMnemonic.words,
+          error: null,
+        ),
+      );
+    } catch (e) {
+      emit(state.copyWith(error: e.toString()));
+    }
+  }
+
+  void onLanguageChanged(bip39.Language? value) {
+    if (value == null) return;
+
+    try {
+      emit(state.copyWith(selectedLanguage: value, error: null));
+      translate();
+    } catch (e) {
+      emit(state.copyWith(error: e.toString()));
+    }
+  }
+}

--- a/lib/features/experimental/mnemonic_translate/mnemonic_translate_locator.dart
+++ b/lib/features/experimental/mnemonic_translate/mnemonic_translate_locator.dart
@@ -1,0 +1,19 @@
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_repository.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/domain/usecases/get_default_mnemonic_usecase.dart';
+import 'package:bb_mobile/locator.dart';
+
+class MnemonicTranslateLocator {
+  static void setup() {
+    registerUsecases();
+  }
+
+  static void registerUsecases() {
+    locator.registerFactory<GetDefaultMnemonicUsecase>(
+      () => GetDefaultMnemonicUsecase(
+        walletRepository: locator<WalletRepository>(),
+        seedRepository: locator<SeedRepository>(),
+      ),
+    );
+  }
+}

--- a/lib/features/experimental/mnemonic_translate/mnemonic_translate_page.dart
+++ b/lib/features/experimental/mnemonic_translate/mnemonic_translate_page.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/domain/usecases/get_default_mnemonic_usecase.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_cubit.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_state.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
+import 'package:bb_mobile/ui/components/text/text.dart';
+import 'package:bb_mobile/ui/themes/app_theme.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+
+class MnemonicTranslatePage extends StatefulWidget {
+  const MnemonicTranslatePage({super.key});
+
+  @override
+  State<MnemonicTranslatePage> createState() => _MnemonicTranslatePageState();
+}
+
+class _MnemonicTranslatePageState extends State<MnemonicTranslatePage>
+    with PrivacyScreen {
+  @override
+  void initState() {
+    super.initState();
+    enableScreenPrivacy();
+  }
+
+  @override
+  void dispose() {
+    unawaited(disableScreenPrivacy());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create:
+          (_) => MnemonicTranslateCubit(
+            getDefaultMnemonicUsecase: locator<GetDefaultMnemonicUsecase>(),
+          ),
+      child: const _MnemonicTranslateView(),
+    );
+  }
+}
+
+class _MnemonicTranslateView extends StatelessWidget {
+  const _MnemonicTranslateView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.colour.secondaryFixed,
+      appBar: AppBar(
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        flexibleSpace: TopBar(
+          title: 'Mnemonic Translator',
+          color: context.colour.secondaryFixed,
+          onBack: () => context.pop(),
+        ),
+      ),
+      body: BlocBuilder<MnemonicTranslateCubit, MnemonicTranslateState>(
+        builder: (context, state) {
+          final cubit = context.read<MnemonicTranslateCubit>();
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _MnemonicDisplay(words: state.translatedMnemonic),
+                const Gap(16),
+                if (state.passphrase != null)
+                  _PassphraseDisplay(passphrase: state.passphrase!),
+                if (state.error != null) ...[
+                  const Gap(8),
+                  Text(
+                    'Error: ${state.error}',
+                    style: context.font.bodyMedium?.copyWith(
+                      color: context.colour.error,
+                    ),
+                  ),
+                ],
+                const Expanded(child: SizedBox()),
+                SizedBox(
+                  height: 56,
+                  child: Material(
+                    elevation: 4,
+                    color: context.colour.onPrimary,
+                    borderRadius: BorderRadius.circular(4.0),
+                    child: Center(
+                      child: DropdownButtonFormField<bip39.Language>(
+                        alignment: Alignment.centerLeft,
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          contentPadding: EdgeInsets.symmetric(
+                            horizontal: 16.0,
+                          ),
+                        ),
+                        icon: Icon(
+                          Icons.keyboard_arrow_down,
+                          color: context.colour.secondary,
+                        ),
+                        value: state.selectedLanguage,
+                        items:
+                            state.languages
+                                .map(
+                                  (language) =>
+                                      DropdownMenuItem<bip39.Language>(
+                                        value: language,
+                                        child: BBText(
+                                          _getLanguageDisplayName(language),
+                                          style: context.font.headlineSmall,
+                                        ),
+                                      ),
+                                )
+                                .toList(),
+                        onChanged: cubit.onLanguageChanged,
+                      ),
+                    ),
+                  ),
+                ),
+                const Gap(32),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _getLanguageDisplayName(bip39.Language language) {
+    switch (language) {
+      case bip39.Language.english:
+        return '🇺🇸 English';
+      case bip39.Language.french:
+        return '🇫🇷 French';
+      case bip39.Language.spanish:
+        return '🇪🇸 Spanish';
+      case bip39.Language.italian:
+        return '🇮🇹 Italian';
+      case bip39.Language.portuguese:
+        return '🇵🇹 Portuguese';
+      case bip39.Language.czech:
+        return '🇨🇿 Czech';
+      case bip39.Language.japanese:
+        return '🇯🇵 Japanese';
+      case bip39.Language.korean:
+        return '🇰🇷 Korean';
+      case bip39.Language.simplifiedChinese:
+        return '🇨🇳 Chinese (Simplified)';
+      case bip39.Language.traditionalChinese:
+        return '🇹🇼 Chinese (Traditional)';
+    }
+  }
+}
+
+class _MnemonicDisplay extends StatelessWidget {
+  const _MnemonicDisplay({required this.words});
+
+  final List<String> words;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: context.colour.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          if (words.length == 12) ...[
+            for (var i = 0; i < 6; i++)
+              Row(
+                children: [
+                  _MnemonicWord(index: i, number: i + 1, word: words[i]),
+                  const Gap(8),
+                  _MnemonicWord(
+                    index: i + 6,
+                    number: i + 7,
+                    word: words[i + 6],
+                  ),
+                ],
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PassphraseDisplay extends StatelessWidget {
+  const _PassphraseDisplay({required this.passphrase});
+
+  final String passphrase;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: context.colour.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: context.colour.surface, width: 0.5),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          BBText(
+            'Passphrase',
+            style: context.font.labelMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colour.surface,
+              letterSpacing: 0,
+              fontSize: 14,
+            ),
+          ),
+          Expanded(
+            child: BBText(
+              passphrase,
+              style: context.font.bodyLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+                fontSize: 14,
+                color: context.colour.secondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MnemonicWord extends StatelessWidget {
+  const _MnemonicWord({
+    required this.index,
+    required this.number,
+    required this.word,
+  });
+
+  final int index;
+  final int number;
+  final String word;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        decoration: BoxDecoration(
+          color: context.colour.onPrimary,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: context.colour.surface),
+        ),
+        height: 41,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Expanded(
+              flex: 2,
+              child: Container(
+                width: 34,
+                height: 34,
+                decoration: BoxDecoration(
+                  color: context.colour.secondary,
+                  border: Border.all(color: context.colour.secondary),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Center(
+                  child: BBText(
+                    number < 10 ? '0$number' : '$number',
+                    style: context.font.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 16,
+                      color: context.colour.onPrimary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const Gap(8),
+            Expanded(
+              flex: 6,
+              child: BBText(
+                word,
+                textAlign: TextAlign.start,
+                maxLines: 1,
+                style: context.font.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 14,
+                  color: context.colour.secondary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/experimental/mnemonic_translate/mnemonic_translate_router.dart
+++ b/lib/features/experimental/mnemonic_translate/mnemonic_translate_router.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_page.dart';
+import 'package:go_router/go_router.dart';
+
+enum MnemonicTranslateRoutes {
+  translator('/mnemonic-translate');
+
+  final String path;
+  const MnemonicTranslateRoutes(this.path);
+}
+
+class MnemonicTranslateRouterConfig {
+  static final route = ShellRoute(
+    builder: (context, state, child) => child,
+    routes: [
+      GoRoute(
+        name: MnemonicTranslateRoutes.translator.name,
+        path: MnemonicTranslateRoutes.translator.path,
+        builder: (context, state) => const MnemonicTranslatePage(),
+      ),
+    ],
+  );
+}

--- a/lib/features/experimental/mnemonic_translate/mnemonic_translate_state.dart
+++ b/lib/features/experimental/mnemonic_translate/mnemonic_translate_state.dart
@@ -1,0 +1,18 @@
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'mnemonic_translate_state.freezed.dart';
+
+@freezed
+abstract class MnemonicTranslateState with _$MnemonicTranslateState {
+  const factory MnemonicTranslateState({
+    @Default([]) List<String> defaultMnemonic,
+    @Default([]) List<String> translatedMnemonic,
+    @Default(null) String? passphrase,
+    @Default(bip39.Language.values) List<bip39.Language> languages,
+    @Default(bip39.Language.english) bip39.Language selectedLanguage,
+    String? error,
+  }) = _MnemonicTranslateState;
+
+  factory MnemonicTranslateState.initial() => const MnemonicTranslateState();
+}

--- a/lib/features/settings/ui/screens/experimental_settings_screen.dart
+++ b/lib/features/settings/ui/screens/experimental_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_router.dart';
 import 'package:bb_mobile/features/experimental/scan_signed_tx/scan_signed_tx_router.dart';
 import 'package:bb_mobile/ui/components/navbar/top_bar.dart';
 import 'package:bb_mobile/ui/themes/app_theme.dart';
@@ -34,6 +35,18 @@ class ExperimentalSettingsScreen extends StatelessWidget {
                   title: const Text('Scan / Paste Transaction'),
                   onTap: () => context.pushNamed(ScanSignedTxRoutes.go.name),
                   trailing: const Icon(Icons.qr_code_scanner),
+                ),
+                ListTile(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                  tileColor: Colors.transparent,
+                  title: const Text('Mnemonic Translator'),
+                  onTap:
+                      () => context.pushNamed(
+                        MnemonicTranslateRoutes.translator.name,
+                      ),
+                  trailing: const Icon(Icons.translate),
                 ),
               ],
             ),

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/features/buy/buy_locator.dart';
 import 'package:bb_mobile/features/electrum_settings/electrum_settings_locator.dart';
 import 'package:bb_mobile/features/exchange/exchange_locator.dart';
 import 'package:bb_mobile/features/experimental/import_watch_only_wallet/import_watch_only_locator.dart';
+import 'package:bb_mobile/features/experimental/mnemonic_translate/mnemonic_translate_locator.dart';
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_locator.dart';
 import 'package:bb_mobile/features/key_server/key_server_locator.dart';
 import 'package:bb_mobile/features/legacy_seed_view/legacy_seed_view_locator.dart';
@@ -58,6 +59,7 @@ class AppLocator {
     BackupWalletLocator.setup();
     TestWalletBackupLocator.setup();
     ImportWatchOnlyLocator.setup();
+    MnemonicTranslateLocator.setup();
     SwapLocator.setup();
     ExchangeLocator.setup();
     BuyLocator.setup();


### PR DESCRIPTION
This feature displays the mnemonic localized in different languages. It is available only to `superuser` accounts in the `Experimental / Danger zone`.

If this feature gets accepted, I can go further and add support for recovering mnemonics in all supported languages **making this wallet one of the few truly supporting multilingual mnemonics**.

This is a first step toward internationalization. [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki) defines and supports wordlists in many languages.

When I implemented [bip39_mnemonic](https://pub.dev/packages/bip39_mnemonic), my main motivation over the existing and unmaintained [bip39](https://pub.dev/packages/bip39) package was to offer proper multi-language support.

I've [tested](https://github.com/ethicnology/dart-bip39-mnemonic/blob/main/test/vectors.dart) all available vectors for each supported language, achieving [100% coverage](https://app.codecov.io/gh/ethicnology/dart-bip39-mnemonic).

https://github.com/user-attachments/assets/3c729bab-ceab-40eb-8f1a-0ace3dc8e960

