### PR TITLE
fix: resolve type cast error when setting custom absolute fees

### DIFF
--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -222,7 +222,6 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         );
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
-          feeRate: fastestFee.value as double,
         );
       }
     } catch (e) {
@@ -240,10 +239,9 @@ class PayBloc extends Bloc<PayEvent, PayState> {
       final createdPayOrder = await _placePayOrderUsecase.execute(
         orderAmount: walletSelectionState.amount,
         recipientId: walletSelectionState.selectedRecipient.id,
-        network:
-            event.wallet.isLiquid
-                ? OrderBitcoinNetwork.liquid
-                : OrderBitcoinNetwork.bitcoin,
+        network: event.wallet.isLiquid
+            ? OrderBitcoinNetwork.liquid
+            : OrderBitcoinNetwork.bitcoin,
       );
 
       if (!event.wallet.isLiquid) {
@@ -405,27 +403,19 @@ class PayBloc extends Bloc<PayEvent, PayState> {
             message: 'Transaction fees not calculated. Please try again.',
           );
         }
-        final bitcoinFees = await _getNetworkFeesUsecase.execute(
-          isLiquid: false,
-        );
-        final fastestFee = bitcoinFees.fastest;
 
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: wallet.id,
           address: payPaymentState.payOrder.bitcoinAddress!,
           amountSat: payinAmountSat,
           networkFee: NetworkFee.absolute(absoluteFees),
-          selectedInputs:
-              payPaymentState.selectedUtxos.isNotEmpty
-                  ? payPaymentState.selectedUtxos
-                  : null,
+          selectedInputs: payPaymentState.selectedUtxos.isNotEmpty
+              ? payPaymentState.selectedUtxos
+              : null,
           replaceByFee: payPaymentState.replaceByFee,
         );
         final absoluteFeesUpdated = await _calculateBitcoinAbsoluteFeesUsecase
-            .execute(
-              psbt: preparedSend.unsignedPsbt,
-              feeRate: fastestFee.value as double,
-            );
+            .execute(psbt: preparedSend.unsignedPsbt);
         emit(payPaymentState.copyWith(absoluteFees: absoluteFeesUpdated));
         final signedTx = await _signBitcoinTxUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
@@ -648,15 +638,13 @@ class PayBloc extends Bloc<PayEvent, PayState> {
           address: dummyAddressForFeeCalculation.address,
           amountSat: payinAmountSat,
           networkFee: fastestFee,
-          selectedInputs:
-              payPaymentState.selectedUtxos.isNotEmpty
-                  ? payPaymentState.selectedUtxos
-                  : null,
+          selectedInputs: payPaymentState.selectedUtxos.isNotEmpty
+              ? payPaymentState.selectedUtxos
+              : null,
           replaceByFee: payPaymentState.replaceByFee,
         );
         final absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
-          feeRate: fastestFee.value as double,
         );
         emit(payPaymentState.copyWith(absoluteFees: absoluteFees));
       }

--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -235,7 +235,6 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         );
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
-          feeRate: fastestFee.value as double,
         );
       }
     } catch (e) {
@@ -425,10 +424,6 @@ class SellBloc extends Bloc<SellEvent, SellState> {
             message: 'Transaction fees not calculated. Please try again.',
           );
         }
-        final bitcoinFees = await _getNetworkFeesUsecase.execute(
-          isLiquid: false,
-        );
-        final fastestFee = bitcoinFees.fastest;
 
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: wallet.id,
@@ -441,10 +436,7 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           replaceByFee: sellPaymentState.replaceByFee,
         );
         final absoluteFeesUpdated = await _calculateBitcoinAbsoluteFeesUsecase
-            .execute(
-              psbt: preparedSend.unsignedPsbt,
-              feeRate: fastestFee.value as double,
-            );
+            .execute(psbt: preparedSend.unsignedPsbt);
         emit(sellPaymentState.copyWith(absoluteFees: absoluteFeesUpdated));
         final signedTx = await _signBitcoinTxUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
@@ -670,7 +662,6 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         );
         final absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
-          feeRate: fastestFee.value as double,
         );
         emit(sellPaymentState.copyWith(absoluteFees: absoluteFees));
       }

--- a/lib/features/send/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart
+++ b/lib/features/send/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart
@@ -9,7 +9,7 @@ class CalculateBitcoinAbsoluteFeesUsecase {
   }) : _bitcoinWalletRepository = bitcoinWalletRepository;
 
   /// Returns (amount, absFees)
-  Future<int> execute({required String psbt, required double feeRate}) async {
+  Future<int> execute({required String psbt}) async {
     try {
       final absFee = await _bitcoinWalletRepository.getTxFeeAmount(psbt: psbt);
       return absFee;

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -1208,7 +1208,6 @@ class SendCubit extends Cubit<SendState> {
           final bitcoinAbsoluteFeesSat =
               await _calculateBitcoinAbsoluteFeesUsecase.execute(
                 psbt: signedPsbtAndTxSize.signedPsbt,
-                feeRate: state.selectedFee!.value as double,
               );
           if (state.chainSwap != null) {
             final settings = await _getSettingsUsecase.execute();
@@ -1355,7 +1354,6 @@ class SendCubit extends Cubit<SendState> {
             final bitcoinAbsoluteFeesSat =
                 await _calculateBitcoinAbsoluteFeesUsecase.execute(
                   psbt: signedPsbtAndTxSize.signedPsbt,
-                  feeRate: state.selectedFee!.value as double,
                 );
             final settings = await _getSettingsUsecase.execute();
             final updatedSwap = await _updateSendSwapLockupFeesUsecase.execute(
@@ -1637,7 +1635,6 @@ class SendCubit extends Cubit<SendState> {
         );
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: dummyDrainTxInfo.unsignedPsbt,
-          feeRate: networkFee.value as double,
         );
         emit(state.copyWith(bitcoinTxSize: dummyDrainTxInfo.txSize));
       }

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -407,7 +407,6 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
           bitcoinAbsoluteFeesSat = await _calculateBitcoinAbsoluteFeesUsecase
               .execute(
                 psbt: signedPsbtAndTxSize.signedPsbt,
-                feeRate: state.bitcoinNetworkFees!.fastest.value as double,
               );
           final settings = await _getSettingsUsecase.execute();
           final updatedSwap = await _updateSendSwapLockupFeesUsecase.execute(
@@ -459,7 +458,6 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
         bitcoinAbsoluteFeesSat = await _calculateBitcoinAbsoluteFeesUsecase
             .execute(
               psbt: signedPsbtAndTxSize.signedPsbt,
-              feeRate: state.bitcoinNetworkFees!.fastest.value as double,
             );
         final settings = await _getSettingsUsecase.execute();
         final updatedSwap = await _updateSendSwapLockupFeesUsecase.execute(
@@ -827,7 +825,6 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
 
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: dummyDrainTxInfo.unsignedPsbt,
-          feeRate: networkFee.value as double,
         );
 
         log.info("Absolute fees: $absoluteFees");


### PR DESCRIPTION
Removed teh unused feeRate parameter from CalculateBitcoinAbsoluteFeesUsecase that was causing 'int is not a subtype of double' error when users set custom absolute fees. The parameter was never used as the use case extracts fees directly from the PSBT.

Fixes #1592 