### PR TITLE
fix: disableFeedback on dialpad for sensitive PINs

### DIFF
--- a/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
+++ b/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
@@ -100,6 +100,7 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                   ),
                   const Gap(130),
                   DialPad(
+                    disableFeedback: true,
                     onNumberPressed:
                         (value) => context.read<AppUnlockBloc>().add(
                           AppUnlockPinCodeNumberAdded(int.parse(value)),

--- a/lib/features/key_server/ui/screens/confirm_screen.dart
+++ b/lib/features/key_server/ui/screens/confirm_screen.dart
@@ -90,6 +90,7 @@ class ConfirmScreen extends StatelessWidget {
               ),
               if (state.authInputType == AuthInputType.pin)
                 DialPad(
+                  disableFeedback: true,
                   onNumberPressed:
                       (e) => context.read<KeyServerCubit>().enterKey(e),
                   onBackspacePressed:

--- a/lib/features/key_server/ui/screens/enter_screen.dart
+++ b/lib/features/key_server/ui/screens/enter_screen.dart
@@ -108,6 +108,7 @@ class EnterScreen extends StatelessWidget {
               ),
               if (state.authInputType == AuthInputType.pin)
                 DialPad(
+                  disableFeedback: true,
                   onNumberPressed:
                       (e) => context.read<KeyServerCubit>().enterKey(e),
                   onBackspacePressed:

--- a/lib/features/key_server/ui/screens/recover_with_secret_screen.dart
+++ b/lib/features/key_server/ui/screens/recover_with_secret_screen.dart
@@ -95,6 +95,7 @@ class RecoverWithSecretScreen extends StatelessWidget {
               ),
               if (state.authInputType == AuthInputType.pin)
                 DialPad(
+                  disableFeedback: true,
                   onNumberPressed:
                       (e) => context.read<KeyServerCubit>().enterKey(e),
                   onBackspacePressed:

--- a/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
@@ -96,6 +96,7 @@ class ChoosePinCodeScreen extends StatelessWidget {
                       () => context.read<PinCodeSettingBloc>().add(
                         const PinCodeSettingPinCodeNumberRemoved(),
                       ),
+                  disableFeedback: true,
                 ),
               ],
             ),

--- a/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
@@ -98,6 +98,7 @@ class ConfirmPinCodeScreen extends StatelessWidget {
                   ),
                   const Gap(130),
                   DialPad(
+                    disableFeedback: true,
                     onNumberPressed:
                         (value) => context.read<PinCodeSettingBloc>().add(
                           PinCodeSettingPinCodeConfirmationNumberAdded(

--- a/lib/ui/components/dialpad/dial_pad.dart
+++ b/lib/ui/components/dialpad/dial_pad.dart
@@ -7,15 +7,19 @@ class DialPad extends StatelessWidget {
     super.key,
     required this.onNumberPressed,
     required this.onBackspacePressed,
+    this.disableFeedback = false,
   });
 
   final Function(String) onNumberPressed;
   final Function() onBackspacePressed;
+  final bool disableFeedback;
 
   Widget numPadButton(BuildContext context, String num) {
     return Expanded(
       child: InkWell(
         onTap: () => onNumberPressed(num),
+        splashFactory: disableFeedback ? NoSplash.splashFactory : null,
+        highlightColor: disableFeedback ? Colors.transparent : null,
         child: SizedBox(
           height: 64,
 
@@ -35,6 +39,8 @@ class DialPad extends StatelessWidget {
     return Expanded(
       child: InkWell(
         onTap: onBackspacePressed,
+        splashFactory: disableFeedback ? NoSplash.splashFactory : null,
+        highlightColor: disableFeedback ? Colors.transparent : null,
         child: SizedBox(
           height: 64,
 


### PR DESCRIPTION
Adds a field to DialPad to allow disableFeedback. Defaults to false. Set to true for all sensitive features that use DialPad.