### PR TITLE
Ipad responsiveness: Full width wallet home top background + constrain QR sizes

### DIFF
--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -79,6 +79,7 @@ class ReceiveQRDetails extends StatelessWidget {
           child: Container(
             margin: const EdgeInsets.symmetric(horizontal: 42),
             padding: const EdgeInsets.all(16),
+            constraints: const BoxConstraints(maxHeight: 300, maxWidth: 300),
             decoration: BoxDecoration(
               color: context.colour.onPrimary,
               borderRadius: BorderRadius.circular(12),

--- a/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
@@ -58,7 +58,7 @@ class _UIState extends State<_UI> {
 
   @override
   void initState() {
-    image = Image.asset(Assets.backgrounds.bgRed.path, fit: BoxFit.fitHeight);
+    image = Image.asset(Assets.backgrounds.bgRed.path, fit: BoxFit.fitWidth);
     super.initState();
   }
 

--- a/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
@@ -58,7 +58,7 @@ class _UIState extends State<_UI> {
 
   @override
   void initState() {
-    image = Image.asset(Assets.backgrounds.bgRed.path, fit: BoxFit.fitWidth);
+    image = Image.asset(Assets.backgrounds.bgRed.path, fit: BoxFit.fill);
     super.initState();
   }
 


### PR DESCRIPTION
This PR fixes the background of the top section of the wallet home which doesn't fill the whole space on ipad.
It also fixes the QR size which is unconstrained and takes up almost the whole screen on ipad.

QR size before:

<img width="745" height="982" alt="Screenshot 2025-08-07 at 18 50 00" src="https://github.com/user-attachments/assets/d4559a1f-aa99-4ffb-92de-7db4b169629b" />

QR size after:
<img width="739" height="978" alt="Screenshot 2025-08-07 at 19 03 41" src="https://github.com/user-attachments/assets/9b5dcb56-1245-42a0-bb6c-906255b7771d" />
r:
