### PR TITLE
remove unneccessary amount controller 

### DIFF
--- a/lib/features/swap/ui/swap_page.dart
+++ b/lib/features/swap/ui/swap_page.dart
@@ -275,9 +275,6 @@ class SwapTransferAmountField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fromAmount = context.select(
-      (SwapCubit cubit) => cubit.state.fromAmount,
-    );
     final toAmount = context.select(
       (SwapCubit cubit) => cubit.state.toAmount.split(' ')[0],
     );
@@ -322,7 +319,6 @@ class SwapTransferAmountField extends StatelessWidget {
                     children: [
                       Expanded(
                         child: TextFormField(
-                          controller: TextEditingController(text: fromAmount),
                           keyboardType: const TextInputType.numberWithOptions(
                             decimal: true,
                           ),


### PR DESCRIPTION
An amount controller was not needed here and it was setting the new value after change, but that making the value change again, which triggers the controller again etc. creating some kind of infinite loop when trying to delete parts.