### PR TITLE
Minor UI edits on AutoSwap warning feature

### DIFF
--- a/lib/core/widgets/cards/autoswap_warning_card.dart
+++ b/lib/core/widgets/cards/autoswap_warning_card.dart
@@ -16,35 +16,44 @@ class AutoSwapWarningCard extends StatelessWidget {
         onTap();
       },
       child: Container(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(14),
         decoration: BoxDecoration(
-          color: context.appColors.secondary,
+          color: context.appColors.surfaceContainer,
+          border: Border.all(
+            color: context.appColors.surfaceContainerHighest,
+            width: 1,
+          ),
           borderRadius: BorderRadius.circular(2),
         ),
         child: Row(
           children: [
             Icon(
-              Icons.swap_horiz,
-              color: context.appColors.onSecondary,
-              size: 32,
+              Icons.check_circle_outline,
+              color: context.appColors.success,
+              size: 24,
             ),
-            const Gap(16),
+            const Gap(14),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   BBText(
                     context.loc.autoswapWarningCardTitle,
-                    style: context.font.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                    color: context.appColors.onSecondary,
+                    style: context.font.bodyMedium,
+                    color: context.appColors.onSurface,
                   ),
-                  const Gap(4),
-                  BBText(
-                    context.loc.autoswapWarningCardSubtitle,
-                    style: context.font.bodySmall,
-                    color: context.appColors.onSecondary,
+                  const Gap(2),
+                  GestureDetector(
+                    onTap: () {
+                      onTap();
+                    },
+                    child: Text(
+                      'Click to learn more, disable or configure',
+                      style: context.font.bodySmall?.copyWith(
+                        decoration: TextDecoration.underline,
+                        color: context.appColors.onSurfaceVariant,
+                      ),
+                    ),
                   ),
                 ],
               ),

--- a/lib/features/autoswap/presentation/autoswap_settings_cubit.dart
+++ b/lib/features/autoswap/presentation/autoswap_settings_cubit.dart
@@ -144,7 +144,7 @@ class AutoSwapSettingsCubit extends Cubit<AutoSwapSettingsState> {
             int.tryParse(state.triggerBalanceSatsInput ?? '0') ?? 0;
       }
 
-      // Validate trigger balance is at least 2x the base balance
+      // Validate maximum balance is at least 2x the target balance
       if (triggerBalanceSats < 2 * balanceThresholdSats) {
         emit(
           state.copyWith(saving: false, error: 'autoswapTriggerBalanceError'),
@@ -329,7 +329,7 @@ class AutoSwapSettingsCubit extends Cubit<AutoSwapSettingsState> {
             int.tryParse(state.triggerBalanceSatsInput ?? '0') ?? 0;
       }
 
-      // Validate trigger balance is at least 2x the base balance
+      // Validate maximum balance is at least 2x the target balance
       if (triggerBalanceSats < 2 * balanceThresholdSats) {
         emit(
           state.copyWith(saving: false, error: 'autoswapTriggerBalanceError'),

--- a/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
+++ b/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
@@ -125,7 +125,7 @@ class _AmountThresholdField extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         BBText(
-          'Base Instant Wallet Balance',
+          'Target Instant Wallet Balance',
           style: context.font.bodyLarge?.copyWith(
             color: context.appColors.text,
           ),
@@ -234,7 +234,7 @@ class _TriggerBalanceField extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         BBText(
-          'Trigger At Balance',
+          'Maximum Instant Wallet Balance',
           style: context.font.bodyLarge?.copyWith(
             color: context.appColors.text,
           ),

--- a/lib/features/autoswap/ui/widgets/autoswap_settings.dart
+++ b/lib/features/autoswap/ui/widgets/autoswap_settings.dart
@@ -294,7 +294,7 @@ class _TriggerBalanceField extends StatelessWidget {
       crossAxisAlignment: .start,
       children: [
         BBText(
-          'Trigger At Balance',
+          'Maximum Instant Wallet Balance',
           style: context.font.bodyLarge?.copyWith(
             color: context.appColors.text,
           ),

--- a/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
+++ b/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
@@ -10,7 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
 
-class AutoSwapWarningBottomSheet extends StatefulWidget {
+class AutoSwapWarningBottomSheet extends StatelessWidget {
   const AutoSwapWarningBottomSheet({super.key});
 
   static Future<void> show(BuildContext context) {
@@ -19,15 +19,6 @@ class AutoSwapWarningBottomSheet extends StatefulWidget {
       child: const AutoSwapWarningBottomSheet(),
     );
   }
-
-  @override
-  State<AutoSwapWarningBottomSheet> createState() =>
-      _AutoSwapWarningBottomSheetState();
-}
-
-class _AutoSwapWarningBottomSheetState
-    extends State<AutoSwapWarningBottomSheet> {
-  bool _dontShowAgain = false;
 
   @override
   Widget build(BuildContext context) {
@@ -42,82 +33,73 @@ class _AutoSwapWarningBottomSheetState
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           BBText(
+            context.loc.autoswapInfoTitle,
+            style: context.font.headlineMedium,
+            color: context.appColors.onSurface,
+          ),
+          const Gap(12),
+          BBText(
             context.loc.autoswapWarningDescription,
             style: context.font.bodyMedium,
             color: context.appColors.onSurface,
           ),
           const Gap(16),
-
           BBText(
             context.loc.autoswapWarningTitle,
-            style: context.font.headlineSmall,
-            color: context.appColors.onSurface,
-          ),
-          const Gap(16),
-          BBText(
-            context.loc.autoswapWarningBaseBalance,
             style: context.font.bodyLarge,
             color: context.appColors.onSurface,
           ),
           const Gap(8),
           BBText(
-            context.loc.autoswapWarningTriggerAmount,
-            style: context.font.bodyLarge,
+            context.loc.autoswapWarningBaseBalance,
+            style: context.font.bodyMedium,
             color: context.appColors.onSurface,
           ),
-          const Gap(24),
+          const Gap(4),
+          BBText(
+            context.loc.autoswapWarningTriggerAmount,
+            style: context.font.bodyMedium,
+            color: context.appColors.onSurface,
+          ),
+          const Gap(16),
           BBText(
             context.loc.autoswapWarningExplanation,
             style: context.font.bodyMedium,
             color: context.appColors.onSurface,
           ),
-          const Gap(16),
-
-          Row(
-            children: [
-              Checkbox(
-                value: _dontShowAgain,
-                onChanged: (value) {
-                  setState(() {
-                    _dontShowAgain = value ?? false;
-                  });
-                },
-              ),
-              Expanded(
-                child: BBText(
-                  context.loc.autoswapWarningDontShowAgain,
-                  style: context.font.bodyMedium,
-                  color: context.appColors.onSurface,
-                ),
-              ),
-            ],
-          ),
-          const Gap(16),
-          GestureDetector(
-            onTap: () {
-              Navigator.of(context).pop();
-              context.pushNamed(SettingsRoute.autoswapSettings.name);
-            },
-            child: BBText(
-              context.loc.autoswapWarningSettingsLink,
-              style: context.font.bodyMedium?.copyWith(
-                color: context.appColors.error,
-                decoration: TextDecoration.underline,
-              ),
-            ),
-          ),
           const Gap(24),
           BBButton.big(
-            label: context.loc.autoswapWarningOkButton,
+            label: context.loc.autoswapInfoDismissButton,
             onPressed: () {
-              if (_dontShowAgain) {
-                context.read<WalletBloc>().add(const DismissAutoSwapWarning());
-              }
+              context.read<WalletBloc>().add(const DismissAutoSwapWarning());
               Navigator.of(context).pop();
             },
             bgColor: context.appColors.onSurface,
-            textStyle: context.font.headlineLarge,
             textColor: context.appColors.surface,
+          ),
+          const Gap(12),
+          BBButton.big(
+            label: context.loc.autoswapInfoSettingsButton,
+            onPressed: () {
+              Navigator.of(context).pop();
+              context.pushNamed(SettingsRoute.autoswapSettings.name);
+            },
+            bgColor: context.appColors.surface,
+            textColor: context.appColors.onSurface,
+            outlined: true,
+          ),
+          const Gap(16),
+          Center(
+            child: GestureDetector(
+              onTap: () => Navigator.of(context).pop(),
+              child: BBText(
+                context.loc.autoswapInfoRemindLater,
+                style: context.font.bodyMedium?.copyWith(
+                  decoration: TextDecoration.underline,
+                ),
+                color: context.appColors.onSurfaceVariant,
+              ),
+            ),
           ),
         ],
       ),

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -4787,11 +4787,11 @@
   "@autoswapMaxBalanceInfoText": {
     "description": "Help text explaining how the max balance threshold works"
   },
-  "autoswapBaseBalanceInfoText": "Your instant payment wallet balance will return to this balance after an autoswap.",
+  "autoswapBaseBalanceInfoText": "Your instant payment wallet balance will return to this target balance after an autoswap.",
   "@autoswapBaseBalanceInfoText": {
     "description": "Info text explaining what happens to the balance after an autoswap"
   },
-  "autoswapTriggerAtBalanceInfoText": "Autoswap will trigger when your balance goes above this amount.",
+  "autoswapTriggerAtBalanceInfoText": "Autoswap will trigger when your balance goes above this maximum balance.",
   "@autoswapTriggerAtBalanceInfoText": {
     "description": "Info text explaining when autoswap will trigger"
   },
@@ -4852,7 +4852,7 @@
       }
     }
   },
-  "autoswapWarningCardTitle": "Autoswap is enabled.",
+  "autoswapWarningCardTitle": "Autoswap is enabled",
   "@autoswapWarningCardTitle": {
     "description": "Title text shown on the autoswap warning card on home screen"
   },
@@ -4860,7 +4860,7 @@
   "@autoswapWarningCardSubtitle": {
     "description": "Subtitle text shown on the autoswap warning card on home screen"
   },
-  "autoswapWarningDescription": "Autoswap ensures that a good balance is maintained between your Instant Payments and Secure Bitcoin Wallet.",
+  "autoswapWarningDescription": "Autoswap ensures you don't accidentally keep too much money in the Instant Payment Wallet, which is not secure for long-term storage.",
   "@autoswapWarningDescription": {
     "description": "Description text at the top of the autoswap warning bottom sheet"
   },
@@ -4868,15 +4868,15 @@
   "@autoswapWarningTitle": {
     "description": "Title text in the autoswap warning bottom sheet"
   },
-  "autoswapWarningBaseBalance": "Base Balance 0.01 BTC",
+  "autoswapWarningBaseBalance": "Target Balance 0.01 BTC",
   "@autoswapWarningBaseBalance": {
-    "description": "Base balance text shown in the autoswap warning bottom sheet"
+    "description": "Target balance text shown in the autoswap warning bottom sheet"
   },
-  "autoswapWarningTriggerAmount": "Trigger Amount of 0.02 BTC",
+  "autoswapWarningTriggerAmount": "Maximum Balance of 0.02 BTC",
   "@autoswapWarningTriggerAmount": {
-    "description": "Trigger amount text shown in the autoswap warning bottom sheet"
+    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
   },
-  "autoswapWarningExplanation": "When your balance exceeds the trigger amount, a swap will be triggered. The base amount will be kept in your Instant Payments wallet and the remaining amount will be swapped into your Secure Bitcoin Wallet.",
+  "autoswapWarningExplanation": "When your balance exceeds the maximum balance, a swap will be triggered. The target balance will be kept in your Instant Payments wallet and the remaining amount will be swapped into your Secure Bitcoin Wallet.",
   "@autoswapWarningExplanation": {
     "description": "Explanation text in the autoswap warning bottom sheet"
   },
@@ -4891,6 +4891,22 @@
   "autoswapWarningOkButton": "OK",
   "@autoswapWarningOkButton": {
     "description": "OK button label in the autoswap warning bottom sheet"
+  },
+  "autoswapInfoTitle": "Autoswap is active",
+  "@autoswapInfoTitle": {
+    "description": "Title for autoswap information bottom sheet"
+  },
+  "autoswapInfoDismissButton": "Got it, don't show again",
+  "@autoswapInfoDismissButton": {
+    "description": "Primary button to dismiss autoswap info permanently"
+  },
+  "autoswapInfoSettingsButton": "Configure settings",
+  "@autoswapInfoSettingsButton": {
+    "description": "Secondary button to navigate to autoswap settings"
+  },
+  "autoswapInfoRemindLater": "Remind me later",
+  "@autoswapInfoRemindLater": {
+    "description": "Tertiary action to close sheet without dismissing"
   },
   "autoswapLoadSettingsError": "Failed to load auto swap settings",
   "@autoswapLoadSettingsError": {
@@ -4935,9 +4951,9 @@
       }
     }
   },
-  "autoswapTriggerBalanceError": "Trigger balance must be at least 2x the base balance",
+  "autoswapTriggerBalanceError": "Maximum balance must be at least 2x the target balance",
   "@autoswapTriggerBalanceError": {
-    "description": "Validation error shown when trigger balance is less than 2x the base balance"
+    "description": "Validation error shown when maximum balance is less than 2x the target balance"
   },
   "arkNoTransactionsYet": "No transactions yet.",
   "@arkNoTransactionsYet": {


### PR DESCRIPTION
- Updated home card to soft status indicator style (light grey, green checkmark)
- Restructured bottom sheet with 3 clear action buttons
- Changed terminology: "Base/Trigger Balance" to "Target/Maximum Balance"
- Updated description text for clarity
- localization also updated
<img width="1080" height="2400" alt="Screenshot_1767582520" src="https://github.com/user-attachments/assets/e1f25c71-b054-452b-a823-982862db2978" />
<img width="1080" height="2400" alt="Screenshot_1767582526" src="https://github.com/user-attachments/assets/deef6858-663e-48ee-adbe-a4b895fcb77d" />
<img width="1080" height="2400" alt="Screenshot_1767582534" src="https://github.com/user-attachments/assets/b9da89c5-c646-4a35-b9d6-a5236abe4d15" />
<img width="1080" height="2400" alt="Screenshot_1767582550" src="https://github.com/user-attachments/assets/9752f411-372b-46b9-9c20-dcadca00ba70" />
<img width="1080" height="2400" alt="Screenshot_1767582553" src="https://github.com/user-attachments/assets/2e59e651-fc6f-4ac4-a161-aaa5267ad432" />
<img width="1080" height="2400" alt="Screenshot_1767582560" src="https://github.com/user-attachments/assets/4317252d-14f0-41cd-ab5f-a091e7909e85" />
