### PR TITLE
fix max send button in Ark

### DIFF
--- a/lib/features/ark/ui/send_amount_page.dart
+++ b/lib/features/ark/ui/send_amount_page.dart
@@ -67,7 +67,6 @@ class _SendAmountPageState extends State<SendAmountPage> {
       //  having a mismatch between the currency and exchange rate if something
       //  goes wrong in the Cubit or just because of race conditions.
       if (state.currencyCode != _currencyCode) {
-        _controller.text = '';
         setState(() {
           _currencyCode = state.currencyCode!;
           _equivalentAmount = _calculateEquivalentAmount();
@@ -103,6 +102,8 @@ class _SendAmountPageState extends State<SendAmountPage> {
   void _onCurrencyCodeChanged(String? newCode) {
     if (newCode != null && newCode != _currencyCode) {
       context.read<ArkCubit>().onSendCurrencyCodeChanged(newCode);
+      // Clear the amount input when changing currency
+      _controller.text = '';
     }
   }
 
@@ -211,9 +212,7 @@ class _SendAmountPageState extends State<SendAmountPage> {
                               .onSendCurrencyCodeChanged(
                                 _preferredBitcoinUnit.code,
                               );
-                          setState(() {
-                            _controller.text = _calculateMaxAmountValue();
-                          });
+                          _controller.text = _calculateMaxAmountValue();
                         },
                         walletLabel: 'Ark Instant Payments',
                       ),


### PR DESCRIPTION
When the MAX button is pressed, the amount input currency is changed to sats/btc so that we can show the exact bitcoin amount to send and we don't need to convert the balance to fiat. This simplifies the max amount feature and makes sure there are no rounding issues while converting the input amount back and forth between fiat and sats/btc.

We also clear the amount when currencies are changed since amounts for some currency might be invalid in another currency, for example 0.25 USD is a valid amount, but 0.25 sats isn't.

The above two behaviors are kept the same in this PR, but a bug with them is fixed, namely that the max amount after being set was also cleared when the currency was changed after pressing the MAX button. Now the amount is never cleared when pressing the MAX button, only when the user explicitly changes the currency.
 