### PR TITLE
Better handling of broadcast errors. 

### DIFF
--- a/lib/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart
+++ b/lib/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/blockchain/data/repository/bitcoin_blockchain_repository.dart';
+import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:convert/convert.dart';
 
@@ -35,10 +36,4 @@ class BroadcastBitcoinTransactionUsecase {
       throw BroadcastTransactionException(e.toString());
     }
   }
-}
-
-class BroadcastTransactionException implements Exception {
-  final String message;
-
-  BroadcastTransactionException(this.message);
 }

--- a/lib/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart
+++ b/lib/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/blockchain/domain/repositories/liquid_blockchain_repository.dart';
+import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 
 class BroadcastLiquidTransactionUsecase {
@@ -25,10 +26,4 @@ class BroadcastLiquidTransactionUsecase {
       throw BroadcastTransactionException(e.toString());
     }
   }
-}
-
-class BroadcastTransactionException implements Exception {
-  final String message;
-
-  BroadcastTransactionException(this.message);
 }

--- a/lib/core/errors/send_errors.dart
+++ b/lib/core/errors/send_errors.dart
@@ -60,3 +60,14 @@ class ConfirmTransactionException implements Exception {
 
   String get title => 'Confirmation Failed';
 }
+
+class BroadcastTransactionException implements Exception {
+  final String message;
+
+  BroadcastTransactionException(this.message);
+
+  @override
+  String toString() => message;
+
+  String get title => 'Broadcast Failed';
+}

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/errors/send_errors.dart'
+    show BroadcastTransactionException;
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
@@ -1253,6 +1255,22 @@ class SendCubit extends Cubit<SendState> {
       emit(
         state.copyWith(broadcastingTransaction: false, step: SendStep.success),
       );
+    } on GetWalletException catch (e) {
+      emit(
+        state.copyWith(
+          confirmTransactionException: ConfirmTransactionException(e.message),
+          broadcastingTransaction: false,
+        ),
+      );
+    } on BroadcastTransactionException catch (_) {
+      emit(
+        state.copyWith(
+          confirmTransactionException: ConfirmTransactionException(
+            'Failed to broadcast transaction. Check your network connection and try again.',
+          ),
+          broadcastingTransaction: false,
+        ),
+      );
     } catch (e) {
       emit(
         state.copyWith(
@@ -1287,8 +1305,6 @@ class SendCubit extends Cubit<SendState> {
         walletId: state.selectedWallet!.id,
         txId: state.txId!,
       );
-      // Sync the wallet so the transaction is picked up by the watcher
-      await _getWalletUsecase.execute(state.selectedWallet!.id, sync: true);
     } catch (e) {
       emit(state.copyWith(step: SendStep.confirm));
       log.severe(e.toString());


### PR DESCRIPTION
Made a common broadcast error for liquid and bitcoin.
Simple error message on broadcast fail.
Removed redundant call to getWalletUsecase in confirmTransaction - already called in broadcastTransaction