### PR TITLE
feat: localization of core/swaps

### DIFF
--- a/lib/core/swaps/domain/entity/swap.dart
+++ b/lib/core/swaps/domain/entity/swap.dart
@@ -1,9 +1,11 @@
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/percentage.dart';
 import 'package:bb_mobile/core/utils/string_formatting.dart';
 import 'package:bolt11_decoder/bolt11_decoder.dart';
 import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'swap.freezed.dart';
@@ -38,21 +40,21 @@ enum SwapStatus {
   expired,
   failed;
 
-  String get displayName {
+  String displayName(BuildContext context) {
     switch (this) {
       case SwapStatus.pending:
-        return 'Pending';
+        return context.loc.coreSwapsStatusPending;
       case SwapStatus.paid:
       case SwapStatus.claimable:
       case SwapStatus.refundable:
       case SwapStatus.canCoop:
-        return 'In Progress';
+        return context.loc.coreSwapsStatusInProgress;
       case SwapStatus.completed:
-        return 'Completed';
+        return context.loc.coreSwapsStatusCompleted;
       case SwapStatus.expired:
-        return 'Expired';
+        return context.loc.coreSwapsStatusExpired;
       case SwapStatus.failed:
-        return 'Failed';
+        return context.loc.coreSwapsStatusFailed;
     }
   }
 }
@@ -311,13 +313,13 @@ sealed class Swap with _$Swap {
   bool get isChainSwapExternal =>
       this is ChainSwap && (this as ChainSwap).receiveWalletId == null;
 
-  String get swapAction =>
+  String swapAction(BuildContext context) =>
       status == SwapStatus.claimable
-          ? 'Claim'
+          ? context.loc.coreSwapsActionClaim
           : status == SwapStatus.canCoop
-          ? 'Close'
+          ? context.loc.coreSwapsActionClose
           : status == SwapStatus.refundable
-          ? 'Refund'
+          ? context.loc.coreSwapsActionRefund
           : '';
 
   bool get swapCompleted => status == SwapStatus.completed;
@@ -426,82 +428,82 @@ class Invoice {
 }
 
 extension SwapStatusMessage on Swap {
-  String getDisplayMessage() {
+  String getDisplayMessage(BuildContext context) {
     if (isLnReceiveSwap) {
       switch (status) {
         case SwapStatus.pending:
-          return "Swap is not yet initialized.";
+          return context.loc.coreSwapsLnReceivePending;
         case SwapStatus.paid:
-          return "Sender has paid the invoice.";
+          return context.loc.coreSwapsLnReceivePaid;
         case SwapStatus.claimable:
-          return "Swap is ready to be claimed.";
+          return context.loc.coreSwapsLnReceiveClaimable;
         case SwapStatus.refundable:
-          return "Swap is ready to be refunded.";
+          return context.loc.coreSwapsLnReceiveRefundable;
         case SwapStatus.canCoop:
-          return "Swap will complete momentarily.";
+          return context.loc.coreSwapsLnReceiveCanCoop;
         case SwapStatus.completed:
-          return "Swap is completed.";
+          return context.loc.coreSwapsLnReceiveCompleted;
         case SwapStatus.expired:
-          return "Swap Expired.";
+          return context.loc.coreSwapsLnReceiveExpired;
         case SwapStatus.failed:
-          return "Swap Failed.";
+          return context.loc.coreSwapsLnReceiveFailed;
       }
     } else if (isLnSendSwap) {
       switch (status) {
         case SwapStatus.pending:
-          return "Swap is not yet initialized.";
+          return context.loc.coreSwapsLnSendPending;
         case SwapStatus.paid:
-          return "Invoice will be paid after you payment receives confirmation.";
+          return context.loc.coreSwapsLnSendPaid;
         case SwapStatus.claimable:
-          return "Swap is ready to be claimed.";
+          return context.loc.coreSwapsLnSendClaimable;
         case SwapStatus.refundable:
-          return "Swap is ready to be refunded.";
+          return context.loc.coreSwapsLnSendRefundable;
         case SwapStatus.canCoop:
-          return "Swap will complete momentarily.";
+          return context.loc.coreSwapsLnSendCanCoop;
         case SwapStatus.completed:
           final swap = this;
           if (swap is LnSendSwap && swap.refundTxid != null) {
-            return "Swap has been refunded.";
+            return context.loc.coreSwapsLnSendCompletedRefunded;
           } else {
-            return "Swap is completed successfully.";
+            return context.loc.coreSwapsLnSendCompletedSuccess;
           }
         case SwapStatus.expired:
-          return "Swap Expired";
+          return context.loc.coreSwapsLnSendExpired;
         case SwapStatus.failed:
           final swap = this;
           if (swap is LnSendSwap && swap.sendTxid != null) {
-            return "Swap will be refunded shortly.";
+            return context.loc.coreSwapsLnSendFailedRefunding;
           } else {
-            return "Swap Failed.";
+            return context.loc.coreSwapsLnSendFailed;
           }
       }
     } else if (isChainSwap) {
       switch (status) {
         case SwapStatus.pending:
-          return "Transfer is not yet initialized.";
+          return context.loc.coreSwapsChainPending;
         case SwapStatus.paid:
-          return "Waiting for transfer provider's payment to receive confirmation. This may take a while to complete.";
+          return context.loc.coreSwapsChainPaid;
         case SwapStatus.claimable:
-          return "Transfer is ready to be claimed.";
+          return context.loc.coreSwapsChainClaimable;
         case SwapStatus.refundable:
-          return "Transfer is ready to be refunded.";
+          return context.loc.coreSwapsChainRefundable;
         case SwapStatus.canCoop:
-          return "Transfer will complete momentarily.";
+          return context.loc.coreSwapsChainCanCoop;
         case SwapStatus.completed:
           final swap = this;
           if (swap is ChainSwap && swap.refundTxid != null) {
-            return "Transfer has been refunded.";
+            return context.loc.coreSwapsChainCompletedRefunded;
           } else {
-            return "Transfer is completed successfully.";
+            return context.loc.coreSwapsChainCompletedSuccess;
           }
         case SwapStatus.expired:
-          return "Transfer Expired";
+          return context.loc.coreSwapsChainExpired;
         case SwapStatus.failed:
           final swap = this;
           if (swap is ChainSwap && swap.sendTxid != null) {
-            return "Transfer will be refunded shortly.";
+            return context.loc.coreSwapsChainFailedRefunding;
           } else {
-            return "Transfer Failed.";
+            return context.loc.coreSwapsChainFailed;
           }
       }
     }

--- a/lib/core/wallet/domain/entities/wallet_transaction.dart
+++ b/lib/core/wallet/domain/entities/wallet_transaction.dart
@@ -1,6 +1,8 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/transaction_input.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/transaction_output.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'wallet_transaction.freezed.dart';
@@ -11,12 +13,12 @@ enum WalletTransactionStatus {
   pending,
   confirmed;
 
-  String get displayName {
+  String displayName(BuildContext context) {
     switch (this) {
       case WalletTransactionStatus.pending:
-        return 'Pending';
+        return context.loc.coreWalletTransactionStatusPending;
       case WalletTransactionStatus.confirmed:
-        return 'Confirmed';
+        return context.loc.coreWalletTransactionStatusConfirmed;
     }
   }
 }

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -55,7 +55,7 @@ class TransactionDetailsScreen extends StatelessWidget {
     final isOrderType = tx?.isOrder == true;
     final walletTransaction = tx?.walletTransaction;
     final swap = tx?.swap;
-    final swapAction = swap?.swapAction ?? '';
+    final swapAction = swap?.swapAction(context) ?? '';
     final isChainSwap = swap?.isChainSwap ?? false;
     final retryingSwap = context.select(
       (TransactionDetailsCubit bloc) => bloc.state.retryingSwap,

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -184,7 +184,7 @@ class TransactionDetailsTable extends StatelessWidget {
             ),
           DetailsTableItem(
             label: context.loc.transactionDetailLabelStatus,
-            displayValue: walletTransaction.status.displayName,
+            displayValue: walletTransaction.status.displayName(context),
           ),
           if (walletTransaction.confirmationTime != null)
             DetailsTableItem(
@@ -740,9 +740,9 @@ class TransactionDetailsTable extends StatelessWidget {
                         swap.isLnSendSwap &&
                             (swap as LnSendSwap).refundTxid != null)
                     ? context.loc.transactionDetailLabelRefunded
-                    : swap.status.displayName,
+                    : swap.status.displayName(context),
             expandableChild: BBText(
-              swap.getDisplayMessage(),
+              swap.getDisplayMessage(context),
               style: context.font.bodySmall?.copyWith(
                 color: context.appColors.secondary,
               ),

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -27,6 +27,158 @@
       }
     }
   },
+  "coreSwapsStatusPending": "Pending",
+  "@coreSwapsStatusPending": {
+    "description": "Display name for pending swap status"
+  },
+  "coreSwapsStatusInProgress": "In Progress",
+  "@coreSwapsStatusInProgress": {
+    "description": "Display name for in-progress swap status (paid, claimable, refundable, canCoop)"
+  },
+  "coreSwapsStatusCompleted": "Completed",
+  "@coreSwapsStatusCompleted": {
+    "description": "Display name for completed swap status"
+  },
+  "coreSwapsStatusExpired": "Expired",
+  "@coreSwapsStatusExpired": {
+    "description": "Display name for expired swap status"
+  },
+  "coreSwapsStatusFailed": "Failed",
+  "@coreSwapsStatusFailed": {
+    "description": "Display name for failed swap status"
+  },
+  "coreSwapsActionClaim": "Claim",
+  "@coreSwapsActionClaim": {
+    "description": "Action label for claiming a swap"
+  },
+  "coreSwapsActionClose": "Close",
+  "@coreSwapsActionClose": {
+    "description": "Action label for closing a swap cooperatively"
+  },
+  "coreSwapsActionRefund": "Refund",
+  "@coreSwapsActionRefund": {
+    "description": "Action label for refunding a swap"
+  },
+  "coreSwapsLnReceivePending": "Swap is not yet initialized.",
+  "@coreSwapsLnReceivePending": {
+    "description": "Status message for pending Lightning receive swap"
+  },
+  "coreSwapsLnReceivePaid": "Sender has paid the invoice.",
+  "@coreSwapsLnReceivePaid": {
+    "description": "Status message for paid Lightning receive swap"
+  },
+  "coreSwapsLnReceiveClaimable": "Swap is ready to be claimed.",
+  "@coreSwapsLnReceiveClaimable": {
+    "description": "Status message for claimable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveRefundable": "Swap is ready to be refunded.",
+  "@coreSwapsLnReceiveRefundable": {
+    "description": "Status message for refundable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveCanCoop": "Swap will complete momentarily.",
+  "@coreSwapsLnReceiveCanCoop": {
+    "description": "Status message for Lightning receive swap that can complete cooperatively"
+  },
+  "coreSwapsLnReceiveCompleted": "Swap is completed.",
+  "@coreSwapsLnReceiveCompleted": {
+    "description": "Status message for completed Lightning receive swap"
+  },
+  "coreSwapsLnReceiveExpired": "Swap Expired.",
+  "@coreSwapsLnReceiveExpired": {
+    "description": "Status message for expired Lightning receive swap"
+  },
+  "coreSwapsLnReceiveFailed": "Swap Failed.",
+  "@coreSwapsLnReceiveFailed": {
+    "description": "Status message for failed Lightning receive swap"
+  },
+  "coreSwapsLnSendPending": "Swap is not yet initialized.",
+  "@coreSwapsLnSendPending": {
+    "description": "Status message for pending Lightning send swap"
+  },
+  "coreSwapsLnSendPaid": "Invoice will be paid after your payment receives confirmation.",
+  "@coreSwapsLnSendPaid": {
+    "description": "Status message for paid Lightning send swap"
+  },
+  "coreSwapsLnSendClaimable": "Swap is ready to be claimed.",
+  "@coreSwapsLnSendClaimable": {
+    "description": "Status message for claimable Lightning send swap"
+  },
+  "coreSwapsLnSendRefundable": "Swap is ready to be refunded.",
+  "@coreSwapsLnSendRefundable": {
+    "description": "Status message for refundable Lightning send swap"
+  },
+  "coreSwapsLnSendCanCoop": "Swap will complete momentarily.",
+  "@coreSwapsLnSendCanCoop": {
+    "description": "Status message for Lightning send swap that can complete cooperatively"
+  },
+  "coreSwapsLnSendCompletedRefunded": "Swap has been refunded.",
+  "@coreSwapsLnSendCompletedRefunded": {
+    "description": "Status message for Lightning send swap completed via refund"
+  },
+  "coreSwapsLnSendCompletedSuccess": "Swap is completed successfully.",
+  "@coreSwapsLnSendCompletedSuccess": {
+    "description": "Status message for successfully completed Lightning send swap"
+  },
+  "coreSwapsLnSendExpired": "Swap Expired",
+  "@coreSwapsLnSendExpired": {
+    "description": "Status message for expired Lightning send swap"
+  },
+  "coreSwapsLnSendFailedRefunding": "Swap will be refunded shortly.",
+  "@coreSwapsLnSendFailedRefunding": {
+    "description": "Status message for failed Lightning send swap that will be refunded"
+  },
+  "coreSwapsLnSendFailed": "Swap Failed.",
+  "@coreSwapsLnSendFailed": {
+    "description": "Status message for failed Lightning send swap"
+  },
+  "coreSwapsChainPending": "Transfer is not yet initialized.",
+  "@coreSwapsChainPending": {
+    "description": "Status message for pending chain swap"
+  },
+  "coreSwapsChainPaid": "Waiting for transfer provider's payment to receive confirmation. This may take a while to complete.",
+  "@coreSwapsChainPaid": {
+    "description": "Status message for paid chain swap"
+  },
+  "coreSwapsChainClaimable": "Transfer is ready to be claimed.",
+  "@coreSwapsChainClaimable": {
+    "description": "Status message for claimable chain swap"
+  },
+  "coreSwapsChainRefundable": "Transfer is ready to be refunded.",
+  "@coreSwapsChainRefundable": {
+    "description": "Status message for refundable chain swap"
+  },
+  "coreSwapsChainCanCoop": "Transfer will complete momentarily.",
+  "@coreSwapsChainCanCoop": {
+    "description": "Status message for chain swap that can complete cooperatively"
+  },
+  "coreSwapsChainCompletedRefunded": "Transfer has been refunded.",
+  "@coreSwapsChainCompletedRefunded": {
+    "description": "Status message for chain swap completed via refund"
+  },
+  "coreSwapsChainCompletedSuccess": "Transfer is completed successfully.",
+  "@coreSwapsChainCompletedSuccess": {
+    "description": "Status message for successfully completed chain swap"
+  },
+  "coreSwapsChainExpired": "Transfer Expired",
+  "@coreSwapsChainExpired": {
+    "description": "Status message for expired chain swap"
+  },
+  "coreSwapsChainFailedRefunding": "Transfer will be refunded shortly.",
+  "@coreSwapsChainFailedRefunding": {
+    "description": "Status message for failed chain swap that will be refunded"
+  },
+  "coreSwapsChainFailed": "Transfer Failed.",
+  "@coreSwapsChainFailed": {
+    "description": "Status message for failed chain swap"
+  },
+  "coreWalletTransactionStatusPending": "Pending",
+  "@coreWalletTransactionStatusPending": {
+    "description": "Display name for pending wallet transaction status"
+  },
+  "coreWalletTransactionStatusConfirmed": "Confirmed",
+  "@coreWalletTransactionStatusConfirmed": {
+    "description": "Display name for confirmed wallet transaction status"
+  },
   "onboardingScreenTitle": "Welcome",
   "@onboardingScreenTitle": {
     "description": "The title of the onboarding screen"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -27,6 +27,158 @@
       }
     }
   },
+  "coreSwapsStatusPending": "Pendiente",
+  "@coreSwapsStatusPending": {
+    "description": "Display name for pending swap status"
+  },
+  "coreSwapsStatusInProgress": "En progreso",
+  "@coreSwapsStatusInProgress": {
+    "description": "Display name for in-progress swap status (paid, claimable, refundable, canCoop)"
+  },
+  "coreSwapsStatusCompleted": "Completado",
+  "@coreSwapsStatusCompleted": {
+    "description": "Display name for completed swap status"
+  },
+  "coreSwapsStatusExpired": "Expirado",
+  "@coreSwapsStatusExpired": {
+    "description": "Display name for expired swap status"
+  },
+  "coreSwapsStatusFailed": "Fallido",
+  "@coreSwapsStatusFailed": {
+    "description": "Display name for failed swap status"
+  },
+  "coreSwapsActionClaim": "Reclamar",
+  "@coreSwapsActionClaim": {
+    "description": "Action label for claiming a swap"
+  },
+  "coreSwapsActionClose": "Cerrar",
+  "@coreSwapsActionClose": {
+    "description": "Action label for closing a swap cooperatively"
+  },
+  "coreSwapsActionRefund": "Reembolsar",
+  "@coreSwapsActionRefund": {
+    "description": "Action label for refunding a swap"
+  },
+  "coreSwapsLnReceivePending": "El intercambio aún no está inicializado.",
+  "@coreSwapsLnReceivePending": {
+    "description": "Status message for pending Lightning receive swap"
+  },
+  "coreSwapsLnReceivePaid": "El remitente ha pagado la factura.",
+  "@coreSwapsLnReceivePaid": {
+    "description": "Status message for paid Lightning receive swap"
+  },
+  "coreSwapsLnReceiveClaimable": "El intercambio está listo para ser reclamado.",
+  "@coreSwapsLnReceiveClaimable": {
+    "description": "Status message for claimable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveRefundable": "El intercambio está listo para ser reembolsado.",
+  "@coreSwapsLnReceiveRefundable": {
+    "description": "Status message for refundable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveCanCoop": "El intercambio se completará en breve.",
+  "@coreSwapsLnReceiveCanCoop": {
+    "description": "Status message for Lightning receive swap that can complete cooperatively"
+  },
+  "coreSwapsLnReceiveCompleted": "El intercambio está completado.",
+  "@coreSwapsLnReceiveCompleted": {
+    "description": "Status message for completed Lightning receive swap"
+  },
+  "coreSwapsLnReceiveExpired": "Intercambio expirado.",
+  "@coreSwapsLnReceiveExpired": {
+    "description": "Status message for expired Lightning receive swap"
+  },
+  "coreSwapsLnReceiveFailed": "Intercambio fallido.",
+  "@coreSwapsLnReceiveFailed": {
+    "description": "Status message for failed Lightning receive swap"
+  },
+  "coreSwapsLnSendPending": "El intercambio aún no está inicializado.",
+  "@coreSwapsLnSendPending": {
+    "description": "Status message for pending Lightning send swap"
+  },
+  "coreSwapsLnSendPaid": "La factura se pagará después de que su pago reciba confirmación.",
+  "@coreSwapsLnSendPaid": {
+    "description": "Status message for paid Lightning send swap"
+  },
+  "coreSwapsLnSendClaimable": "El intercambio está listo para ser reclamado.",
+  "@coreSwapsLnSendClaimable": {
+    "description": "Status message for claimable Lightning send swap"
+  },
+  "coreSwapsLnSendRefundable": "El intercambio está listo para ser reembolsado.",
+  "@coreSwapsLnSendRefundable": {
+    "description": "Status message for refundable Lightning send swap"
+  },
+  "coreSwapsLnSendCanCoop": "El intercambio se completará en breve.",
+  "@coreSwapsLnSendCanCoop": {
+    "description": "Status message for Lightning send swap that can complete cooperatively"
+  },
+  "coreSwapsLnSendCompletedRefunded": "El intercambio ha sido reembolsado.",
+  "@coreSwapsLnSendCompletedRefunded": {
+    "description": "Status message for Lightning send swap completed via refund"
+  },
+  "coreSwapsLnSendCompletedSuccess": "El intercambio se ha completado con éxito.",
+  "@coreSwapsLnSendCompletedSuccess": {
+    "description": "Status message for successfully completed Lightning send swap"
+  },
+  "coreSwapsLnSendExpired": "Intercambio expirado",
+  "@coreSwapsLnSendExpired": {
+    "description": "Status message for expired Lightning send swap"
+  },
+  "coreSwapsLnSendFailedRefunding": "El intercambio será reembolsado en breve.",
+  "@coreSwapsLnSendFailedRefunding": {
+    "description": "Status message for failed Lightning send swap that will be refunded"
+  },
+  "coreSwapsLnSendFailed": "Intercambio fallido.",
+  "@coreSwapsLnSendFailed": {
+    "description": "Status message for failed Lightning send swap"
+  },
+  "coreSwapsChainPending": "La transferencia aún no está inicializada.",
+  "@coreSwapsChainPending": {
+    "description": "Status message for pending chain swap"
+  },
+  "coreSwapsChainPaid": "Esperando confirmación del pago del proveedor de transferencia. Esto puede tardar un tiempo en completarse.",
+  "@coreSwapsChainPaid": {
+    "description": "Status message for paid chain swap"
+  },
+  "coreSwapsChainClaimable": "La transferencia está lista para ser reclamada.",
+  "@coreSwapsChainClaimable": {
+    "description": "Status message for claimable chain swap"
+  },
+  "coreSwapsChainRefundable": "La transferencia está lista para ser reembolsada.",
+  "@coreSwapsChainRefundable": {
+    "description": "Status message for refundable chain swap"
+  },
+  "coreSwapsChainCanCoop": "La transferencia se completará en breve.",
+  "@coreSwapsChainCanCoop": {
+    "description": "Status message for chain swap that can complete cooperatively"
+  },
+  "coreSwapsChainCompletedRefunded": "La transferencia ha sido reembolsada.",
+  "@coreSwapsChainCompletedRefunded": {
+    "description": "Status message for chain swap completed via refund"
+  },
+  "coreSwapsChainCompletedSuccess": "La transferencia se ha completado con éxito.",
+  "@coreSwapsChainCompletedSuccess": {
+    "description": "Status message for successfully completed chain swap"
+  },
+  "coreSwapsChainExpired": "Transferencia expirada",
+  "@coreSwapsChainExpired": {
+    "description": "Status message for expired chain swap"
+  },
+  "coreSwapsChainFailedRefunding": "La transferencia será reembolsada en breve.",
+  "@coreSwapsChainFailedRefunding": {
+    "description": "Status message for failed chain swap that will be refunded"
+  },
+  "coreSwapsChainFailed": "Transferencia fallida.",
+  "@coreSwapsChainFailed": {
+    "description": "Status message for failed chain swap"
+  },
+  "coreWalletTransactionStatusPending": "Pendiente",
+  "@coreWalletTransactionStatusPending": {
+    "description": "Display name for pending wallet transaction status"
+  },
+  "coreWalletTransactionStatusConfirmed": "Confirmado",
+  "@coreWalletTransactionStatusConfirmed": {
+    "description": "Display name for confirmed wallet transaction status"
+  },
   "onboardingScreenTitle": "Bienvenido",
   "@onboardingScreenTitle": {
     "description": "El título de la pantalla de inicio"

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -27,6 +27,158 @@
       }
     }
   },
+  "coreSwapsStatusPending": "En attente",
+  "@coreSwapsStatusPending": {
+    "description": "Display name for pending swap status"
+  },
+  "coreSwapsStatusInProgress": "En cours",
+  "@coreSwapsStatusInProgress": {
+    "description": "Display name for in-progress swap status (paid, claimable, refundable, canCoop)"
+  },
+  "coreSwapsStatusCompleted": "Terminé",
+  "@coreSwapsStatusCompleted": {
+    "description": "Display name for completed swap status"
+  },
+  "coreSwapsStatusExpired": "Expiré",
+  "@coreSwapsStatusExpired": {
+    "description": "Display name for expired swap status"
+  },
+  "coreSwapsStatusFailed": "Échoué",
+  "@coreSwapsStatusFailed": {
+    "description": "Display name for failed swap status"
+  },
+  "coreSwapsActionClaim": "Réclamer",
+  "@coreSwapsActionClaim": {
+    "description": "Action label for claiming a swap"
+  },
+  "coreSwapsActionClose": "Fermer",
+  "@coreSwapsActionClose": {
+    "description": "Action label for closing a swap cooperatively"
+  },
+  "coreSwapsActionRefund": "Rembourser",
+  "@coreSwapsActionRefund": {
+    "description": "Action label for refunding a swap"
+  },
+  "coreSwapsLnReceivePending": "L'échange n'est pas encore initialisé.",
+  "@coreSwapsLnReceivePending": {
+    "description": "Status message for pending Lightning receive swap"
+  },
+  "coreSwapsLnReceivePaid": "L'expéditeur a payé la facture.",
+  "@coreSwapsLnReceivePaid": {
+    "description": "Status message for paid Lightning receive swap"
+  },
+  "coreSwapsLnReceiveClaimable": "L'échange est prêt à être réclamé.",
+  "@coreSwapsLnReceiveClaimable": {
+    "description": "Status message for claimable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveRefundable": "L'échange est prêt à être remboursé.",
+  "@coreSwapsLnReceiveRefundable": {
+    "description": "Status message for refundable Lightning receive swap"
+  },
+  "coreSwapsLnReceiveCanCoop": "L'échange sera complété sous peu.",
+  "@coreSwapsLnReceiveCanCoop": {
+    "description": "Status message for Lightning receive swap that can complete cooperatively"
+  },
+  "coreSwapsLnReceiveCompleted": "L'échange est terminé.",
+  "@coreSwapsLnReceiveCompleted": {
+    "description": "Status message for completed Lightning receive swap"
+  },
+  "coreSwapsLnReceiveExpired": "Échange expiré.",
+  "@coreSwapsLnReceiveExpired": {
+    "description": "Status message for expired Lightning receive swap"
+  },
+  "coreSwapsLnReceiveFailed": "Échange échoué.",
+  "@coreSwapsLnReceiveFailed": {
+    "description": "Status message for failed Lightning receive swap"
+  },
+  "coreSwapsLnSendPending": "L'échange n'est pas encore initialisé.",
+  "@coreSwapsLnSendPending": {
+    "description": "Status message for pending Lightning send swap"
+  },
+  "coreSwapsLnSendPaid": "La facture sera payée après confirmation de votre paiement.",
+  "@coreSwapsLnSendPaid": {
+    "description": "Status message for paid Lightning send swap"
+  },
+  "coreSwapsLnSendClaimable": "L'échange est prêt à être réclamé.",
+  "@coreSwapsLnSendClaimable": {
+    "description": "Status message for claimable Lightning send swap"
+  },
+  "coreSwapsLnSendRefundable": "L'échange est prêt à être remboursé.",
+  "@coreSwapsLnSendRefundable": {
+    "description": "Status message for refundable Lightning send swap"
+  },
+  "coreSwapsLnSendCanCoop": "L'échange sera complété sous peu.",
+  "@coreSwapsLnSendCanCoop": {
+    "description": "Status message for Lightning send swap that can complete cooperatively"
+  },
+  "coreSwapsLnSendCompletedRefunded": "L'échange a été remboursé.",
+  "@coreSwapsLnSendCompletedRefunded": {
+    "description": "Status message for Lightning send swap completed via refund"
+  },
+  "coreSwapsLnSendCompletedSuccess": "L'échange est terminé avec succès.",
+  "@coreSwapsLnSendCompletedSuccess": {
+    "description": "Status message for successfully completed Lightning send swap"
+  },
+  "coreSwapsLnSendExpired": "Échange expiré",
+  "@coreSwapsLnSendExpired": {
+    "description": "Status message for expired Lightning send swap"
+  },
+  "coreSwapsLnSendFailedRefunding": "L'échange sera remboursé sous peu.",
+  "@coreSwapsLnSendFailedRefunding": {
+    "description": "Status message for failed Lightning send swap that will be refunded"
+  },
+  "coreSwapsLnSendFailed": "Échange échoué.",
+  "@coreSwapsLnSendFailed": {
+    "description": "Status message for failed Lightning send swap"
+  },
+  "coreSwapsChainPending": "Le transfert n'est pas encore initialisé.",
+  "@coreSwapsChainPending": {
+    "description": "Status message for pending chain swap"
+  },
+  "coreSwapsChainPaid": "En attente de la confirmation du paiement du fournisseur de transfert. Cela peut prendre un certain temps.",
+  "@coreSwapsChainPaid": {
+    "description": "Status message for paid chain swap"
+  },
+  "coreSwapsChainClaimable": "Le transfert est prêt à être réclamé.",
+  "@coreSwapsChainClaimable": {
+    "description": "Status message for claimable chain swap"
+  },
+  "coreSwapsChainRefundable": "Le transfert est prêt à être remboursé.",
+  "@coreSwapsChainRefundable": {
+    "description": "Status message for refundable chain swap"
+  },
+  "coreSwapsChainCanCoop": "Le transfert sera complété sous peu.",
+  "@coreSwapsChainCanCoop": {
+    "description": "Status message for chain swap that can complete cooperatively"
+  },
+  "coreSwapsChainCompletedRefunded": "Le transfert a été remboursé.",
+  "@coreSwapsChainCompletedRefunded": {
+    "description": "Status message for chain swap completed via refund"
+  },
+  "coreSwapsChainCompletedSuccess": "Le transfert est terminé avec succès.",
+  "@coreSwapsChainCompletedSuccess": {
+    "description": "Status message for successfully completed chain swap"
+  },
+  "coreSwapsChainExpired": "Transfert expiré",
+  "@coreSwapsChainExpired": {
+    "description": "Status message for expired chain swap"
+  },
+  "coreSwapsChainFailedRefunding": "Le transfert sera remboursé sous peu.",
+  "@coreSwapsChainFailedRefunding": {
+    "description": "Status message for failed chain swap that will be refunded"
+  },
+  "coreSwapsChainFailed": "Transfert échoué.",
+  "@coreSwapsChainFailed": {
+    "description": "Status message for failed chain swap"
+  },
+  "coreWalletTransactionStatusPending": "En attente",
+  "@coreWalletTransactionStatusPending": {
+    "description": "Display name for pending wallet transaction status"
+  },
+  "coreWalletTransactionStatusConfirmed": "Confirmé",
+  "@coreWalletTransactionStatusConfirmed": {
+    "description": "Display name for confirmed wallet transaction status"
+  },
   "onboardingScreenTitle": "Bienvenue",
   "@onboardingScreenTitle": {
     "description": "Le titre de l'écran d'intégration"


### PR DESCRIPTION
## Summary

Localize `core/swaps` module with 38 new translation keys for swap status display names, swap actions, and status messages.

**Changes:**
- Convert `SwapStatus.displayName` getter to method with `BuildContext` parameter
- Convert `Swap.swapAction` getter to method with `BuildContext` parameter  
- Convert `SwapStatusMessage.getDisplayMessage()` to method with `BuildContext` parameter
- Convert `WalletTransactionStatus.displayName` getter to method with `BuildContext` parameter
- Add 38 new ARB keys across all 3 language files (en, fr, es)
- Update transaction UI to use the new localized methods

**New ARB Keys (38 total):**

| Prefix | Description | Count |
|--------|-------------|-------|
| `coreSwapsStatus*` | Swap status display names (Pending, In Progress, Completed, Expired, Failed) | 5 |
| `coreSwapsAction*` | Swap action labels (Claim, Close, Refund) | 3 |
| `coreSwapsLnReceive*` | Lightning receive swap status messages | 8 |
| `coreSwapsLnSend*` | Lightning send swap status messages | 10 |
| `coreSwapsChain*` | Chain swap status messages | 10 |
| `coreWalletTransactionStatus*` | Wallet transaction status display names | 2 |

**Files Modified:**
- `lib/core/swaps/domain/entity/swap.dart` - Localized status/action/message methods
- `lib/core/wallet/domain/entities/wallet_transaction.dart` - Localized status displayName
- `lib/features/transactions/ui/screens/transaction_details_screen.dart` - Updated swapAction call
- `lib/features/transactions/ui/widgets/transaction_details_table.dart` - Updated displayName/getDisplayMessage calls
- `localization/app_en.arb` - 38 new English keys
- `localization/app_fr.arb` - 38 new French translations
- `localization/app_es.arb` - 38 new Spanish translations

## Test Plan

- [x] Run `fvm flutter analyze --fatal-warnings --fatal-infos` - passes
- [x] Run `python3 linux/validate_localizations.py` - passes

## Notes

- Pattern follows the established `displayName(context)` pattern used in `vault_provider.dart`
- The `toTranslated()` pattern is specifically for error classes, not entity enums