### PR TITLE
fix: `ledgerNanoSPlus` UI overflow `SigningDevice`

### DIFF
--- a/lib/features/import_watch_only_wallet/presentation/watch_only_details_widget.dart
+++ b/lib/features/import_watch_only_wallet/presentation/watch_only_details_widget.dart
@@ -69,7 +69,7 @@ class _DescriptorDetailsWidget extends StatelessWidget {
                 ),
               ),
               SizedBox(
-                width: 200,
+                width: 220,
                 child: DropdownButtonFormField<SignerDeviceEntity?>(
                   alignment: Alignment.centerLeft,
                   decoration: const InputDecoration(
@@ -87,7 +87,7 @@ class _DescriptorDetailsWidget extends StatelessWidget {
                             (value) => DropdownMenuItem<SignerDeviceEntity?>(
                               value: value,
                               child: BBText(
-                                value?.displayName ?? 'Not supported',
+                                value?.displayName ?? 'Unkown',
                                 style: context.font.headlineSmall,
                               ),
                             ),


### PR DESCRIPTION
<img width="750" height="1334" alt="overflowed" src="https://github.com/user-attachments/assets/74455cb0-0e5f-46ea-a835-724ff9f28ad6" />
