### PR TITLE
add currency code to currency toggle in buy amount input

### DIFF
--- a/lib/features/buy/ui/widgets/buy_amount_input_fields.dart
+++ b/lib/features/buy/ui/widgets/buy_amount_input_fields.dart
@@ -147,6 +147,12 @@ class _BuyAmountInputFieldsState extends State<BuyAmountInputFields> {
                         ),
                       ),
                       const Gap(8.0),
+                      Text(
+                        isFiatCurrencyInput ? bitcoinUnit.code : currency.code,
+                        style: context.font.bodyMedium?.copyWith(
+                          color: context.colour.outline,
+                        ),
+                      ),
                       // CurrencyText(
                       //   amountSat ?? 0,
                       //   showFiat: !isFiatCurrencyInput,


### PR DESCRIPTION
Fixes following reported issue:

> during Buy flow observing that the ‘BTC’ or ‘Fait’ is missing next to the BTC <-> Fiat conversion icon.