### PR TITLE
feat: localization of core/recoverbull

### DIFF
--- a/lib/core/recoverbull/domain/entity/vault_provider.dart
+++ b/lib/core/recoverbull/domain/entity/vault_provider.dart
@@ -1,18 +1,20 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
+import 'package:flutter/material.dart';
 
 enum VaultProvider {
   googleDrive,
   iCloud,
   customLocation;
 
-  String get name {
+  String displayName(BuildContext context) {
     switch (this) {
       case VaultProvider.googleDrive:
-        return 'Google Drive';
+        return context.loc.recoverbullSelectGoogleDrive;
       case VaultProvider.iCloud:
-        return 'Apple iCloud';
+        return context.loc.recoverbullSelectAppleIcloud;
       case VaultProvider.customLocation:
-        return 'Custom location';
+        return context.loc.recoverbullSelectCustomLocationProvider;
     }
   }
 
@@ -27,13 +29,13 @@ enum VaultProvider {
     }
   }
 
-  String get description {
+  String description(BuildContext context) {
     switch (this) {
       case VaultProvider.googleDrive:
       case VaultProvider.iCloud:
-        return 'Quick & easy';
+        return context.loc.recoverbullSelectQuickAndEasy;
       case VaultProvider.customLocation:
-        return 'Take your time';
+        return context.loc.recoverbullSelectTakeYourTime;
     }
   }
 }

--- a/lib/core/recoverbull/errors.dart
+++ b/lib/core/recoverbull/errors.dart
@@ -1,8 +1,13 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:flutter/material.dart';
 import 'package:recoverbull/recoverbull.dart';
 
 class RecoverBullError extends BullException {
   RecoverBullError(super.message);
+
+  /// Returns the localized error message.
+  String toTranslated(BuildContext context) => message;
 }
 
 class ServerError extends RecoverBullError {
@@ -25,28 +30,57 @@ class ServerError extends RecoverBullError {
 }
 
 class InvalidCredentialsError extends ServerError {
-  InvalidCredentialsError()
-    : super('Wrong password for this backup file. Please check your password.');
+  InvalidCredentialsError() : super('InvalidCredentialsError');
+
+  @override
+  String toTranslated(BuildContext context) =>
+      context.loc.recoverbullErrorInvalidCredentials;
 }
 
 class RateLimitedError extends ServerError {
   final Duration retryIn;
 
-  RateLimitedError({required this.retryIn})
-    : super(
-        'Rate-limited. Retry in ${retryIn.inMinutes == 0 ? "${retryIn.inSeconds} seconds" : "${retryIn.inMinutes} minutes"} ',
-      );
+  RateLimitedError({required this.retryIn}) : super('RateLimitedError');
+
+  @override
+  String toTranslated(BuildContext context) {
+    final seconds = retryIn.inSeconds;
+    final minutes = retryIn.inMinutes;
+
+    final String formattedTime;
+    if (seconds < 60) {
+      formattedTime = context.loc.durationSeconds(seconds.toString());
+    } else {
+      formattedTime =
+          minutes == 1
+              ? context.loc.durationMinute(minutes.toString())
+              : context.loc.durationMinutes(minutes.toString());
+    }
+
+    return context.loc.recoverbullErrorRateLimited(formattedTime);
+  }
 }
 
 class KeyServerErrorRejected extends ServerError {
-  KeyServerErrorRejected() : super('Rejected by the Key Server');
+  KeyServerErrorRejected() : super('KeyServerErrorRejected');
+
+  @override
+  String toTranslated(BuildContext context) =>
+      context.loc.recoverbullErrorRejected;
 }
 
 class KeyServerErrorServiceUnavailable extends ServerError {
-  KeyServerErrorServiceUnavailable()
-    : super('Service unavailable. Please check your connection.');
+  KeyServerErrorServiceUnavailable() : super('KeyServerErrorServiceUnavailable');
+
+  @override
+  String toTranslated(BuildContext context) =>
+      context.loc.recoverbullErrorServiceUnavailable;
 }
 
 class InvalidVaultFileError extends BullException {
-  InvalidVaultFileError() : super('Invalid vault file.');
+  InvalidVaultFileError() : super('InvalidVaultFileError');
+
+  /// Returns the localized error message.
+  String toTranslated(BuildContext context) =>
+      context.loc.recoverbullErrorInvalidVaultFile;
 }

--- a/lib/core/widgets/cards/provider_cart.dart
+++ b/lib/core/widgets/cards/provider_cart.dart
@@ -78,11 +78,11 @@ class _ProviderCardState extends State<ProviderCard>
                       crossAxisAlignment: .start,
                       children: [
                         BBText(
-                          widget.provider.name,
+                          widget.provider.displayName(context),
                           style: context.font.headlineMedium,
                         ),
                         const Gap(10),
-                        OptionsTag(text: widget.provider.description),
+                        OptionsTag(text: widget.provider.description(context)),
                       ],
                     ),
                   ),

--- a/lib/features/recoverbull/errors.dart
+++ b/lib/features/recoverbull/errors.dart
@@ -140,3 +140,10 @@ class InvalidVaultCredentials extends RecoverBullError {
     return context.loc.recoverbullErrorInvalidCredentials;
   }
 }
+
+class InvalidVaultFileFormatError extends RecoverBullError {
+  @override
+  String toTranslated(BuildContext context) {
+    return context.loc.recoverbullSelectBackupFileNotValidError;
+  }
+}

--- a/lib/features/recoverbull/presentation/bloc.dart
+++ b/lib/features/recoverbull/presentation/bloc.dart
@@ -266,7 +266,12 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
       log.fine('Vault selected');
     } catch (e) {
       log.severe('$OnVaultSelection: $e');
-      emit(state.copyWith(error: SelectVaultError()));
+      switch (e) {
+        case core.InvalidVaultFileError():
+          emit(state.copyWith(error: InvalidVaultFileFormatError()));
+        default:
+          emit(state.copyWith(error: SelectVaultError()));
+      }
     } finally {
       emit(state.copyWith(isLoading: false));
     }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -11618,5 +11618,17 @@
   "withdrawOrderAlreadyConfirmedError": "This withdrawal order has already been confirmed.",
   "@withdrawOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed withdrawal order"
+  },
+  "recoverbullErrorRejected": "Rejected by the Key Server",
+  "@recoverbullErrorRejected": {
+    "description": "Error message when request is rejected by the key server"
+  },
+  "recoverbullErrorServiceUnavailable": "Service unavailable. Please check your connection.",
+  "@recoverbullErrorServiceUnavailable": {
+    "description": "Error message when key server service is unavailable"
+  },
+  "recoverbullErrorInvalidVaultFile": "Invalid vault file.",
+  "@recoverbullErrorInvalidVaultFile": {
+    "description": "Error message when vault file format is invalid"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -11618,5 +11618,17 @@
   "withdrawOrderAlreadyConfirmedError": "Esta orden de retiro ya ha sido confirmada.",
   "@withdrawOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed withdrawal order"
+  },
+  "recoverbullErrorRejected": "Rechazado por el servidor de claves",
+  "@recoverbullErrorRejected": {
+    "description": "Error message when request is rejected by the key server"
+  },
+  "recoverbullErrorServiceUnavailable": "Servicio no disponible. Por favor, verifica tu conexión.",
+  "@recoverbullErrorServiceUnavailable": {
+    "description": "Error message when key server service is unavailable"
+  },
+  "recoverbullErrorInvalidVaultFile": "Archivo de bóveda inválido.",
+  "@recoverbullErrorInvalidVaultFile": {
+    "description": "Error message when vault file format is invalid"
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -11619,5 +11619,17 @@
   "withdrawOrderAlreadyConfirmedError": "Cet ordre de retrait a déjà été confirmé.",
   "@withdrawOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed withdrawal order"
+  },
+  "recoverbullErrorRejected": "Rejeté par le serveur de clés",
+  "@recoverbullErrorRejected": {
+    "description": "Error message when request is rejected by the key server"
+  },
+  "recoverbullErrorServiceUnavailable": "Service indisponible. Veuillez vérifier votre connexion.",
+  "@recoverbullErrorServiceUnavailable": {
+    "description": "Error message when key server service is unavailable"
+  },
+  "recoverbullErrorInvalidVaultFile": "Fichier de coffre invalide.",
+  "@recoverbullErrorInvalidVaultFile": {
+    "description": "Error message when vault file format is invalid"
   }
 }


### PR DESCRIPTION
## Summary

This PR localizes the `lib/core/recoverbull` module, adding `toTranslated()` methods to error classes and converting hardcoded strings to use ARB localization keys.

## Changes

### Core Layer (`lib/core/recoverbull`)
- **`errors.dart`**: Added `toTranslated(BuildContext context)` methods to all error classes:
  - `InvalidCredentialsError`
  - `RateLimitedError` (with dynamic time formatting)
  - `KeyServerErrorRejected`
  - `KeyServerErrorServiceUnavailable`
  - `InvalidVaultFileError`

- **`domain/entity/vault_provider.dart`**: 
  - Converted `name` getter to `displayName(BuildContext context)` method
  - Converted `description` getter to `description(BuildContext context)` method

### Widget Layer (`lib/core/widgets`)
- **`cards/provider_cart.dart`**: Updated to pass context to `displayName()` and `description()` methods

### Feature Layer (`lib/features/recoverbull`)
- **`errors.dart`**: Added `InvalidVaultFileFormatError` class using existing ARB key
- **`presentation/bloc.dart`**: Updated `_onVaultSelection` to catch `InvalidVaultFileError` and emit proper localized error

### ARB Files
Added 3 new keys in all languages (en/fr/es):
- `recoverbullErrorRejected` - "Rejected by the Key Server"
- `recoverbullErrorServiceUnavailable` - "Service unavailable. Please check your connection."
- `recoverbullErrorInvalidVaultFile` - "Invalid vault file."

## Files Modified
- `lib/core/recoverbull/domain/entity/vault_provider.dart`
- `lib/core/recoverbull/errors.dart`
- `lib/core/widgets/cards/provider_cart.dart`
- `lib/features/recoverbull/errors.dart`
- `lib/features/recoverbull/presentation/bloc.dart`
- `localization/app_en.arb`
- `localization/app_fr.arb`
- `localization/app_es.arb`

## Testing
- [x] `fvm flutter analyze --fatal-warnings --fatal-infos` passes with no issues
- [ ] Manual testing of vault provider selection UI in all languages
- [ ] Manual testing of error messages when vault file is invalid

## Translation Notes
| Key | EN | FR | ES |
|-----|----|----|-----|
| `recoverbullErrorRejected` | Rejected by the Key Server | Rejeté par le serveur de clés | Rechazado por el servidor de claves |
| `recoverbullErrorServiceUnavailable` | Service unavailable. Please check your connection. | Service indisponible. Veuillez vérifier votre connexion. | Servicio no disponible. Por favor, verifica tu conexión. |
| `recoverbullErrorInvalidVaultFile` | Invalid vault file. | Fichier de coffre invalide. | Archivo de bóveda inválido. |