### PR TITLE
feat: add all order type filters to exchange transactions page

### DIFF
--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -53,6 +53,13 @@ sealed class Transaction with _$Transaction {
   bool get isOrder => order != null;
   bool get isBuyOrder => isOrder && order!.orderType == OrderType.buy;
   bool get isSellOrder => isOrder && order!.orderType == OrderType.sell;
+  bool get isWithdrawOrder => isOrder && order!.orderType == OrderType.withdraw;
+  bool get isPayOrder => isOrder && order!.orderType == OrderType.fiatPayment;
+  bool get isFundingOrder => isOrder && order!.orderType == OrderType.funding;
+  bool get isRewardOrder => isOrder && order!.orderType == OrderType.reward;
+  bool get isRefundOrder => isOrder && order!.orderType == OrderType.refund;
+  bool get isBalanceAdjustmentOrder =>
+      isOrder && order!.orderType == OrderType.balanceAdjustment;
   bool get isOutgoing => walletTransaction != null
       ? walletTransaction!.isOutgoing
       : swap?.isLnSendSwap == true ||

--- a/lib/features/transactions/presentation/blocs/transactions_state.dart
+++ b/lib/features/transactions/presentation/blocs/transactions_state.dart
@@ -1,6 +1,20 @@
 part of 'transactions_cubit.dart';
 
-enum TransactionsFilter { all, send, receive, swap, payjoin, sell, buy }
+enum TransactionsFilter {
+  all,
+  send,
+  receive,
+  swap,
+  payjoin,
+  sell,
+  buy,
+  withdraw,
+  pay,
+  funding,
+  reward,
+  refund,
+  balanceAdjustment,
+}
 
 @freezed
 abstract class TransactionsState with _$TransactionsState {
@@ -19,6 +33,12 @@ abstract class TransactionsState with _$TransactionsState {
           TransactionsFilter.all,
           TransactionsFilter.sell,
           TransactionsFilter.buy,
+          TransactionsFilter.withdraw,
+          TransactionsFilter.pay,
+          TransactionsFilter.funding,
+          TransactionsFilter.reward,
+          TransactionsFilter.refund,
+          TransactionsFilter.balanceAdjustment,
         ]
       : TransactionsFilter.values;
 
@@ -168,6 +188,12 @@ abstract class TransactionsState with _$TransactionsState {
             tx.isPayjoin && !shouldFilterOutgoingChainSwap,
           TransactionsFilter.sell => tx.isSellOrder,
           TransactionsFilter.buy => tx.isBuyOrder,
+          TransactionsFilter.withdraw => tx.isWithdrawOrder,
+          TransactionsFilter.pay => tx.isPayOrder,
+          TransactionsFilter.funding => tx.isFundingOrder,
+          TransactionsFilter.reward => tx.isRewardOrder,
+          TransactionsFilter.refund => tx.isRefundOrder,
+          TransactionsFilter.balanceAdjustment => tx.isBalanceAdjustmentOrder,
         };
       }).toList();
 

--- a/lib/features/transactions/ui/widgets/txs_filter_row.dart
+++ b/lib/features/transactions/ui/widgets/txs_filter_row.dart
@@ -37,6 +37,17 @@ class _TxsFilterRowState extends State<TxsFilterRow> {
                       context.loc.transactionFilterPayjoin,
                     TransactionsFilter.sell => context.loc.transactionFilterSell,
                     TransactionsFilter.buy => context.loc.transactionFilterBuy,
+                    TransactionsFilter.withdraw =>
+                      context.loc.transactionFilterWithdraw,
+                    TransactionsFilter.pay => context.loc.transactionFilterPay,
+                    TransactionsFilter.funding =>
+                      context.loc.transactionFilterFunding,
+                    TransactionsFilter.reward =>
+                      context.loc.transactionFilterReward,
+                    TransactionsFilter.refund =>
+                      context.loc.transactionFilterRefund,
+                    TransactionsFilter.balanceAdjustment =>
+                      context.loc.transactionFilterBalanceAdjustment,
                   },
                   isSelected: selectedFilter == filter,
                   onTap: () {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -2490,6 +2490,30 @@
   "@transactionFilterBuy": {
     "description": "Filter option to show only buy orders"
   },
+  "transactionFilterWithdraw": "Withdraw",
+  "@transactionFilterWithdraw": {
+    "description": "Filter option to show only withdraw orders"
+  },
+  "transactionFilterPay": "Pay",
+  "@transactionFilterPay": {
+    "description": "Filter option to show only fiat payment orders"
+  },
+  "transactionFilterFunding": "Funding",
+  "@transactionFilterFunding": {
+    "description": "Filter option to show only funding orders"
+  },
+  "transactionFilterReward": "Reward",
+  "@transactionFilterReward": {
+    "description": "Filter option to show only reward orders"
+  },
+  "transactionFilterRefund": "Refund",
+  "@transactionFilterRefund": {
+    "description": "Filter option to show only refund orders"
+  },
+  "transactionFilterBalanceAdjustment": "Adjustment",
+  "@transactionFilterBalanceAdjustment": {
+    "description": "Filter option to show only balance adjustment orders"
+  },
   "transactionNetworkLightning": "Lightning",
   "@transactionNetworkLightning": {
     "description": "Label for Lightning network transactions"


### PR DESCRIPTION
## Summary

- Add missing order type filters to the exchange Transactions page
- Previously only showed All, Sell, and Buy filters
- Now includes: Withdraw, Pay, Funding, Reward, Refund, and Balance Adjustment filters

## Changes

**Transaction Entity** (`lib/features/transactions/domain/entities/transaction.dart`)
- Added helper getters: `isWithdrawOrder`, `isPayOrder`, `isFundingOrder`, `isRewardOrder`, `isRefundOrder`, `isBalanceAdjustmentOrder`

**Transactions State** (`lib/features/transactions/presentation/blocs/transactions_state.dart`)
- Extended `TransactionsFilter` enum with 6 new values
- Updated `availableFilters` to include all exchange filters when `exchangeOnly` is true
- Updated filter logic in `filteredTransactionsByDay`

**Filter Row Widget** (`lib/features/transactions/ui/widgets/txs_filter_row.dart`)
- Added switch cases for new filter types with localized labels

**Localization** (`localization/app_en.arb`)
- Added localization strings for all new filter labels

## Test plan

- [x] Navigate to Exchange Settings > Transactions
- [x] Verify all filter buttons are visible: All, Sell, Buy, Withdraw, Pay, Funding, Reward, Refund, Adjustment
- [x] Test each filter to ensure it correctly filters the transaction list by order type