### PR TITLE
fix max amount in send

### DIFF
--- a/lib/core/widgets/price_input/price_input.dart
+++ b/lib/core/widgets/price_input/price_input.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
-class PriceInput extends StatefulWidget {
+class PriceInput extends StatelessWidget {
   const PriceInput({
     super.key,
 
@@ -16,6 +16,7 @@ class PriceInput extends StatefulWidget {
     this.error,
     required this.focusNode,
     this.readOnly = false,
+    this.isMax = false,
   });
 
   final String currency;
@@ -27,35 +28,16 @@ class PriceInput extends StatefulWidget {
   final String? error;
   final FocusNode focusNode;
   final bool readOnly;
-
-  @override
-  State<PriceInput> createState() => _PriceInputState();
-}
-
-class _PriceInputState extends State<PriceInput> {
-  @override
-  void initState() {
-    super.initState();
-    widget.focusNode.addListener(() {
-      setState(() {});
-    });
-  }
-
-  @override
-  void dispose() {
-    widget.focusNode.removeListener(() {});
-    super.dispose();
-  }
+  final bool isMax;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         BBText(
-          widget.error ?? '',
+          error ?? '',
           style: context.font.bodyLarge,
-          color:
-              widget.error != null ? context.colour.error : Colors.transparent,
+          color: error != null ? context.colour.error : Colors.transparent,
           maxLines: 2,
         ),
         const Gap(8),
@@ -70,35 +52,45 @@ class _PriceInputState extends State<PriceInput> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     IntrinsicWidth(
-                      child: TextField(
-                        controller: widget.amountController,
-                        focusNode: widget.focusNode,
-                        keyboardType: TextInputType.none,
-                        showCursor: true,
-                        readOnly: widget.readOnly,
-                        cursorColor: context.colour.outline,
-                        cursorOpacityAnimates: true,
-                        cursorHeight: 30,
-                        style: context.font.displaySmall!.copyWith(
-                          fontSize: 36,
-                          color: context.colour.outlineVariant,
-                        ),
-                        textAlign: TextAlign.center,
-                        decoration: InputDecoration(
-                          border: InputBorder.none,
-                          contentPadding: EdgeInsets.zero,
-                          isDense: false,
-                          hintText: widget.focusNode.hasFocus ? null : "0",
-                          hintStyle: context.font.displaySmall!.copyWith(
-                            fontSize: 36,
-                            color: context.colour.outlineVariant,
-                          ),
-                        ),
-                      ),
+                      child:
+                          isMax
+                              ? Text(
+                                'MAX',
+                                style: context.font.displaySmall!.copyWith(
+                                  fontSize: 36,
+                                  color: context.colour.outlineVariant,
+                                ),
+                              )
+                              : TextField(
+                                controller: amountController,
+                                focusNode: focusNode,
+                                keyboardType: TextInputType.none,
+                                showCursor: true,
+                                readOnly: readOnly,
+                                cursorColor: context.colour.outline,
+                                cursorOpacityAnimates: true,
+                                cursorHeight: 30,
+                                style: context.font.displaySmall!.copyWith(
+                                  fontSize: 36,
+                                  color: context.colour.outlineVariant,
+                                ),
+                                textAlign: TextAlign.center,
+                                decoration: InputDecoration(
+                                  border: InputBorder.none,
+                                  contentPadding: EdgeInsets.zero,
+                                  isDense: false,
+                                  hintText: focusNode.hasFocus ? null : "0",
+                                  hintStyle: context.font.displaySmall!
+                                      .copyWith(
+                                        fontSize: 36,
+                                        color: context.colour.outlineVariant,
+                                      ),
+                                ),
+                              ),
                     ),
                     const Gap(8),
                     BBText(
-                      widget.currency,
+                      currency,
                       style: context.font.displaySmall,
                       color: context.colour.outlineVariant,
                       maxLines: 1,
@@ -110,8 +102,8 @@ class _PriceInputState extends State<PriceInput> {
             const Gap(16),
             InkWell(
               onTap: () async {
-                final selected = await _openPopup(context, widget.currency);
-                if (selected != null) widget.onCurrencyChanged(selected);
+                final selected = await _openPopup(context, currency);
+                if (selected != null) onCurrencyChanged(selected);
               },
               child: Icon(
                 Icons.arrow_drop_down,
@@ -123,7 +115,7 @@ class _PriceInputState extends State<PriceInput> {
         ),
         const Gap(14),
         BBText(
-          '~${widget.amountEquivalent}',
+          '~$amountEquivalent',
           style: context.font.bodyLarge,
           color: context.colour.surfaceContainer,
         ),
@@ -134,7 +126,7 @@ class _PriceInputState extends State<PriceInput> {
             width: 200,
             alignment: Alignment.center,
             child: TextField(
-              onChanged: widget.onNoteChanged,
+              onChanged: onNoteChanged,
               textAlignVertical: TextAlignVertical.center,
               textAlign: TextAlign.center,
               decoration: InputDecoration(
@@ -165,7 +157,7 @@ class _PriceInputState extends State<PriceInput> {
       constraints: const BoxConstraints(maxWidth: double.infinity),
       builder: (context) {
         return CurrencyBottomSheet(
-          availableCurrencies: widget.availableCurrencies,
+          availableCurrencies: availableCurrencies,
           selectedValue: selected,
         );
       },

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -689,49 +689,72 @@ class SendCubit extends Cubit<SendState> {
     );
   }
 
-  Future<void> amountChanged(String amount) async {
+  Future<void> amountChanged({String? amount, bool isMax = false}) async {
     try {
       clearAllExceptions();
       String validatedAmount;
 
-      if (amount.isEmpty) {
-        validatedAmount = amount;
-      } else if (state.isInputAmountFiat) {
-        final amountFiat = double.tryParse(amount);
-        final isDecimalPoint = amount == '.';
+      if (amount == null) {
+        if (!isMax) {
+          throw Exception('Amount should be provided if max is not selected');
+        }
 
-        validatedAmount =
-            amountFiat == null && !isDecimalPoint ? state.amount : amount;
-      } else if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
-        // If the amount is in sats, make sure it is a valid BigInt and do not
-        //  allow a decimal point.
-        final amountSats = BigInt.tryParse(amount);
-        final hasDecimals = amount.contains('.');
+        // To avoid converting rounding errors when max is set, set the
+        //  input currency to bitcoin unit if it was fiat
+        if (state.isInputAmountFiat) {
+          final bitcoinUnit = state.bitcoinUnit ?? BitcoinUnit.btc;
+          emit(state.copyWith(inputAmountCurrencyCode: bitcoinUnit.code));
+        }
 
-        validatedAmount =
-            amountSats == null ||
-                    hasDecimals ||
-                    amountSats > ConversionConstants.maxSatsAmount
-                ? state.amount
-                : amountSats.toString();
+        final totalBalanceSat = state.selectedWallet?.balanceSat ?? BigInt.zero;
+        if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
+          validatedAmount = totalBalanceSat.toString();
+        } else {
+          final totalBalanceBtc = ConvertAmount.satsToBtc(
+            totalBalanceSat.toInt(),
+          );
+          validatedAmount = totalBalanceBtc.toStringAsFixed(8);
+        }
       } else {
-        // If the amount is in BTC, make sure it is a valid double and
-        //  do not allow more than 8 decimal places.
-        final amountBtc = double.tryParse(amount);
-        final decimals = amount.split('.').last.length;
-        final isDecimalPoint = amount == '.';
+        if (amount.isEmpty) {
+          validatedAmount = amount;
+        } else if (state.isInputAmountFiat) {
+          final amountFiat = double.tryParse(amount);
+          final isDecimalPoint = amount == '.';
 
-        validatedAmount =
-            (amountBtc == null && !isDecimalPoint) ||
-                    decimals > BitcoinUnit.btc.decimals ||
-                    (amountBtc != null &&
-                        amountBtc >
-                            ConversionConstants.maxBitcoinAmount.toDouble())
-                ? state.amount
-                : amount;
+          validatedAmount =
+              amountFiat == null && !isDecimalPoint ? state.amount : amount;
+        } else if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
+          // If the amount is in sats, make sure it is a valid BigInt and do not
+          //  allow a decimal point.
+          final amountSats = BigInt.tryParse(amount);
+          final hasDecimals = amount.contains('.');
+
+          validatedAmount =
+              amountSats == null ||
+                      hasDecimals ||
+                      amountSats > ConversionConstants.maxSatsAmount
+                  ? state.amount
+                  : amountSats.toString();
+        } else {
+          // If the amount is in BTC, make sure it is a valid double and
+          //  do not allow more than 8 decimal places.
+          final amountBtc = double.tryParse(amount);
+          final decimals = amount.split('.').last.length;
+          final isDecimalPoint = amount == '.';
+
+          validatedAmount =
+              (amountBtc == null && !isDecimalPoint) ||
+                      decimals > BitcoinUnit.btc.decimals ||
+                      (amountBtc != null &&
+                          amountBtc >
+                              ConversionConstants.maxBitcoinAmount.toDouble())
+                  ? state.amount
+                  : amount;
+        }
       }
 
-      emit(state.copyWith(amount: validatedAmount, sendMax: false));
+      emit(state.copyWith(amount: validatedAmount, sendMax: isMax));
       await updateBestWallet();
     } catch (e) {
       emit(state.copyWith(error: e.toString()));
@@ -809,12 +832,6 @@ class SendCubit extends Cubit<SendState> {
     } catch (e) {
       emit(state.copyWith(loadingBestWallet: false));
     }
-  }
-
-  void onMaxPressed() {
-    if (state.selectedWallet == null) return;
-    clearAllExceptions();
-    emit(state.copyWith(amount: '0', sendMax: true));
   }
 
   void noteChanged(String note) => emit(state.copyWith(label: note));
@@ -925,6 +942,7 @@ class SendCubit extends Cubit<SendState> {
         state.copyWith(
           step: SendStep.confirm,
           confirmedAmountSat: state.inputAmountSat,
+          amountConfirmedClicked: false,
         ),
       );
     } else {
@@ -1100,7 +1118,7 @@ class SendCubit extends Cubit<SendState> {
               state.selectedWallet!.balanceSat.toInt() -
               (state.absoluteFees ?? 0);
           final maxAmount =
-              state.bitcoinUnit == BitcoinUnit.btc
+              state.inputAmountCurrencyCode == BitcoinUnit.btc.code
                   ? ConvertAmount.satsToBtc(maxAmountSat)
                   : state.isInputAmountFiat
                   ? ConvertAmount.satsToFiat(maxAmountSat, state.exchangeRate)
@@ -1342,20 +1360,6 @@ class SendCubit extends Cubit<SendState> {
     );
 
     emit(state.copyWith(exchangeRate: exchangeRate));
-  }
-
-  void onNumberPressed(String n) {
-    amountChanged(state.amount + n);
-    // updateFiatApproximatedAmount();
-  }
-
-  void onBackspacePressed() {
-    if (state.amount.isEmpty) return;
-
-    final newAmount = state.amount.substring(0, state.amount.length - 1);
-    emit(state.copyWith(amount: newAmount));
-
-    // updateFiatApproximatedAmount();
   }
 
   void _watchSendSwap(String swapId) {

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -416,8 +416,6 @@ abstract class SendState with _$SendState {
           : selectedWallet!.isLiquid
           ? false
           : true;
-
-  String get displayAmount => sendMax ? 'MAX' : amount;
 }
 
 extension SendStateFeePercent on SendState {


### PR DESCRIPTION
This PR fixes the following things that were causing problems with the send amounts and mainly with MAX amount:

- Make sure the equivalent amount is correct and shown when MAX is set
- Made PriceInput stateless since it didn't manage any state and Stateless is better to be sure re-renders are done if constructor params change
- Don't use the amount textfield to show 'MAX' anymore, just show a Text field when max is set. This makes it less error prone since the amount controller should only have amounts, so text that can be parsed to a numeric value.
- Change the amount when max is set, and switch input currency to a bitcoin unit if it was fiat input
- Keep isMax in the state of the screen to render things like showing the 'MAX' correctly
- Reset the amountConfirmedClicked field if no build errors exist so that the amount can be updated after coming back from the confirm screen again