### PR TITLE
Buy amount UI improvements

### DIFF
--- a/lib/core/exchange/data/models/user_summary_model.dart
+++ b/lib/core/exchange/data/models/user_summary_model.dart
@@ -5,7 +5,7 @@ class UserSummaryModel {
   final String email;
   final List<UserBalanceModel> balances;
   final String language;
-  final String currency;
+  final String? currency;
   final UserDcaModel dca;
   final UserAutoBuyModel autoBuy;
 
@@ -16,7 +16,7 @@ class UserSummaryModel {
     required this.email,
     required this.balances,
     required this.language,
-    required this.currency,
+    this.currency,
     required this.dca,
     required this.autoBuy,
   });
@@ -34,7 +34,7 @@ class UserSummaryModel {
               .map((e) => UserBalanceModel.fromJson(e as Map<String, dynamic>))
               .toList(),
       language: json['language'] as String,
-      currency: json['currency'] as String,
+      currency: json['currency'] as String?,
       dca: UserDcaModel.fromJson(json['dca'] as Map<String, dynamic>),
       autoBuy: UserAutoBuyModel.fromJson(
         json['autoBuy'] as Map<String, dynamic>,

--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -4,12 +4,13 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'order.freezed.dart';
 
 enum FiatCurrency {
-  cad('CAD'),
-  eur('EUR'),
-  mxn('MXN');
+  cad('CAD', decimals: 2),
+  eur('EUR', decimals: 2),
+  mxn('MXN', decimals: 2);
 
-  const FiatCurrency(this.code);
+  const FiatCurrency(this.code, {required this.decimals});
   final String code;
+  final int decimals;
 
   static FiatCurrency fromCode(String code) {
     switch (code.toUpperCase()) {

--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -6,7 +6,9 @@ part 'order.freezed.dart';
 enum FiatCurrency {
   cad('CAD', decimals: 2),
   eur('EUR', decimals: 2),
-  mxn('MXN', decimals: 2);
+  mxn('MXN', decimals: 2),
+  crc('CRC', decimals: 2),
+  usd('USD', decimals: 2);
 
   const FiatCurrency(this.code, {required this.decimals});
   final String code;
@@ -20,6 +22,10 @@ enum FiatCurrency {
         return FiatCurrency.eur;
       case 'MXN':
         return FiatCurrency.mxn;
+      case 'CRC':
+        return FiatCurrency.crc;
+      case 'USD':
+        return FiatCurrency.usd;
       default:
         throw Exception('Unknown FiatCurrency: $code');
     }

--- a/lib/core/exchange/domain/entity/user_summary.dart
+++ b/lib/core/exchange/domain/entity/user_summary.dart
@@ -157,7 +157,7 @@ class UserSummary {
   final String email;
   final List<UserBalance> balances;
   final String language;
-  final String currency;
+  final String? currency;
   final UserDca dca;
   final UserAutoBuy autoBuy;
 
@@ -168,7 +168,7 @@ class UserSummary {
     required this.email,
     required this.balances,
     required this.language,
-    required this.currency,
+    this.currency,
     required this.dca,
     required this.autoBuy,
   });
@@ -223,4 +223,8 @@ class UserSummary {
       currency.hashCode ^
       dca.hashCode ^
       autoBuy.hashCode;
+
+  bool get isFullyVerifiedKycLevel => groups.contains('KYC_IDENTITY_VERIFIED');
+  bool get isLightKycLevel => groups.contains('KYC_LIGHT_VERIFICATION');
+  bool get isLimitedKycLevel => groups.contains('KYC_LIMITED_VERIFICATION');
 }

--- a/lib/core/utils/amount_formatting.dart
+++ b/lib/core/utils/amount_formatting.dart
@@ -34,11 +34,19 @@ class FormatAmount {
     }
   }
 
-  static String fiat(double fiat, String currencyCode) {
-    final currencyFormatter = NumberFormat.currency(
-      name: currencyCode,
-      customPattern: '#,##0.00 ¤',
-    );
+  static String fiat(
+    double fiat,
+    String currencyCode, {
+    bool simpleFormat = false,
+  }) {
+    final currencyFormatter =
+        simpleFormat
+            ? NumberFormat.simpleCurrency(name: currencyCode)
+            : NumberFormat.currency(
+              name: currencyCode,
+              customPattern: '#,##0.00 ¤',
+            );
+
     return currencyFormatter.format(fiat);
   }
 }

--- a/lib/features/buy/buy_locator.dart
+++ b/lib/features/buy/buy_locator.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_new_receive_address_use_case.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/buy/domain/usecases/accelerate_buy_order_usecase.dart';
@@ -28,6 +29,7 @@ class BuyLocator {
         convertSatsToCurrencyAmountUsecase:
             locator<ConvertSatsToCurrencyAmountUsecase>(),
         accelerateBuyOrderUsecase: locator<AccelerateBuyOrderUsecase>(),
+        getSettingsUsecase: locator<GetSettingsUsecase>(),
       ),
     );
   }

--- a/lib/features/buy/presentation/buy_bloc.dart
+++ b/lib/features/buy/presentation/buy_bloc.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_new_receive_address_use_case.dart';
@@ -33,6 +34,7 @@ class BuyBloc extends Bloc<BuyEvent, BuyState> {
     required ConvertSatsToCurrencyAmountUsecase
     convertSatsToCurrencyAmountUsecase,
     required AccelerateBuyOrderUsecase accelerateBuyOrderUsecase,
+    required GetSettingsUsecase getSettingsUsecase,
   }) : _getWalletsUsecase = getWalletsUsecase,
        _getNewReceiveAddressUsecase = getNewReceiveAddressUsecase,
        _getExchangeUserSummaryUsecase = getExchangeUserSummaryUsecase,
@@ -42,6 +44,7 @@ class BuyBloc extends Bloc<BuyEvent, BuyState> {
        _getNetworkFeesUsecase = getNetworkFeesUsecase,
        _convertSatsToCurrencyAmountUsecase = convertSatsToCurrencyAmountUsecase,
        _accelerateBuyOrderUsecase = accelerateBuyOrderUsecase,
+       _getSettingsUsecase = getSettingsUsecase,
        super(const BuyState()) {
     on<_BuyStarted>(_onStarted);
     on<_BuyAmountInputChanged>(_onAmountInputChanged);
@@ -64,16 +67,20 @@ class BuyBloc extends Bloc<BuyEvent, BuyState> {
   final GetNetworkFeesUsecase _getNetworkFeesUsecase;
   final ConvertSatsToCurrencyAmountUsecase _convertSatsToCurrencyAmountUsecase;
   final AccelerateBuyOrderUsecase _accelerateBuyOrderUsecase;
+  final GetSettingsUsecase _getSettingsUsecase;
 
   Future<void> _onStarted(_BuyStarted event, Emitter<BuyState> emit) async {
     try {
       final summary = await _getExchangeUserSummaryUsecase.execute();
+      final currencyInput =
+          summary.currency ??
+          (await _getSettingsUsecase.execute()).currencyCode;
       emit(
         state.copyWith(
           userSummary: summary,
           apiKeyException: null,
           getUserSummaryException: null,
-          currencyInput: summary.currency,
+          currencyInput: currencyInput,
         ),
       );
 

--- a/lib/features/buy/presentation/buy_event.dart
+++ b/lib/features/buy/presentation/buy_event.dart
@@ -7,6 +7,8 @@ sealed class BuyEvent with _$BuyEvent {
       _BuyAmountInputChanged;
   const factory BuyEvent.currencyInputChanged(String currencyCode) =
       _BuyCurrencyInputChanged;
+  const factory BuyEvent.fiatCurrencyInputToggled() =
+      _BuyFiatCurrencyInputToggled;
   const factory BuyEvent.selectedWalletChanged(Wallet? wallet) =
       _BuySelectedWalletChanged;
   const factory BuyEvent.bitcoinAddressInputChanged(String bitcoinAddress) =

--- a/lib/features/buy/presentation/buy_state.dart
+++ b/lib/features/buy/presentation/buy_state.dart
@@ -8,8 +8,10 @@ sealed class BuyState with _$BuyState {
     ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
     @Default('') String amountInput,
+    @Default(true) bool isFiatCurrencyInput,
+    @Default(BitcoinUnit.btc) BitcoinUnit bitcoinUnit,
     @Default('') String currencyInput,
-    double? exchangeRate,
+    @Default(0.0) double exchangeRate,
     @Default([]) List<Wallet> wallets,
     GetWalletsException? getWalletsException,
     Wallet? selectedWallet,
@@ -39,7 +41,41 @@ sealed class BuyState with _$BuyState {
 
   double? get balance => balances[currencyInput];
 
-  double? get amount => double.tryParse(amountInput.replaceAll(',', '.'));
+  int? get maxAmountSat =>
+      balance != null && exchangeRate > 0
+          ? (balance! / exchangeRate * 1e8).round()
+          : null;
+
+  double? get amount =>
+      isFiatCurrencyInput
+          ? _truncateToDecimals(
+            double.tryParse(amountInput.replaceAll(',', '.').trim()) ?? 0,
+            currency?.decimals ?? 2,
+          )
+          : amountBtc != null
+          ? _truncateToDecimals(
+            amountBtc! * exchangeRate,
+            currency?.decimals ?? 2,
+          )
+          : null;
+
+  double? get amountBtc =>
+      isFiatCurrencyInput
+          ? amount != null && exchangeRate > 0
+              ? amount! / exchangeRate
+              : null
+          : bitcoinUnit == BitcoinUnit.btc
+          ? double.tryParse(amountInput.replaceAll(',', '.').trim())
+          : amountSat != null
+          ? amountSat! * 1e-8
+          : null;
+
+  int? get amountSat =>
+      !isFiatCurrencyInput && bitcoinUnit == BitcoinUnit.sats
+          ? int.tryParse(amountInput.trim())
+          : amountBtc != null
+          ? (amountBtc! * 1e8).round()
+          : null;
 
   FiatCurrency? get currency =>
       currencyInput.isNotEmpty ? FiatCurrency.fromCode(currencyInput) : null;
@@ -49,7 +85,11 @@ sealed class BuyState with _$BuyState {
   }
 
   bool get isBalanceTooLow {
-    return balance == null || (amount ?? 0) > balance!;
+    return balance != null &&
+        ((amount ?? 0) > balance! ||
+            maxAmountSat != null &&
+                amountSat != null &&
+                amountSat! > maxAmountSat!);
   }
 
   bool get isValidDestination {
@@ -58,5 +98,10 @@ sealed class BuyState with _$BuyState {
 
   bool get canCreateOrder {
     return !isAmountTooLow && !isBalanceTooLow && isValidDestination;
+  }
+
+  double _truncateToDecimals(double value, int decimals) {
+    final factor = math.pow(10, decimals);
+    return (value * factor).truncate() / factor;
   }
 }

--- a/lib/features/buy/presentation/buy_state.dart
+++ b/lib/features/buy/presentation/buy_state.dart
@@ -39,7 +39,7 @@ sealed class BuyState with _$BuyState {
 
   double? get balance => balances[currencyInput];
 
-  double? get amount => double.tryParse(amountInput);
+  double? get amount => double.tryParse(amountInput.replaceAll(',', '.'));
 
   FiatCurrency? get currency =>
       currencyInput.isNotEmpty ? FiatCurrency.fromCode(currencyInput) : null;

--- a/lib/features/buy/ui/screens/buy_accelerate_screen.dart
+++ b/lib/features/buy/ui/screens/buy_accelerate_screen.dart
@@ -42,7 +42,7 @@ class BuyAccelerateScreen extends StatelessWidget {
       (BuyBloc bloc) => bloc.state.exchangeRate,
     );
     final absoluteFeeFiatEstimate =
-        absoluteFee != null && exchangeRate != null
+        absoluteFee != null && exchangeRate > 0
             ? ConvertAmount.satsToFiat(absoluteFee, exchangeRate)
             : null;
     final formattedFeeFiatEstimate =

--- a/lib/features/buy/ui/screens/buy_input_screen.dart
+++ b/lib/features/buy/ui/screens/buy_input_screen.dart
@@ -30,6 +30,9 @@ class BuyInputScreen extends StatelessWidget {
       final error = bloc.state.createOrderBuyError;
       return error is AboveMaxAmountBuyError ? error : null;
     });
+    final insufficientFunds = context.select(
+      (BuyBloc bloc) => bloc.state.isBalanceTooLow,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -83,6 +86,13 @@ class BuyInputScreen extends StatelessWidget {
                         ),
                       ),
                     ],
+                  ),
+                if (insufficientFunds)
+                  Text(
+                    'You do not have enough balance to create this order.',
+                    style: context.font.bodyMedium?.copyWith(
+                      color: context.colour.error,
+                    ),
                   ),
                 const Gap(16),
                 BBButton.big(

--- a/lib/features/exchange/presentation/exchange_state.dart
+++ b/lib/features/exchange/presentation/exchange_state.dart
@@ -27,11 +27,9 @@ abstract class ExchangeState with _$ExchangeState {
   bool get hasUser => userSummary != null;
 
   bool get isFullyVerifiedKycLevel =>
-      userSummary?.groups.contains('KYC_IDENTITY_VERIFIED') ?? false;
-  bool get isLightKycLevel =>
-      userSummary?.groups.contains('KYC_LIGHT_VERIFICATION') ?? false;
-  bool get isLimitedKycLevel =>
-      userSummary?.groups.contains('KYC_LIMITED_VERIFICATION') ?? false;
+      userSummary?.isFullyVerifiedKycLevel ?? false;
+  bool get isLightKycLevel => userSummary?.isLightKycLevel ?? false;
+  bool get isLimitedKycLevel => userSummary?.isLimitedKycLevel ?? false;
 
   List<UserBalance> get balances =>
       userSummary?.balances.where((b) => b.amount > 0).toList() ?? [];


### PR DESCRIPTION
This PR mainly updates the amount input component to be visually more equal to the web exchange and to be able to see the exchange rate and input an amount in bitcoin/sats as well.

It does some other minor refactors for the exchange and amount formatting like:

- Changing the currency in user summary to nullable, since a user that just signed up doesn't seem to have a currency yet and this was throwing an error.
- Show a 0 balance for a newly created user without balances and without a set currency in the set currency of the wallet
- Adding a parameter to the fiat amount formatting to show the amount with the symbol instead of the code
- Adding more currencies to the Order fiat currencies, since balances are returned for them too.