### PR TITLE
Faster load for transactions

### DIFF
--- a/lib/features/transactions/presentation/blocs/transactions_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transactions_cubit.dart
@@ -15,6 +15,9 @@ part 'transactions_cubit.freezed.dart';
 part 'transactions_state.dart';
 
 class TransactionsCubit extends Cubit<TransactionsState> {
+  static final Map<String?, List<Transaction>> _transactionsCache = {};
+  static final Set<TransactionsCubit> _activeCubits = {};
+
   TransactionsCubit({
     String? walletId,
     required GetTransactionsUsecase getTransactionsUsecase,
@@ -24,12 +27,18 @@ class TransactionsCubit extends Cubit<TransactionsState> {
        _watchStartedWalletSyncsUsecase = watchStartedWalletSyncsUsecase,
        _watchFinishedWalletSyncsUsecase = watchFinishedWalletSyncsUsecase,
        super(TransactionsState(walletId: walletId)) {
+    _activeCubits.add(this);
     _startedSyncSubscription = _watchStartedWalletSyncsUsecase
         .execute(walletId: walletId)
         .listen((_) => emit(state.copyWith(isSyncing: true)));
     _finishedSyncSubscription = _watchFinishedWalletSyncsUsecase
         .execute(walletId: walletId)
         .listen((_) => _onSyncFinished());
+
+    final cachedTransactions = _transactionsCache[walletId];
+    if (cachedTransactions != null) {
+      emit(state.copyWith(transactions: cachedTransactions));
+    }
   }
 
   final GetTransactionsUsecase _getTransactionsUsecase;
@@ -42,6 +51,7 @@ class TransactionsCubit extends Cubit<TransactionsState> {
 
   @override
   Future<void> close() async {
+    _activeCubits.remove(this);
     await Future.wait([
       _startedSyncSubscription?.cancel() ?? Future.value(),
       _finishedSyncSubscription?.cancel() ?? Future.value(),
@@ -51,22 +61,68 @@ class TransactionsCubit extends Cubit<TransactionsState> {
 
   Future<void> loadTxs() async {
     try {
-      // if (state.isSyncing) {
-      //   return; // Already syncing, no need to fetch again
-      // }
-      // Load local txs from db to get latest state from tx details page updates
+      final cachedTransactions = _transactionsCache[state.walletId];
+      if (cachedTransactions != null) {
+        emit(
+          state.copyWith(
+            transactions: cachedTransactions,
+            isSyncing: true,
+            err: null,
+          ),
+        );
+      } else {
+        emit(state.copyWith(isSyncing: true));
+      }
 
-      emit(state.copyWith(isSyncing: true));
       final transactions = await _getTransactionsUsecase.execute(
         walletId: state.walletId,
       );
+
+      _transactionsCache[state.walletId] = transactions;
 
       emit(
         state.copyWith(transactions: transactions, isSyncing: false, err: null),
       );
     } catch (e) {
       if (!isClosed) {
-        emit(state.copyWith(err: e));
+        emit(state.copyWith(err: e, isSyncing: false));
+      }
+    }
+  }
+
+  static void updateTransactionInCache(
+    Transaction updatedTransaction, {
+    required String? walletId,
+  }) {
+    final transactions = _transactionsCache[walletId];
+    if (transactions == null) return;
+
+    final index = transactions.indexWhere((tx) {
+      if (tx.walletTransaction?.txId ==
+          updatedTransaction.walletTransaction?.txId) {
+        return true;
+      }
+      if (tx.swap?.id == updatedTransaction.swap?.id) {
+        return true;
+      }
+      if (tx.payjoin?.id == updatedTransaction.payjoin?.id) {
+        return true;
+      }
+      if (tx.order?.orderId == updatedTransaction.order?.orderId) {
+        return true;
+      }
+      return false;
+    });
+
+    if (index != -1) {
+      final updatedTransactions = List<Transaction>.from(transactions);
+      updatedTransactions[index] = updatedTransaction;
+      _transactionsCache[walletId] = updatedTransactions;
+
+      for (final cubit in _activeCubits.toList()) {
+        if (!cubit.isClosed && cubit.state.walletId == walletId) {
+          cubit.emit(cubit.state.copyWith(transactions: updatedTransactions));
+        }
       }
     }
   }

--- a/lib/features/transactions/ui/transactions_router.dart
+++ b/lib/features/transactions/ui/transactions_router.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transactions_cubit.dart';
 import 'package:bb_mobile/features/transactions/ui/screens/transaction_details_screen.dart';
@@ -39,11 +40,15 @@ class TransactionsRouter {
       builder: (context, state) {
         final txId = state.pathParameters['txId']!;
         final walletId = state.uri.queryParameters['walletId']!;
+        final preloadedTransaction = state.extra as Transaction?;
         return BlocProvider(
           create:
               (context) =>
-                  locator<TransactionDetailsCubit>()
-                    ..initByWalletTxId(txId, walletId: walletId),
+                  locator<TransactionDetailsCubit>()..initByWalletTxId(
+                    txId,
+                    walletId: walletId,
+                    preloadedTransaction: preloadedTransaction,
+                  ),
           child: const TransactionDetailsScreen(),
         );
       },

--- a/lib/features/transactions/ui/widgets/tx_list_item.dart
+++ b/lib/features/transactions/ui/widgets/tx_list_item.dart
@@ -4,8 +4,10 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
+import 'package:bb_mobile/features/transactions/presentation/blocs/transactions_cubit.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 import 'package:timeago/timeago.dart' as timeago;
@@ -76,33 +78,42 @@ class TxListItem extends StatelessWidget {
             tx.order is WithdrawOrder ||
             tx.order is FundingOrder);
     return InkWell(
-      onTap: () {
+      onTap: () async {
         if (tx.walletTransaction != null) {
-          context.pushNamed(
+          await context.pushNamed(
             TransactionsRoute.transactionDetails.name,
             pathParameters: {'txId': tx.walletTransaction!.txId},
             queryParameters: {'walletId': tx.walletTransaction!.walletId},
+            extra: tx,
           );
-          return;
+          if (context.mounted) {
+            await context.read<TransactionsCubit>().loadTxs();
+          }
         } else if (tx.swap != null) {
-          context.pushNamed(
+          await context.pushNamed(
             TransactionsRoute.swapTransactionDetails.name,
             pathParameters: {'swapId': tx.swap!.id},
             queryParameters: {'walletId': tx.swap!.walletId},
           );
-          return;
+          if (context.mounted) {
+            await context.read<TransactionsCubit>().loadTxs();
+          }
         } else if (tx.payjoin != null) {
-          context.pushNamed(
+          await context.pushNamed(
             TransactionsRoute.payjoinTransactionDetails.name,
             pathParameters: {'payjoinId': tx.payjoin!.id},
           );
-          return;
+          if (context.mounted) {
+            await context.read<TransactionsCubit>().loadTxs();
+          }
         } else if (tx.order != null) {
-          context.pushNamed(
+          await context.pushNamed(
             TransactionsRoute.orderTransactionDetails.name,
             pathParameters: {'orderId': tx.order!.orderId},
           );
-          return;
+          if (context.mounted) {
+            await context.read<TransactionsCubit>().loadTxs();
+          }
         }
       },
       child: Container(


### PR DESCRIPTION
This PR solves part of the problem in https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1454

It solves the following:
- Faster load of transaction details by passing data from the tx list cubit for faster initialization
- Cache transaction in the transaction cubit so user can still see all transactions on second visit to tx list page

What it still does not solve:
- First load of tx list is still slow (I attempted a few things but they did not really affect the speed much - will try out a few more things)