### PR TITLE
feat: implement reactive electrum error banner system

### DIFF
--- a/lib/core/electrum/domain/value_objects/electrum_sync_result.dart
+++ b/lib/core/electrum/domain/value_objects/electrum_sync_result.dart
@@ -1,0 +1,9 @@
+class ElectrumSyncResult {
+  final bool isLiquid;
+  final bool success;
+
+  const ElectrumSyncResult({
+    required this.isLiquid,
+    required this.success,
+  });
+}

--- a/lib/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart
+++ b/lib/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_sync_result.dart';
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+
+class WatchElectrumSyncResultsUsecase {
+  final WalletRepository _walletRepository;
+
+  WatchElectrumSyncResultsUsecase({required WalletRepository walletRepository})
+    : _walletRepository = walletRepository;
+
+  Stream<ElectrumSyncResult> execute() {
+    try {
+      return _walletRepository.electrumSyncResultStream;
+    } catch (e) {
+      throw WatchElectrumSyncResultsException(e.toString());
+    }
+  }
+}
+
+class WatchElectrumSyncResultsException extends BullException {
+  WatchElectrumSyncResultsException(super.message);
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -33,6 +33,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.d
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/import_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_started_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_address_usecase.dart';
@@ -147,6 +148,11 @@ class WalletLocator {
     );
     locator.registerFactory<WatchFinishedWalletSyncsUsecase>(
       () => WatchFinishedWalletSyncsUsecase(
+        walletRepository: locator<WalletRepository>(),
+      ),
+    );
+    locator.registerFactory<WatchElectrumSyncResultsUsecase>(
+      () => WatchElectrumSyncResultsUsecase(
         walletRepository: locator<WalletRepository>(),
       ),
     );

--- a/lib/features/wallet/presentation/bloc/wallet_event.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_event.dart
@@ -34,10 +34,6 @@ class StartTorInitialization extends WalletEvent {
   const StartTorInitialization();
 }
 
-class CheckAllWarnings extends WalletEvent {
-  const CheckAllWarnings();
-}
-
 class BlockAutoSwapUntilNextExecution extends WalletEvent {
   const BlockAutoSwapUntilNextExecution();
 }
@@ -53,4 +49,9 @@ class ExecuteAutoSwapFeeOverride extends WalletEvent {
 class RefreshArkWalletBalance extends WalletEvent {
   final int? amount;
   const RefreshArkWalletBalance({this.amount});
+}
+
+class ElectrumSyncResultChanged extends WalletEvent {
+  final ElectrumSyncResult result;
+  const ElectrumSyncResultChanged(this.result);
 }

--- a/lib/features/wallet/wallet_locator.dart
+++ b/lib/features/wallet/wallet_locator.dart
@@ -1,6 +1,5 @@
 import 'package:bb_mobile/core/ark/usecases/check_ark_wallet_setup_usecase.dart';
 import 'package:bb_mobile/core/ark/usecases/get_ark_wallet_usecase.dart';
-import 'package:bb_mobile/core/electrum/application/usecases/check_for_online_electrum_servers_usecase.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/auto_swap_execution_usecase.dart';
@@ -13,6 +12,7 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_started_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/features/wallet/domain/usecase/get_unconfirmed_incoming_balance_usecase.dart';
@@ -48,12 +48,12 @@ class WalletLocator {
             locator<WatchStartedWalletSyncsUsecase>(),
         watchFinishedWalletSyncsUsecase:
             locator<WatchFinishedWalletSyncsUsecase>(),
+        watchElectrumSyncResultsUsecase:
+            locator<WatchElectrumSyncResultsUsecase>(),
         restartSwapWatcherUsecase: locator<RestartSwapWatcherUsecase>(),
         initializeTorUsecase: locator<InitTorUsecase>(),
         checkForTorInitializationOnStartupUsecase:
             locator<IsTorRequiredUsecase>(),
-        checkForOnlineElectrumServersUsecase:
-            locator<CheckForOnlineElectrumServersUsecase>(),
         getUnconfirmedIncomingBalanceUsecase:
             locator<GetUnconfirmedIncomingBalanceUsecase>(),
         getAutoSwapSettingsUsecase: locator<GetAutoSwapSettingsUsecase>(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -204,7 +204,6 @@ class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
               // If wallets exist and the app has started successfully,
               // we can start the wallet bloc to fetch the wallets.
               context.read<WalletBloc>().add(const WalletStarted());
-              context.read<WalletBloc>().add(const CheckAllWarnings());
             },
           ),
           BlocListener<SettingsCubit, SettingsState>(


### PR DESCRIPTION
Electrum error banner only appeared/disappeared on app restart. Pulling to refresh didn't update it. Used polling-based health checks that duplicated work already done by wallet syncs.

This PR makes it reactive. Wallet syncs now emit success/failure events and banner updates immediately.

Changes:

- ElectrumSyncResult - emitted when syncs succeed/fail
- WatchElectrumSyncResultsUsecase - streams results to UI
- WalletBloc._onElectrumSyncResultChanged - updates warnings from sync events
- Removed CheckAllWarnings polling mechanism

Issue: https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1565