### PR TITLE
fix: remove hardcoded network filters in `BackupSettingsCubit`

### DIFF
--- a/lib/features/backup_settings/backup_settings_locator.dart
+++ b/lib/features/backup_settings/backup_settings_locator.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_la
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_to_file_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/select_file_path_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/select_folder_path_usecase.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/backup_settings/presentation/cubit/backup_settings_cubit.dart';
 import 'package:bb_mobile/locator.dart';
@@ -15,7 +16,7 @@ class BackupSettingsLocator {
     locator.registerFactory<BackupSettingsCubit>(
       () => BackupSettingsCubit(
         getWalletsUsecase: locator<GetWalletsUsecase>(),
-
+        settingsRepository: locator<SettingsRepository>(),
         selectFolderPathUsecase: locator<SelectFolderPathUsecase>(),
         saveToFileSystemUsecase: locator<SaveToFileSystemUsecase>(),
         createBackupKeyFromDefaultSeedUsecase:


### PR DESCRIPTION
@i5hi found this error related to hardcoded mainnet network filters that was throwing errors when switching to testnet

<img width="352" height="720" alt="image" src="https://github.com/user-attachments/assets/9581fb7c-786e-4415-b0de-7c422b724aca" />
