### PR TITLE
unmix amount input check and balance check

### DIFF
--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -302,8 +302,7 @@ abstract class SendState with _$SendState {
       // ignore: avoid_bool_literals_in_conditional_expressions
       selectedWallet == null
           ? false
-          : (inputAmountSat <= selectedWallet!.balanceSat.toInt()) &&
-              (inputAmountSat > 0);
+          : (inputAmountSat <= selectedWallet!.balanceSat.toInt());
 
   String sendTypeName() {
     switch (sendType) {

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -559,6 +559,9 @@ class SendAmountConfirmButton extends StatelessWidget {
     final loadingBestWallet = context.select(
       (SendCubit cubit) => cubit.state.loadingBestWallet,
     );
+    final inputAmountSat = context.select(
+      (SendCubit cubit) => cubit.state.inputAmountSat,
+    );
     return BBButton.big(
       label: 'Continue',
       onPressed: () {
@@ -568,7 +571,8 @@ class SendAmountConfirmButton extends StatelessWidget {
           amountConfirmedClicked ||
           !hasBalance ||
           creatingSwap ||
-          loadingBestWallet,
+          loadingBestWallet ||
+          inputAmountSat <= 0,
       bgColor: context.colour.secondary,
       textColor: context.colour.onPrimary,
     );


### PR DESCRIPTION
The balance check was now also an amount input check, which are two different things, needed in different places, so this PR separates and uses both were needed, for validation and to enable/disable the Continue button.