### PR TITLE
fetch transactions only once to enrich all addresses

### DIFF
--- a/lib/core/wallet/data/repositories/wallet_address_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_address_repository.dart
@@ -164,14 +164,14 @@ class WalletAddressRepository {
             : completeHistory;
 
     // Enrich addresses with balance and transaction data in parallel
-    /*final enrichedAddresses = await _enrichAddresses(
+    final enrichedAddresses = await _enrichAddresses(
       addressHistory: trimmedHistory,
       walletModel: walletModel,
       isBdkWallet: isBdkWallet,
-    );*/
+    );
 
     // Return the enriched addresses
-    return trimmedHistory.map((model) {
+    return enrichedAddresses.map((model) {
       return WalletAddressMapper.toEntity(model);
     }).toList();
   }
@@ -272,36 +272,38 @@ class WalletAddressRepository {
   }
 
   // ignore: unused_element
-  Future<List<WalletAddress>> _enrichAddresses({
+  Future<List<WalletAddressModel>> _enrichAddresses({
     required List<WalletAddressModel> addressHistory,
     required WalletModel walletModel,
     required bool isBdkWallet,
   }) async {
+    final allTransactions =
+        isBdkWallet
+            ? await _bdkWallet.getTransactions(wallet: walletModel)
+            : await _lwkWallet.getTransactions(wallet: walletModel);
+
     final enrichedAddresses = await Future.wait(
       addressHistory.map((addressModel) async {
         // Fetch balance and transactions in parallel
-        final (balanceSat, transactions) =
+        final balanceSat =
             isBdkWallet
-                ? await (
-                  _bdkWallet.getAddressBalanceSat(
-                    addressModel.address,
-                    wallet: walletModel,
+                ? await _bdkWallet.getAddressBalanceSat(
+                  addressModel.address,
+                  wallet: walletModel,
+                )
+                : await _lwkWallet.getAddressBalanceSat(
+                  addressModel.address,
+                  wallet: walletModel,
+                );
+
+        final transactions =
+            allTransactions
+                .where(
+                  (tx) => tx.outputs.any(
+                    (element) => element.address == addressModel.address,
                   ),
-                  _bdkWallet.getTransactions(
-                    wallet: walletModel,
-                    toAddress: addressModel.address,
-                  ),
-                ).wait
-                : await (
-                  _lwkWallet.getAddressBalanceSat(
-                    addressModel.address,
-                    wallet: walletModel,
-                  ),
-                  _lwkWallet.getTransactions(
-                    wallet: walletModel,
-                    toAddress: addressModel.address,
-                  ),
-                ).wait;
+                )
+                .toList();
 
         // Update if balance or transaction count changed
         if (addressModel.balanceSat != balanceSat.toInt() ||
@@ -315,7 +317,7 @@ class WalletAddressRepository {
         }
 
         // TODO: Get labels for the addresses
-        return WalletAddressMapper.toEntity(addressModel, labels: <String>[]);
+        return addressModel;
       }),
     );
     return enrichedAddresses;


### PR DESCRIPTION
This PR uncomments the address enriching with extra data again, but with one optimization of only fetching all transactions once instead of for every address individually. This solves the earlier problem of crashing due to too many concurrent `isMine` checks.

A lot more optimizations can still be done, for example now the utxo lists are fetched for every address again as well to check the balance, instead of one time to get the balance of all addresses. But at least this can fix the crashing already and still give this extra info for an address.