### PR TITLE
Fix type in wanring message (Fixes #1505)

### DIFF
--- a/lib/features/fund_exchange/ui/screens/fund_exchange_warning_screen.dart
+++ b/lib/features/fund_exchange/ui/screens/fund_exchange_warning_screen.dart
@@ -96,7 +96,7 @@ class FundExchangeWarningScreen extends StatelessWidget {
                   );
                 },
                 title: BBText(
-                  'I confirm that I am not being asked asked to buy Bitcoin by someone else.',
+                  'I confirm that I am not being asked to buy Bitcoin by someone else.',
                   style: theme.textTheme.bodyLarge,
                 ),
                 controlAffinity: ListTileControlAffinity.leading,


### PR DESCRIPTION
## Summary

This PR fixes a small typo in the warning message where the text currently reads `asked asked`.

## Changes

- Update the warning message string to remove the duplicated word, so it now correctly reads `asked`.