### PR TITLE
feat: localization of features/test_wallet_backup

### DIFF
--- a/lib/features/test_wallet_backup/ui/app_bar_widget.dart
+++ b/lib/features/test_wallet_backup/ui/app_bar_widget.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
@@ -96,7 +97,7 @@ Future<String?> _showWalletPicker({
                   Center(
                     child: BBText(
                       wallet.isDefault
-                          ? 'Default Wallets'
+                          ? context.loc.testBackupDefaultWallets
                           : wallet.displayLabel,
                       style: context.font.bodyLarge?.copyWith(
                         fontWeight: FontWeight.w600,
@@ -108,7 +109,7 @@ Future<String?> _showWalletPicker({
             ),
           ),
           BBButton.big(
-            label: 'Confirm',
+            label: context.loc.testBackupConfirm,
             onPressed: () {
               final wallet = wallets[controller.selectedItem];
               context.read<TestWalletBackupBloc>().add(

--- a/lib/features/test_wallet_backup/ui/screens/backup_test_success.dart
+++ b/lib/features/test_wallet_backup/ui/screens/backup_test_success.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
@@ -34,12 +35,12 @@ class BackupTestSuccessScreen extends StatelessWidget {
                 ),
                 const Gap(8),
                 BBText(
-                  'Test completed successfully!',
+                  context.loc.testBackupSuccessTitle,
                   style: context.font.headlineLarge,
                 ),
                 const Gap(8),
                 BBText(
-                  'You are able to recover access to a lost Bitcoin wallet',
+                  context.loc.testBackupSuccessMessage,
                   style: context.font.bodyMedium,
                   textAlign: TextAlign.center,
                 ),
@@ -49,7 +50,7 @@ class BackupTestSuccessScreen extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(bottom: 24),
               child: BBButton.big(
-                label: 'Got it',
+                label: context.loc.testBackupSuccessButton,
                 bgColor: context.appColors.secondary,
                 textColor: context.appColors.onPrimary,
                 onPressed: () {

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/mixins/privacy_screen.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -35,8 +36,10 @@ class _ShowMnemonicScreenState extends State<ShowMnemonicScreen>
       builder: (context, snapshot) {
         return BlocBuilder<TestWalletBackupBloc, TestWalletBackupState>(
           builder: (context, state) {
-            final title =
-                'Test ${state.selectedWallet?.isDefault ?? false ? 'Default Wallets' : state.selectedWallet?.displayLabel ?? ''}';
+            final walletName = state.selectedWallet?.isDefault ?? false
+                ? context.loc.testBackupDefaultWallets
+                : state.selectedWallet?.displayLabel ?? '';
+            final title = context.loc.testBackupWalletTitle(walletName);
 
             return Scaffold(
               backgroundColor: context.appColors.onSecondary,
@@ -54,7 +57,7 @@ class _ShowMnemonicScreenState extends State<ShowMnemonicScreen>
                     child: Column(
                       children: [
                         BBButton.big(
-                          label: "Next",
+                          label: context.loc.testBackupNext,
                           onPressed: () {
                             Navigator.of(context).push(
                               MaterialPageRoute(
@@ -99,7 +102,7 @@ class _MnemonicDisplay extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           BBText(
-            'Write down your recovery phrase\nin the correct order',
+            context.loc.testBackupWriteDownPhrase,
             textAlign: TextAlign.center,
             style: context.font.headlineLarge?.copyWith(
               fontWeight: FontWeight.w600,
@@ -108,7 +111,7 @@ class _MnemonicDisplay extends StatelessWidget {
           ),
           const Gap(20),
           BBText(
-            'Store it somewhere safe.',
+            context.loc.testBackupStoreItSafe,
             textAlign: TextAlign.center,
             style: context.font.labelMedium?.copyWith(
               fontWeight: FontWeight.w700,
@@ -119,7 +122,7 @@ class _MnemonicDisplay extends StatelessWidget {
           ),
           if (lastPhysicalBackup != null) ...[
             BBText(
-              'Last backup test: ${lastPhysicalBackup.toString().substring(0, 19)}',
+              context.loc.testBackupLastBackupTest(lastPhysicalBackup.toString().substring(0, 19)),
               textAlign: TextAlign.center,
               style: context.font.labelMedium?.copyWith(
                 fontWeight: FontWeight.w700,
@@ -177,7 +180,7 @@ class _MnemonicDisplay extends StatelessWidget {
                     ),
                   ),
                   child: BBText(
-                    'DO NOT SHARE WITH ANYONE',
+                    context.loc.testBackupDoNotShare,
                     textAlign: TextAlign.center,
                     style: context.font.headlineMedium?.copyWith(
                       fontWeight: FontWeight.w500,
@@ -196,19 +199,19 @@ class _MnemonicDisplay extends StatelessWidget {
                     children: [
                       _buildWarningItem(
                         icon: CupertinoIcons.check_mark,
-                        text: 'Transcribe',
+                        text: context.loc.testBackupTranscribe,
                         iconColor: const Color(0xFF34C759),
                         context: context,
                       ),
                       _buildWarningItem(
                         icon: CupertinoIcons.xmark,
-                        text: 'Digital copy',
+                        text: context.loc.testBackupDigitalCopy,
                         iconColor: context.appColors.error,
                         context: context,
                       ),
                       _buildWarningItem(
                         icon: CupertinoIcons.xmark,
-                        text: 'Screenshot',
+                        text: context.loc.testBackupScreenshot,
                         iconColor: context.appColors.error,
                         context: context,
                       ),
@@ -355,7 +358,7 @@ class _PassphraseWidget extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           BBText(
-            'Passphrase',
+            context.loc.testBackupPassphrase,
             style: context.font.labelMedium?.copyWith(
               fontWeight: FontWeight.w700,
               color: context.appColors.surface,

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/mixins/privacy_screen.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart';
@@ -55,8 +56,10 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
             }
           },
           builder: (context, state) {
-            final title =
-                'Test ${state.selectedWallet?.isDefault ?? false ? 'Default Wallets' : state.selectedWallet?.displayLabel ?? ''}';
+            final walletName = state.selectedWallet?.isDefault ?? false
+                ? context.loc.testBackupDefaultWallets
+                : state.selectedWallet?.displayLabel ?? '';
+            final title = context.loc.testBackupWalletTitle(walletName);
             final reorderedMnemonic =
                 context.watch<TestWalletBackupBloc>().state.reorderedMnemonic;
             final mnemonic =
@@ -78,7 +81,7 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       BBText(
-                        'Tap the recovery words in the \nright order',
+                        context.loc.testBackupTapWordsInOrder,
                         textAlign: TextAlign.center,
                         maxLines: 2,
                         style: context.font.headlineLarge?.copyWith(
@@ -92,7 +95,7 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
                         Column(
                           children: [
                             BBText(
-                              'What is word number $nextWordNumber?',
+                              context.loc.testBackupWhatIsWordNumber(nextWordNumber),
                               textAlign: TextAlign.center,
                               style: context.font.labelMedium?.copyWith(
                                 fontWeight: FontWeight.w700,
@@ -105,7 +108,7 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
                         )
                       else
                         BBText(
-                          'You have selected all words',
+                          context.loc.testBackupAllWordsSelected,
                           textAlign: TextAlign.center,
                           style: context.font.labelMedium?.copyWith(
                             fontWeight: FontWeight.w700,


### PR DESCRIPTION
## Summary

- Replaced all hardcoded strings with `context.loc` calls in 4 Dart files
- Used existing ARB keys (no new keys needed)
- Full support for English, French, and Spanish translations

## Changes

### Existing ARB Keys Used (17 total)
- `testBackupSuccessTitle` - Success screen title
- `testBackupSuccessMessage` - Success description
- `testBackupSuccessButton` - Got it button
- `testBackupWriteDownPhrase` - Instructions header
- `testBackupStoreItSafe` - Safety reminder
- `testBackupLastBackupTest` - Last backup timestamp (parameterized)
- `testBackupDoNotShare` - Security warning
- `testBackupTranscribe` / `testBackupDigitalCopy` / `testBackupScreenshot` - Warning items
- `testBackupTapWordsInOrder` - Verification instructions
- `testBackupWhatIsWordNumber` - Word quiz prompt (parameterized)
- `testBackupAllWordsSelected` - Completion message
- `testBackupDefaultWallets` - Default wallet label
- `testBackupWalletTitle` - Wallet title template (parameterized)
- `testBackupConfirm` - Confirm button
- `testBackupNext` - Next button
- `testBackupPassphrase` - Passphrase label

### Files Modified
- `lib/features/test_wallet_backup/ui/screens/backup_test_success.dart`
- `lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart`
- `lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart`
- `lib/features/test_wallet_backup/ui/app_bar_widget.dart`

## Testing

- [x] Validation script passes
- [x] Flutter analyze passes with no issues
- [x] All 2410 keys synchronized across en/fr/es