### PR TITLE
share instance across isolates and use WAL pragma

### DIFF
--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -42,7 +42,19 @@ class SqliteDatabase extends _$SqliteDatabase {
   static QueryExecutor _openConnection() {
     return driftDatabase(
       name: 'bullbitcoin_sqlite',
-      native: const DriftNativeOptions(),
+      native: DriftNativeOptions(
+        /// When using a shared instance, stream queries synchronize across the two
+        /// isolates. Also, drift then manages concurrent access to the database,
+        /// preventing "database is locked" errors due to concurrent transactions.
+        shareAcrossIsolates: true,
+        setup: (database) {
+          // This is important, as accessing the database across threads otherwise
+          // causes "database locked" errors.
+          // With write-ahead logging (WAL) enabled, a single writer and multiple
+          // readers can operate on the database in parallel.
+          database.execute('pragma journal_mode = WAL;');
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
This PR adds two configurations that could prevent `database locked` errors as mentioned in the Drift docs or from comments in the drift code.

I did a lot of hot reloads, which was when I was experiencing the error in dev before, and until now, with these configuration, I haven't had the error anymore.