### PR TITLE
fix: testnet unconfirmed balance and swaps showing up on mainnet and vice versa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ app.*.map.json
 .fvm/
 
 today.md
+
+CLAUDE.md
+.zed/

--- a/lib/core/swaps/data/datasources/boltz_storage_datasource.dart
+++ b/lib/core/swaps/data/datasources/boltz_storage_datasource.dart
@@ -109,17 +109,24 @@ class BoltzStorageDatasource {
     };
   }
 
-  Future<List<SwapModel>> fetchAll({String? walletId}) async {
+  Future<List<SwapModel>> fetchAll({String? walletId, bool? isTestnet}) async {
     final all =
-        await _localSwapStorage.managers.swaps
-            .filter(
-              (f) =>
-                  walletId == null
-                      ? const Constant(true) // No filtering
-                      : f.sendWalletId.equals(walletId) |
-                          f.receiveWalletId.equals(walletId),
-            )
-            .get();
+        await _localSwapStorage.managers.swaps.filter((f) {
+          Expression<bool> expr = const Constant(true);
+
+          if (walletId != null) {
+            expr =
+                expr &
+                (f.sendWalletId.equals(walletId) |
+                    f.receiveWalletId.equals(walletId));
+          }
+
+          if (isTestnet != null) {
+            expr = expr & f.isTestnet.equals(isTestnet);
+          }
+
+          return expr;
+        }).get();
     return all.map((e) => SwapModel.fromSqlite(e)).toList();
   }
 

--- a/lib/core/swaps/data/repository/boltz_swap_repository_impl.dart
+++ b/lib/core/swaps/data/repository/boltz_swap_repository_impl.dart
@@ -507,8 +507,8 @@ class BoltzSwapRepositoryImpl implements SwapRepository {
   }
 
   @override
-  Future<List<Swap>> getOngoingSwaps() async {
-    final allSwapModels = await _boltz.storage.fetchAll();
+  Future<List<Swap>> getOngoingSwaps({bool? isTestnet}) async {
+    final allSwapModels = await _boltz.storage.fetchAll(isTestnet: isTestnet);
 
     final allSwaps =
         allSwapModels.map((swapModel) => swapModel.toEntity()).toList();
@@ -529,8 +529,11 @@ class BoltzSwapRepositoryImpl implements SwapRepository {
   }
 
   @override
-  Future<List<Swap>> getAllSwaps({String? walletId}) async {
-    final allSwapModels = await _boltz.storage.fetchAll(walletId: walletId);
+  Future<List<Swap>> getAllSwaps({String? walletId, bool? isTestnet}) async {
+    final allSwapModels = await _boltz.storage.fetchAll(
+      walletId: walletId,
+      isTestnet: isTestnet,
+    );
     final allSwaps =
         allSwapModels.map((swapModel) => swapModel.toEntity()).toList();
     return allSwaps;
@@ -588,8 +591,11 @@ class BoltzSwapRepositoryImpl implements SwapRepository {
   }
 
   @override
-  Future<LnSendSwap?> getSendSwapByInvoice({required String invoice}) async {
-    final allSwaps = await _boltz.storage.fetchAll();
+  Future<LnSendSwap?> getSendSwapByInvoice({
+    required String invoice,
+    bool? isTestnet,
+  }) async {
+    final allSwaps = await _boltz.storage.fetchAll(isTestnet: isTestnet);
     for (final swapModel in allSwaps) {
       final swap = swapModel.toEntity();
       if (swap.type == SwapType.lightningToBitcoin ||

--- a/lib/core/swaps/domain/repositories/swap_repository.dart
+++ b/lib/core/swaps/domain/repositories/swap_repository.dart
@@ -140,8 +140,8 @@ abstract class SwapRepository {
   // SWAP STORAGE UTILITY
   Future<Swap> getSwap({required String swapId});
   Future<LnSendSwap?> getSendSwapByInvoice({required String invoice});
-  Future<List<Swap>> getOngoingSwaps();
-  Future<List<Swap>> getAllSwaps({String? walletId});
+  Future<List<Swap>> getOngoingSwaps({bool? isTestnet});
+  Future<List<Swap>> getAllSwaps({String? walletId, bool? isTestnet});
   Future<Swap?> getSwapByTxId(String txId);
 
   Future<void> updateSwap({required Swap swap});

--- a/lib/core/swaps/domain/usecases/get_swaps_usecase.dart
+++ b/lib/core/swaps/domain/usecases/get_swaps_usecase.dart
@@ -22,8 +22,14 @@ class GetSwapsUsecase {
 
       final swaps =
           isTestnet
-              ? await _testnetSwapRepository.getAllSwaps(walletId: walletId)
-              : await _mainnetSwapRepository.getAllSwaps(walletId: walletId);
+              ? await _testnetSwapRepository.getAllSwaps(
+                walletId: walletId,
+                isTestnet: true,
+              )
+              : await _mainnetSwapRepository.getAllSwaps(
+                walletId: walletId,
+                isTestnet: false,
+              );
       return swaps;
     } catch (e) {
       throw GetSwapsException('Failed to fetch swaps: $e');

--- a/lib/core/wallet/domain/usecases/check_wallet_has_ongoing_swaps_usecase.dart
+++ b/lib/core/wallet/domain/usecases/check_wallet_has_ongoing_swaps_usecase.dart
@@ -23,7 +23,9 @@ class CheckWalletHasOngoingSwapsUsecase {
 
       final swapRepository =
           isTestnet ? _testnetSwapRepository : _mainnetSwapRepository;
-      final ongoingSwaps = await swapRepository.getOngoingSwaps();
+      final ongoingSwaps = await swapRepository.getOngoingSwaps(
+        isTestnet: isTestnet,
+      );
 
       // Check if any ongoing swap is associated with this wallet
       final hasOngoingSwaps = ongoingSwaps.any((swap) {

--- a/lib/features/transactions/domain/usecases/get_transactions_usecase.dart
+++ b/lib/features/transactions/domain/usecases/get_transactions_usecase.dart
@@ -62,7 +62,10 @@ class GetTransactionsUsecase {
               environment: environment,
             ),
             orderRepository.getOrders(),
-            swapRepository.getAllSwaps(walletId: walletId),
+            swapRepository.getAllSwaps(
+              walletId: walletId,
+              isTestnet: environment.isTestnet,
+            ),
           ).wait;
 
       // Add related payjoins, swaps and orders to the broadcasted wallet transactions

--- a/lib/features/wallet/domain/usecase/get_unconfirmed_incoming_balance_usecase.dart
+++ b/lib/features/wallet/domain/usecase/get_unconfirmed_incoming_balance_usecase.dart
@@ -21,7 +21,9 @@ class GetUnconfirmedIncomingBalanceUsecase {
     final swapRepository =
         environment.isTestnet ? _testnetSwapRepository : _mainnetSwapRepository;
 
-    final allSwaps = await swapRepository.getAllSwaps();
+    final allSwaps = await swapRepository.getAllSwaps(
+      isTestnet: environment.isTestnet,
+    );
 
     final filtered = allSwaps.where(
       (s) =>


### PR DESCRIPTION

- Ensures getAllSwaps and related queries are filtered by environment
- Updates BoltzStorageDatasource.fetchAll() to support isTestnet filtering
- Modifies SwapRepository and usecases to pass environment filtering
- Prevents cross-network swap and balance display issues