### PR TITLE
Add BIP49 support for Liquid wallets (Aqua compatibility)

### DIFF
--- a/lib/core/utils/descriptor_derivation.dart
+++ b/lib/core/utils/descriptor_derivation.dart
@@ -47,10 +47,23 @@ class DescriptorDerivation {
     required ScriptType scriptType,
     required bool isTestnet,
   }) async {
-    final lwk.Descriptor confidentialDescriptor = await lwk
-        .Descriptor.newConfidential(
-      network: isTestnet ? lwk.Network.testnet : lwk.Network.mainnet,
+    final network = isTestnet ? lwk.Network.testnet : lwk.Network.mainnet;
+
+    // Map ScriptType to lwk.ScriptVariant
+    final lwk.ScriptVariant scriptVariant = switch (scriptType) {
+      ScriptType.bip84 => lwk.ScriptVariant.wpkh,
+      ScriptType.bip49 => lwk.ScriptVariant.shWpkh,
+      ScriptType.bip44 => throw UnsupportedError(
+          'BIP44 is not supported for Liquid wallets. Use BIP84 or BIP49.',
+        ),
+    };
+
+    // Use lwk-dart's BIP49 support with proper script variant
+    final lwk.Descriptor confidentialDescriptor =
+        await lwk.Descriptor.newConfidentialWithScript(
+      network: network,
       mnemonic: mnemonic,
+      scriptVariant: scriptVariant,
     );
 
     return confidentialDescriptor.ctDescriptor;
@@ -104,4 +117,5 @@ class DescriptorDerivation {
 
     return descriptor.asString();
   }
+
 }

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -269,6 +269,20 @@ class WalletRepository {
             )
             .toList();
 
+    // Sort wallets: Liquid first, then Bitcoin; defaults before non-defaults within each network
+    filteredWallets.sort((a, b) {
+      // First, sort by network (Liquid first)
+      if (a.isLiquid != b.isLiquid) {
+        return a.isLiquid ? -1 : 1;
+      }
+      // Within same network, defaults first
+      if (a.isDefault != b.isDefault) {
+        return a.isDefault ? -1 : 1;
+      }
+      // If both same network and same default status, maintain original order
+      return 0;
+    });
+
     final balances = await Future.wait(
       filteredWallets.map((wallet) => _getBalance(wallet, sync: sync)),
     );

--- a/lib/core/wallet/domain/usecases/detect_liquid_script_type_usecase.dart
+++ b/lib/core/wallet/domain/usecases/detect_liquid_script_type_usecase.dart
@@ -1,0 +1,57 @@
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+
+/// Detects the appropriate script type for a Liquid wallet during recovery.
+///
+/// This usecase checks if the user has legacy BIP49 (Aqua wallet) funds by:
+/// 1. Creating a temporary BIP49 Liquid wallet
+/// 2. Syncing it to check on-chain balance
+/// 3. Deleting the temporary wallet
+/// 4. Returning BIP49 if funds found, otherwise BIP84
+///
+/// NOTE: We must create a temporary wallet because lwk-dart requires disk-based
+/// wallets (no in-memory option like BDK) and doesn't support address derivation
+/// without wallet creation. This is a one-time cost during wallet recovery for
+/// Aqua compatibility.
+class DetectLiquidScriptTypeUsecase {
+  final WalletRepository _walletRepository;
+
+  DetectLiquidScriptTypeUsecase({
+    required WalletRepository walletRepository,
+  }) : _walletRepository = walletRepository;
+
+  Future<ScriptType> execute({
+    required Seed seed,
+    required Network network,
+    DateTime? birthday,
+  }) async {
+    // Check BIP49 first for Aqua compatibility
+    final testBip49Wallet = await _walletRepository.createWallet(
+      seed: seed,
+      network: network,
+      scriptType: ScriptType.bip49,
+      isDefault: false,
+      birthday: birthday,
+      sync: true, // Must sync to detect on-chain funds
+    );
+
+    final hasFunds = testBip49Wallet.balanceSat > BigInt.zero;
+    await _walletRepository.deleteWallet(walletId: testBip49Wallet.id);
+
+    if (hasFunds) {
+      log.fine(
+        'Detected BIP49 Liquid wallet with balance: ${testBip49Wallet.balanceSat}',
+      );
+      log.warning(
+        'Importing legacy BIP49 Liquid wallet (Aqua compatibility). '
+        'Consider migrating to BIP84 for lower transaction fees.',
+      );
+      return ScriptType.bip49;
+    }
+
+    log.fine('No funds in BIP49 Liquid wallet, using BIP84');
+    return ScriptType.bip84;
+  }
+}

--- a/lib/core/wallet/domain/usecases/import_wallet_usecase.dart
+++ b/lib/core/wallet/domain/usecases/import_wallet_usecase.dart
@@ -4,21 +4,25 @@ import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/detect_liquid_script_type_usecase.dart';
 
 class ImportWalletUsecase {
   final SeedRepository _seedRepository;
   final SettingsRepository _settingsRepository;
   final WalletRepository _wallet;
+  final DetectLiquidScriptTypeUsecase _detectLiquidScriptTypeUsecase;
 
   ImportWalletUsecase({
     required SeedRepository seedRepository,
     required SettingsRepository settingsRepository,
     required WalletRepository walletRepository,
+    required DetectLiquidScriptTypeUsecase detectLiquidScriptTypeUsecase,
   }) : _seedRepository = seedRepository,
        _settingsRepository = settingsRepository,
-       _wallet = walletRepository;
+       _wallet = walletRepository,
+       _detectLiquidScriptTypeUsecase = detectLiquidScriptTypeUsecase;
 
-  Future<Wallet> execute({
+  Future<List<Wallet>> execute({
     required List<String> mnemonicWords,
     ScriptType scriptType = ScriptType.bip84,
     String passphrase = '',
@@ -32,13 +36,18 @@ class ImportWalletUsecase {
           environment.isMainnet
               ? Network.bitcoinMainnet
               : Network.bitcoinTestnet;
+      final liquidNetwork =
+          environment.isMainnet ? Network.liquidMainnet : Network.liquidTestnet;
 
       final seed = await _seedRepository.createFromMnemonic(
         mnemonicWords: mnemonicWords,
         passphrase: passphrase,
       );
 
-      final wallet = _wallet.createWallet(
+      final importedWallets = <Wallet>[];
+
+      // Create Bitcoin wallet with user-selected script type
+      final bitcoinWallet = await _wallet.createWallet(
         seed: seed,
         network: bitcoinNetwork,
         scriptType: scriptType,
@@ -46,10 +55,30 @@ class ImportWalletUsecase {
         sync: false,
         label: label,
       );
+      importedWallets.add(bitcoinWallet);
+      log.fine('Bitcoin wallet imported: ${bitcoinWallet.derivationPath}');
 
-      log.fine('Wallet imported');
+      // For Liquid, check if user has legacy BIP49 (Aqua) funds
+      final liquidScriptType = await _detectLiquidScriptTypeUsecase.execute(
+        seed: seed,
+        network: liquidNetwork,
+      );
 
-      return wallet;
+      // Create Liquid wallet with determined script type
+      final liquidWallet = await _wallet.createWallet(
+        seed: seed,
+        network: liquidNetwork,
+        scriptType: liquidScriptType,
+        isDefault: false,
+        sync: false,
+        label: label,
+      );
+      importedWallets.add(liquidWallet);
+      log.fine('Liquid wallet imported: ${liquidWallet.derivationPath}');
+
+      log.fine('Wallets imported: ${importedWallets.length} total');
+
+      return importedWallets;
     } catch (e) {
       throw ImportWalletException(e.toString());
     }

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -26,6 +26,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_status_usecas
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/detect_liquid_script_type_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transactions_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
@@ -129,12 +130,18 @@ class WalletLocator {
   }
 
   static void registerUsecases() {
+    locator.registerFactory<DetectLiquidScriptTypeUsecase>(
+      () => DetectLiquidScriptTypeUsecase(
+        walletRepository: locator<WalletRepository>(),
+      ),
+    );
     locator.registerFactory<CreateDefaultWalletsUsecase>(
       () => CreateDefaultWalletsUsecase(
         seedRepository: locator<SeedRepository>(),
         settingsRepository: locator<SettingsRepository>(),
         mnemonicGenerator: locator<MnemonicGenerator>(),
         walletRepository: locator<WalletRepository>(),
+        detectLiquidScriptTypeUsecase: locator<DetectLiquidScriptTypeUsecase>(),
       ),
     );
     locator.registerFactory<GetWalletUsecase>(
@@ -210,6 +217,7 @@ class WalletLocator {
         walletRepository: locator<WalletRepository>(),
         seedRepository: locator<SeedRepository>(),
         settingsRepository: locator<SettingsRepository>(),
+        detectLiquidScriptTypeUsecase: locator<DetectLiquidScriptTypeUsecase>(),
       ),
     );
     locator.registerFactory<TheDirtyUsecase>(

--- a/lib/core/wallet/wallet_metadata_service.dart
+++ b/lib/core/wallet/wallet_metadata_service.dart
@@ -157,7 +157,10 @@ class WalletMetadataService {
       xpubFingerprint: xpub.fingerprintHex,
       signer: Signer.local,
       signerDevice: null,
-      xpub: xpub.convert(scriptType.getXpubType(network)),
+      // For Liquid, always use standard xpub format (LWK doesn't support ypub/zpub)
+      xpub: network.isLiquid
+          ? xpub.toBase58()
+          : xpub.convert(scriptType.getXpubType(network)),
       externalPublicDescriptor: descriptor,
       internalPublicDescriptor: changeDescriptor,
       isDefault: isDefault,

--- a/lib/features/import_mnemonic/presentation/cubit.dart
+++ b/lib/features/import_mnemonic/presentation/cubit.dart
@@ -61,13 +61,13 @@ class ImportMnemonicCubit extends Cubit<ImportMnemonicState> {
       emit(state.copyWith(isLoading: true, error: null));
 
       final mnemonic = state.mnemonic!;
-      final wallet = await _importWalletUsecase.execute(
+      final wallets = await _importWalletUsecase.execute(
         mnemonicWords: mnemonic.words,
         label: mnemonic.label,
         passphrase: mnemonic.passphrase,
         scriptType: state.scriptType,
       );
-      emit(state.copyWith(wallet: wallet, isLoading: false));
+      emit(state.copyWith(wallets: wallets, isLoading: false));
     } catch (e) {
       emit(
         state.copyWith(

--- a/lib/features/import_mnemonic/presentation/state.dart
+++ b/lib/features/import_mnemonic/presentation/state.dart
@@ -18,7 +18,7 @@ sealed class ImportMnemonicState with _$ImportMnemonicState {
     @Default(null) Mnemonic? mnemonic,
     @Default(ScriptType.bip84) ScriptType scriptType,
     @Default(false) bool isLoading,
-    @Default(null) Wallet? wallet,
+    @Default(null) List<Wallet>? wallets,
     @Default(null) ({BigInt satoshis, int transactions})? bip44Status,
     @Default(null) ({BigInt satoshis, int transactions})? bip49Status,
     @Default(null) ({BigInt satoshis, int transactions})? bip84Status,

--- a/lib/features/import_mnemonic/router.dart
+++ b/lib/features/import_mnemonic/router.dart
@@ -48,7 +48,7 @@ class ImportMnemonicRouter {
           return BlocListener<ImportMnemonicCubit, ImportMnemonicState>(
             listenWhen:
                 (previous, current) =>
-                    previous.wallet == null && current.wallet != null,
+                    previous.wallets == null && current.wallets != null,
             listener: (context, state) {
               // Trigger wallet refresh before navigating to home
               context.read<WalletBloc>().add(const WalletStarted());


### PR DESCRIPTION
  ## Summary

  Adds BIP49 (nested SegWit) support for Liquid wallets to enable automatic recovery of Aqua wallet funds.

  When importing/recovering a wallet, the system now automatically detects whether the user has legacy BIP49 Liquid funds (Aqua compatibility) or should use the newer BIP84 (native SegWit) standard.

  ## Dependencies

   **Requires lwk-dart PR #66** for BIP49 support: https://github.com/SatoshiPortal/lwk-dart/pull/66

  Pubspec files are intentionally excluded from this PR. Reviewers will need to configure local dependencies to point to lwk-dart PR #66 for testing.

  ## Network Requirement: 
  BIP49 detection requires network connectivity during wallet import to check on-chain balances. This adds latency on slow networks (5-30 seconds tested with Network Link
  Conditioner).

  ## Key Changes

  - Created `DetectLiquidScriptTypeUsecase` to centralize BIP49 detection logic
  - Automatically checks for BIP49 funds during wallet recovery
  - Falls back to BIP84 if no BIP49 funds detected
  - Added BIP49 (P2SH-P2WPKH) script variant support for Liquid descriptors
  - Fixed bug in import wallet flow where sync was disabled during detection

  ## Related Work

  PR #1376 fixed the import wallet flow to properly sync existing Liquid wallets. This PR extends that functionality to also auto-detect and support BIP49 Liquid wallets (Aqua compatibility).


