### PR TITLE
feat: localization of features/bip329_labels

### DIFF
--- a/lib/features/bip329_labels/page.dart
+++ b/lib/features/bip329_labels/page.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/labels/domain/export_labels_usecase.dart';
 import 'package:bb_mobile/core/labels/domain/import_labels_usecase.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
@@ -31,7 +32,7 @@ class Bip329LabelsPage extends StatelessWidget {
           automaticallyImplyLeading: false,
           flexibleSpace: TopBar(
             onBack: () => context.pop(),
-            title: 'BIP329 Labels',
+            title: context.loc.bip329LabelsTitle,
           ),
         ),
         body: BlocConsumer<Bip329LabelsCubit, Bip329LabelsState>(
@@ -42,13 +43,13 @@ class Bip329LabelsPage extends StatelessWidget {
               exportSuccess: (labelsCount) {
                 SnackBarUtils.showSnackBar(
                   context,
-                  '$labelsCount labels exported',
+                  context.loc.bip329LabelsExportSuccess(labelsCount),
                 );
               },
               importSuccess: (labelsCount) {
                 SnackBarUtils.showSnackBar(
                   context,
-                  '$labelsCount labels imported',
+                  context.loc.bip329LabelsImportSuccess(labelsCount),
                 );
               },
               error: (message) {
@@ -74,7 +75,7 @@ class Bip329LabelsPage extends StatelessWidget {
                   const Spacer(),
 
                   BBText(
-                    'BIP329 Labels Import/Export',
+                    context.loc.bip329LabelsHeading,
                     style: context.font.headlineLarge,
                     textAlign: TextAlign.center,
                   ),
@@ -82,7 +83,7 @@ class Bip329LabelsPage extends StatelessWidget {
                   const Gap(16),
 
                   BBText(
-                    'Import or export wallet labels using the BIP329 standard format.',
+                    context.loc.bip329LabelsDescription,
                     style: context.font.bodyLarge,
                     textAlign: TextAlign.center,
                   ),
@@ -90,7 +91,7 @@ class Bip329LabelsPage extends StatelessWidget {
                   const Spacer(),
 
                   BBButton.big(
-                    label: 'Import Labels',
+                    label: context.loc.bip329LabelsImportButton,
                     onPressed: isLoading ? () {} : () => cubit.importLabels(),
                     bgColor: Theme.of(context).colorScheme.primary,
                     textColor: Theme.of(context).colorScheme.onPrimary,
@@ -102,7 +103,7 @@ class Bip329LabelsPage extends StatelessWidget {
                   const Gap(16),
 
                   BBButton.big(
-                    label: 'Export Labels',
+                    label: context.loc.bip329LabelsExportButton,
                     onPressed: isLoading ? () {} : () => cubit.exportLabels(),
                     bgColor: Theme.of(context).colorScheme.secondary,
                     textColor: Theme.of(context).colorScheme.onSecondary,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -6916,6 +6916,44 @@
       }
     }
   },
+  "bip329LabelsTitle": "BIP329 Labels",
+  "@bip329LabelsTitle": {
+    "description": "Title for BIP329 labels page"
+  },
+  "bip329LabelsHeading": "BIP329 Labels Import/Export",
+  "@bip329LabelsHeading": {
+    "description": "Main heading on BIP329 labels page"
+  },
+  "bip329LabelsDescription": "Import or export wallet labels using the BIP329 standard format.",
+  "@bip329LabelsDescription": {
+    "description": "Description of BIP329 labels functionality"
+  },
+  "bip329LabelsImportButton": "Import Labels",
+  "@bip329LabelsImportButton": {
+    "description": "Button text to import labels"
+  },
+  "bip329LabelsExportButton": "Export Labels",
+  "@bip329LabelsExportButton": {
+    "description": "Button text to export labels"
+  },
+  "bip329LabelsExportSuccess": "{count, plural, =1{1 label exported} other{{count} labels exported}}",
+  "@bip329LabelsExportSuccess": {
+    "description": "Success message after exporting labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bip329LabelsImportSuccess": "{count, plural, =1{1 label imported} other{{count} labels imported}}",
+  "@bip329LabelsImportSuccess": {
+    "description": "Success message after importing labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "legacySeedsNoSeeds": "No legacy seeds found.",
   "@legacySeedsNoSeeds": {
     "description": "Empty state message when no legacy seeds exist"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -6916,6 +6916,44 @@
       }
     }
   },
+  "bip329LabelsTitle": "Etiquetas BIP329",
+  "@bip329LabelsTitle": {
+    "description": "Title for BIP329 labels page"
+  },
+  "bip329LabelsHeading": "Importar/Exportar etiquetas BIP329",
+  "@bip329LabelsHeading": {
+    "description": "Main heading on BIP329 labels page"
+  },
+  "bip329LabelsDescription": "Importa o exporta etiquetas de billetera usando el formato estándar BIP329.",
+  "@bip329LabelsDescription": {
+    "description": "Description of BIP329 labels functionality"
+  },
+  "bip329LabelsImportButton": "Importar etiquetas",
+  "@bip329LabelsImportButton": {
+    "description": "Button text to import labels"
+  },
+  "bip329LabelsExportButton": "Exportar etiquetas",
+  "@bip329LabelsExportButton": {
+    "description": "Button text to export labels"
+  },
+  "bip329LabelsExportSuccess": "{count, plural, =1{1 etiqueta exportada} other{{count} etiquetas exportadas}}",
+  "@bip329LabelsExportSuccess": {
+    "description": "Success message after exporting labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bip329LabelsImportSuccess": "{count, plural, =1{1 etiqueta importada} other{{count} etiquetas importadas}}",
+  "@bip329LabelsImportSuccess": {
+    "description": "Success message after importing labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "legacySeedsNoSeeds": "No se encontraron semillas heredadas.",
   "@legacySeedsNoSeeds": {
     "description": "Empty state message when no legacy seeds exist"

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -6916,6 +6916,44 @@
       }
     }
   },
+  "bip329LabelsTitle": "Étiquettes BIP329",
+  "@bip329LabelsTitle": {
+    "description": "Title for BIP329 labels page"
+  },
+  "bip329LabelsHeading": "Import/Export d'étiquettes BIP329",
+  "@bip329LabelsHeading": {
+    "description": "Main heading on BIP329 labels page"
+  },
+  "bip329LabelsDescription": "Importez ou exportez les étiquettes de portefeuille en utilisant le format standard BIP329.",
+  "@bip329LabelsDescription": {
+    "description": "Description of BIP329 labels functionality"
+  },
+  "bip329LabelsImportButton": "Importer les étiquettes",
+  "@bip329LabelsImportButton": {
+    "description": "Button text to import labels"
+  },
+  "bip329LabelsExportButton": "Exporter les étiquettes",
+  "@bip329LabelsExportButton": {
+    "description": "Button text to export labels"
+  },
+  "bip329LabelsExportSuccess": "{count, plural, =1{1 étiquette exportée} other{{count} étiquettes exportées}}",
+  "@bip329LabelsExportSuccess": {
+    "description": "Success message after exporting labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bip329LabelsImportSuccess": "{count, plural, =1{1 étiquette importée} other{{count} étiquettes importées}}",
+  "@bip329LabelsImportSuccess": {
+    "description": "Success message after importing labels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "legacySeedsNoSeeds": "Aucune graine héritée trouvée.",
   "@legacySeedsNoSeeds": {
     "description": "Empty state message when no legacy seeds exist"


### PR DESCRIPTION
## Overview

This PR localizes the **bip329_labels** feature, enabling multi-language support for English, French, and Spanish.

**Feature:** `lib/features/bip329_labels`  
**Strings localized:** 7  
**New ARB keys added:** 7  
**Files modified:** 1 Dart file + 3 ARB files

<img width="600" height="665" alt="final_image_600px" src="https://github.com/user-attachments/assets/ac0e956b-54c3-46f9-8eeb-bb42f4cb805d" />


## Changes

### Files Updated

- ✅ [page.dart](lib/features/bip329_labels/page.dart) - 7 strings localized
- ✅ [app_en.arb](localization/app_en.arb) - 7 new keys added
- ✅ [app_fr.arb](localization/app_fr.arb) - 7 new keys added (French translations)
- ✅ [app_es.arb](localization/app_es.arb) - 7 new keys added (Spanish translations)

### New ARB Keys Added

1. **bip329LabelsTitle** - Page title ("BIP329 Labels")
2. **bip329LabelsHeading** - Main heading ("BIP329 Labels Import/Export")
3. **bip329LabelsDescription** - Feature description
4. **bip329LabelsImportButton** - Import button text
5. **bip329LabelsExportButton** - Export button text
6. **bip329LabelsExportSuccess** - Export success message (with plural support)
7. **bip329LabelsImportSuccess** - Import success message (with plural support)

### Localization Details

All strings now use `context.loc` pattern for internationalization:

- **Title bar**: `context.loc.bip329LabelsTitle`
- **Main heading**: `context.loc.bip329LabelsHeading`
- **Description**: `context.loc.bip329LabelsDescription`
- **Import button**: `context.loc.bip329LabelsImportButton`
- **Export button**: `context.loc.bip329LabelsExportButton`
- **Export success**: `context.loc.bip329LabelsExportSuccess(labelsCount)` - Uses ICU plural format
- **Import success**: `context.loc.bip329LabelsImportSuccess(labelsCount)` - Uses ICU plural format

### Code Quality

- Added import for `build_context_x.dart` to enable `context.loc` access
- Implemented proper plural handling for success messages using ICU message format
- Maintained existing code structure and behavior
- Already uses `Theme.of(context)` for theming (no ambiguity issues)

## Translations

### French
- "BIP329 Labels" → "Étiquettes BIP329"
- "Import Labels" → "Importer les étiquettes"
- "Export Labels" → "Exporter les étiquettes"
- "{count} labels exported" → "{count} étiquettes exportées"

### Spanish
- "BIP329 Labels" → "Etiquetas BIP329"
- "Import Labels" → "Importar etiquetas"
- "Export Labels" → "Exportar etiquetas"
- "{count} labels exported" → "{count} etiquetas exportadas"

## Checklist

- [x] All hardcoded strings replaced with `context.loc` calls
- [x] All three ARB files synchronized (en, fr, es)
- [x] Proper plural forms implemented
- [x] Localization validation passed
- [x] Flutter analyze passed