### PR TITLE
hide external wallets/signers and watch-only wallets to sell from

### DIFF
--- a/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
@@ -3,12 +3,10 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/scrollable_column.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
-import 'package:bb_mobile/features/sell/ui/sell_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_cards.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 
 class SellWalletSelectionScreen extends StatelessWidget {
   const SellWalletSelectionScreen({super.key});
@@ -51,8 +49,9 @@ class SellWalletSelectionScreen extends StatelessWidget {
                             : (wallet) => context.read<SellBloc>().add(
                               SellEvent.walletSelected(wallet: wallet),
                             ),
+                    hideWatchOnly: true,
                   ),
-                  const Gap(24.0),
+                  /*const Gap(24.0),
                   ListTile(
                     tileColor: context.colour.onPrimary,
                     shape: const Border(),
@@ -65,7 +64,7 @@ class SellWalletSelectionScreen extends StatelessWidget {
                             : () => context.pushNamed(
                               SellRoute.sellExternalWalletNetworkSelection.name,
                             ),
-                  ),
+                  ),*/
                   const Gap(24.0),
                   const _SellError(),
                 ],

--- a/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
@@ -49,7 +49,7 @@ class SellWalletSelectionScreen extends StatelessWidget {
                             : (wallet) => context.read<SellBloc>().add(
                               SellEvent.walletSelected(wallet: wallet),
                             ),
-                    hideWatchOnly: true,
+                    localSignersOnly: true,
                   ),
                   /*const Gap(24.0),
                   ListTile(

--- a/lib/features/wallet/ui/widgets/wallet_cards.dart
+++ b/lib/features/wallet/ui/widgets/wallet_cards.dart
@@ -7,9 +7,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
 class WalletCards extends StatelessWidget {
-  const WalletCards({super.key, this.padding, this.onTap});
+  const WalletCards({
+    super.key,
+    this.padding,
+    this.onTap,
+    this.hideWatchOnly = false,
+  });
 
   final EdgeInsetsGeometry? padding;
+  final bool hideWatchOnly;
   final Function(Wallet wallet)? onTap;
 
   static Color cardDetails(BuildContext context, Wallet wallet) {
@@ -30,7 +36,14 @@ class WalletCards extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final wallets = context.select((WalletBloc bloc) => bloc.state.wallets);
+    final wallets = context.select(
+      (WalletBloc bloc) =>
+          bloc.state.wallets
+              .where(
+                (w) => !hideWatchOnly || (!w.isWatchOnly && !w.signsRemotely),
+              )
+              .toList(),
+    );
     final syncStatus = context.select(
       (WalletBloc bloc) => bloc.state.syncStatus,
     );

--- a/lib/features/wallet/ui/widgets/wallet_cards.dart
+++ b/lib/features/wallet/ui/widgets/wallet_cards.dart
@@ -11,11 +11,11 @@ class WalletCards extends StatelessWidget {
     super.key,
     this.padding,
     this.onTap,
-    this.hideWatchOnly = false,
+    this.localSignersOnly = false,
   });
 
   final EdgeInsetsGeometry? padding;
-  final bool hideWatchOnly;
+  final bool localSignersOnly;
   final Function(Wallet wallet)? onTap;
 
   static Color cardDetails(BuildContext context, Wallet wallet) {
@@ -38,11 +38,9 @@ class WalletCards extends StatelessWidget {
   Widget build(BuildContext context) {
     final wallets = context.select(
       (WalletBloc bloc) =>
-          bloc.state.wallets
-              .where(
-                (w) => !hideWatchOnly || (!w.isWatchOnly && !w.signsRemotely),
-              )
-              .toList(),
+          localSignersOnly
+              ? bloc.state.wallets.where((w) => w.signsLocally)
+              : bloc.state.wallets,
     );
     final syncStatus = context.select(
       (WalletBloc bloc) => bloc.state.syncStatus,


### PR DESCRIPTION
Hide until we added selling from these types properly.