### PR TITLE
fix: fix the recoverbull path and improve the bip85 integration

### DIFF
--- a/integration_test/bip85_derivation_test.dart
+++ b/integration_test/bip85_derivation_test.dart
@@ -14,7 +14,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/main.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:bip39_mnemonic/bip39_mnemonic.dart';
-import 'package:bip85/bip85.dart' as bip85;
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main({bool isInitialized = false}) async {

--- a/lib/core/bip85/data/bip85_datasource.dart
+++ b/lib/core/bip85/data/bip85_datasource.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/storage/tables/bip85_derivations_table.dart';
 import 'package:bip32_keys/bip32_keys.dart' as bip32;
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
-import 'package:bip85/bip85.dart' as bip85;
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:convert/convert.dart';
 import 'package:drift/drift.dart';
 

--- a/lib/core/storage/tables/bip85_derivations_table.dart
+++ b/lib/core/storage/tables/bip85_derivations_table.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
-import 'package:bip85/bip85.dart' as bip85;
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:drift/drift.dart';
 
 @DataClassName('Bip85DerivationRow')

--- a/lib/core/utils/recoverbull_bip85.dart
+++ b/lib/core/utils/recoverbull_bip85.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
+import 'package:bip85_entropy/bip85_entropy.dart';
 import 'package:hex/hex.dart';
 
 class RecoverbullBip85Utils {
-  static final bip85.CustomApplication recoverbullApplication = bip85
-      .CustomApplication.fromNumber(1608);
+  static final CustomApplication recoverbullApplication =
+      CustomApplication.fromNumber(1608);
 
   static int findApplicationNumber(String path) {
     // Old format was using `m/` prefix, which was unnecessarirly added by rust-bip85 before I forked it.
@@ -21,13 +21,11 @@ class RecoverbullBip85Utils {
 
   static String generateBackupKeyPath() {
     final randomIndex = _getRandomIndex();
-    return formatRecoverBullPath(randomIndex);
+    return formatRecoverBullPath(randomIndex).toString();
   }
 
-  static String formatRecoverBullPath(int index) {
-    // /!\ The bip85 path should be finished by a single quote /!\
-    // /!\ We keep this typo to ensure encryption keys derived today are still valid with old vaults. /!\
-    return "${recoverbullApplication.number}'/0'/$index"; // <--- this should be $index'
+  static Bip85HardenedPath formatRecoverBullPath(int index) {
+    return Bip85HardenedPath("${recoverbullApplication.number}'/0'/$index'");
   }
 
   // m/1608'/0'/586053381' -> 0'/586053381
@@ -40,7 +38,7 @@ class RecoverbullBip85Utils {
 
   static String deriveBackupKey(String xprv, String path) {
     final clearedPath = clearPathFromPrefixAndAppNumber(path);
-    final derivation = bip85.Bip85Entropy.derive(
+    final derivation = Bip85Entropy.derive(
       xprvBase58: xprv,
       application: recoverbullApplication,
       path: clearedPath,

--- a/lib/core/utils/recoverbull_bip85.dart
+++ b/lib/core/utils/recoverbull_bip85.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:bip85/bip85.dart' as bip85;
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:hex/hex.dart';
 
 class RecoverbullBip85Utils {

--- a/lib/core/widgets/bip85_derivation_widget.dart
+++ b/lib/core/widgets/bip85_derivation_widget.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bip85/bip85.dart';
+import 'package:bip85_entropy/bip85_entropy.dart';
 import 'package:flutter/material.dart';
 
 class Bip85DerivationWidget extends StatefulWidget {
@@ -22,9 +22,9 @@ class _Bip85DerivationWidgetState extends State<Bip85DerivationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final data = Bip85Entropy.deriveFromPath(
+    final data = Bip85Entropy.deriveFromRawPath(
       xprvBase58: widget.xprvBase58,
-      path: widget.derivation.path,
+      rawPath: widget.derivation.path,
     );
 
     return Container(

--- a/lib/core/widgets/bip85_derivation_widget.dart
+++ b/lib/core/widgets/bip85_derivation_widget.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bip85_entropy/bip85_entropy.dart';
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:flutter/material.dart';
 
 class Bip85DerivationWidget extends StatefulWidget {
@@ -22,9 +22,9 @@ class _Bip85DerivationWidgetState extends State<Bip85DerivationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final data = Bip85Entropy.deriveFromRawPath(
+    final data = bip85.Bip85Entropy.deriveFromHardenedPath(
       xprvBase58: widget.xprvBase58,
-      rawPath: widget.derivation.path,
+      path: bip85.Bip85HardenedPath(widget.derivation.path),
     );
 
     return Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,12 +125,11 @@ packages:
   bip85_entropy:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "5e1a9f8e5d7fc517034eddf3fe36f5271135cd73"
-      resolved-ref: "5e1a9f8e5d7fc517034eddf3fe36f5271135cd73"
-      url: "https://github.com/ethicnology/dart-bip85-entropy.git"
-    source: git
-    version: "1.0.0"
+      name: bip85_entropy
+      sha256: "1a0a2467831d25d3a0ce5740397daa67105c5b50795e3783c29bc377c7c9371f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   bitcoin_base:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -122,12 +122,12 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
-  bip85:
+  bip85_entropy:
     dependency: "direct main"
     description:
       path: "."
-      ref: "01fac31dff26bc0269b9895540262dca75a7f911"
-      resolved-ref: "01fac31dff26bc0269b9895540262dca75a7f911"
+      ref: "5e1a9f8e5d7fc517034eddf3fe36f5271135cd73"
+      resolved-ref: "5e1a9f8e5d7fc517034eddf3fe36f5271135cd73"
       url: "https://github.com/ethicnology/dart-bip85-entropy.git"
     source: git
     version: "1.0.0"
@@ -312,10 +312,10 @@ packages:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "2f757024a48696ff4814a789b0bd90f5660c0fb25f393ab4564fb483327930e2"
+      sha256: ea1ef6ba79cdbed93df2d3eeef11542a90dec24dbcd9cde574926b86d7a09a10
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   camera_web:
     dependency: transitive
     description:
@@ -895,10 +895,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ebc94ed30fd13cefd397cb1658b593f21571f014b7d1197eeb41fb95f05d899a
+      sha256: "517b20870220c48752eafa0ba1a797a092fb22df0d89535fd9991e86ee2cdd9c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -1518,10 +1518,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   posix:
     dependency: transitive
     description:
@@ -1749,18 +1749,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: f393d92c71bdcc118d6203d07c991b9be0f84b1a6f89dd4f7eed348131329924
+      sha256: "5c225083e72ea56c96d94ba1dd14fb89c8bb7731c8496ee840ab77be9bb67ae2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.9.1"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "2b03273e71867a8a4d030861fc21706200debe5c5858a4b9e58f4a1c129586a4"
+      sha256: "69c80d812ef2500202ebd22002cbfc1b6565e9ff56b2f971e757fac5d42294df"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.39"
+    version: "0.5.40"
   sqlparser:
     dependency: transitive
     description:
@@ -1926,10 +1926,10 @@ packages:
     dependency: transitive
     description:
       name: unorm_dart
-      sha256: "8e3870a1caa60bde8352f9597dd3535d8068613269444f8e35ea8925ec84c1f5"
+      sha256: "0c69186b03ca6addab0774bcc0f4f17b88d4ce78d9d4d8f0619e30a99ead58e7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1+1"
+    version: "0.3.2"
   ur:
     dependency: "direct main"
     description:
@@ -2047,10 +2047,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,10 +56,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: any
-  bip85_entropy:
-    git:
-      url: https://github.com/ethicnology/dart-bip85-entropy.git
-      ref: 5e1a9f8e5d7fc517034eddf3fe36f5271135cd73
+  bip85_entropy: ^1.0.2
   bip21_uri: ^2.1.3
   bip32_keys: ^3.0.1
   bip39_mnemonic: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,10 +56,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: any
-  bip85:
+  bip85_entropy:
     git:
       url: https://github.com/ethicnology/dart-bip85-entropy.git
-      ref: 01fac31dff26bc0269b9895540262dca75a7f911
+      ref: 5e1a9f8e5d7fc517034eddf3fe36f5271135cd73
   bip21_uri: ^2.1.3
   bip32_keys: ^3.0.1
   bip39_mnemonic: ^4.0.0

--- a/test/recoverbull_bip85_test.dart
+++ b/test/recoverbull_bip85_test.dart
@@ -15,7 +15,7 @@ void main() {
     Network.bitcoinMainnet,
   );
 
-  final validRecoverbullCustomPaths = [
+  final recoverbullPathWithMissingLastSingleQuote = [
     "m/1608'/0'/586053381",
     "1608'/0'/586053381",
   ];
@@ -24,7 +24,7 @@ void main() {
       '151a5a41f5eac5d49e67e0fad0bddd3beebe0f0e4b7739435997506cf12d9fce';
 
   group('Recoverbull Bip85', () {
-    for (final path in validRecoverbullCustomPaths) {
+    for (final path in recoverbullPathWithMissingLastSingleQuote) {
       test('deriveBackupKey', () {
         final derivedKey = RecoverbullBip85Utils.deriveBackupKey(xprv, path);
         expect(derivedKey, expectedKeyForPath);


### PR DESCRIPTION
### Changes
- Published the dependency as `bip85_entropy` on pub.dev to avoid confusion with the rust bindings published under `bip85`
- Fixed Recoverbull BIP85 derivation path to properly use hardened paths
- **OLD**: `1608'/0'/randomIndex` (missing final `'`)
- **NEW**: `1608'/0'/randomIndex'` (properly hardened)
- Maintains compatibility with existing vaults encrypted using the old path format, while new derivations use the correct hardened path specification.
