### PR TITLE
fix reloading outside of /kyc path

### DIFF
--- a/lib/features/exchange/ui/screens/exchange_kyc_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_kyc_screen.dart
@@ -45,8 +45,9 @@ class _ExchangeKycScreenState extends State<ExchangeKycScreen> {
 
             final isKyc = url.path.startsWith('/kyc');
             final isLogin = url.path.contains('/login');
+            final isEmailVerification = url.path.contains('/verification');
 
-            final allow = isKyc || isLogin;
+            final allow = isKyc || isLogin || isEmailVerification;
             log.info('UrlChange: ${url.path} → allow: $allow');
 
             // Anything that is not a KYC or login URL should not be allowed and
@@ -70,8 +71,9 @@ class _ExchangeKycScreenState extends State<ExchangeKycScreen> {
             final isBBLogo = url.path.contains('/bb-logo');
             final isLogin = url.path.contains('/login');
             final isKyc = url.path.contains('/kyc');
+            final isEmailVerification = url.path.contains('/verification');
 
-            final allow = isKyc || isLogin || isBBLogo;
+            final allow = isKyc || isLogin || isBBLogo || isEmailVerification;
 
             if (allow) {
               return NavigationDecision.navigate;
@@ -123,7 +125,10 @@ class _ExchangeKycScreenState extends State<ExchangeKycScreen> {
                 })()
               ''');
 
-              final isRendered = result.toString() == '-1';
+              final isRendered = result.toString() != '0';
+              log.info(
+                'Flutter WebView ${isRendered ? 'rendered' : 'not rendered'} for url: $url with result: $result',
+              );
               log.info('Flutter Web rendered based on tabindex: $isRendered');
 
               if (!isRendered) {

--- a/lib/features/exchange/ui/screens/exchange_kyc_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_kyc_screen.dart
@@ -110,12 +110,12 @@ class _ExchangeKycScreenState extends State<ExchangeKycScreen> {
             //  web app has been rendered successfully. If the tabindex is -1,
             //  it indicates that the Flutter web app is ready and rendered.
 
-            // Wait 5 seconds for Flutter to render and then check if the
+            // Wait 10 seconds for Flutter to render and then check if the
             //  flutter-view tabindex is -1, which indicates that the
             //  Flutter web app has been rendered successfully.
             // If it is still 0, it means that the Flutter web app has not been
             //  rendered correctly, and we should reload the WebView.
-            await Future.delayed(const Duration(seconds: 5));
+            await Future.delayed(const Duration(seconds: 10));
 
             try {
               final result = await _controller.runJavaScriptReturningResult('''


### PR DESCRIPTION
On the KYC path, we know the page is rendered if the flutterview tabIndex is '-1' and not '0'. Other pages might not have this and therefore might reload since something else than '-1' is returned, for example "<null>". Checking strictly for '0' to know the page is not rendered, solves this.

This PR also enables going from the /kyc flow to /verification flow to not block the user as long as this redirection still happens/is permitted by the web app.