### PR TITLE
Fix confirm button for custom fee unreachable on iOS

### DIFF
--- a/lib/features/send/ui/widgets/fee_options_modal.dart
+++ b/lib/features/send/ui/widgets/fee_options_modal.dart
@@ -28,7 +28,12 @@ class FeeOptionsModal extends StatelessWidget {
         ),
     ];
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
       child: SafeArea(
         child: SingleChildScrollView(
           child: Column(


### PR DESCRIPTION
Currently, when entering custom fee amount on iOS the keyboard covers the confirm button which prevents the user from confirming, and closing the keyboard closes the sheet, which prevents completely from setting the custom fee.
This PR fixes the padding when the keyboard is open so the user can confirm the custom fees.