### PR TITLE
remove widget key based on input value which re-renders on every change

### DIFF
--- a/lib/features/swap/ui/swap_page.dart
+++ b/lib/features/swap/ui/swap_page.dart
@@ -322,7 +322,6 @@ class SwapTransferAmountField extends StatelessWidget {
                     children: [
                       Expanded(
                         child: TextFormField(
-                          key: ValueKey(fromAmount),
                           initialValue: fromAmount,
                           keyboardType: const TextInputType.numberWithOptions(
                             decimal: true,


### PR DESCRIPTION
The key on the field uses the amount value as key, but this changes when the user types, so this made the component rerender at every change and so focus was lost from the old field everytime. A key of a component should be fixed for the same component.