### PR TITLE
uncomment external wallet button in sell flow

### DIFF
--- a/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
@@ -3,10 +3,12 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/scrollable_column.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
+import 'package:bb_mobile/features/sell/ui/sell_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_cards.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 
 class SellWalletSelectionScreen extends StatelessWidget {
   const SellWalletSelectionScreen({super.key});
@@ -51,7 +53,7 @@ class SellWalletSelectionScreen extends StatelessWidget {
                             ),
                     localSignersOnly: true,
                   ),
-                  /*const Gap(24.0),
+                  const Gap(24.0),
                   ListTile(
                     tileColor: context.colour.onPrimary,
                     shape: const Border(),
@@ -64,7 +66,7 @@ class SellWalletSelectionScreen extends StatelessWidget {
                             : () => context.pushNamed(
                               SellRoute.sellExternalWalletNetworkSelection.name,
                             ),
-                  ),*/
+                  ),
                   const Gap(24.0),
                   const _SellError(),
                 ],


### PR DESCRIPTION
This shouldn't have been hidden, only external signes for now still, not external wallets.