### PR TITLE
fix: Show pending correctly for a pending onchain in tx list

### DIFF
--- a/lib/features/transactions/ui/widgets/tx_list_item.dart
+++ b/lib/features/transactions/ui/widgets/tx_list_item.dart
@@ -221,26 +221,54 @@ class TxListItem extends StatelessWidget {
                       ),
                     ],
                   )
-                else if (date != null || !tx.isOngoingSwap)
+                else if (tx.walletTransaction?.isConfirmed ?? false)
                   Row(
                     children: [
                       BBText(
                         date ?? '',
                         style: context.font.labelSmall?.copyWith(
-                          color:
-                              tx.isOngoingSwap
-                                  ? context.colour.secondary
-                                  : context.colour.outline,
+                          color: context.colour.outline,
                         ),
                       ),
                       const Gap(4.0),
                       Icon(
-                        tx.isOngoingSwap ? Icons.sync : Icons.check_circle,
+                        Icons.check_circle,
                         size: 12.0,
-                        color:
-                            tx.isOngoingSwap
-                                ? context.colour.secondary
-                                : context.colour.inverseSurface,
+                        color: context.colour.inverseSurface,
+                      ),
+                    ],
+                  )
+                else if (date != null && (tx.isSwap || isOrderType))
+                  Row(
+                    children: [
+                      BBText(
+                        date,
+                        style: context.font.labelSmall?.copyWith(
+                          color: context.colour.outline,
+                        ),
+                      ),
+                      const Gap(4.0),
+                      Icon(
+                        Icons.check_circle,
+                        size: 12.0,
+                        color: context.colour.inverseSurface,
+                      ),
+                    ],
+                  )
+                else if (date != null && tx.isOngoingSwap)
+                  Row(
+                    children: [
+                      BBText(
+                        date,
+                        style: context.font.labelSmall?.copyWith(
+                          color: context.colour.secondary,
+                        ),
+                      ),
+                      const Gap(4.0),
+                      Icon(
+                        Icons.sync,
+                        size: 12.0,
+                        color: context.colour.secondary,
                       ),
                     ],
                   )


### PR DESCRIPTION
Pending onchain was showing a tick without a date. Should say pending. This was a regression caused during a fixed for chain swap that should be Pending or completed based on swap status. 

Needs to be tested with swaps.