### PR TITLE
Try creating wallet before saving descriptor

### DIFF
--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -122,8 +122,6 @@ class WalletRepository {
       watchOnlyDescriptor,
     );
 
-    await _walletMetadataDatasource.store(metadata);
-
     // Fetch the balance (in the future maybe other details of the wallet too)
     final balance = await _getBalance(metadata, sync: sync);
 
@@ -131,6 +129,8 @@ class WalletRepository {
     for (final wallet in allWallets) {
       if (wallet.id == metadata.id) throw 'Wallet already exists';
     }
+
+    await _walletMetadataDatasource.store(metadata);
 
     // Return the created wallet entity
     return Wallet(
@@ -167,8 +167,6 @@ class WalletRepository {
       label: label,
     );
 
-    await _walletMetadataDatasource.store(metadata);
-
     // Fetch the balance (in the future maybe other details of the wallet too)
     final balance = await _getBalance(metadata, sync: sync);
 
@@ -176,6 +174,8 @@ class WalletRepository {
     for (final wallet in allWallets) {
       if (wallet.id == metadata.id) throw 'Wallet already exists';
     }
+
+    await _walletMetadataDatasource.store(metadata);
 
     // Return the created wallet entity
     return Wallet(


### PR DESCRIPTION
Currently if a user accidentally saves a "bad" descriptor the wallet will enter a state where loading any wallets would fail. This is because it will store the bad descriptor, then try to load it with other wallets and just exit when reaching the bad one, causing potentially all wallets to stop loading. 

An example of bad descriptor could be: "wsh([8ea549b5/44h/1h/0h]tpubDDbJwGy6JCTXyAVdzgodLh2kQa9pXwMZ6t9eubvX4r47t8LXGToS4arokoAyTGtWngV62Hqfz7jjv8561LXuNd87d6jKdAuyn1UzbAafAgk/0/*)" (note it's WSH but passes just a key like a normal single sig).

This PR fixes the issue by moving saving the wallet after doing further actions like getting the balance which tries to create the wallet, and checking the wallet doesn't already exist.