### PR TITLE
feat: localization of features/backup_wallet

### DIFF
--- a/lib/features/backup_wallet/ui/screens/backup_check_list_screen.dart
+++ b/lib/features/backup_wallet/ui/screens/backup_check_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/generic_extensions.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
@@ -22,14 +23,14 @@ class BackCheckListScreen extends StatelessWidget {
     );
     final lastPhysicalBackup = defaultWallet?.latestPhysicalBackup;
 
-    final instructions = backupInstructions();
+    final instructions = backupInstructions(context);
     return Scaffold(
       appBar: AppBar(
         forceMaterialTransparency: true,
         automaticallyImplyLeading: false,
         flexibleSpace: TopBar(
           onBack: () => context.pop(),
-          title: 'Backup best practices',
+          title: context.loc.backupWalletBestPracticesTitle,
         ),
       ),
       body: SingleChildScrollView(
@@ -41,7 +42,7 @@ class BackCheckListScreen extends StatelessWidget {
               if (lastPhysicalBackup != null) ...[
                 const Gap(8),
                 BBText(
-                  'Last backup test: ${lastPhysicalBackup.toString().substring(0, 19)}',
+                  '${context.loc.backupWalletLastBackupTest}${lastPhysicalBackup.toString().substring(0, 19)}',
                   style: context.font.bodyMedium,
                 ),
               ],
@@ -75,7 +76,7 @@ class BackCheckListScreen extends StatelessWidget {
                     () => context.pushNamed(
                       TestWalletBackupSubroute.testPhysicalBackup.name,
                     ),
-                label: 'Backup',
+                label: context.loc.backupWalletBackupButton,
               ),
               const Gap(60),
             ],
@@ -85,19 +86,13 @@ class BackCheckListScreen extends StatelessWidget {
     );
   }
 
-  List<String> backupInstructions() {
+  List<String> backupInstructions(BuildContext context) {
     return [
-      'If you lose your 12 word backup, you will not be able to recover access to the Bitcoin Wallet.',
-      'Without a backup, if you lose or break your phone, or if you uninstall the Bull Bitcoin app, your bitcoins will be lost forever.',
-      'Anybody with access to your 12 word backup can steal your bitcoins. Hide it well.',
-      'Do not make digital copies of your backup. Write it down on a piece of paper, or engraved in metal.',
-      'Your backup is not protected by passphrase. Add a passphrase to your backup later by creating a new wallet.',
-      // (No passphrase)
-      // If you lose your 12 word backup, you will not be able to recover access to the Bitcoin Wallet.
-      // Without a backup, if you lose or break your phone, or if you uninstall the Bull Bitcoin app, your bitcoins will be lost forever.
-      // Anybody with access to your 12 word backup can steal your bitcoins. Hide it well.
-      // Do not make digital copies of your backup. Write it down on a piece of paper, or engraved in metal.
-      // Your backup is not protected by passphrase. Add a passphrase to your backup later by creating a new wallet.
+      context.loc.backupWalletInstructionLoseBackup,
+      context.loc.backupWalletInstructionLosePhone,
+      context.loc.backupWalletInstructionSecurityRisk,
+      context.loc.backupWalletInstructionNoDigitalCopies,
+      context.loc.backupWalletInstructionNoPassphrase,
     ];
   }
 }

--- a/lib/features/backup_wallet/ui/screens/backup_options_screen.dart
+++ b/lib/features/backup_wallet/ui/screens/backup_options_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/cards/backup_option_card.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -29,7 +30,7 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
         automaticallyImplyLeading: false,
         flexibleSpace: TopBar(
           onBack: () => context.pop(),
-          title: 'Backup your wallet',
+          title: context.loc.backupWalletTitle,
         ),
       ),
       body: SafeArea(
@@ -40,7 +41,7 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
             children: [
               const Gap(20),
               BBText(
-                'Without a backup, you will eventually lose access to your money. It is critically important to do a backup.',
+                context.loc.backupWalletImportanceWarning,
                 textAlign: TextAlign.center,
                 style: context.font.bodyLarge,
                 maxLines: 5,
@@ -53,10 +54,9 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
                   height: 45,
                   fit: BoxFit.cover,
                 ),
-                title: 'Encrypted vault',
-                description:
-                    'Anonymous backup with strong encryption using your cloud.\nRequires Tor.',
-                tag: 'Easy and simple (1 minute)',
+                title: context.loc.backupWalletEncryptedVaultTitle,
+                description: context.loc.backupWalletEncryptedVaultDescription,
+                tag: context.loc.backupWalletEncryptedVaultTag,
                 onTap:
                     () => {
                       context.pushNamed(
@@ -77,10 +77,9 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
                   height: 45,
                   fit: BoxFit.cover,
                 ),
-                title: 'Physical backup',
-                description:
-                    'Write down 12 words on a piece of paper. Keep them safe and make sure not to lose them.',
-                tag: 'Trustless (take your time)',
+                title: context.loc.backupWalletPhysicalBackupTitle,
+                description: context.loc.backupWalletPhysicalBackupDescription,
+                tag: context.loc.backupWalletPhysicalBackupTag,
                 onTap:
                     () => context.pushNamed(
                       BackupWalletSubroute.physicalCheckList.name,
@@ -129,7 +128,7 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
                   );
                 },
                 child: BBText(
-                  "How to decide?",
+                  context.loc.backupWalletHowToDecide,
                   style: context.font.headlineLarge?.copyWith(
                     color: context.colour.primary,
                   ),

--- a/lib/features/backup_wallet/ui/screens/backup_success_screen.dart
+++ b/lib/features/backup_wallet/ui/screens/backup_success_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/loading/status_screen.dart';
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:flutter/material.dart';
@@ -9,11 +10,10 @@ class BackupSuccessScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StatusScreen(
-      title: 'Backup completed!',
-      description:
-          "Now let's test your backup to make sure everything was done properly.",
+      title: context.loc.backupWalletSuccessTitle,
+      description: context.loc.backupWalletSuccessDescription,
       isLoading: false,
-      buttonText: 'Test Backup',
+      buttonText: context.loc.backupWalletSuccessTestButton,
       onTap:
           () => context.goNamed(
             BackupSettingsSubroute.testbackupOptions.name,

--- a/lib/features/backup_wallet/ui/widgets/how_to_decide.dart
+++ b/lib/features/backup_wallet/ui/widgets/how_to_decide.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
@@ -26,7 +27,7 @@ class HowToDecideBackupOption extends StatelessWidget {
                 children: [
                   const Spacer(),
                   BBText(
-                    "How to decide",
+                    context.loc.backupWalletHowToDecideBackupModalTitle,
                     style: context.font.headlineMedium,
                     textAlign: TextAlign.center,
                   ),
@@ -47,9 +48,7 @@ class HowToDecideBackupOption extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       BBText(
-                        "One of the most common ways people lose their Bitcoin is because they lose the physical backup. "
-                        "Anybody that finds your physical backup will be able to take all your Bitcoin. "
-                        "If you are very confident that you can hide it well and never lose it, it's a good option.",
+                        context.loc.backupWalletHowToDecideBackupLosePhysical,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,
@@ -58,11 +57,7 @@ class HowToDecideBackupOption extends StatelessWidget {
                       ),
                       const Gap(32),
                       BBText(
-                        "The encrypted vault prevents you from thieves looking to steal your backup. "
-                        "It also prevents you from accidentally losing your backup since it will be stored in your cloud. "
-                        "Cloud storage providers like Google or Apple won't have access to your Bitcoin because the encryption password is too strong. "
-                        "There is a small possibility that the web server that stores your backup's encryption key could be compromised. "
-                        "In this event, the security of the backup in your cloud account could be at risk.",
+                        context.loc.backupWalletHowToDecideBackupEncryptedVault,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,
@@ -75,14 +70,13 @@ class HowToDecideBackupOption extends StatelessWidget {
                           style: context.font.bodyMedium,
                           children: [
                             TextSpan(
-                              text: 'Physical backup: ',
+                              text: context.loc.backupWalletHowToDecideBackupPhysicalRecommendation,
                               style: context.font.labelMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
                             TextSpan(
-                              text:
-                                  'You are confident in your own operational security capabilities to hide and preserve your Bitcoin seed words.',
+                              text: context.loc.backupWalletHowToDecideBackupPhysicalRecommendationText,
                               style: context.font.labelMedium,
                             ),
                           ],
@@ -94,14 +88,13 @@ class HowToDecideBackupOption extends StatelessWidget {
                           style: context.font.bodyMedium,
                           children: [
                             TextSpan(
-                              text: 'Encrypted vault: ',
+                              text: context.loc.backupWalletHowToDecideBackupEncryptedRecommendation,
                               style: context.font.labelMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
                             TextSpan(
-                              text:
-                                  'You are not sure and you need more time to learn about backup security practices.',
+                              text: context.loc.backupWalletHowToDecideBackupEncryptedRecommendationText,
                               style: context.font.labelMedium,
                             ),
                           ],
@@ -109,7 +102,7 @@ class HowToDecideBackupOption extends StatelessWidget {
                       ),
                       const Gap(12),
                       BBText(
-                        'Visit recoverbull.com for more information.',
+                        context.loc.backupWalletHowToDecideBackupMoreInfo,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,
@@ -151,7 +144,7 @@ class HowToDecideVaultLocation extends StatelessWidget {
                 children: [
                   const Spacer(),
                   BBText(
-                    "How to decide",
+                    context.loc.backupWalletHowToDecideBackupModalTitle,
                     style: context.font.headlineMedium,
                     textAlign: TextAlign.center,
                   ),
@@ -172,7 +165,7 @@ class HowToDecideVaultLocation extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       BBText(
-                        "Cloud storage providers like Google or Apple won't have access to your Bitcoin because the encryption password is too strong. They can only access your Bitcoin in the unlikely event they collude with the key server (the online service which stores your encryption password). If the key server ever gets hacked, your Bitcoin could be at risk with Google or Apple cloud.",
+                        context.loc.backupWalletHowToDecideVaultCloudSecurity,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,
@@ -181,7 +174,7 @@ class HowToDecideVaultLocation extends StatelessWidget {
                       ),
                       const Gap(32),
                       BBText(
-                        'A custom location can be much more secure, depending on which location you choose. You must also make sure not to lose the backup file or to lose the device on which your backup file is stored.',
+                        context.loc.backupWalletHowToDecideVaultCustomLocation,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,
@@ -194,14 +187,13 @@ class HowToDecideVaultLocation extends StatelessWidget {
                           style: context.font.bodyMedium,
                           children: [
                             TextSpan(
-                              text: 'Custom location: ',
+                              text: context.loc.backupWalletHowToDecideVaultCustomRecommendation,
                               style: context.font.labelMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
                             TextSpan(
-                              text:
-                                  'you are confident you will not lose the vault file and it will still be accessible if you lose your phone.',
+                              text: context.loc.backupWalletHowToDecideVaultCustomRecommendationText,
                               style: context.font.labelMedium,
                             ),
                           ],
@@ -213,14 +205,13 @@ class HowToDecideVaultLocation extends StatelessWidget {
                           style: context.font.bodyMedium,
                           children: [
                             TextSpan(
-                              text: 'Google or Apple cloud: ',
+                              text: context.loc.backupWalletHowToDecideVaultCloudRecommendation,
                               style: context.font.labelMedium?.copyWith(
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
                             TextSpan(
-                              text:
-                                  'you want to make sure you never lose access to your vault file even if you lose your devices.',
+                              text: context.loc.backupWalletHowToDecideVaultCloudRecommendationText,
                               style: context.font.labelMedium,
                             ),
                           ],
@@ -228,7 +219,7 @@ class HowToDecideVaultLocation extends StatelessWidget {
                       ),
                       const Gap(12),
                       BBText(
-                        'Visit recoverbull.com for more information.',
+                        context.loc.backupWalletHowToDecideVaultMoreInfo,
                         style: context.font.labelMedium?.copyWith(
                           height: 1.5,
                           fontSize: 14,


### PR DESCRIPTION
## Overview

Localize the `backup_wallet` feature to support English, French, and Spanish translations.

**Files Modified:** 4
**Strings Localized:** 30 (0 new keys added)

<img width="800" height="887" alt="final_2_images_800px_corrected" src="https://github.com/user-attachments/assets/01d20a68-e8a7-4da7-adcb-7927a6771d90" />

<img width="400" height="890" alt="Screenshot_1762899165" src="https://github.com/user-attachments/assets/e034dcf6-8e7f-4076-9738-1b4d9bb788c9" />

## Changes

### Dart Files Updated

#### `backup_options_screen.dart` (7 strings)
- Screen title → `backupWalletTitle`
- Importance warning → `backupWalletImportanceWarning`
- Encrypted vault title → `backupWalletEncryptedVaultTitle`
- Encrypted vault description → `backupWalletEncryptedVaultDescription`
- Encrypted vault tag → `backupWalletEncryptedVaultTag`
- Physical backup title → `backupWalletPhysicalBackupTitle`
- Physical backup description → `backupWalletPhysicalBackupDescription`
- Physical backup tag → `backupWalletPhysicalBackupTag`
- "How to decide?" link → `backupWalletHowToDecide`

#### `backup_success_screen.dart` (3 strings)
- Success title → `backupWalletSuccessTitle`
- Success description → `backupWalletSuccessDescription`
- Test Backup button → `backupWalletSuccessTestButton`

#### `backup_check_list_screen.dart` (7 strings)
- Best practices title → `backupWalletBestPracticesTitle`
- Last backup test label → `backupWalletLastBackupTest`
- Instruction 1 → `backupWalletInstructionLoseBackup`
- Instruction 2 → `backupWalletInstructionLosePhone`
- Instruction 3 → `backupWalletInstructionSecurityRisk`
- Instruction 4 → `backupWalletInstructionNoDigitalCopies`
- Instruction 5 → `backupWalletInstructionNoPassphrase`
- Backup button → `backupWalletBackupButton`
- Modified `backupInstructions()` method to accept BuildContext parameter

#### `how_to_decide.dart` (13 strings)
- Modal title (2x) → `backupWalletHowToDecideBackupModalTitle`
- Physical backup explanation → `backupWalletHowToDecideBackupLosePhysical`
- Encrypted vault explanation → `backupWalletHowToDecideBackupEncryptedVault`
- Physical backup recommendation label → `backupWalletHowToDecideBackupPhysicalRecommendation`
- Physical backup recommendation text → `backupWalletHowToDecideBackupPhysicalRecommendationText`
- Encrypted vault recommendation label → `backupWalletHowToDecideBackupEncryptedRecommendation`
- Encrypted vault recommendation text → `backupWalletHowToDecideBackupEncryptedRecommendationText`
- Vault cloud security explanation → `backupWalletHowToDecideVaultCloudSecurity`
- Vault custom location explanation → `backupWalletHowToDecideVaultCustomLocation`
- Custom location recommendation label → `backupWalletHowToDecideVaultCustomRecommendation`
- Custom location recommendation text → `backupWalletHowToDecideVaultCustomRecommendationText`
- Cloud recommendation label → `backupWalletHowToDecideVaultCloudRecommendation`
- Cloud recommendation text → `backupWalletHowToDecideVaultCloudRecommendationText`
- More info link (2x) → `backupWalletHowToDecideBackupMoreInfo`, `backupWalletHowToDecideVaultMoreInfo`

## Validation

- ✅ All ARB files validated with `python3 linux/validate_localizations.py`
- ✅ Localization files regenerated with `make l10n`
- ✅ Pre-commit hooks passed
- ✅ All three languages (en, fr, es) synchronized

## Notes

All backup_wallet localization keys already existed in the ARB files. No new keys needed to be added.

The `how_to_decide.dart` file contains informational modals explaining the differences between backup options, with detailed security considerations translated into all three languages.
