### PR TITLE
fix: use bash shebang in pre-commit hook

### DIFF
--- a/.git_hooks/pre-commit
+++ b/.git_hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 echo "Begin pre-commit hook"
 
 # Prefer FVM Flutter if present; else try `fvm flutter`; else global flutter


### PR DESCRIPTION
## Summary

Fixed the shebang in the pre-commit hook from `#!/bin/sh` to `#!/bin/bash` to ensure compatibility with the bash-specific syntax used in the script.

## Problem

The pre-commit hook uses the `[[ ]]` test operator (line 5), which is bash-specific. On systems where `/bin/sh` is linked to `dash`, `ash`, or other minimal POSIX shells (common on Debian/Ubuntu), this syntax is not supported and causes the hook to fail.

## Solution

Changed the shebang from `#!/bin/sh` to `#!/bin/bash` to explicitly require bash, ensuring the `[[ -x ... ]]` conditional works correctly across all systems.

## Changes

- [.git_hooks/pre-commit](.git_hooks/pre-commit#L1): Changed shebang from `#!/bin/sh` to `#!/bin/bash`

## Testing

- Verified the hook syntax requires bash features (`[[ ]]` operator)
- Confirmed this is a defensive programming practice when using bash-specific features