### PR TITLE
6.5.0+135

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -488,11 +488,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 131;
+				CURRENT_PROJECT_VERSION = 135;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.4.0;
-				FLUTTER_BUILD_NUMBER = 131;
+				FLUTTER_BUILD_NAME = 6.5.0;
+				FLUTTER_BUILD_NUMBER = 135;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -501,7 +501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 6.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -679,11 +679,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 131;
+				CURRENT_PROJECT_VERSION = 135;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.4.0;
-				FLUTTER_BUILD_NUMBER = 131;
+				FLUTTER_BUILD_NAME = 6.5.0;
+				FLUTTER_BUILD_NUMBER = 135;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -692,7 +692,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 6.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -708,11 +708,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 131;
+				CURRENT_PROJECT_VERSION = 135;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.4.0;
-				FLUTTER_BUILD_NUMBER = 131;
+				FLUTTER_BUILD_NAME = 6.5.0;
+				FLUTTER_BUILD_NUMBER = 135;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 6.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.4.0+131
+version: 6.5.0+135
 
 
 environment:


### PR DESCRIPTION
`Reposted from PR https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/1670 by @ethicnology `

### New 🆕 
- Introducing system labels (localized) for exchange orders automatically applied to confirmed orders (Buy/Sell). These labels are not removable.
- Each UTXO during coin selection is displaying labels and inherited labels from transaction and address.
- Addresses page show addresses labels
- Labels are consistently displayed across the codebase thanks to `LabelsWidget`
- [Weblate translations](https://hosted.weblate.org/engage/bull/)

### Bug Fixes
- #1511
- #319 

### Experimental
- French, Spanish, Finnish translations
- Dark mode

### Technical
- Upgrade to latest `flutter` `3.38.3` and `dart` to `3.10`
- Upgrade all `flutter_rust_bridge` dependencies to `2.11.1`
- Upgrade all dependencies to latest
- Downgrade `file_picker` to 13.3.6 due to a regression on Android

### Bravo to occasional contributors
- @leesalminen AI reviews with Claude
- @gluneau variabilization of translations
- @wired-pasteque wallet selection and translations
- @tlindi for Finnish translations (+ remu)

### Shoutout to my collaborators
@i5hi @kumulynja @basantagoswami @kiranmetri @BullishNode 
