### PR TITLE
Exchange settings no auth

### DIFF
--- a/lib/features/exchange/ui/exchange_router.dart
+++ b/lib/features/exchange/ui/exchange_router.dart
@@ -22,7 +22,7 @@ class ExchangeRouter {
       name: ExchangeRoute.exchangeHome.name,
       path: ExchangeRoute.exchangeHome.path,
       redirect: (context, state) {
-        // Redirect to auth screen if API key is invalid
+        // Redirect to auth screen if the user is logged out
         final notLoggedIn = context.read<ExchangeCubit>().state.notLoggedIn;
         if (notLoggedIn) {
           return ExchangeRoute.exchangeAuth.path;
@@ -32,16 +32,7 @@ class ExchangeRouter {
       pageBuilder: (context, state) {
         return NoTransitionPage(
           key: state.pageKey,
-          child: BlocListener<ExchangeCubit, ExchangeState>(
-            listenWhen:
-                (previous, current) =>
-                    !previous.notLoggedIn && current.notLoggedIn,
-            listener: (context, state) {
-              // Redirect to auth screen if the API key becomes invalid
-              context.goNamed(ExchangeRoute.exchangeAuth.name);
-            },
-            child: const ExchangeHomeScreen(),
-          ),
+          child: const ExchangeHomeScreen(),
         );
       },
       routes: [

--- a/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
+++ b/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
@@ -15,13 +15,6 @@ class ExchangeSettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = context.select((ExchangeCubit cubit) => cubit.state);
 
-    // Redirect to exchange auth if user is not logged in
-    if (state.notLoggedIn) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        context.goNamed(ExchangeRoute.exchangeAuth.name);
-      });
-    }
-
     return Scaffold(
       appBar: AppBar(title: const Text('Exchange Settings')),
       body: SafeArea(
@@ -135,22 +128,31 @@ class ExchangeSettingsScreen extends StatelessWidget {
                     }
                   },
                 ),
-                SettingsEntryItem(
-                  icon: Icons.logout,
-                  title: 'Log Out',
-                  onTap: () {
-                    if (state.notLoggedIn) {
-                      NotLoggedInBottomSheet.show(context);
-                    } else {
-                      LogoutConfirmationBottomSheet.show(
-                        context,
-                        onConfirm: () async {
-                          await context.read<ExchangeCubit>().logout();
-                        },
-                      );
-                    }
-                  },
-                ),
+                if (state.notLoggedIn)
+                  SettingsEntryItem(
+                    icon: Icons.login,
+                    title: 'Log In',
+                    onTap: () {
+                      context.goNamed(ExchangeRoute.exchangeAuth.name);
+                    },
+                  ),
+                if (!state.notLoggedIn)
+                  SettingsEntryItem(
+                    icon: Icons.logout,
+                    title: 'Log Out',
+                    onTap: () {
+                      if (state.notLoggedIn) {
+                        NotLoggedInBottomSheet.show(context);
+                      } else {
+                        LogoutConfirmationBottomSheet.show(
+                          context,
+                          onConfirm: () async {
+                            await context.read<ExchangeCubit>().logout();
+                          },
+                        );
+                      }
+                    },
+                  ),
               ],
             ),
           ),

--- a/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
+++ b/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:bb_mobile/core/widgets/logout_confirmation_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/not_logged_in_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
-import 'package:bb_mobile/features/exchange/presentation/exchange_state.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter/material.dart';

--- a/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
+++ b/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
@@ -2,6 +2,8 @@ import 'package:bb_mobile/core/widgets/logout_confirmation_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/not_logged_in_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
+import 'package:bb_mobile/features/exchange/presentation/exchange_state.dart';
+import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,6 +15,13 @@ class ExchangeSettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final state = context.select((ExchangeCubit cubit) => cubit.state);
+
+    // Redirect to exchange auth if user is not logged in
+    if (state.notLoggedIn) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        context.goNamed(ExchangeRoute.exchangeAuth.name);
+      });
+    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('Exchange Settings')),

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -86,6 +86,7 @@ class SettingsRouter {
       GoRoute(
         name: SettingsRoute.exchangeSettings.name,
         path: SettingsRoute.exchangeSettings.path,
+
         builder: (context, state) => const ExchangeSettingsScreen(),
       ),
       GoRoute(

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -3,6 +3,9 @@ import 'package:bb_mobile/features/address_view/ui/screens/addresses_screen.dart
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:bb_mobile/features/backup_settings/ui/screens/backup_settings_screen.dart';
 import 'package:bb_mobile/features/backup_wallet/ui/backup_wallet_router.dart';
+import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
+import 'package:bb_mobile/features/exchange/presentation/exchange_state.dart';
+import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/experimental/experimental_router.dart';
 import 'package:bb_mobile/features/legacy_seed_view/presentation/legacy_seed_view_cubit.dart';
 import 'package:bb_mobile/features/legacy_seed_view/ui/legacy_seed_view_screen.dart';
@@ -87,7 +90,17 @@ class SettingsRouter {
         name: SettingsRoute.exchangeSettings.name,
         path: SettingsRoute.exchangeSettings.path,
 
-        builder: (context, state) => const ExchangeSettingsScreen(),
+        builder:
+            (context, state) => BlocListener<ExchangeCubit, ExchangeState>(
+              listenWhen:
+                  (previous, current) =>
+                      !previous.notLoggedIn && current.notLoggedIn,
+              listener: (context, state) {
+                // Redirect to auth screen if the user logged out
+                context.goNamed(ExchangeRoute.exchangeAuth.name);
+              },
+              child: const ExchangeSettingsScreen(),
+            ),
       ),
       GoRoute(
         name: SettingsRoute.exchangeAccountInfo.name,


### PR DESCRIPTION
Redirect to auth from exchange settings for a user who is not logged in.
And show logout button in settings only when the user is logged in, else show login button that navigates to exchange auth screen.