### PR TITLE
feat: localization features/broadcast_signed_tx

### DIFF
--- a/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
+++ b/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/inputs/paste_input.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
@@ -25,7 +26,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
         forceMaterialTransparency: true,
         automaticallyImplyLeading: false,
         flexibleSpace: TopBar(
-          title: 'Broadcast signed transaction',
+          title: context.loc.broadcastSignedTxPageTitle,
           onBack: () => context.pop(),
         ),
       ),
@@ -44,7 +45,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
                     ),
                     child: PasteInput(
                       text: state.transaction?.data ?? '',
-                      hint: 'Paste a PSBT or transaction HEX',
+                      hint: context.loc.broadcastSignedTxPasteHint,
                       onChanged: cubit.tryParseTransaction,
                     ),
                   ),
@@ -59,7 +60,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
 
                   const Gap(16),
                   BBButton.small(
-                    label: 'Camera',
+                    label: context.loc.broadcastSignedTxCameraButton,
                     onPressed: () {
                       cubit.resetState();
                       context.pushNamed(
@@ -73,7 +74,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
                   ),
                   const Gap(32),
                   BBButton.small(
-                    label: 'PushTx',
+                    label: context.loc.broadcastSignedTxPushTxButton,
                     onPressed:
                         () => context.pushNamed(
                           BroadcastSignedTxRoute.broadcastScanNfc.name,
@@ -100,7 +101,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
                           child: Padding(
                             padding: const EdgeInsets.all(16),
                             child: BBButton.big(
-                              label: 'PushTx',
+                              label: context.loc.broadcastSignedTxPushTxButton,
                               bgColor: context.colour.secondary,
                               textColor: context.colour.onPrimary,
                               onPressed: cubit.pushTxUri,
@@ -113,7 +114,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
                           child: Padding(
                             padding: const EdgeInsets.all(16),
                             child: BBButton.big(
-                              label: 'Broadcast',
+                              label: context.loc.broadcastSignedTxBroadcast,
                               bgColor: context.colour.secondary,
                               textColor: context.colour.onPrimary,
                               onPressed: cubit.broadcastTransaction,
@@ -133,7 +134,7 @@ class BroadcastSignedTxPage extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(left: 100, right: 100),
                     child: BBButton.big(
-                      label: 'Done',
+                      label: context.loc.broadcastSignedTxDoneButton,
                       bgColor: context.colour.secondary,
                       textColor: context.colour.onPrimary,
                       onPressed:

--- a/lib/features/broadcast_signed_tx/presentation/pages/scan_nfc_page.dart
+++ b/lib/features/broadcast_signed_tx/presentation/pages/scan_nfc_page.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/nfc_scanner_widget.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart';
@@ -15,7 +16,10 @@ class ScanNfcPage extends StatelessWidget {
       appBar: AppBar(
         forceMaterialTransparency: true,
         automaticallyImplyLeading: false,
-        flexibleSpace: TopBar(title: 'NFC', onBack: () => context.pop()),
+        flexibleSpace: TopBar(
+          title: context.loc.broadcastSignedTxNfcTitle,
+          onBack: () => context.pop(),
+        ),
       ),
       body: BlocBuilder<BroadcastSignedTxCubit, BroadcastSignedTxState>(
         builder: (context, state) {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -6960,6 +6960,30 @@
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },
+  "broadcastSignedTxPageTitle": "Broadcast signed transaction",
+  "@broadcastSignedTxPageTitle": {
+    "description": "Page title for broadcast signed transaction screen"
+  },
+  "broadcastSignedTxPasteHint": "Paste a PSBT or transaction HEX",
+  "@broadcastSignedTxPasteHint": {
+    "description": "Hint text for paste input field"
+  },
+  "broadcastSignedTxCameraButton": "Camera",
+  "@broadcastSignedTxCameraButton": {
+    "description": "Button to open camera QR scanner"
+  },
+  "broadcastSignedTxPushTxButton": "PushTx",
+  "@broadcastSignedTxPushTxButton": {
+    "description": "Button to use PushTx NFC device"
+  },
+  "broadcastSignedTxDoneButton": "Done",
+  "@broadcastSignedTxDoneButton": {
+    "description": "Button to finish after successful broadcast"
+  },
+  "broadcastSignedTxNfcTitle": "NFC",
+  "@broadcastSignedTxNfcTitle": {
+    "description": "Title for NFC scanning page"
+  },
   "addressViewTitle": "Address Details",
   "@addressViewTitle": {
     "description": "AppBar title for address details screen"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -6960,6 +6960,30 @@
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },
+  "broadcastSignedTxPageTitle": "Transmitir transacción firmada",
+  "@broadcastSignedTxPageTitle": {
+    "description": "Page title for broadcast signed transaction screen"
+  },
+  "broadcastSignedTxPasteHint": "Pegar un PSBT o HEX de transacción",
+  "@broadcastSignedTxPasteHint": {
+    "description": "Hint text for paste input field"
+  },
+  "broadcastSignedTxCameraButton": "Cámara",
+  "@broadcastSignedTxCameraButton": {
+    "description": "Button to open camera QR scanner"
+  },
+  "broadcastSignedTxPushTxButton": "PushTx",
+  "@broadcastSignedTxPushTxButton": {
+    "description": "Button to use PushTx NFC device"
+  },
+  "broadcastSignedTxDoneButton": "Hecho",
+  "@broadcastSignedTxDoneButton": {
+    "description": "Button to finish after successful broadcast"
+  },
+  "broadcastSignedTxNfcTitle": "NFC",
+  "@broadcastSignedTxNfcTitle": {
+    "description": "Title for NFC scanning page"
+  },
   "addressViewTitle": "Detalles de la dirección",
   "@addressViewTitle": {
     "description": "AppBar title for address details screen"

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -6960,6 +6960,30 @@
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },
+  "broadcastSignedTxPageTitle": "Diffuser une transaction signée",
+  "@broadcastSignedTxPageTitle": {
+    "description": "Page title for broadcast signed transaction screen"
+  },
+  "broadcastSignedTxPasteHint": "Coller un PSBT ou un HEX de transaction",
+  "@broadcastSignedTxPasteHint": {
+    "description": "Hint text for paste input field"
+  },
+  "broadcastSignedTxCameraButton": "Caméra",
+  "@broadcastSignedTxCameraButton": {
+    "description": "Button to open camera QR scanner"
+  },
+  "broadcastSignedTxPushTxButton": "PushTx",
+  "@broadcastSignedTxPushTxButton": {
+    "description": "Button to use PushTx NFC device"
+  },
+  "broadcastSignedTxDoneButton": "Terminé",
+  "@broadcastSignedTxDoneButton": {
+    "description": "Button to finish after successful broadcast"
+  },
+  "broadcastSignedTxNfcTitle": "NFC",
+  "@broadcastSignedTxNfcTitle": {
+    "description": "Title for NFC scanning page"
+  },
   "addressViewTitle": "Détails de l'adresse",
   "@addressViewTitle": {
     "description": "AppBar title for address details screen"


### PR DESCRIPTION
## Overview

This PR localizes the **broadcast_signed_tx** feature, enabling multi-language support for English, French, and Spanish.

**Feature:** `lib/features/broadcast_signed_tx`  
**Strings localized:** 7  
**New ARB keys added:** 6  
**Files modified:** 2 Dart files + 3 ARB files

## Changes

### Files Updated

- ✅ [broadcast_signed_tx_page.dart](lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart) - 6 strings localized
- ✅ [scan_nfc_page.dart](lib/features/broadcast_signed_tx/presentation/pages/scan_nfc_page.dart) - 1 string localized
- ✅ [app_en.arb](localization/app_en.arb) - 6 new keys added
- ✅ [app_fr.arb](localization/app_fr.arb) - 6 new keys added (French translations)
- ✅ [app_es.arb](localization/app_es.arb) - 6 new keys added (Spanish translations)

### New ARB Keys Added

1. **broadcastSignedTxPageTitle** - Page title ("Broadcast signed transaction")
2. **broadcastSignedTxPasteHint** - Paste input hint ("Paste a PSBT or transaction HEX")
3. **broadcastSignedTxCameraButton** - Camera QR scanner button
4. **broadcastSignedTxPushTxButton** - PushTx NFC button
5. **broadcastSignedTxDoneButton** - Done button after successful broadcast
6. **broadcastSignedTxNfcTitle** - NFC scanning page title

### Localization Details

All strings now use `context.loc` pattern for internationalization:

**broadcast_signed_tx_page.dart:**
- **Page title**: `context.loc.broadcastSignedTxPageTitle`
- **Paste hint**: `context.loc.broadcastSignedTxPasteHint`
- **Camera button**: `context.loc.broadcastSignedTxCameraButton`
- **PushTx buttons** (2 instances): `context.loc.broadcastSignedTxPushTxButton`
- **Broadcast button**: `context.loc.broadcastSignedTxBroadcast` (existing key)
- **Done button**: `context.loc.broadcastSignedTxDoneButton`

**scan_nfc_page.dart:**
- **NFC title**: `context.loc.broadcastSignedTxNfcTitle`

### Code Quality

- Added import for `build_context_x.dart` to both files
- Maintained existing code structure and behavior
- Used existing `broadcastSignedTxBroadcast` key where applicable

## Testing

- ✅ Localization generation successful (`make l10n`)
- ✅ Flutter analyze passed (pre-commit hook)
- ✅ All three language files (en, fr, es) remain synchronized

## Translations

### French
- "Broadcast signed transaction" → "Diffuser une transaction signée"
- "Paste a PSBT or transaction HEX" → "Coller un PSBT ou un HEX de transaction"
- "Camera" → "Caméra"
- "Done" → "Terminé"

### Spanish
- "Broadcast signed transaction" → "Transmitir transacción firmada"
- "Paste a PSBT or transaction HEX" → "Pegar un PSBT o HEX de transacción"
- "Camera" → "Cámara"
- "Done" → "Hecho"

## Checklist

- [x] All hardcoded strings replaced with `context.loc` calls
- [x] All three ARB files synchronized (en, fr, es)
- [x] Localization validation passed
- [x] Flutter analyze passed
- [x] Commit message follows conventional commits format