### PR TITLE
make selected wallet route a subroute of wallet details route

### DIFF
--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -24,7 +24,7 @@ enum SettingsRoute {
   currency('currency'),
   backupSettings('backup-settings'),
   walletDetailsWalletList('wallet-details'),
-  walletDetailsSelectedWallet('wallet-details/:walletId'),
+  walletDetailsSelectedWallet(':walletId'),
   logs('logs'),
   legacySeeds('legacy-seeds'),
   experimental('experimental-settings');
@@ -64,14 +64,16 @@ class SettingsRouter {
         path: SettingsRoute.walletDetailsWalletList.path,
         name: SettingsRoute.walletDetailsWalletList.name,
         builder: (context, state) => const WalletsListScreen(),
-      ),
-      GoRoute(
-        path: SettingsRoute.walletDetailsSelectedWallet.path,
-        name: SettingsRoute.walletDetailsSelectedWallet.name,
-        builder: (context, state) {
-          final walletId = state.pathParameters['walletId']!;
-          return WalletDetailsScreen(walletId: walletId);
-        },
+        routes: [
+          GoRoute(
+            path: SettingsRoute.walletDetailsSelectedWallet.path,
+            name: SettingsRoute.walletDetailsSelectedWallet.name,
+            builder: (context, state) {
+              final walletId = state.pathParameters['walletId']!;
+              return WalletDetailsScreen(walletId: walletId);
+            },
+          ),
+        ],
       ),
       GoRoute(
         path: SettingsRoute.logs.path,


### PR DESCRIPTION
The screen of a selected wallet should be a subroute of the wallets list for the wallet details setting, to reflect the navigation better and only have the routes of the main settings screen as the first level routes of the settings routes.

Also to avoid having a path that has two times `wallet-details` when going to the selected wallet through the wallets list from settings.