### PR TITLE
feat: Show labels during coin selection

### DIFF
--- a/lib/core/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/core/widgets/coin_selection_bottom_sheet.dart
@@ -147,7 +147,9 @@ class CommonCoinSelectTile extends StatelessWidget {
     final addressType = utxo.addressKeyChain == WalletAddressKeyChain.external
         ? 'Receive'
         : 'Change';
-    final label = utxo.labels.join(', ');
+    // Combine output labels and address labels
+    final allLabels = [...utxo.labels, ...utxo.addressLabels];
+    final hasLabels = allLabels.isNotEmpty;
 
     return GestureDetector(
       onTap: onTap,
@@ -182,12 +184,33 @@ class CommonCoinSelectTile extends StatelessWidget {
                         ),
                       ],
                     ),
-                    subtitle: BBText(
-                      label,
-                      style: context.font.labelMedium?.copyWith(
-                        color: context.appColors.outline,
-                      ),
-                    ),
+                    subtitle: hasLabels
+                        ? Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: allLabels
+                                .map(
+                                  (label) => Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: context.appColors.primaryContainer,
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: BBText(
+                                      label,
+                                      style: context.font.labelSmall?.copyWith(
+                                        color:
+                                            context.appColors.onPrimaryContainer,
+                                      ),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          )
+                        : null,
                     trailing: RadioGroup<bool>(
                       groupValue: selected,
                       onChanged: (_) => onTap(),

--- a/lib/features/send/ui/widgets/coin_select_tile.dart
+++ b/lib/features/send/ui/widgets/coin_select_tile.dart
@@ -43,7 +43,9 @@ class CoinSelectTile extends StatelessWidget {
         utxo.addressKeyChain == WalletAddressKeyChain.external
             ? context.loc.sendReceive
             : context.loc.sendChange;
-    final label = utxo.labels.join(', ');
+    // Combine output labels and address labels
+    final allLabels = [...utxo.labels, ...utxo.addressLabels];
+    final hasLabels = allLabels.isNotEmpty;
 
     return GestureDetector(
       onTap: onTap,
@@ -78,12 +80,33 @@ class CoinSelectTile extends StatelessWidget {
                         ),
                       ],
                     ),
-                    subtitle: BBText(
-                      label,
-                      style: context.font.labelMedium?.copyWith(
-                        color: context.appColors.outline,
-                      ),
-                    ),
+                    subtitle: hasLabels
+                        ? Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: allLabels
+                                .map(
+                                  (label) => Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: context.appColors.primaryContainer,
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: BBText(
+                                      label,
+                                      style: context.font.labelSmall?.copyWith(
+                                        color:
+                                            context.appColors.onPrimaryContainer,
+                                      ),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          )
+                        : null,
                     trailing: RadioGroup<bool>(
                       groupValue: selected,
                       onChanged: (_) => onTap(),


### PR DESCRIPTION
## Summary

Enhanced the coin selection UI to better display labels:

- Combined both output labels and address labels for display
- Show labels as styled tag/chip components with background color
- Only show label section when labels exist (no more empty space)
- Use Wrap widget for proper multi-label display

Closes #1653

Generated with [Claude Code](https://claude.ai/code)