### PR TITLE
use BLoC event transformer to ignore new confirmations while one is processing

### DIFF
--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -33,6 +33,7 @@ import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usec
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bip21_uri/bip21_uri.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -90,7 +91,10 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     on<SellWalletSelected>(_onWalletSelected);
     on<SellExternalWalletNetworkSelected>(_onExternalWalletNetworkSelected);
     on<SellOrderRefreshTimePassed>(_onOrderRefreshTimePassed);
-    on<SellSendPaymentConfirmed>(_onSendPaymentConfirmed);
+    on<SellSendPaymentConfirmed>(
+      _onSendPaymentConfirmed,
+      transformer: droppable(), // Prevent multiple simultaneous confirmations
+    );
     on<SellPollOrderStatus>(_onPollOrderStatus);
     on<SellReplaceByFeeChanged>(_onReplaceByFeeChanged);
     on<SellUtxosSelected>(_onUtxosSelected);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -172,6 +172,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.1.0"
+  bloc_concurrency:
+    dependency: "direct main"
+    description:
+      name: bloc_concurrency
+      sha256: "86b7b17a0a78f77fca0d7c030632b59b593b22acea2d96972588f40d4ef53a94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   blockchain_utils:
     dependency: transitive
     description:
@@ -306,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: "0efb057a1fecdbf9b697272fbf79afbd47ac0e7bd69b4d900d3f304b31d93bad"
+      sha256: "087a9fadef20325cb246b4c13344a3ce8e408acfc3e0c665ebff0ec3144d7163"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.22+7"
+    version: "0.9.22+8"
   camera_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -130,6 +130,7 @@ dependencies:
   path: ^1.9.1
   http: ^1.6.0
   lints: ^6.0.0
+  bloc_concurrency: ^0.3.0
 
 dev_dependencies:
   build_runner: ^2.10.4


### PR DESCRIPTION
Added the [bloc_concurrency](https://pub.dev/packages/bloc_concurrency) package to solve this with a "quick" but definitive fix. This doesn't mean we shouldn't solve the underlying cause of the state variable being used wrongly in the confirmation event handler anymore, but using the bloc_concurrency package here and in other BLoCs is a great first line of defense to avoid concurrency issues even if the underlying code isn't concurrency safe yet.