### PR TITLE
refactor: increase top buttons size to ease tapping

### DIFF
--- a/lib/core/widgets/navbar/top_bar_bull_logo.dart
+++ b/lib/core/widgets/navbar/top_bar_bull_logo.dart
@@ -40,8 +40,8 @@ class _BullLogo extends StatelessWidget {
         onTap: onTap,
         child: Image.asset(
           Assets.logos.bbLogoSmall.path,
-          width: 32,
-          height: 32,
+          width: 40,
+          height: 40,
         ),
       ); //.animate(delay: 300.ms).fadeIn();
     }

--- a/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
 class WalletHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -26,21 +27,21 @@ class WalletHomeAppBar extends StatelessWidget implements PreferredSizeWidget {
       actionsPadding: const EdgeInsets.only(right: 16),
       actions: [
         IconButton(
-          padding: const EdgeInsets.only(right: 16),
           onPressed: () {
             context.pushNamed(TransactionsRoute.transactions.name);
           },
           visualDensity: VisualDensity.compact,
           color: context.colour.onPrimary,
-          iconSize: 24,
+          iconSize: 32,
           icon: const Icon(Icons.history),
         ),
+        const Gap(16),
         InkWell(
           onTap: () => context.pushNamed(SettingsRoute.settings.name),
           child: Image.asset(
             Assets.icons.settingsLine.path,
-            width: 24,
-            height: 24,
+            width: 32,
+            height: 32,
             color: context.colour.onPrimary,
           ),
         ),


### PR DESCRIPTION
The size of icons are too smalls, not easy to tap them on real device
This PR slightly increase there size

before
<img width="1320" height="2868" alt="simulator_screenshot_5AFE825D-9ABD-48E2-BCA6-AC4B58DD6B4A" src="https://github.com/user-attachments/assets/e896edde-6055-4c66-8778-da59679a1d5a" />

after
<img width="1320" height="2868" alt="simulator_screenshot_BD4C42F7-D4FA-4EF2-B4D8-5B0B631A1DBA" src="https://github.com/user-attachments/assets/e4b83d2f-f6ba-4d96-9593-9e3eb3d35385" />
