### PR TITLE
make sure the decimal point is shown on numeric iOS keyboards

### DIFF
--- a/lib/core/widgets/inputs/text_input.dart
+++ b/lib/core/widgets/inputs/text_input.dart
@@ -106,7 +106,7 @@ class _BBInputTextState extends State<BBInputText> {
           widget.onlyPaste
               ? TextInputType.none
               : widget.onlyNumbers
-              ? TextInputType.number
+              ? const TextInputType.numberWithOptions(decimal: true)
               : TextInputType.multiline,
       textInputAction:
           shouldPreventNewlines


### PR DESCRIPTION
This PR solves the following reported problem:

> When swapping….on the keyboard it doesn’t give me the option to add a period. So to swap 0.0023 for example, i have to either type it elsewhere and copy it or find another way to put a period. 

As a quick fix for this, I added the decimal option to true in BBTextInput, but the real solution to have correct keyboard input, input formatting and validation is to make a better reusable component or reusable functions with a `TextFormField`. We should plan this in the task to review/improve/remove all reusable components and maybe create new reusable components that are more useful than some of the ones we have now. An example of how to use the inputFormatting and validation can already be shown in this pull request for DCA: https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/1224, but we should make it reusable and apply everywhere.