### PR TITLE
feat: localization `app_startup`

### DIFF
--- a/lib/features/app_startup/ui/app_startup_widget.dart
+++ b/lib/features/app_startup/ui/app_startup_widget.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/share_logs_widget.dart';
@@ -116,7 +117,7 @@ class AppStartupFailureScreen extends StatelessWidget {
                     Icon(Icons.error_outline, color: context.colour.error),
                     const Gap(8),
                     Text(
-                      'Startup Error',
+                      context.loc.appStartupErrorTitle,
                       style: context.font.headlineLarge?.copyWith(
                         color: context.colour.error,
                       ),
@@ -128,8 +129,8 @@ class AppStartupFailureScreen extends StatelessWidget {
                   child: Text(
                     e is SeedNotFoundException
                         ? hasBackup
-                            ? 'On v5.4.0 a critical bug was discovered in one of our dependencies which affect private key storage. Your app has been affected by this. You will have to delete this app and reinstall it with your backed up seed.'
-                            : 'On v5.4.0 a critical bug was discovered in one of our dependencies which affect private key storage. Your app has been affected by this. Contact our support team.'
+                            ? context.loc.appStartupErrorMessageWithBackup
+                            : context.loc.appStartupErrorMessageNoBackup
                         : e.toString(),
                     style: context.font.bodyMedium?.copyWith(
                       color: context.colour.secondary.withValues(alpha: 0.7),
@@ -144,7 +145,7 @@ class AppStartupFailureScreen extends StatelessWidget {
                   // ignore: deprecated_member_use
                   launchUrl(url, mode: LaunchMode.externalApplication);
                 },
-                label: 'Contact Support',
+                label: context.loc.appStartupContactSupportButton,
                 bgColor: context.colour.primary,
                 textColor: context.colour.onPrimary,
               ),

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -7967,5 +7967,21 @@
   "addressViewChangeAddressesDescription": "Display wallet Change addresses",
   "@addressViewChangeAddressesDescription": {
     "description": "Description for the coming soon dialog when trying to view change addresses"
+  },
+  "appStartupErrorTitle": "Startup Error",
+  "@appStartupErrorTitle": {
+    "description": "Title shown when the app fails to start up properly"
+  },
+  "appStartupErrorMessageWithBackup": "On v5.4.0 a critical bug was discovered in one of our dependencies which affect private key storage. Your app has been affected by this. You will have to delete this app and reinstall it with your backed up seed.",
+  "@appStartupErrorMessageWithBackup": {
+    "description": "Error message shown when app startup fails due to seed storage issue and user has a backup"
+  },
+  "appStartupErrorMessageNoBackup": "On v5.4.0 a critical bug was discovered in one of our dependencies which affect private key storage. Your app has been affected by this. Contact our support team.",
+  "@appStartupErrorMessageNoBackup": {
+    "description": "Error message shown when app startup fails due to seed storage issue and user has no backup"
+  },
+  "appStartupContactSupportButton": "Contact Support",
+  "@appStartupContactSupportButton": {
+    "description": "Button label to contact support when app startup fails"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -7967,5 +7967,21 @@
   "addressViewChangeAddressesDescription": "Mostrar direcciones de cambio de la billetera",
   "@addressViewChangeAddressesDescription": {
     "description": "Descripción del diálogo próximamente al intentar ver direcciones de cambio"
+  },
+  "appStartupErrorTitle": "Error de inicio",
+  "@appStartupErrorTitle": {
+    "description": "Título mostrado cuando la aplicación no se inicia correctamente"
+  },
+  "appStartupErrorMessageWithBackup": "En la versión 5.4.0 se descubrió un error crítico en una de nuestras dependencias que afecta el almacenamiento de claves privadas. Su aplicación ha sido afectada por esto. Deberá eliminar esta aplicación y reinstalarla con su frase de recuperación respaldada.",
+  "@appStartupErrorMessageWithBackup": {
+    "description": "Mensaje de error mostrado cuando el inicio de la aplicación falla debido a un problema de almacenamiento de frase de recuperación y el usuario tiene una copia de seguridad"
+  },
+  "appStartupErrorMessageNoBackup": "En la versión 5.4.0 se descubrió un error crítico en una de nuestras dependencias que afecta el almacenamiento de claves privadas. Su aplicación ha sido afectada por esto. Contacte a nuestro equipo de soporte.",
+  "@appStartupErrorMessageNoBackup": {
+    "description": "Mensaje de error mostrado cuando el inicio de la aplicación falla debido a un problema de almacenamiento de frase de recuperación y el usuario no tiene una copia de seguridad"
+  },
+  "appStartupContactSupportButton": "Contactar Soporte",
+  "@appStartupContactSupportButton": {
+    "description": "Etiqueta del botón para contactar al soporte cuando falla el inicio de la aplicación"
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -7967,5 +7967,21 @@
   "addressViewChangeAddressesDescription": "Afficher les adresses de change du portefeuille",
   "@addressViewChangeAddressesDescription": {
     "description": "Description de la boîte de dialogue à venir lors de la tentative d'affichage des adresses de change"
+  },
+  "appStartupErrorTitle": "Erreur de démarrage",
+  "@appStartupErrorTitle": {
+    "description": "Titre affiché lorsque l'application ne démarre pas correctement"
+  },
+  "appStartupErrorMessageWithBackup": "Dans la version 5.4.0, un bogue critique a été découvert dans l'une de nos dépendances qui affecte le stockage des clés privées. Votre application a été affectée par cela. Vous devrez supprimer cette application et la réinstaller avec votre phrase de récupération sauvegardée.",
+  "@appStartupErrorMessageWithBackup": {
+    "description": "Message d'erreur affiché lorsque le démarrage de l'application échoue en raison d'un problème de stockage de phrase de récupération et que l'utilisateur a une sauvegarde"
+  },
+  "appStartupErrorMessageNoBackup": "Dans la version 5.4.0, un bogue critique a été découvert dans l'une de nos dépendances qui affecte le stockage des clés privées. Votre application a été affectée par cela. Contactez notre équipe d'assistance.",
+  "@appStartupErrorMessageNoBackup": {
+    "description": "Message d'erreur affiché lorsque le démarrage de l'application échoue en raison d'un problème de stockage de phrase de récupération et que l'utilisateur n'a pas de sauvegarde"
+  },
+  "appStartupContactSupportButton": "Contacter le support",
+  "@appStartupContactSupportButton": {
+    "description": "Libellé du bouton pour contacter le support lorsque le démarrage de l'application échoue"
   }
 }


### PR DESCRIPTION
## Localization: App Startup

### Overview
- Feature: `lib/features/app_startup`
- Strings localized: 4
- Files modified: 4

### Changes
- [x] Added 4 new localization keys to ARB files
- [x] Replaced hardcoded strings in 1 Dart file
- [x] Added BuildContextX import where needed
- [x] Validated with `validate_localizations.py`
- [x] Generated localization files with `make l10n`

### Localization Keys Added
- `appStartupErrorTitle` - "Startup Error"
- `appStartupErrorMessageWithBackup` - Error message for users with backup
- `appStartupErrorMessageNoBackup` - Error message for users without backup
- `appStartupContactSupportButton` - "Contact Support" button

### Testing
- [x] Validated synchronization across all three ARB files (en, fr, es)
- [x] No hardcoded strings remain in app_startup feature
- [x] Code compiles without errors related to this change
- [x] Validation script passes (all 1854 keys synchronized)

### Files Modified
- `lib/features/app_startup/ui/app_startup_widget.dart`
- `localization/app_en.arb`
- `localization/app_fr.arb`
- `localization/app_es.arb`

### Checklist
- [x] All ARB files synchronized
- [x] Validation script passes
- [x] No breaking changes
- [x] Follows naming conventions
- [x] BuildContextX import added

### Notes
This is a small feature with only 4 strings to localize, all related to the error screen shown when app startup fails due to the seed storage issue discovered in v5.4.0.