### PR TITLE
feat: allow autoswap to any bitcoin walletId

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -239,41 +239,41 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  bdk_flutter: 86c9ba59ee282dee08c3a29599abe867d10a8b10
+  bdk_flutter: cef9180019b4c6b67a3e3dfb74611683fe140107
   boltz: 6388ec2412f3753b63a9e65c97f87ea26f43bddc
-  camera_avfoundation: adb0207d868b2d873e895371d88448399ab78d87
-  dart_bbqr: 10143a83ef3919f9ac06974e3bbe23cac4abc39b
+  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
+  dart_bbqr: bfd89cc8a74538d94ef6d87d11e4a2ad55578e7d
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
-  flutter_nfc_kit: 3985c93f749b9cb4747479205c2f10bd2f877a11
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  flutter_zxing: d527c3ff9c7f3606dd29a7ec8c4055f7daa088c5
-  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
+  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
+  flutter_nfc_kit: e1b71583eafd2c9650bc86844a7f2d185fb414f6
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  flutter_zxing: e8bcc43bd3056c70c271b732ed94e7a16fd62f93
+  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   lwk: 22e06bc5664247d6b2dac91cfe209b63b70dd580
-  no_screenshot: 67d110f12466f4913b488803d4e498d03ef2889e
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  no_screenshot: 6d183496405a3ab709a67a54e5cd0f639e94729e
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   payjoin_flutter: 6397d7b698cdad6453be4949ab6aca1863f6c5e5
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   ScreenProtectorKit: 83a6281b02c7a5902ee6eac4f5045f674e902ae4
   SDWebImage: 9f177d83116802728e122410fb25ad88f5c7608a
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   sqlite3: 73513155ec6979715d3904ef53a8d68892d4032b
-  sqlite3_flutter_libs: 86f82662868ee26ff3451f73cac9c5fc2a1f57fa
+  sqlite3_flutter_libs: 83f8e9f5b6554077f1d93119fe20ebaa5f3a9ef1
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  tor: 662a9f5b980b5c86decb8ba611de9bcd4c8286eb
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_cookie_manager: eaf920722b493bd0f7611b5484771ca53fed03f7
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  tor: 767208930250ef7be241963b75568c55c0a81890
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_cookie_manager: d63a76cabdf42a7ea3d92768ac67d4853a1367f8
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 3402bb9f9a69470d12a30feec0fd288c203ab3f5
 

--- a/lib/core/swaps/data/datasources/boltz_storage_datasource.dart
+++ b/lib/core/swaps/data/datasources/boltz_storage_datasource.dart
@@ -29,6 +29,7 @@ class BoltzStorageDatasource {
             feeThresholdPercent: settings.feeThresholdPercent,
             blockTillNextExecution: Value(settings.blockTillNextExecution),
             alwaysBlock: Value(settings.alwaysBlock),
+            recipientWalletId: Value(settings.recipientWalletId),
           ),
         );
   }
@@ -51,6 +52,7 @@ class BoltzStorageDatasource {
             feeThresholdPercent: settings.feeThresholdPercent,
             blockTillNextExecution: Value(settings.blockTillNextExecution),
             alwaysBlock: Value(settings.alwaysBlock),
+            recipientWalletId: Value(settings.recipientWalletId),
           ),
         );
   }

--- a/lib/core/swaps/data/models/auto_swap_model.dart
+++ b/lib/core/swaps/data/models/auto_swap_model.dart
@@ -12,6 +12,7 @@ sealed class AutoSwapModel with _$AutoSwapModel {
     @Default(3.0) double feeThresholdPercent,
     @Default(false) bool blockTillNextExecution,
     @Default(false) bool alwaysBlock,
+    @Default(null) String? recipientWalletId,
   }) = _AutoSwapModel;
 
   const AutoSwapModel._();
@@ -23,6 +24,7 @@ sealed class AutoSwapModel with _$AutoSwapModel {
       feeThresholdPercent: entity.feeThresholdPercent,
       blockTillNextExecution: entity.blockTillNextExecution,
       alwaysBlock: entity.alwaysBlock,
+      recipientWalletId: entity.recipientWalletId,
     );
   }
 
@@ -33,6 +35,7 @@ sealed class AutoSwapModel with _$AutoSwapModel {
       feeThresholdPercent: feeThresholdPercent,
       blockTillNextExecution: blockTillNextExecution,
       alwaysBlock: alwaysBlock,
+      recipientWalletId: recipientWalletId,
     );
   }
 
@@ -43,6 +46,7 @@ sealed class AutoSwapModel with _$AutoSwapModel {
       feeThresholdPercent: row.feeThresholdPercent,
       blockTillNextExecution: row.blockTillNextExecution,
       alwaysBlock: row.alwaysBlock,
+      recipientWalletId: row.recipientWalletId,
     );
   }
 
@@ -54,6 +58,7 @@ sealed class AutoSwapModel with _$AutoSwapModel {
       feeThresholdPercent: feeThresholdPercent,
       blockTillNextExecution: blockTillNextExecution,
       alwaysBlock: alwaysBlock,
+      recipientWalletId: recipientWalletId,
     );
   }
 }

--- a/lib/core/swaps/data/repository/boltz_swap_repository.dart
+++ b/lib/core/swaps/data/repository/boltz_swap_repository.dart
@@ -366,7 +366,7 @@ class BoltzSwapRepository {
         sendTxid: txid,
         status:
             swap.status == SwapStatus.pending ? SwapStatus.paid : swap.status,
-        // TODO: add server fees for chain swaps
+        // add server lockupfees for chain swaps
         fees: swap.fees?.copyWith(
           lockupFee: (swap.fees?.lockupFee ?? 0) + absoluteFees,
         ),

--- a/lib/core/swaps/domain/entity/auto_swap.dart
+++ b/lib/core/swaps/domain/entity/auto_swap.dart
@@ -11,6 +11,7 @@ sealed class AutoSwap with _$AutoSwap {
     @Default(3.0) double feeThresholdPercent,
     @Default(false) bool blockTillNextExecution,
     @Default(false) bool alwaysBlock,
+    @Default(null) String? recipientWalletId,
   }) = _AutoSwap;
 
   const AutoSwap._();

--- a/lib/features/autoswap/autoswap_locator.dart
+++ b/lib/features/autoswap/autoswap_locator.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/get_auto_swap_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/save_auto_swap_settings_usecase.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/features/autoswap/presentation/autoswap_settings_cubit.dart';
 import 'package:bb_mobile/locator.dart';
 
@@ -12,6 +13,7 @@ class AutoSwapLocator {
         getAutoSwapSettingsUsecase: locator<GetAutoSwapSettingsUsecase>(),
         saveAutoSwapSettingsUsecase: locator<SaveAutoSwapSettingsUsecase>(),
         getSettingsUsecase: locator<GetSettingsUsecase>(),
+        walletRepository: locator<WalletRepository>(),
       ),
     );
   }

--- a/lib/features/autoswap/presentation/autoswap_settings_state.dart
+++ b/lib/features/autoswap/presentation/autoswap_settings_state.dart
@@ -16,6 +16,9 @@ abstract class AutoSwapSettingsState with _$AutoSwapSettingsState {
     BitcoinUnit? bitcoinUnit,
     @Default(false) bool alwaysBlock,
     @Default(false) bool showInfo,
+    @Default([]) List<Wallet> availableBitcoinWallets,
+    String? selectedBitcoinWalletId,
+    @Default(false) bool loadingWallets,
   }) = _AutoSwapSettingsState;
 
   const AutoSwapSettingsState._();

--- a/lib/features/autoswap/ui/widgets/autoswap_settings.dart
+++ b/lib/features/autoswap/ui/widgets/autoswap_settings.dart
@@ -416,6 +416,9 @@ class _WalletSelectionDropdown extends StatelessWidget {
     final enabled = context.select(
       (AutoSwapSettingsCubit cubit) => cubit.state.enabledToggle,
     );
+    final showInfo = context.select(
+      (AutoSwapSettingsCubit cubit) => cubit.state.showInfo,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -500,17 +503,18 @@ class _WalletSelectionDropdown extends StatelessWidget {
             context.read<AutoSwapSettingsCubit>().onWalletSelected(walletId);
           },
         ),
-        const Gap(4),
-        BBText(
-          'Choose which Bitcoin wallet will receive the swapped funds (required)',
-
-          style: context.font.labelSmall?.copyWith(
-            color:
-                enabled && selectedWalletId == null
-                    ? context.colour.error
-                    : context.colour.surfaceContainer,
+        if (showInfo) ...[
+          const Gap(4),
+          BBText(
+            'Choose which Bitcoin wallet will receive the swapped funds (required)',
+            style: context.font.labelSmall?.copyWith(
+              color:
+                  enabled && selectedWalletId == null
+                      ? context.colour.error
+                      : context.colour.surfaceContainer,
+            ),
           ),
-        ),
+        ],
       ],
     );
   }
@@ -529,7 +533,8 @@ class _SaveButton extends StatelessWidget {
       (AutoSwapSettingsCubit cubit) => cubit.state.selectedBitcoinWalletId,
     );
 
-    final isDisabled = saving || (enabled && selectedWalletId == null);
+    final isDisabled =
+        saving || !enabled || (enabled && selectedWalletId == null);
 
     return BBButton.big(
       label: 'Save',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "1b3b173f3379c8f941446267868548b6fc67e9134d81f4842eb98bb729451359"
+      sha256: ba95c961bafcd8686d1cf63be864eb59447e795e124d98d6a27d91fcd13602fb
       url: "https://pub.dev"
     source: hosted
-    version: "8.11.2"
+    version: "8.11.1"
   camera:
     dependency: transitive
     description:
@@ -1556,10 +1556,10 @@ packages:
     dependency: transitive
     description:
       name: socks5_proxy
-      sha256: "80fa31a9ebfc0dc8de7b0e568c8d8927b65558ef2c7591cbee5afac814fb8f74"
+      sha256: "05c889410e9519207dfcf720c2da7d06fcdea0b5a9b2916d88a4e05c065ac9a9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   source_gen:
     dependency: transitive
     description:


### PR DESCRIPTION
Migration for `recipientWalletId` in autoswap is already completed on develop.

This PR just uses this new field and updates existing functionality to use a provided wallet ID rather than using the default wallet all the time. 

Since the value is set as null in the db; the code will now check for null and replace with defaultBitcoinWalletId; following which this value should never be set to null again. This will ensure existing behaviour does not change.

Users can then change the value in autoswap settings where providing a value for recipientWalletId is required.