### PR TITLE
feat: localization of feature/backup_settings

### DIFF
--- a/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
+++ b/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
@@ -90,12 +90,12 @@ class _BackupTestStatusWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _StatusRow(
-              label: 'Physical Backup',
+              label: context.loc.backupSettingsPhysicalBackup,
               isTested: state.isDefaultPhysicalBackupTested,
             ),
             const Gap(15),
             _StatusRow(
-              label: 'Encrypted Vault',
+              label: context.loc.backupSettingsEncryptedVault,
               isTested: state.isDefaultEncryptedBackupTested,
             ),
           ],
@@ -118,7 +118,7 @@ class _StatusRow extends StatelessWidget {
         Text(label, style: context.font.bodyMedium),
         const Spacer(),
         Text(
-          isTested ? 'Tested' : 'Not Tested',
+          isTested ? context.loc.backupSettingsTested : context.loc.backupSettingsNotTested,
           style: context.font.bodyMedium?.copyWith(
             color:
                 isTested ? context.colour.inverseSurface : context.colour.error,
@@ -135,7 +135,7 @@ class _TestBackupButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBButton.big(
-      label: 'Test Backup',
+      label: context.loc.backupSettingsTestBackup,
       onPressed:
           () => context.pushNamed(
             BackupSettingsSubroute.testbackupOptions.name,
@@ -155,7 +155,7 @@ class _StartBackupButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBButton.big(
-      label: 'Start Backup',
+      label: context.loc.backupSettingsStartBackup,
       onPressed:
           () => context.pushNamed(BackupSettingsSubroute.backupOptions.name),
       bgColor: context.colour.secondary,
@@ -170,7 +170,7 @@ class _ViewVaultKeyButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBButton.big(
-      label: 'View Vault Key',
+      label: context.loc.backupSettingsViewVaultKey,
       onPressed: () async {
         final confirmed = await ViewVaultKeyWarningBottomSheet.show(context);
         if (confirmed == true) {
@@ -214,7 +214,7 @@ class ErrorWidget extends StatelessWidget {
               Icon(Icons.error_outline, color: context.colour.error, size: 20),
               const Gap(8),
               Text(
-                'Error',
+                context.loc.backupSettingsError,
                 style: context.font.titleSmall?.copyWith(
                   color: context.colour.error,
                   fontWeight: FontWeight.bold,
@@ -241,7 +241,7 @@ class _Bip329LabelsButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BBButton.big(
-      label: 'Labels',
+      label: context.loc.backupSettingsLabelsButton,
       onPressed: () => context.push(Bip329LabelsRouter.route.path),
       bgColor: context.colour.secondary,
       textColor: context.colour.onSecondary,

--- a/lib/features/backup_settings/ui/widgets/view_vault_key_warning_bottom_sheet.dart
+++ b/lib/features/backup_settings/ui/widgets/view_vault_key_warning_bottom_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -40,7 +41,7 @@ class ViewVaultKeyWarningBottomSheet extends StatelessWidget {
                   children: [
                     const Gap(24),
                     BBText(
-                      'Security Warning',
+                      context.loc.backupSettingsSecurityWarning,
                       style: context.font.headlineMedium,
                     ),
                     GestureDetector(
@@ -60,7 +61,7 @@ class ViewVaultKeyWarningBottomSheet extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     BBText(
-                      'Warning: Be careful where you save the backup key.',
+                      context.loc.backupSettingsKeyWarningBold,
                       style: context.font.bodyMedium?.copyWith(
                         color: context.colour.secondary,
                         fontWeight: FontWeight.bold,
@@ -69,13 +70,13 @@ class ViewVaultKeyWarningBottomSheet extends StatelessWidget {
                     ),
                     const Gap(24),
                     BBText(
-                      'It is critically important that you do not save the backup key at the same place where you save your backup file. Always store them on separate devices or separate cloud providers.',
+                      context.loc.backupSettingsKeyWarningMessage,
                       maxLines: 4,
                       style: context.font.bodyMedium,
                     ),
                     const Gap(16),
                     BBText(
-                      'For example, if you used Google Drive for your backup file, do not use Google Drive for your backup key.',
+                      context.loc.backupSettingsKeyWarningExample,
                       maxLines: 3,
                       style: context.font.bodyMedium,
                     ),
@@ -84,7 +85,7 @@ class ViewVaultKeyWarningBottomSheet extends StatelessWidget {
                       children: [
                         Expanded(
                           child: BBButton.big(
-                            label: 'Cancel',
+                            label: context.loc.cancelButton,
                             onPressed: () => Navigator.of(context).pop(false),
                             bgColor: Colors.transparent,
                             outlined: true,
@@ -95,7 +96,7 @@ class ViewVaultKeyWarningBottomSheet extends StatelessWidget {
                         const Gap(16),
                         Expanded(
                           child: BBButton.big(
-                            label: 'Continue',
+                            label: context.loc.sendContinue,
                             onPressed: () => context.pop(true),
                             bgColor: context.colour.secondary,
                             textStyle: context.font.headlineLarge,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -5668,6 +5668,10 @@
   "@backupSettingsKeyWarningExample": {
     "description": "Example explaining backup key storage separation"
   },
+  "backupSettingsLabelsButton": "Labels",
+  "@backupSettingsLabelsButton": {
+    "description": "Button text to manage transaction labels"
+  },
   "backupWalletImportanceWarning": "Without a backup, you will eventually lose access to your money. It is critically important to do a backup.",
   "@backupWalletImportanceWarning": {
     "description": "Warning message emphasizing the importance of creating a backup"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -5668,6 +5668,10 @@
   "@backupSettingsKeyWarningExample": {
     "description": "Example explaining backup key storage separation"
   },
+  "backupSettingsLabelsButton": "Etiquetas",
+  "@backupSettingsLabelsButton": {
+    "description": "Button text to manage transaction labels"
+  },
   "backupWalletImportanceWarning": "Sin un respaldo, eventualmente perderá el acceso a su dinero. Es críticamente importante hacer un respaldo.",
   "@backupWalletImportanceWarning": {
     "description": "Warning message emphasizing the importance of creating a backup"

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -5668,6 +5668,10 @@
   "@backupSettingsKeyWarningExample": {
     "description": "Example explaining backup key storage separation"
   },
+  "backupSettingsLabelsButton": "Étiquettes",
+  "@backupSettingsLabelsButton": {
+    "description": "Button text to manage transaction labels"
+  },
   "backupWalletImportanceWarning": "Sans sauvegarde, vous finirez par perdre l'accès à votre argent. Il est absolument essentiel d'effectuer une sauvegarde.",
   "@backupWalletImportanceWarning": {
     "description": "Warning message emphasizing the importance of creating a backup"


### PR DESCRIPTION
## Overview

Localize the `backup_settings` feature to support English, French, and Spanish translations.

**Files Modified:** 5
**Strings Localized:** 8 (1 new key added)

<img width="600" height="1336" alt="Screenshot_1762894553" src="https://github.com/user-attachments/assets/7443b5e6-f12b-4d6d-acad-7a2354893f8a" />


## Changes

### Localization Keys
- ✅ **1 new key added** to all three ARB files:
  - `backupSettingsLabelsButton` (Labels/Étiquettes/Etiquetas)

### Dart Files Updated

#### `backup_settings_screen.dart` (8 strings)
- Physical Backup / Encrypted Vault labels → `backupSettingsPhysicalBackup`, `backupSettingsEncryptedVault`
- Tested / Not Tested status → `backupSettingsTested`, `backupSettingsNotTested`
- Test Backup button → `backupSettingsTestBackup`
- Start Backup button → `backupSettingsStartBackup`
- View Vault Key button → `backupSettingsViewVaultKey`
- Error label → `backupSettingsError`
- Labels button → `backupSettingsLabelsButton`

#### `view_vault_key_warning_bottom_sheet.dart` (5 strings)
- Security Warning title → `backupSettingsSecurityWarning`
- Warning bold text → `backupSettingsKeyWarningBold`
- Warning message → `backupSettingsKeyWarningMessage`
- Warning example → `backupSettingsKeyWarningExample`
- Cancel button → `cancelButton`
- Continue button → `sendContinue`

## Validation

- ✅ All ARB files validated with `python3 linux/validate_localizations.py`
- ✅ Localization files regenerated with `make l10n`
- ✅ Pre-commit hooks passed
- ✅ All three languages (en, fr, es) synchronized

## Testing

Please test in all three languages:
1. Navigate to: Settings → Wallet Settings → Backup Settings
2. Verify all labels display correctly
3. Test "View Vault Key" button → verify warning dialog shows translated text
4. Verify all button labels are localized

## Notes

Most backup_settings keys already existed in the ARB files. Only one new key (`backupSettingsLabelsButton`) was needed.

## Related

Part of the localization effort tracked in `linux/localization-overarching-plan.md`.