### PR TITLE
feat: localization of features/status_check

### DIFF
--- a/lib/features/status_check/service_status_page.dart
+++ b/lib/features/status_check/service_status_page.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/status/domain/entity/service_status.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/presentation/state.dart';
@@ -12,7 +13,7 @@ class ServiceStatusPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Service Status')),
+      appBar: AppBar(title: Text(context.loc.statusCheckTitle)),
       body: BlocBuilder<ServiceStatusCubit, ServiceStatusState>(
         builder: (context, state) {
           final serviceStatus = state.serviceStatus;
@@ -64,7 +65,9 @@ class ServiceStatusPage extends StatelessWidget {
                           children: [
                             if (serviceStatus.lastChecked != null)
                               BBText(
-                                'Last checked: ${_formatDateTime(serviceStatus.lastChecked!)}',
+                                context.loc.statusCheckLastChecked(
+                                  _formatDateTime(serviceStatus.lastChecked!),
+                                ),
                                 style: context.font.bodySmall,
                                 color: context.colour.onSurfaceVariant,
                               ),
@@ -112,7 +115,7 @@ class _ServiceStatusItem extends StatelessWidget {
         ),
         const Spacer(),
         BBText(
-          _getStatusText(),
+          _getStatusText(context),
           style: context.font.bodySmall,
           color: context.colour.onSurfaceVariant,
         ),
@@ -131,14 +134,14 @@ class _ServiceStatusItem extends StatelessWidget {
     }
   }
 
-  String _getStatusText() {
+  String _getStatusText(BuildContext context) {
     switch (service.status) {
       case ServiceStatus.online:
-        return 'Online';
+        return context.loc.statusCheckOnline;
       case ServiceStatus.offline:
-        return 'Offline';
+        return context.loc.statusCheckOffline;
       case ServiceStatus.unknown:
-        return 'Unknown';
+        return context.loc.statusCheckUnknown;
     }
   }
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -10610,5 +10610,30 @@
   "delete": "Delete",
   "@delete": {
     "description": "Generic delete button label"
+  },
+  "statusCheckTitle": "Service Status",
+  "@statusCheckTitle": {
+    "description": "Title for the service status screen"
+  },
+  "statusCheckLastChecked": "Last checked: {time}",
+  "@statusCheckLastChecked": {
+    "description": "Label showing when services were last checked",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "statusCheckOnline": "Online",
+  "@statusCheckOnline": {
+    "description": "Status text when a service is online"
+  },
+  "statusCheckOffline": "Offline",
+  "@statusCheckOffline": {
+    "description": "Status text when a service is offline"
+  },
+  "statusCheckUnknown": "Unknown",
+  "@statusCheckUnknown": {
+    "description": "Status text when service status is unknown"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -10614,5 +10614,30 @@
   "delete": "Eliminar",
   "@delete": {
     "description": "Generic delete button label"
+  },
+  "statusCheckTitle": "Estado de Servicios",
+  "@statusCheckTitle": {
+    "description": "Title for the service status screen"
+  },
+  "statusCheckLastChecked": "Última verificación: {time}",
+  "@statusCheckLastChecked": {
+    "description": "Label showing when services were last checked",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "statusCheckOnline": "En línea",
+  "@statusCheckOnline": {
+    "description": "Status text when a service is online"
+  },
+  "statusCheckOffline": "Fuera de línea",
+  "@statusCheckOffline": {
+    "description": "Status text when a service is offline"
+  },
+  "statusCheckUnknown": "Desconocido",
+  "@statusCheckUnknown": {
+    "description": "Status text when service status is unknown"
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -10614,5 +10614,30 @@
   "delete": "Supprimer",
   "@delete": {
     "description": "Generic delete button label"
+  },
+  "statusCheckTitle": "État des Services",
+  "@statusCheckTitle": {
+    "description": "Title for the service status screen"
+  },
+  "statusCheckLastChecked": "Dernière vérification : {time}",
+  "@statusCheckLastChecked": {
+    "description": "Label showing when services were last checked",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "statusCheckOnline": "En ligne",
+  "@statusCheckOnline": {
+    "description": "Status text when a service is online"
+  },
+  "statusCheckOffline": "Hors ligne",
+  "@statusCheckOffline": {
+    "description": "Status text when a service is offline"
+  },
+  "statusCheckUnknown": "Inconnu",
+  "@statusCheckUnknown": {
+    "description": "Status text when service status is unknown"
   }
 }


### PR DESCRIPTION
## Localization: status_check

### Overview
- Feature: `lib/features/status_check`
- Strings localized: 5
- Files modified: 4 (1 Dart file + 3 ARB files)
- Branch: `localization/features-status-check`

### Changes
- [x] Added BuildContextX import to affected files
- [x] Replaced hardcoded strings with context.loc calls
- [x] Added ARB keys with proper naming
- [x] Validated with all three validation scripts
- [x] Tested with flutter analyze

### Localized Strings
1. **Screen title**: "Service Status" → `statusCheckTitle`
2. **Last checked label**: "Last checked: {time}" → `statusCheckLastChecked`
3. **Online status**: "Online" → `statusCheckOnline`
4. **Offline status**: "Offline" → `statusCheckOffline`
5. **Unknown status**: "Unknown" → `statusCheckUnknown`

### Notes
- Simple feature with straightforward status text strings
- Uses placeholder parameter for time formatting in statusCheckLastChecked