### PR TITLE
fix: prevent websocket reconnect loop for unauthenticated users

### DIFF
--- a/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
+++ b/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
@@ -62,11 +62,13 @@ class ExchangeNotificationDatasource {
     _isManuallyDisconnected = false;
 
     try {
-      // Verify API key exists
+      // Verify API key exists - don't attempt connection if not authenticated
       final apiKey = await _apiKeyDatasource.get(isTestnet: _isTestnet);
       if (apiKey == null || !apiKey.isActive) {
         _isConnecting = false;
-        throw Exception('API key not available for WebSocket connection');
+        _isManuallyDisconnected = true; // Prevent auto-reconnect loop
+        log.fine('WebSocket connection skipped: user not authenticated');
+        return;
       }
 
       // Build WebSocket URL


### PR DESCRIPTION
## Summary

- Fixes an issue where the websocket connection would continuously retry every 5 seconds for users who are not authenticated, flooding logs with errors

## Problem

When `connect()` was called without a valid API key (user not authenticated):
1. The connection attempt would throw an exception
2. This triggered `_handleDisconnect()` 
3. Which scheduled an auto-reconnect after 5 seconds
4. Creating an infinite loop of failed connection attempts
5. Logs were flooded with "WebSocket connection failed: API key not available" errors

## Solution

When no API key is available, the code now:
- Sets `_isManuallyDisconnected = true` to prevent the auto-reconnect loop from triggering
- Logs at `fine` (debug) level instead of throwing—this is an expected state for unauthenticated users, not an error
- Returns early instead of throwing, avoiding the `_handleDisconnect()` flow entirely

## Test plan

- [x] Verify that unauthenticated users no longer see repeated websocket errors in logs
- [x] Verify that authenticated users can still connect to websocket normally
- [x] Verify that auto-reconnect still works for authenticated users when connection drops