### PR TITLE
feat: localization of features/template

### DIFF
--- a/lib/features/template/ui/template_page.dart
+++ b/lib/features/template/ui/template_page.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/template/domain/ip_address_entity.dart';
 import 'package:bb_mobile/features/template/presentation/template_cubit.dart';
@@ -15,7 +16,7 @@ class TemplatePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: BBText(
-          'IP Address Info',
+          context.loc.templatePageTitle,
           style: Theme.of(context).textTheme.titleLarge,
         ),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -51,7 +52,7 @@ class TemplatePage extends StatelessWidget {
                   onPressed: state.isLoading ? null : cubit.collectIp,
                   icon: const Icon(Icons.download),
                   label: BBText(
-                    'Collect and cache my IP info',
+                    context.loc.templateCollectIpButton,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),
@@ -59,7 +60,7 @@ class TemplatePage extends StatelessWidget {
                   onPressed: state.isLoading ? null : cubit.getCachedIp,
                   icon: const Icon(Icons.remove_red_eye),
                   label: BBText(
-                    'Get cached IP info',
+                    context.loc.templateGetCachedIpButton,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),
@@ -81,7 +82,7 @@ class TemplatePage extends StatelessWidget {
                 ElevatedButton(
                   onPressed: cubit.reset,
                   child: BBText(
-                    'Reset',
+                    context.loc.templateResetButton,
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
                 ),
@@ -123,16 +124,16 @@ class TemplatePage extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12),
-            _infoRow(context, 'User Agent', ip.userAgent),
+            _infoRow(context, context.loc.templateUserAgentLabel, ip.userAgent),
             _infoRow(
               context,
-              'Compression',
-              ip.isCompressionSupported ? 'Yes' : 'No',
+              context.loc.templateCompressionLabel,
+              ip.isCompressionSupported ? context.loc.commonYes : context.loc.commonNo,
             ),
-            _infoRow(context, 'Timestamp', ip.timestamp.toString()),
+            _infoRow(context, context.loc.templateTimestampLabel, ip.timestamp.toString()),
             const SizedBox(height: 8),
             BBText(
-              'Supported Encodings:',
+              context.loc.templateSupportedEncodingsLabel,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             Wrap(
@@ -151,7 +152,7 @@ class TemplatePage extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             BBText(
-              'Accepted MIME Types:',
+              context.loc.templateAcceptedMimeTypesLabel,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             Wrap(

--- a/lib/features/template/ui/template_widget.dart
+++ b/lib/features/template/ui/template_widget.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/template/domain/ip_address_entity.dart';
 import 'package:flutter/material.dart';
 
@@ -66,7 +67,7 @@ class TemplateWidget extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              'Connection: ${ipAddressData!.displayInfo}',
+                              context.loc.templateConnectionLabel(ipAddressData!.displayInfo),
                               style: const TextStyle(
                                 fontSize: 12,
                                 fontWeight: FontWeight.w600,
@@ -88,8 +89,8 @@ class TemplateWidget extends StatelessWidget {
                                 const SizedBox(width: 4),
                                 Text(
                                   ipAddressData!.isSecureConnection
-                                      ? 'Secure'
-                                      : 'Insecure',
+                                      ? context.loc.templateSecure
+                                      : context.loc.templateInsecure,
                                   style: TextStyle(
                                     fontSize: 10,
                                     color:
@@ -109,8 +110,8 @@ class TemplateWidget extends StatelessWidget {
                                 const SizedBox(width: 4),
                                 Text(
                                   ipAddressData!.isMobileUserAgent
-                                      ? 'Mobile'
-                                      : 'Desktop',
+                                      ? context.loc.templateMobile
+                                      : context.loc.templateDesktop,
                                   style: TextStyle(
                                     fontSize: 10,
                                     color: context.appColors.textMuted,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -10635,5 +10635,74 @@
   "statusCheckUnknown": "Unknown",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "templatePageTitle": "IP Address Info",
+  "@templatePageTitle": {
+    "description": "AppBar title for the template page"
+  },
+  "templateCollectIpButton": "Collect and cache my IP info",
+  "@templateCollectIpButton": {
+    "description": "Button to collect and cache IP information"
+  },
+  "templateGetCachedIpButton": "Get cached IP info",
+  "@templateGetCachedIpButton": {
+    "description": "Button to retrieve cached IP information"
+  },
+  "templateResetButton": "Reset",
+  "@templateResetButton": {
+    "description": "Button to reset the template state"
+  },
+  "templateUserAgentLabel": "User Agent",
+  "@templateUserAgentLabel": {
+    "description": "Label for user agent info row"
+  },
+  "templateCompressionLabel": "Compression",
+  "@templateCompressionLabel": {
+    "description": "Label for compression support info row"
+  },
+  "templateTimestampLabel": "Timestamp",
+  "@templateTimestampLabel": {
+    "description": "Label for timestamp info row"
+  },
+  "templateSupportedEncodingsLabel": "Supported Encodings:",
+  "@templateSupportedEncodingsLabel": {
+    "description": "Label for supported encodings section"
+  },
+  "templateAcceptedMimeTypesLabel": "Accepted MIME Types:",
+  "@templateAcceptedMimeTypesLabel": {
+    "description": "Label for accepted MIME types section"
+  },
+  "templateConnectionLabel": "Connection: {info}",
+  "@templateConnectionLabel": {
+    "description": "Connection info display with IP details",
+    "placeholders": {
+      "info": {
+        "type": "String"
+      }
+    }
+  },
+  "templateSecure": "Secure",
+  "@templateSecure": {
+    "description": "Label for secure connection status"
+  },
+  "templateInsecure": "Insecure",
+  "@templateInsecure": {
+    "description": "Label for insecure connection status"
+  },
+  "templateMobile": "Mobile",
+  "@templateMobile": {
+    "description": "Label for mobile device type"
+  },
+  "templateDesktop": "Desktop",
+  "@templateDesktop": {
+    "description": "Label for desktop device type"
+  },
+  "commonYes": "Yes",
+  "@commonYes": {
+    "description": "Common affirmative response"
+  },
+  "commonNo": "No",
+  "@commonNo": {
+    "description": "Common negative response"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -10639,5 +10639,74 @@
   "statusCheckUnknown": "Desconocido",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "templatePageTitle": "Info de dirección IP",
+  "@templatePageTitle": {
+    "description": "AppBar title for the template page"
+  },
+  "templateCollectIpButton": "Recopilar y almacenar mi info IP",
+  "@templateCollectIpButton": {
+    "description": "Button to collect and cache IP information"
+  },
+  "templateGetCachedIpButton": "Obtener info IP almacenada",
+  "@templateGetCachedIpButton": {
+    "description": "Button to retrieve cached IP information"
+  },
+  "templateResetButton": "Reiniciar",
+  "@templateResetButton": {
+    "description": "Button to reset the template state"
+  },
+  "templateUserAgentLabel": "Agente de usuario",
+  "@templateUserAgentLabel": {
+    "description": "Label for user agent info row"
+  },
+  "templateCompressionLabel": "Compresión",
+  "@templateCompressionLabel": {
+    "description": "Label for compression support info row"
+  },
+  "templateTimestampLabel": "Marca de tiempo",
+  "@templateTimestampLabel": {
+    "description": "Label for timestamp info row"
+  },
+  "templateSupportedEncodingsLabel": "Codificaciones soportadas:",
+  "@templateSupportedEncodingsLabel": {
+    "description": "Label for supported encodings section"
+  },
+  "templateAcceptedMimeTypesLabel": "Tipos MIME aceptados:",
+  "@templateAcceptedMimeTypesLabel": {
+    "description": "Label for accepted MIME types section"
+  },
+  "templateConnectionLabel": "Conexión: {info}",
+  "@templateConnectionLabel": {
+    "description": "Connection info display with IP details",
+    "placeholders": {
+      "info": {
+        "type": "String"
+      }
+    }
+  },
+  "templateSecure": "Seguro",
+  "@templateSecure": {
+    "description": "Label for secure connection status"
+  },
+  "templateInsecure": "Inseguro",
+  "@templateInsecure": {
+    "description": "Label for insecure connection status"
+  },
+  "templateMobile": "Móvil",
+  "@templateMobile": {
+    "description": "Label for mobile device type"
+  },
+  "templateDesktop": "Escritorio",
+  "@templateDesktop": {
+    "description": "Label for desktop device type"
+  },
+  "commonYes": "Sí",
+  "@commonYes": {
+    "description": "Common affirmative response"
+  },
+  "commonNo": "No",
+  "@commonNo": {
+    "description": "Common negative response"
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -10639,5 +10639,74 @@
   "statusCheckUnknown": "Inconnu",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "templatePageTitle": "Infos adresse IP",
+  "@templatePageTitle": {
+    "description": "AppBar title for the template page"
+  },
+  "templateCollectIpButton": "Collecter et mettre en cache mes infos IP",
+  "@templateCollectIpButton": {
+    "description": "Button to collect and cache IP information"
+  },
+  "templateGetCachedIpButton": "Obtenir les infos IP en cache",
+  "@templateGetCachedIpButton": {
+    "description": "Button to retrieve cached IP information"
+  },
+  "templateResetButton": "Réinitialiser",
+  "@templateResetButton": {
+    "description": "Button to reset the template state"
+  },
+  "templateUserAgentLabel": "Agent utilisateur",
+  "@templateUserAgentLabel": {
+    "description": "Label for user agent info row"
+  },
+  "templateCompressionLabel": "Compression",
+  "@templateCompressionLabel": {
+    "description": "Label for compression support info row"
+  },
+  "templateTimestampLabel": "Horodatage",
+  "@templateTimestampLabel": {
+    "description": "Label for timestamp info row"
+  },
+  "templateSupportedEncodingsLabel": "Encodages supportés :",
+  "@templateSupportedEncodingsLabel": {
+    "description": "Label for supported encodings section"
+  },
+  "templateAcceptedMimeTypesLabel": "Types MIME acceptés :",
+  "@templateAcceptedMimeTypesLabel": {
+    "description": "Label for accepted MIME types section"
+  },
+  "templateConnectionLabel": "Connexion : {info}",
+  "@templateConnectionLabel": {
+    "description": "Connection info display with IP details",
+    "placeholders": {
+      "info": {
+        "type": "String"
+      }
+    }
+  },
+  "templateSecure": "Sécurisé",
+  "@templateSecure": {
+    "description": "Label for secure connection status"
+  },
+  "templateInsecure": "Non sécurisé",
+  "@templateInsecure": {
+    "description": "Label for insecure connection status"
+  },
+  "templateMobile": "Mobile",
+  "@templateMobile": {
+    "description": "Label for mobile device type"
+  },
+  "templateDesktop": "Bureau",
+  "@templateDesktop": {
+    "description": "Label for desktop device type"
+  },
+  "commonYes": "Oui",
+  "@commonYes": {
+    "description": "Common affirmative response"
+  },
+  "commonNo": "Non",
+  "@commonNo": {
+    "description": "Common negative response"
   }
 }


### PR DESCRIPTION
## Summary

- Added 16 new localization keys for template feature UI strings
- Replaced all hardcoded strings with `context.loc` calls in 2 Dart files
- Full support for English, French, and Spanish translations

## Changes

### New ARB Keys Added (16 total)
- `templatePageTitle` - AppBar title
- `templateCollectIpButton` - Collect IP button
- `templateGetCachedIpButton` - Get cached IP button
- `templateResetButton` - Reset button
- `templateUserAgentLabel` - User agent row label
- `templateCompressionLabel` - Compression row label
- `templateTimestampLabel` - Timestamp row label
- `templateSupportedEncodingsLabel` - Encodings section header
- `templateAcceptedMimeTypesLabel` - MIME types section header
- `templateConnectionLabel` - Connection info (parameterized)
- `templateSecure` / `templateInsecure` - Connection status
- `templateMobile` / `templateDesktop` - Device type
- `commonYes` / `commonNo` - Common responses

### Files Modified
- `lib/features/template/ui/template_page.dart`
- `lib/features/template/ui/template_widget.dart`
- `localization/app_en.arb`
- `localization/app_fr.arb`
- `localization/app_es.arb`

## Testing

- [x] Validation script passes
- [x] Flutter analyze passes with no issues
- [x] All 2426 keys synchronized across en/fr/es