### PR TITLE
feat: make autoswap warning values dynamic and reactive

### DIFF
--- a/lib/core/storage/database_seeds.dart
+++ b/lib/core/storage/database_seeds.dart
@@ -79,8 +79,8 @@ class DatabaseSeeds {
           const AutoSwapRow(
             id: 1,
             enabled: true,
-            balanceThresholdSats: 500000,
-            triggerBalanceSats: 1000000,
+            balanceThresholdSats: 1000000,
+            triggerBalanceSats: 2000000,
             feeThresholdPercent: 1.0,
             blockTillNextExecution: false,
             alwaysBlock: false,
@@ -93,8 +93,8 @@ class DatabaseSeeds {
           const AutoSwapRow(
             id: 2,
             enabled: true,
-            balanceThresholdSats: 500000,
-            triggerBalanceSats: 1000000,
+            balanceThresholdSats: 1000000,
+            triggerBalanceSats: 2000000,
             feeThresholdPercent: 1.0,
             blockTillNextExecution: false,
             alwaysBlock: false,

--- a/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
+++ b/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/core/widgets/switch/bb_switch.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/autoswap/presentation/autoswap_settings_cubit.dart';
+import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -22,8 +23,15 @@ class AutoSwapSettingsScreen extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(title: Text(context.loc.autoswapSettingsTitle)),
         body: SafeArea(
-          child: BlocBuilder<AutoSwapSettingsCubit, AutoSwapSettingsState>(
-            builder: (context, state) {
+          child: BlocListener<AutoSwapSettingsCubit, AutoSwapSettingsState>(
+            listenWhen: (previous, current) =>
+                previous.successfullySaved != current.successfullySaved &&
+                current.successfullySaved,
+            listener: (context, state) {
+              context.read<WalletBloc>().add(const WalletRefreshed());
+            },
+            child: BlocBuilder<AutoSwapSettingsCubit, AutoSwapSettingsState>(
+              builder: (context, state) {
               final enabled = state.enabledToggle;
 
               return SingleChildScrollView(
@@ -61,6 +69,7 @@ class AutoSwapSettingsScreen extends StatelessWidget {
               );
             },
           ),
+            ),
         ),
       ),
     );

--- a/lib/features/autoswap/ui/widgets/autoswap_settings.dart
+++ b/lib/features/autoswap/ui/widgets/autoswap_settings.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/core/widgets/switch/bb_switch.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/autoswap/presentation/autoswap_settings_cubit.dart';
+import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -53,6 +54,7 @@ class _AutoSwapSettingsContentState extends State<AutoSwapSettingsContent> {
           previous.successfullySaved != current.successfullySaved &&
           current.successfullySaved,
       listener: (context, state) {
+        context.read<WalletBloc>().add(const WalletRefreshed());
         Navigator.of(context).pop();
       },
       child: BlocBuilder<AutoSwapSettingsCubit, AutoSwapSettingsState>(

--- a/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
+++ b/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
@@ -1,8 +1,12 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/amount_conversions.dart';
+import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
@@ -22,6 +26,26 @@ class AutoSwapWarningBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final autoSwapSettings = context.select(
+      (WalletBloc bloc) => bloc.state.autoSwapSettings,
+    );
+
+    final bitcoinUnit = context.select(
+      (SettingsCubit cubit) => cubit.state.bitcoinUnit ?? BitcoinUnit.btc,
+    );
+
+    final targetBalance = autoSwapSettings != null
+        ? (bitcoinUnit == BitcoinUnit.btc
+            ? FormatAmount.btc(ConvertAmount.satsToBtc(autoSwapSettings.balanceThresholdSats))
+            : FormatAmount.sats(autoSwapSettings.balanceThresholdSats))
+        : (bitcoinUnit == BitcoinUnit.btc ? '0.01 BTC' : '1,000,000 sats');
+
+    final maxBalance = autoSwapSettings != null
+        ? (bitcoinUnit == BitcoinUnit.btc
+            ? FormatAmount.btc(ConvertAmount.satsToBtc(autoSwapSettings.triggerBalanceSats))
+            : FormatAmount.sats(autoSwapSettings.triggerBalanceSats))
+        : (bitcoinUnit == BitcoinUnit.btc ? '0.02 BTC' : '2,000,000 sats');
+
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
@@ -51,13 +75,13 @@ class AutoSwapWarningBottomSheet extends StatelessWidget {
           ),
           const Gap(8),
           BBText(
-            context.loc.autoswapWarningBaseBalance,
+            'Target Balance $targetBalance',
             style: context.font.bodyMedium,
             color: context.appColors.onSurface,
           ),
           const Gap(4),
           BBText(
-            context.loc.autoswapWarningTriggerAmount,
+            'Maximum Balance of $maxBalance',
             style: context.font.bodyMedium,
             color: context.appColors.onSurface,
           ),


### PR DESCRIPTION
## Summary
- Display actual user-configured values in autoswap warning instead of hardcoded strings
- Update database seeds to match model defaults (1M/2M instead of 500k/1M)
- Read values from WalletBloc state and convert to BTC/sats for display
- Respect user unit preference in autoswap warning
- Trigger WalletRefreshed on settings save to reload values in WalletBloc
- Apply BlocListener pattern in settings screen and bottom sheet

## Changes
- `database_seeds.dart`: Updated threshold values
- `autoswap_settings_screen.dart`: Added WalletBloc refresh on save
- `autoswap_settings.dart`: Added WalletBloc refresh on save
- `autoswap_warning_bottom_sheet.dart`: Dynamic values display based on user settings

## Test plan
- [ ] Verify autoswap warning shows correct threshold values
- [ ] Change threshold values in settings and verify warning updates
- [ ] Toggle between BTC/sats and verify display format changes

---
*Note: These changes were originally part of PR #1765 but have been split into a separate PR for cleaner review.*