### PR TITLE
fix: downsizing mnemonic length reset the focus

### DIFF
--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -320,6 +320,7 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
     if (oldWidget.words.length != widget.words.length) {
       _disposeFocusNodes();
       _initializeFocusNodes();
+      _focusedDisplayIndex = 0;
     }
   }
 


### PR DESCRIPTION
1. Select 24 words length mnemonic
2. Fill the mnemonic with words
3. Switch to 12 words
4. The app crash

This fix reset the focus when the mnemonic length is modified