### PR TITLE
iOS accessibility migration

### DIFF
--- a/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_data_source_impl.dart
+++ b/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_data_source_impl.dart
@@ -12,18 +12,79 @@ class SecureStorageDatasourceImpl implements KeyValueStorageDatasource<String> {
   }
 
   @override
-  Future<Map<String, String>> getAll() {
-    return _storage.readAll();
+  Future<Map<String, String>> getAll() async {
+    final firstUnlockThisDeviceReadResults = await _storage.readAll();
+
+    // The following is needed because we used to have no background processing needs
+    // but now we do, so some values may have been stored with more restrictive accessibility
+    // (unlocked) then the current default (first unlock this device).
+    if (firstUnlockThisDeviceReadResults.isNotEmpty) {
+      return firstUnlockThisDeviceReadResults;
+    }
+
+    final unlockedReadResults = await _storage.readAll(
+      iOptions: IOSOptions(accessibility: KeychainAccessibility.unlocked),
+    );
+    for (final entry in unlockedReadResults.entries) {
+      // Re-save the values with the default accessibility for future reads and
+      // reads from background processes.
+      await _storage.write(key: entry.key, value: entry.value);
+    }
+
+    return unlockedReadResults;
   }
 
   @override
-  Future<String?> getValue(String key) {
-    return _storage.read(key: key);
+  Future<String?> getValue(String key) async {
+    final firstUnlockThisDeviceReadResult = await _storage.read(key: key);
+
+    // The following is needed because we used to have no background processing needs
+    // but now we do, so some values may have been stored with more restrictive accessibility
+    // (unlocked) then the current default (first unlock this device).
+    if (firstUnlockThisDeviceReadResult != null) {
+      return firstUnlockThisDeviceReadResult;
+    }
+
+    final unlockedReadResult = await _storage.read(
+      key: key,
+      iOptions: IOSOptions(accessibility: KeychainAccessibility.unlocked),
+    );
+    if (unlockedReadResult != null) {
+      // Re-save the value with the default accessibility for future reads and
+      // reads from background processes.
+      await _storage.write(key: key, value: unlockedReadResult);
+    }
+    return unlockedReadResult;
   }
 
   @override
-  Future<bool> hasValue(String key) {
-    return _storage.containsKey(key: key);
+  Future<bool> hasValue(String key) async {
+    final firstUnlockThisDeviceCheck = await _storage.containsKey(key: key);
+
+    // The following is needed because we used to have no background processing needs
+    // but now we do, so some values may have been stored with more restrictive accessibility
+    // (unlocked) then the current default (first unlock this device).
+    if (firstUnlockThisDeviceCheck) {
+      return true;
+    }
+
+    final unlockedCheck = await _storage.containsKey(
+      key: key,
+      iOptions: IOSOptions(accessibility: KeychainAccessibility.unlocked),
+    );
+
+    if (unlockedCheck) {
+      final value = await _storage.read(
+        key: key,
+        iOptions: IOSOptions(accessibility: KeychainAccessibility.unlocked),
+      );
+      if (value != null) {
+        // Re-save the value with the default accessibility for future reads and
+        // reads from background processes.
+        await _storage.write(key: key, value: value);
+      }
+    }
+    return unlockedCheck;
   }
 
   @override


### PR DESCRIPTION
iOS accessibility in the `FlutterSecureStorage` instance was changed from `unlocked` to `first_unlock_this_device` to let the background processes have access to the data stored in secure storage. However, this means the data itself should be migrated to get this less restrictive policy as well, otherwise the background tasks will still find nothing, since the data was previously written with more restrictive accessibility policy. This PR does a dynamic on-demand migration when the data is not found with the `first_unlock_this_device` policy. It will then check it with the `unlocked` policy and then write it to an item in secure storage with the `first_unlock_this_device` policy, so next time it will find it there right away and the background tasks can access that now as well.