### PR TITLE
fix: Submarine Swaps amounts in `TransactionDetailsAmount`, `TransactionDetailsTable`, `TxListItem`

### DIFF
--- a/lib/features/transactions/ui/widgets/transaction_details_amount.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_amount.dart
@@ -13,8 +13,9 @@ class TransactionDetailsAmount extends StatelessWidget {
     final tx = context.select(
       (TransactionDetailsCubit bloc) => bloc.state.transaction,
     );
+    final isLnSwap = tx?.isLnSwap ?? false;
     final isOrder = tx?.isOrder ?? false;
-    final amountSat = tx?.amountSat;
+    final amountSat = isLnSwap ? tx?.swap?.amountSat : tx?.amountSat;
     final orderAmountAndCurrency = tx?.order?.amountAndCurrencyToDisplay();
     final showOrderInFiat =
         isOrder &&

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -74,13 +74,12 @@ class TransactionDetailsTable extends StatelessWidget {
     final payjoin = transaction?.payjoin;
     final order = transaction?.order;
 
-    final swapFees =
-        (swap?.fees?.claimFee ?? 0) +
-        (swap?.fees?.boltzFee ?? 0) +
-        (swap?.fees?.lockupFee ?? 0);
+    final swapFees = (swap?.fees?.claimFee ?? 0) + (swap?.fees?.boltzFee ?? 0);
     final swapCounterpartTxId = context.select(
       (TransactionDetailsCubit cubit) => cubit.state.swapCounterpartTxId,
     );
+
+    final txFee = swap != null ? swapFees : walletTransaction?.feeSat;
 
     return DetailsTable(
       items: [
@@ -156,11 +155,9 @@ class TransactionDetailsTable extends StatelessWidget {
               label: 'Transaction Fee',
               displayValue:
                   bitcoinUnit == BitcoinUnit.sats
-                      ? FormatAmount.sats(
-                        walletTransaction.feeSat,
-                      ).toUpperCase()
+                      ? FormatAmount.sats(txFee ?? 0).toUpperCase()
                       : FormatAmount.btc(
-                        ConvertAmount.satsToBtc(walletTransaction.feeSat),
+                        ConvertAmount.satsToBtc(txFee ?? 0),
                       ).toUpperCase(),
             ),
           DetailsTableItem(
@@ -732,13 +729,7 @@ class TransactionDetailsTable extends StatelessWidget {
               expandableChild: Column(
                 children: [
                   const Gap(4),
-
-                  _feeRow(
-                    context,
-                    'Network Fee',
-                    (swap.fees?.lockupFee ?? 0) + (swap.fees?.claimFee ?? 0),
-                  ),
-
+                  _feeRow(context, 'Network Fee', swap.fees?.claimFee ?? 0),
                   _feeRow(
                     context,
                     swap.isChainSwap ? 'Transfer Fee' : 'Boltz Swap Fee',

--- a/lib/features/transactions/ui/widgets/tx_list_item.dart
+++ b/lib/features/transactions/ui/widgets/tx_list_item.dart
@@ -147,8 +147,7 @@ class TxListItem extends StatelessWidget {
                     isOrderType && !showOrderInFiat
                         ? orderAmountAndCurrency!.$1.toInt()
                         : tx.isSwap
-                        ? (tx.swap!.amountSat -
-                            tx.swap!.fees!.totalFees(tx.swap!.amountSat))
+                        ? (tx.swap!.amountSat)
                         : tx.amountSat,
                     showFiat: false,
                     style: context.font.bodyLarge,


### PR DESCRIPTION
BEFORE:
<img src="https://github.com/user-attachments/assets/4acbdaed-779f-4b20-a2b1-7edd8baa3cbc" width="50%" />
<img src="https://github.com/user-attachments/assets/8be3843d-ea0b-4b93-ad33-e217a9d5b827" width="50%" />


AFTER
<img src="https://github.com/user-attachments/assets/e59147a9-49b7-4550-b142-f4f007862b99" width="50%" />
<img src="https://github.com/user-attachments/assets/d7909f04-342b-428b-b113-c2bbd254b7bb" width="50%" />
