### PR TITLE
fix: home back navigation redirect to wallet home instead of closing the app, also remove the swipe left/right conflicting with back navigation gesture

### DIFF
--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -1,6 +1,3 @@
-import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bb_mobile/features/receive/ui/receive_router.dart';
-import 'package:bb_mobile/features/send/ui/send_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/auto_swap_fee_warning.dart';
@@ -15,12 +12,6 @@ import 'package:go_router/go_router.dart';
 
 class WalletHomeScreen extends StatelessWidget {
   const WalletHomeScreen({super.key});
-
-  Wallet? _getDefaultWallet(BuildContext context) {
-    final wallets = context.read<WalletBloc>().state.wallets;
-    return wallets.isNotEmpty ? wallets.first : null;
-  }
-
   @override
   Widget build(BuildContext context) {
     // Trigger service status check when the screen loads
@@ -28,23 +19,10 @@ class WalletHomeScreen extends StatelessWidget {
       context.read<WalletBloc>().add(const CheckServiceStatus());
     });
 
-    return GestureDetector(
-      onPanEnd: (details) {
-        // Only handle horizontal swipes with sufficient velocity
-        const minSwipeVelocity = 500.0;
-        final velocity = details.velocity.pixelsPerSecond.dx;
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {},
 
-        if (velocity.abs() > minSwipeVelocity) {
-          final defaultWallet = _getDefaultWallet(context);
-
-          if (velocity > 0) {
-            context.pushNamed(SendRoute.send.name, extra: defaultWallet);
-          } else {
-            // Swipe left = Receive
-            context.pushNamed(ReceiveRoute.receiveLightning.name);
-          }
-        }
-      },
       child: Column(
         children: [
           const WalletHomeTopSection(),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -58,52 +58,60 @@ class AppRouter {
             ExchangeRoute.exchangeLanding.path,
           );
 
-          return Scaffold(
-            // The app bar of the exchange tab is done with a sliver app bar
-            // on the ExchangeHomeScreen itself.
-            appBar: tabIndex == 0 ? const WalletHomeAppBar() : null,
-            extendBodyBehindAppBar: true,
-            body: child,
-            bottomNavigationBar:
-                isExchangeLanding
-                    ? null
-                    : BottomNavigationBar(
-                      currentIndex: tabIndex,
-                      onTap: (index) {
-                        if (index == 0) {
-                          context.goNamed(WalletRoute.walletHome.name);
-                        } else {
-                          // Exchange tab
-                          if (Platform.isIOS) {
-                            final isSuperuser =
-                                context
-                                    .read<SettingsCubit>()
-                                    .state
-                                    .isSuperuser ??
-                                false;
-                            if (isSuperuser) {
-                              context.goNamed(ExchangeRoute.exchangeHome.name);
-                            } else {
-                              context.goNamed(
-                                ExchangeRoute.exchangeLanding.name,
-                              );
-                            }
+          return PopScope(
+            canPop: false,
+            onPopInvokedWithResult: (didPop, _) {
+              context.goNamed(WalletRoute.walletHome.name);
+            },
+            child: Scaffold(
+              // The app bar of the exchange tab is done with a sliver app bar
+              // on the ExchangeHomeScreen itself.
+              appBar: tabIndex == 0 ? const WalletHomeAppBar() : null,
+              extendBodyBehindAppBar: true,
+              body: child,
+              bottomNavigationBar:
+                  isExchangeLanding
+                      ? null
+                      : BottomNavigationBar(
+                        currentIndex: tabIndex,
+                        onTap: (index) {
+                          if (index == 0) {
+                            context.goNamed(WalletRoute.walletHome.name);
                           } else {
-                            context.goNamed(ExchangeRoute.exchangeHome.name);
+                            // Exchange tab
+                            if (Platform.isIOS) {
+                              final isSuperuser =
+                                  context
+                                      .read<SettingsCubit>()
+                                      .state
+                                      .isSuperuser ??
+                                  false;
+                              if (isSuperuser) {
+                                context.goNamed(
+                                  ExchangeRoute.exchangeHome.name,
+                                );
+                              } else {
+                                context.goNamed(
+                                  ExchangeRoute.exchangeLanding.name,
+                                );
+                              }
+                            } else {
+                              context.goNamed(ExchangeRoute.exchangeHome.name);
+                            }
                           }
-                        }
-                      },
-                      items: const [
-                        BottomNavigationBarItem(
-                          icon: Icon(Icons.currency_bitcoin),
-                          label: 'Wallet',
-                        ),
-                        BottomNavigationBarItem(
-                          icon: Icon(Icons.attach_money),
-                          label: 'Exchange',
-                        ),
-                      ],
-                    ),
+                        },
+                        items: const [
+                          BottomNavigationBarItem(
+                            icon: Icon(Icons.currency_bitcoin),
+                            label: 'Wallet',
+                          ),
+                          BottomNavigationBarItem(
+                            icon: Icon(Icons.attach_money),
+                            label: 'Exchange',
+                          ),
+                        ],
+                      ),
+            ),
           );
         },
         routes: [WalletRouter.walletHomeRoute, ...ExchangeRouter.routes],


### PR DESCRIPTION
Closes #1360 #1297 #1281 #1037

[navigation.webm](https://github.com/user-attachments/assets/e1899dfb-fcab-4cf3-8014-74818496b772)
