### PR TITLE
add ARS to supported fiat currencies to fix user summary loading error

### DIFF
--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -8,7 +8,8 @@ enum FiatCurrency {
   cad('CAD', decimals: 2, symbol: '\$'),
   crc('CRC', decimals: 2, symbol: '₡'),
   eur('EUR', decimals: 2, symbol: '€'),
-  mxn('MXN', decimals: 2, symbol: '\$');
+  mxn('MXN', decimals: 2, symbol: '\$'),
+  ars('ARS', decimals: 2, symbol: '\$');
 
   const FiatCurrency(this.code, {required this.decimals, required this.symbol});
   final String code;
@@ -27,6 +28,8 @@ enum FiatCurrency {
         return FiatCurrency.eur;
       case 'MXN':
         return FiatCurrency.mxn;
+      case 'ARS':
+        return FiatCurrency.ars;
       default:
         throw Exception('Unknown FiatCurrency: $code');
     }

--- a/lib/features/pay/ui/widgets/pay_new_recipient_form.dart
+++ b/lib/features/pay/ui/widgets/pay_new_recipient_form.dart
@@ -30,6 +30,7 @@ class _PayNewRecipientFormState extends State<PayNewRecipientForm> {
     {'code': 'EU', 'name': 'Europe', 'flag': '🇪🇺'},
     {'code': 'MX', 'name': 'Mexico', 'flag': '🇲🇽'},
     {'code': 'CR', 'name': 'Costa Rica', 'flag': '🇨🇷'},
+    {'code': 'AR', 'name': 'Argentina', 'flag': '🇦🇷'},
   ];
 
   // Map currency to country code
@@ -45,6 +46,8 @@ class _PayNewRecipientFormState extends State<PayNewRecipientForm> {
         return 'CR';
       case FiatCurrency.usd:
         return 'CR'; // Default fallback
+      case FiatCurrency.ars:
+        return 'AR';
     }
   }
 

--- a/lib/features/withdraw/ui/widgets/new_recipient_form.dart
+++ b/lib/features/withdraw/ui/widgets/new_recipient_form.dart
@@ -30,6 +30,7 @@ class _NewRecipientFormState extends State<NewRecipientForm> {
     {'code': 'EU', 'name': 'Europe', 'flag': '🇪🇺'},
     {'code': 'MX', 'name': 'Mexico', 'flag': '🇲🇽'},
     {'code': 'CR', 'name': 'Costa Rica', 'flag': '🇨🇷'},
+    {'code': 'ARS', 'name': 'Argentina', 'flag': '🇦🇷'},
   ];
 
   // Map currency to country code
@@ -45,6 +46,8 @@ class _NewRecipientFormState extends State<NewRecipientForm> {
         return 'CR';
       case FiatCurrency.usd:
         return 'CR'; // Default fallback
+      case FiatCurrency.ars:
+        return 'ARS';
     }
   }
 


### PR DESCRIPTION
Login was not working for accounts with an ARS balance because of not having ARS in the enum of fiat currencies.