### PR TITLE
fix: Closes #1042 red/pink overlay when scrolling

### DIFF
--- a/lib/core/themes/app_theme.dart
+++ b/lib/core/themes/app_theme.dart
@@ -54,7 +54,7 @@ class AppTheme {
                 ? SystemUiOverlayStyle.light
                 : SystemUiOverlayStyle.dark,
         elevation: 0,
-        scrolledUnderElevation: 32,
+        scrolledUnderElevation: 0,
         titleTextStyle: fonts.textTheme.headlineMedium!.copyWith(
           color: colours.secondary,
         ),


### PR DESCRIPTION
Fixing this annoying bug
https://github.com/user-attachments/assets/bffd0082-b4a4-46b4-9192-c7b5e40daeab

