### PR TITLE
feat: prevent errors due to mixed usage of `encryptedSharedPreferences`

### DIFF
--- a/lib/core/seed/data/repository/seed_repository.dart
+++ b/lib/core/seed/data/repository/seed_repository.dart
@@ -2,9 +2,9 @@ import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/impl/secure_storage_data_source_impl.dart';
+import 'package:bb_mobile/core/storage/secure_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class SeedRepository {
   final SeedDatasource _source;
@@ -52,9 +52,7 @@ class _IsolateParams {
 Future<Seed> _getSeedInIsolate(_IsolateParams params) async {
   try {
     BackgroundIsolateBinaryMessenger.ensureInitialized(params.rootToken);
-    final secureStorage = SecureStorageDatasourceImpl(
-      const FlutterSecureStorage(),
-    );
+    final secureStorage = SecureStorageDatasourceImpl(SecureStorage.init());
     final seedDatasource = SeedDatasource(secureStorage: secureStorage);
     final model = await seedDatasource.get(params.fingerprint);
     return model.toEntity();

--- a/lib/core/storage/migrations/005_hive_to_sqlite/old/old_hive_datasource.dart
+++ b/lib/core/storage/migrations/005_hive_to_sqlite/old/old_hive_datasource.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_storage_keys.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:bb_mobile/core/storage/secure_storage.dart';
 import 'package:hive/hive.dart' show Box, Hive, HiveAesCipher;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
@@ -14,7 +14,8 @@ class OldHiveDatasource {
   static Future<Box> getBox() async {
     final dir = await getApplicationDocumentsDirectory();
     Hive.init(dir.path);
-    final password = await const FlutterSecureStorage().read(
+    final secureStorage = SecureStorage.init();
+    final password = await secureStorage.read(
       key: OldStorageKeys.hiveEncryption.name,
     );
 

--- a/lib/core/storage/migrations/005_hive_to_sqlite/secure_storage_datasource.dart
+++ b/lib/core/storage/migrations/005_hive_to_sqlite/secure_storage_datasource.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_seed.dart';
+import 'package:bb_mobile/core/storage/secure_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class MigrationSecureStorageDatasource {
   final FlutterSecureStorage _storage;
 
-  MigrationSecureStorageDatasource() : _storage = const FlutterSecureStorage();
+  MigrationSecureStorageDatasource() : _storage = SecureStorage.init();
 
   Future<void> store({required String key, required String value}) async {
     await _storage.write(key: key, value: value);

--- a/lib/core/storage/secure_storage.dart
+++ b/lib/core/storage/secure_storage.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorage {
+  static FlutterSecureStorage init() {
+    return const FlutterSecureStorage(
+      aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    );
+  }
+}

--- a/lib/core/storage/storage_locator.dart
+++ b/lib/core/storage/storage_locator.dart
@@ -9,16 +9,16 @@ import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/old_see
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/old_wallet_repository.dart';
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/secure_storage_datasource.dart';
 import 'package:bb_mobile/core/storage/requires_migration_usecase.dart';
+import 'package:bb_mobile/core/storage/secure_storage.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/locator.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class StorageLocator {
   static Future<void> registerDatasources() async {
     locator.registerLazySingleton<KeyValueStorageDatasource<String>>(
-      () => SecureStorageDatasourceImpl(const FlutterSecureStorage()),
+      () => SecureStorageDatasourceImpl(SecureStorage.init()),
       instanceName: LocatorInstanceNameConstants.secureStorageDatasource,
     );
     locator.registerLazySingleton<MigrationSecureStorageDatasource>(


### PR DESCRIPTION
related: 
_A long outstanding problem with the Android part of this package is the deprecated usage of older cryptography usage (CBC with PKCS5/PKCS7 padding) for SDK < 23, and the already deprecated JetSec Crypto library that is being used for the current implementation of SecureSharedPreferences.
To fix these issues, i am moving to a custom implementation of the JetSec Crypto library, and removing all other deprecated methods of encrypting the shared preferences. This requires the minimum SDK to be raised from 21 to 23.
I am currently testing the new implementation in the [branch ](https://github.com/mogol/flutter_secure_storage/tree/version-10)version-10. Any help is greatly appreciated._

https://pub.dev/packages/flutter_secure_storage#note-usage-of-encryptedsharedpreference