### PR TITLE
feat: localization of features/tor_settings

### DIFF
--- a/lib/features/tor_settings/ui/screens/tor_settings_screen.dart
+++ b/lib/features/tor_settings/ui/screens/tor_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/tor_settings/presentation/bloc/tor_settings_cubit.dart';
 import 'package:bb_mobile/features/tor_settings/ui/widgets/tor_proxy_widget.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +21,7 @@ class _TorSettingsScreenState extends State<TorSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Tor Settings')),
+      appBar: AppBar(title: Text(context.loc.torSettingsTitle)),
       body: const SafeArea(
         child: SingleChildScrollView(
           padding: EdgeInsets.all(16),

--- a/lib/features/tor_settings/ui/widgets/tor_connection_status_card.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_connection_status_card.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/tor/tor_status.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
@@ -15,7 +16,7 @@ class TorConnectionStatusCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Connection Status', style: context.font.titleMedium),
+            Text(context.loc.torSettingsConnectionStatus, style: context.font.titleMedium),
             const Gap(16),
             Row(
               children: [
@@ -26,14 +27,14 @@ class TorConnectionStatusCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        _getStatusTitle(status),
+                        _getStatusTitle(context, status),
                         style: context.font.bodyLarge?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
                       ),
                       const Gap(4),
                       Text(
-                        _getStatusDescription(status),
+                        _getStatusDescription(context, status),
                         style: context.font.bodySmall?.copyWith(
                           color: context.appColors.onSurface.withValues(
                             alpha: 0.7,
@@ -51,29 +52,29 @@ class TorConnectionStatusCard extends StatelessWidget {
     );
   }
 
-  String _getStatusTitle(TorStatus status) {
+  String _getStatusTitle(BuildContext context, TorStatus status) {
     switch (status) {
       case TorStatus.online:
-        return 'Connected';
+        return context.loc.torSettingsStatusConnected;
       case TorStatus.connecting:
-        return 'Connecting...';
+        return context.loc.torSettingsStatusConnecting;
       case TorStatus.offline:
-        return 'Disconnected';
+        return context.loc.torSettingsStatusDisconnected;
       case TorStatus.unknown:
-        return 'Status Unknown';
+        return context.loc.torSettingsStatusUnknown;
     }
   }
 
-  String _getStatusDescription(TorStatus status) {
+  String _getStatusDescription(BuildContext context, TorStatus status) {
     switch (status) {
       case TorStatus.online:
-        return 'Tor proxy is running and ready';
+        return context.loc.torSettingsDescConnected;
       case TorStatus.connecting:
-        return 'Establishing Tor connection';
+        return context.loc.torSettingsDescConnecting;
       case TorStatus.offline:
-        return 'Tor proxy is not running';
+        return context.loc.torSettingsDescDisconnected;
       case TorStatus.unknown:
-        return 'Unable to determine Tor status. Ensure Orbot is installed and running.';
+        return context.loc.torSettingsDescUnknown;
     }
   }
 }

--- a/lib/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
@@ -42,16 +43,16 @@ class _TorPortInputBottomSheetState extends State<TorPortInputBottomSheet> {
     super.dispose();
   }
 
-  String? _validatePort(String? value) {
+  String? _validatePort(String? value, BuildContext context) {
     if (value == null || value.isEmpty) {
-      return 'Please enter a port number';
+      return context.loc.torSettingsPortValidationEmpty;
     }
     final port = int.tryParse(value);
     if (port == null) {
-      return 'Please enter a valid number';
+      return context.loc.torSettingsPortValidationInvalid;
     }
     if (port < 1 || port > 65535) {
-      return 'Port must be between 1 and 65535';
+      return context.loc.torSettingsPortValidationRange;
     }
     return null;
   }
@@ -84,7 +85,7 @@ class _TorPortInputBottomSheetState extends State<TorPortInputBottomSheet> {
               children: [
                 Center(
                   child: BBText(
-                    'Tor Proxy Port',
+                    context.loc.torSettingsProxyPort,
                     style: context.font.headlineMedium,
                   ),
                 ),
@@ -103,19 +104,19 @@ class _TorPortInputBottomSheetState extends State<TorPortInputBottomSheet> {
               controller: _controller,
               keyboardType: TextInputType.number,
               inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-              decoration: const InputDecoration(
-                labelText: 'Port Number',
-                hintText: '9050',
-                border: OutlineInputBorder(),
-                helperText: 'Default Orbot port: 9050',
+              decoration: InputDecoration(
+                labelText: context.loc.torSettingsPortNumber,
+                hintText: context.loc.torSettingsPortHint,
+                border: const OutlineInputBorder(),
+                helperText: context.loc.torSettingsPortHelper,
               ),
-              validator: _validatePort,
+              validator: (value) => _validatePort(value, context),
               onFieldSubmitted: (_) => _submit(),
               autofocus: true,
             ),
             const Gap(24),
             BBButton.big(
-              label: 'Save',
+              label: context.loc.torSettingsSaveButton,
               onPressed: _submit,
               bgColor: context.appColors.primary,
               textColor: context.appColors.onPrimary,

--- a/lib/features/tor_settings/ui/widgets/tor_proxy_widget.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_proxy_widget.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/cards/info_card.dart';
 import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
 import 'package:bb_mobile/features/tor_settings/presentation/bloc/tor_settings_cubit.dart';
@@ -21,7 +22,7 @@ class TorProxyWidget extends StatelessWidget {
       children: [
         SettingsEntryItem(
           icon: Icons.security,
-          title: 'Enable Tor Proxy',
+          title: context.loc.torSettingsEnableProxy,
           trailing: Switch(
             value: useTorProxy,
             onChanged: (value) {
@@ -43,9 +44,9 @@ class TorProxyWidget extends StatelessWidget {
           Card(
             child: SettingsEntryItem(
               icon: Icons.settings_ethernet,
-              title: 'Tor Proxy Port',
+              title: context.loc.torSettingsProxyPort,
               trailing: Text(
-                'Port: $torProxyPort',
+                context.loc.torSettingsPortDisplay(torProxyPort),
                 style: context.font.bodySmall,
               ),
               onTap: () async {
@@ -67,12 +68,8 @@ class TorProxyWidget extends StatelessWidget {
           ),
           const Gap(16),
           InfoCard(
-            title: 'Important Information',
-            description:
-                '• Tor proxy only applies to Bitcoin (not Liquid)\n'
-                '• Default Orbot port is 9050\n'
-                '• Ensure Orbot is running before enabling\n'
-                '• Connection may be slower through Tor',
+            title: context.loc.torSettingsInfoTitle,
+            description: context.loc.torSettingsInfoDescription,
             bgColor: context.appColors.tertiaryContainer,
             tagColor: context.appColors.tertiary,
           ),

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -10635,5 +10635,98 @@
   "statusCheckUnknown": "Unknown",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "torSettingsTitle": "Tor Settings",
+  "@torSettingsTitle": {
+    "description": "AppBar title for the Tor settings screen"
+  },
+  "torSettingsEnableProxy": "Enable Tor Proxy",
+  "@torSettingsEnableProxy": {
+    "description": "Label for the toggle to enable/disable Tor proxy"
+  },
+  "torSettingsProxyPort": "Tor Proxy Port",
+  "@torSettingsProxyPort": {
+    "description": "Title for Tor proxy port settings"
+  },
+  "torSettingsPortDisplay": "Port: {port}",
+  "@torSettingsPortDisplay": {
+    "description": "Display text showing current port number",
+    "placeholders": {
+      "port": {
+        "type": "int"
+      }
+    }
+  },
+  "torSettingsPortNumber": "Port Number",
+  "@torSettingsPortNumber": {
+    "description": "Label for port number input field"
+  },
+  "torSettingsPortHint": "9050",
+  "@torSettingsPortHint": {
+    "description": "Hint text for port input showing default value"
+  },
+  "torSettingsPortHelper": "Default Orbot port: 9050",
+  "@torSettingsPortHelper": {
+    "description": "Helper text explaining default Orbot port"
+  },
+  "torSettingsPortValidationEmpty": "Please enter a port number",
+  "@torSettingsPortValidationEmpty": {
+    "description": "Validation error when port is empty"
+  },
+  "torSettingsPortValidationInvalid": "Please enter a valid number",
+  "@torSettingsPortValidationInvalid": {
+    "description": "Validation error when port is not a valid number"
+  },
+  "torSettingsPortValidationRange": "Port must be between 1 and 65535",
+  "@torSettingsPortValidationRange": {
+    "description": "Validation error when port is out of valid range"
+  },
+  "torSettingsSaveButton": "Save",
+  "@torSettingsSaveButton": {
+    "description": "Save button label for Tor port settings"
+  },
+  "torSettingsConnectionStatus": "Connection Status",
+  "@torSettingsConnectionStatus": {
+    "description": "Title for connection status card"
+  },
+  "torSettingsStatusConnected": "Connected",
+  "@torSettingsStatusConnected": {
+    "description": "Status title when Tor is connected"
+  },
+  "torSettingsStatusConnecting": "Connecting...",
+  "@torSettingsStatusConnecting": {
+    "description": "Status title when Tor is connecting"
+  },
+  "torSettingsStatusDisconnected": "Disconnected",
+  "@torSettingsStatusDisconnected": {
+    "description": "Status title when Tor is disconnected"
+  },
+  "torSettingsStatusUnknown": "Status Unknown",
+  "@torSettingsStatusUnknown": {
+    "description": "Status title when Tor status is unknown"
+  },
+  "torSettingsDescConnected": "Tor proxy is running and ready",
+  "@torSettingsDescConnected": {
+    "description": "Description when Tor is connected"
+  },
+  "torSettingsDescConnecting": "Establishing Tor connection",
+  "@torSettingsDescConnecting": {
+    "description": "Description when Tor is connecting"
+  },
+  "torSettingsDescDisconnected": "Tor proxy is not running",
+  "@torSettingsDescDisconnected": {
+    "description": "Description when Tor is disconnected"
+  },
+  "torSettingsDescUnknown": "Unable to determine Tor status. Ensure Orbot is installed and running.",
+  "@torSettingsDescUnknown": {
+    "description": "Description when Tor status is unknown"
+  },
+  "torSettingsInfoTitle": "Important Information",
+  "@torSettingsInfoTitle": {
+    "description": "Title for the Tor information card"
+  },
+  "torSettingsInfoDescription": "• Tor proxy only applies to Bitcoin (not Liquid)\n• Default Orbot port is 9050\n• Ensure Orbot is running before enabling\n• Connection may be slower through Tor",
+  "@torSettingsInfoDescription": {
+    "description": "Information about Tor proxy usage"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -10639,5 +10639,98 @@
   "statusCheckUnknown": "Desconocido",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "torSettingsTitle": "Configuración de Tor",
+  "@torSettingsTitle": {
+    "description": "AppBar title for the Tor settings screen"
+  },
+  "torSettingsEnableProxy": "Habilitar proxy Tor",
+  "@torSettingsEnableProxy": {
+    "description": "Label for the toggle to enable/disable Tor proxy"
+  },
+  "torSettingsProxyPort": "Puerto del proxy Tor",
+  "@torSettingsProxyPort": {
+    "description": "Title for Tor proxy port settings"
+  },
+  "torSettingsPortDisplay": "Puerto: {port}",
+  "@torSettingsPortDisplay": {
+    "description": "Display text showing current port number",
+    "placeholders": {
+      "port": {
+        "type": "int"
+      }
+    }
+  },
+  "torSettingsPortNumber": "Número de puerto",
+  "@torSettingsPortNumber": {
+    "description": "Label for port number input field"
+  },
+  "torSettingsPortHint": "9050",
+  "@torSettingsPortHint": {
+    "description": "Hint text for port input showing default value"
+  },
+  "torSettingsPortHelper": "Puerto Orbot predeterminado: 9050",
+  "@torSettingsPortHelper": {
+    "description": "Helper text explaining default Orbot port"
+  },
+  "torSettingsPortValidationEmpty": "Por favor ingrese un número de puerto",
+  "@torSettingsPortValidationEmpty": {
+    "description": "Validation error when port is empty"
+  },
+  "torSettingsPortValidationInvalid": "Por favor ingrese un número válido",
+  "@torSettingsPortValidationInvalid": {
+    "description": "Validation error when port is not a valid number"
+  },
+  "torSettingsPortValidationRange": "El puerto debe estar entre 1 y 65535",
+  "@torSettingsPortValidationRange": {
+    "description": "Validation error when port is out of valid range"
+  },
+  "torSettingsSaveButton": "Guardar",
+  "@torSettingsSaveButton": {
+    "description": "Save button label for Tor port settings"
+  },
+  "torSettingsConnectionStatus": "Estado de conexión",
+  "@torSettingsConnectionStatus": {
+    "description": "Title for connection status card"
+  },
+  "torSettingsStatusConnected": "Conectado",
+  "@torSettingsStatusConnected": {
+    "description": "Status title when Tor is connected"
+  },
+  "torSettingsStatusConnecting": "Conectando...",
+  "@torSettingsStatusConnecting": {
+    "description": "Status title when Tor is connecting"
+  },
+  "torSettingsStatusDisconnected": "Desconectado",
+  "@torSettingsStatusDisconnected": {
+    "description": "Status title when Tor is disconnected"
+  },
+  "torSettingsStatusUnknown": "Estado desconocido",
+  "@torSettingsStatusUnknown": {
+    "description": "Status title when Tor status is unknown"
+  },
+  "torSettingsDescConnected": "El proxy Tor está activo y listo",
+  "@torSettingsDescConnected": {
+    "description": "Description when Tor is connected"
+  },
+  "torSettingsDescConnecting": "Estableciendo conexión Tor",
+  "@torSettingsDescConnecting": {
+    "description": "Description when Tor is connecting"
+  },
+  "torSettingsDescDisconnected": "El proxy Tor no está activo",
+  "@torSettingsDescDisconnected": {
+    "description": "Description when Tor is disconnected"
+  },
+  "torSettingsDescUnknown": "No se puede determinar el estado de Tor. Asegúrese de que Orbot esté instalado y en ejecución.",
+  "@torSettingsDescUnknown": {
+    "description": "Description when Tor status is unknown"
+  },
+  "torSettingsInfoTitle": "Información importante",
+  "@torSettingsInfoTitle": {
+    "description": "Title for the Tor information card"
+  },
+  "torSettingsInfoDescription": "• El proxy Tor solo aplica a Bitcoin (no Liquid)\n• El puerto Orbot predeterminado es 9050\n• Asegúrese de que Orbot esté ejecutándose antes de habilitar\n• La conexión puede ser más lenta a través de Tor",
+  "@torSettingsInfoDescription": {
+    "description": "Information about Tor proxy usage"
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -10639,5 +10639,98 @@
   "statusCheckUnknown": "Inconnu",
   "@statusCheckUnknown": {
     "description": "Status text when service status is unknown"
+  },
+  "torSettingsTitle": "Paramètres Tor",
+  "@torSettingsTitle": {
+    "description": "AppBar title for the Tor settings screen"
+  },
+  "torSettingsEnableProxy": "Activer le proxy Tor",
+  "@torSettingsEnableProxy": {
+    "description": "Label for the toggle to enable/disable Tor proxy"
+  },
+  "torSettingsProxyPort": "Port du proxy Tor",
+  "@torSettingsProxyPort": {
+    "description": "Title for Tor proxy port settings"
+  },
+  "torSettingsPortDisplay": "Port : {port}",
+  "@torSettingsPortDisplay": {
+    "description": "Display text showing current port number",
+    "placeholders": {
+      "port": {
+        "type": "int"
+      }
+    }
+  },
+  "torSettingsPortNumber": "Numéro de port",
+  "@torSettingsPortNumber": {
+    "description": "Label for port number input field"
+  },
+  "torSettingsPortHint": "9050",
+  "@torSettingsPortHint": {
+    "description": "Hint text for port input showing default value"
+  },
+  "torSettingsPortHelper": "Port Orbot par défaut : 9050",
+  "@torSettingsPortHelper": {
+    "description": "Helper text explaining default Orbot port"
+  },
+  "torSettingsPortValidationEmpty": "Veuillez entrer un numéro de port",
+  "@torSettingsPortValidationEmpty": {
+    "description": "Validation error when port is empty"
+  },
+  "torSettingsPortValidationInvalid": "Veuillez entrer un nombre valide",
+  "@torSettingsPortValidationInvalid": {
+    "description": "Validation error when port is not a valid number"
+  },
+  "torSettingsPortValidationRange": "Le port doit être entre 1 et 65535",
+  "@torSettingsPortValidationRange": {
+    "description": "Validation error when port is out of valid range"
+  },
+  "torSettingsSaveButton": "Enregistrer",
+  "@torSettingsSaveButton": {
+    "description": "Save button label for Tor port settings"
+  },
+  "torSettingsConnectionStatus": "État de connexion",
+  "@torSettingsConnectionStatus": {
+    "description": "Title for connection status card"
+  },
+  "torSettingsStatusConnected": "Connecté",
+  "@torSettingsStatusConnected": {
+    "description": "Status title when Tor is connected"
+  },
+  "torSettingsStatusConnecting": "Connexion en cours...",
+  "@torSettingsStatusConnecting": {
+    "description": "Status title when Tor is connecting"
+  },
+  "torSettingsStatusDisconnected": "Déconnecté",
+  "@torSettingsStatusDisconnected": {
+    "description": "Status title when Tor is disconnected"
+  },
+  "torSettingsStatusUnknown": "État inconnu",
+  "@torSettingsStatusUnknown": {
+    "description": "Status title when Tor status is unknown"
+  },
+  "torSettingsDescConnected": "Le proxy Tor est actif et prêt",
+  "@torSettingsDescConnected": {
+    "description": "Description when Tor is connected"
+  },
+  "torSettingsDescConnecting": "Établissement de la connexion Tor",
+  "@torSettingsDescConnecting": {
+    "description": "Description when Tor is connecting"
+  },
+  "torSettingsDescDisconnected": "Le proxy Tor n'est pas actif",
+  "@torSettingsDescDisconnected": {
+    "description": "Description when Tor is disconnected"
+  },
+  "torSettingsDescUnknown": "Impossible de déterminer l'état de Tor. Assurez-vous qu'Orbot est installé et en cours d'exécution.",
+  "@torSettingsDescUnknown": {
+    "description": "Description when Tor status is unknown"
+  },
+  "torSettingsInfoTitle": "Informations importantes",
+  "@torSettingsInfoTitle": {
+    "description": "Title for the Tor information card"
+  },
+  "torSettingsInfoDescription": "• Le proxy Tor s'applique uniquement à Bitcoin (pas Liquid)\n• Le port Orbot par défaut est 9050\n• Assurez-vous qu'Orbot est en cours d'exécution avant d'activer\n• La connexion peut être plus lente via Tor",
+  "@torSettingsInfoDescription": {
+    "description": "Information about Tor proxy usage"
   }
 }


### PR DESCRIPTION
## Summary
- Add localization support for the `tor_settings` feature
- 22 new ARB keys added to all 3 language files (en, fr, es)
- 4 Dart files updated to use `context.loc`

## Changes

### New ARB Keys (22 total)
- `torSettingsTitle` - Screen title
- `torSettingsEnableProxy` - Toggle label
- `torSettingsProxyPort` - Port settings title
- `torSettingsPortDisplay` - Port display (with parameter)
- `torSettingsPortNumber` - Input label
- `torSettingsPortHint` - Input hint
- `torSettingsPortHelper` - Input helper text
- `torSettingsPortValidationEmpty/Invalid/Range` - Validation messages
- `torSettingsSaveButton` - Save button label
- `torSettingsConnectionStatus` - Connection status header
- `torSettingsStatusConnected/Connecting/Disconnected/Unknown` - Status titles
- `torSettingsDescConnected/Connecting/Disconnected/Unknown` - Status descriptions
- `torSettingsInfoTitle` - Info card title
- `torSettingsInfoDescription` - Info card content

### Files Modified
- `lib/features/tor_settings/ui/screens/tor_settings_screen.dart`
- `lib/features/tor_settings/ui/widgets/tor_connection_status_card.dart`
- `lib/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart`
- `lib/features/tor_settings/ui/widgets/tor_proxy_widget.dart`
- `localization/app_en.arb`
- `localization/app_fr.arb`
- `localization/app_es.arb`

## Test Plan
- [x] Validation script passes
- [x] Flutter analyze passes with no issues

## Translation Notes
- Technical terms (proxy, port) left as-is in both languages
- "Orbot" is a proper noun and remains unchanged