### PR TITLE
Fix issue #1505

### DIFF
--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -2285,7 +2285,7 @@
   "@fundExchangeWarningTactic8": {
     "description": "Eighth scammer tactic warning"
   },
-  "fundExchangeWarningConfirmation": "I confirm that I am not being asked asked to buy Bitcoin by someone else.",
+  "fundExchangeWarningConfirmation": "I confirm that I am not being asked to buy Bitcoin by someone else.",
   "@fundExchangeWarningConfirmation": {
     "description": "Confirmation checkbox text that user is not being coerced to buy Bitcoin"
   },


### PR DESCRIPTION
## Summary

This PR fixes a small typo in the warning message where the text currently reads `asked asked`.

## Changes

- Update the warning message string to remove the duplicated word, so it now correctly reads `asked`.