### PR TITLE
Exchange Announcement Banner improvements

### DIFF
--- a/lib/features/exchange/ui/widgets/announcement_banner.dart
+++ b/lib/features/exchange/ui/widgets/announcement_banner.dart
@@ -77,6 +77,8 @@ class _AnnouncementItem extends StatelessWidget {
                     color: isDarkMode
                         ? context.appColors.onSurface
                         : context.appColors.onSecondary,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   const Gap(4),
                   BBText(


### PR DESCRIPTION

---

### 1. Banner Card Improvements

**Before:** The banner displayed the full description text, taking up multiple lines.

**After:**
- **Description truncated to one line** with ellipsis (`...`) to keep the banner compact
- **Tappable card** — wrapped in `GestureDetector` to open a bottom sheet with full details
- **Theme-aware styling:**
  - **Light mode:** Black background (`secondary`) with white text (`onSecondary`) — original look
  - **Dark mode:** Dark surface background with subtle light border (`outline` at 30% opacity) and light text (`onSurface`)

---

### 2. New Bottom Sheet (`_AnnouncementBottomSheet`)

A new bottom sheet component was added that appears when tapping an announcement:

**Structure:**
- Uses app's existing `BlurredBottomSheet.show()` pattern for consistent styling
- **Drag handle** at the top (40x4px rounded bar)
- **Header row** with:
  - Info icon (24px, uses `onSurface` color — black in light mode, white in dark mode)
  - Title text (`titleLarge` with bold weight)
  - Close button (X icon) on the right
- **Scrollable description** area with comfortable line height (1.5) and 80% opacity for visual hierarchy

**Layout Features:**
- `maxHeight` constraint (80% of screen) to prevent overflow
- `SingleChildScrollView` wraps the description for very long text
- `crossAxisAlignment: center` on the header row for proper icon/text alignment
- Uses `context.appColors.surface` background — adapts to light/dark mode
- Proper padding (24px) and gaps for visual breathing room

---

### 3. Dark Mode Support

All colors use theme-aware `context.appColors` values:

| Element | Light Mode | Dark Mode |
|---------|------------|-----------|
| Banner background | `secondary` (black) | `surface` (dark) |
| Banner border | None | `outline` at 30% opacity |
| Banner text | `onSecondary` (white) | `onSurface` (light) |
| Bottom sheet background | `surface` (light) | `surface` (dark) |
| Bottom sheet text | `onSurface` (dark) | `onSurface` (light) |
| Icons | Theme-appropriate | Theme-appropriate |

---
