### PR TITLE
Double payment prevention

### DIFF
--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -1395,6 +1395,10 @@ class SendCubit extends Cubit<SendState> {
 
   Future<void> broadcastTransaction({bool isPsbt = true}) async {
     try {
+      if (state.txId != null || state.broadcastingTransaction) {
+        log.warning('Transaction already being broadcast or broadcasted');
+        return;
+      }
       emit(state.copyWith(broadcastingTransaction: true));
 
       if (state.selectedWallet!.network.isLiquid) {


### PR DESCRIPTION
If the send bloc has a txid (only possible if a broadcast is successful) - do not allow a successive broadcast. This will only allow 1 transaction to be broadcast in a single send flow.