### PR TITLE
feat: localization of  features/connect_hardware_wallet

### DIFF
--- a/lib/features/connect_hardware_wallet/connect_hardware_wallet_page.dart
+++ b/lib/features/connect_hardware_wallet/connect_hardware_wallet_page.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/tab_menu_vertical_button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/import_coldcard_q/router.dart';
@@ -14,14 +15,14 @@ class ConnectHardwareWalletPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Connect Hardware Wallet')),
+      appBar: AppBar(title: Text(context.loc.connectHardwareWalletTitle)),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Column(
           children: [
             const Gap(32),
             BBText(
-              'Choose the hardware wallet you would like to connect',
+              context.loc.connectHardwareWalletDescription,
               style: context.font.bodyLarge,
               textAlign: TextAlign.center,
               maxLines: 2,
@@ -32,7 +33,7 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                 child: Column(
                   children: [
                     TabMenuVerticalButton(
-                      title: 'Coldcard Q',
+                      title: context.loc.connectHardwareWalletColdcardQ,
                       onTap:
                           () => context.pushNamed(
                             ImportColdcardQRoute.importColdcardQ.name,
@@ -40,14 +41,14 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'Ledger',
+                      title: context.loc.connectHardwareWalletLedger,
                       onTap:
                           () =>
                               context.pushNamed(LedgerRoute.importLedger.name),
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'Blockstream Jade',
+                      title: context.loc.connectHardwareWalletJade,
                       onTap:
                           () => context.pushNamed(
                             ImportQrDeviceRoute.importJade.name,
@@ -55,7 +56,7 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'Keystone',
+                      title: context.loc.connectHardwareWalletKeystone,
                       onTap:
                           () => context.pushNamed(
                             ImportQrDeviceRoute.importKeystone.name,
@@ -63,7 +64,7 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'Krux',
+                      title: context.loc.connectHardwareWalletKrux,
                       onTap:
                           () => context.pushNamed(
                             ImportQrDeviceRoute.importKrux.name,
@@ -71,7 +72,7 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'Foundation Passport',
+                      title: context.loc.connectHardwareWalletPassport,
                       onTap:
                           () => context.pushNamed(
                             ImportQrDeviceRoute.importPassport.name,
@@ -79,7 +80,7 @@ class ConnectHardwareWalletPage extends StatelessWidget {
                     ),
                     const Gap(16),
                     TabMenuVerticalButton(
-                      title: 'SeedSigner',
+                      title: context.loc.connectHardwareWalletSeedSigner,
                       onTap:
                           () => context.pushNamed(
                             ImportQrDeviceRoute.importSeedSigner.name,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -6629,6 +6629,42 @@
   "@seedsignerStep14": {
     "description": "SeedSigner final instruction about broadcasting"
   },
+  "connectHardwareWalletTitle": "Connect Hardware Wallet",
+  "@connectHardwareWalletTitle": {
+    "description": "Title for connect hardware wallet page"
+  },
+  "connectHardwareWalletDescription": "Choose the hardware wallet you would like to connect",
+  "@connectHardwareWalletDescription": {
+    "description": "Description text on connect hardware wallet page"
+  },
+  "connectHardwareWalletColdcardQ": "Coldcard Q",
+  "@connectHardwareWalletColdcardQ": {
+    "description": "Coldcard Q hardware wallet option"
+  },
+  "connectHardwareWalletLedger": "Ledger",
+  "@connectHardwareWalletLedger": {
+    "description": "Ledger hardware wallet option"
+  },
+  "connectHardwareWalletJade": "Blockstream Jade",
+  "@connectHardwareWalletJade": {
+    "description": "Blockstream Jade hardware wallet option"
+  },
+  "connectHardwareWalletKeystone": "Keystone",
+  "@connectHardwareWalletKeystone": {
+    "description": "Keystone hardware wallet option"
+  },
+  "connectHardwareWalletKrux": "Krux",
+  "@connectHardwareWalletKrux": {
+    "description": "Krux hardware wallet option"
+  },
+  "connectHardwareWalletPassport": "Foundation Passport",
+  "@connectHardwareWalletPassport": {
+    "description": "Foundation Passport hardware wallet option"
+  },
+  "connectHardwareWalletSeedSigner": "SeedSigner",
+  "@connectHardwareWalletSeedSigner": {
+    "description": "SeedSigner hardware wallet option"
+  },
   "coldcardInstructionsTitle": "Coldcard Q Instructions",
   "@coldcardInstructionsTitle": {
     "description": "Title for Coldcard Q signing instructions modal"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -6629,6 +6629,42 @@
   "@seedsignerStep14": {
     "description": "SeedSigner final instruction about broadcasting"
   },
+  "connectHardwareWalletTitle": "Conectar billetera de hardware",
+  "@connectHardwareWalletTitle": {
+    "description": "Title for connect hardware wallet page"
+  },
+  "connectHardwareWalletDescription": "Elija la billetera de hardware que desea conectar",
+  "@connectHardwareWalletDescription": {
+    "description": "Description text on connect hardware wallet page"
+  },
+  "connectHardwareWalletColdcardQ": "Coldcard Q",
+  "@connectHardwareWalletColdcardQ": {
+    "description": "Coldcard Q hardware wallet option"
+  },
+  "connectHardwareWalletLedger": "Ledger",
+  "@connectHardwareWalletLedger": {
+    "description": "Ledger hardware wallet option"
+  },
+  "connectHardwareWalletJade": "Blockstream Jade",
+  "@connectHardwareWalletJade": {
+    "description": "Blockstream Jade hardware wallet option"
+  },
+  "connectHardwareWalletKeystone": "Keystone",
+  "@connectHardwareWalletKeystone": {
+    "description": "Keystone hardware wallet option"
+  },
+  "connectHardwareWalletKrux": "Krux",
+  "@connectHardwareWalletKrux": {
+    "description": "Krux hardware wallet option"
+  },
+  "connectHardwareWalletPassport": "Foundation Passport",
+  "@connectHardwareWalletPassport": {
+    "description": "Foundation Passport hardware wallet option"
+  },
+  "connectHardwareWalletSeedSigner": "SeedSigner",
+  "@connectHardwareWalletSeedSigner": {
+    "description": "SeedSigner hardware wallet option"
+  },
   "coldcardInstructionsTitle": "Instrucciones Coldcard Q",
   "@coldcardInstructionsTitle": {
     "description": "Title for Coldcard Q signing instructions modal"

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -6629,6 +6629,42 @@
   "@seedsignerStep14": {
     "description": "SeedSigner final instruction about broadcasting"
   },
+  "connectHardwareWalletTitle": "Connecter un portefeuille matériel",
+  "@connectHardwareWalletTitle": {
+    "description": "Title for connect hardware wallet page"
+  },
+  "connectHardwareWalletDescription": "Choisissez le portefeuille matériel que vous souhaitez connecter",
+  "@connectHardwareWalletDescription": {
+    "description": "Description text on connect hardware wallet page"
+  },
+  "connectHardwareWalletColdcardQ": "Coldcard Q",
+  "@connectHardwareWalletColdcardQ": {
+    "description": "Coldcard Q hardware wallet option"
+  },
+  "connectHardwareWalletLedger": "Ledger",
+  "@connectHardwareWalletLedger": {
+    "description": "Ledger hardware wallet option"
+  },
+  "connectHardwareWalletJade": "Blockstream Jade",
+  "@connectHardwareWalletJade": {
+    "description": "Blockstream Jade hardware wallet option"
+  },
+  "connectHardwareWalletKeystone": "Keystone",
+  "@connectHardwareWalletKeystone": {
+    "description": "Keystone hardware wallet option"
+  },
+  "connectHardwareWalletKrux": "Krux",
+  "@connectHardwareWalletKrux": {
+    "description": "Krux hardware wallet option"
+  },
+  "connectHardwareWalletPassport": "Foundation Passport",
+  "@connectHardwareWalletPassport": {
+    "description": "Foundation Passport hardware wallet option"
+  },
+  "connectHardwareWalletSeedSigner": "SeedSigner",
+  "@connectHardwareWalletSeedSigner": {
+    "description": "SeedSigner hardware wallet option"
+  },
   "coldcardInstructionsTitle": "Instructions Coldcard Q",
   "@coldcardInstructionsTitle": {
     "description": "Title for Coldcard Q signing instructions modal"


### PR DESCRIPTION
## Overview

This PR localizes the **connect_hardware_wallet** feature, enabling multi-language support for English, French, and Spanish.

**Feature:** `lib/features/connect_hardware_wallet`  
**Strings localized:** 9  
**New ARB keys added:** 9  
**Files modified:** 1 Dart file + 3 ARB files

## Changes

### Files Updated

- ✅ [connect_hardware_wallet_page.dart](lib/features/connect_hardware_wallet/connect_hardware_wallet_page.dart) - 9 strings localized
- ✅ [app_en.arb](localization/app_en.arb) - 9 new keys added
- ✅ [app_fr.arb](localization/app_fr.arb) - 9 new keys added (French translations)
- ✅ [app_es.arb](localization/app_es.arb) - 9 new keys added (Spanish translations)

### New ARB Keys Added

1. **connectHardwareWalletTitle** - Page title ("Connect Hardware Wallet")
2. **connectHardwareWalletDescription** - Description text
3. **connectHardwareWalletColdcardQ** - Coldcard Q option
4. **connectHardwareWalletLedger** - Ledger option  
5. **connectHardwareWalletJade** - Blockstream Jade option
6. **connectHardwareWalletKeystone** - Keystone option
7. **connectHardwareWalletKrux** - Krux option
8. **connectHardwareWalletPassport** - Foundation Passport option
9. **connectHardwareWalletSeedSigner** - SeedSigner option

### Localization Details

All strings now use `context.loc` pattern for internationalization:

- **Page title**: `context.loc.connectHardwareWalletTitle`
- **Description**: `context.loc.connectHardwareWalletDescription`
- **Hardware wallet options** (7 devices): Each uses its own specific key

### Code Quality

- Added import for `build_context_x.dart` to enable `context.loc` access
- All existing logic and functionality preserved
- Simple, straightforward localization pattern

## Testing

- ✅ Localization generation successful (`make l10n`)
- ✅ Flutter analyze passed (pre-commit hook)
- ✅ All three language files (en, fr, es) synchronized (1892 keys total)

## Translations

### French
- "Connect Hardware Wallet" → "Connecter un portefeuille matériel"
- "Choose the hardware wallet..." → "Choisissez le portefeuille matériel que vous souhaitez connecter"

### Spanish
- "Connect Hardware Wallet" → "Conectar billetera de hardware"
- "Choose the hardware wallet..." → "Elija la billetera de hardware que desea conectar"

**Note:** Hardware wallet brand names (Coldcard Q, Ledger, Blockstream Jade, Keystone, Krux, Foundation Passport, SeedSigner) remain the same across all languages as they are proper nouns.

## Checklist

- [x] All hardcoded strings replaced with `context.loc` calls
- [x] All three ARB files synchronized (en, fr, es)
- [x] Localization validation passed
- [x] Flutter analyze passed