### PR TITLE
fix: show support login screen on all platforms and update copy

### DIFF
--- a/lib/features/exchange/ui/exchange_router.dart
+++ b/lib/features/exchange/ui/exchange_router.dart
@@ -80,17 +80,10 @@ class ExchangeRouter {
       name: ExchangeRoute.exchangeLoginForSupport.name,
       path: ExchangeRoute.exchangeLoginForSupport.path,
       pageBuilder: (context, state) {
-        Widget screen;
-        if (Platform.isIOS) {
-          final isSuperuser =
-              context.read<SettingsCubit>().state.isSuperuser ?? false;
-          screen = isSuperuser
-              ? const ExchangeLandingScreen()
-              : const ExchangeSupportLoginScreen();
-        } else {
-          screen = const ExchangeLandingScreen();
-        }
-        return NoTransitionPage(key: state.pageKey, child: screen);
+        return NoTransitionPage(
+          key: state.pageKey,
+          child: const ExchangeSupportLoginScreen(),
+        );
       },
     ),
     GoRoute(

--- a/lib/features/exchange/ui/screens/exchange_support_login_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_support_login_screen.dart
@@ -79,33 +79,6 @@ class ExchangeSupportLoginScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              const Gap(16),
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: context.appColors.surfaceContainer,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  crossAxisAlignment: .start,
-                  children: [
-                    Icon(
-                      Icons.info_outline,
-                      color: context.appColors.primary,
-                      size: 20,
-                    ),
-                    const Gap(8),
-                    Expanded(
-                      child: BBText(
-                        context.loc.exchangeSupportLoginAccountInfo,
-                        style: context.font.bodySmall?.copyWith(
-                          color: context.appColors.onSurface,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
               const Gap(40),
               SizedBox(
                 width: double.infinity,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -259,6 +259,14 @@
   "@settingsBitcoinSettingsTitle": {
     "description": "Title for the Bitcoin settings section in the settings menu"
   },
+  "settingsBtcMapTitle": "BTC Map",
+  "@settingsBtcMapTitle": {
+    "description": "Title for BTC Map menu entry in main Settings screen"
+  },
+  "btcMapScreenTitle": "BTC Map",
+  "@btcMapScreenTitle": {
+    "description": "AppBar title for BTC Map webview screen"
+  },
   "settingsSecurityPinTitle": "Security Pin",
   "@settingsSecurityPinTitle": {
     "description": "Title for the security PIN section in the settings menu"
@@ -10355,11 +10363,11 @@
   "@exchangeLandingLoginToUseSupport": {
     "description": "Message prompting user to login to access support chat"
   },
-  "exchangeSupportLoginSubtitle": "Connect to Bull Bitcoin Support Account",
+  "exchangeSupportLoginSubtitle": "Real Human Support",
   "@exchangeSupportLoginSubtitle": {
     "description": "Subtitle on support chat login screen"
   },
-  "exchangeSupportLoginAccessMessage": "You will only have access to the support chat feature.",
+  "exchangeSupportLoginAccessMessage": "Bull Bitcoin is proud to offer real human support to all its users, free of charge. To access this feature, please create an account or log-in. No KYC is required and all messages are 100% confidential, never leaked to 3rd parties.",
   "@exchangeSupportLoginAccessMessage": {
     "description": "Message explaining limited access on support-only login"
   },


### PR DESCRIPTION
## Summary
- Show the support login screen (`ExchangeSupportLoginScreen`) consistently on both Android and iOS when tapping the chat icon while not logged in, instead of falling back to the exchange landing screen
- Removed the platform/superuser branching logic from the `exchangeLoginForSupport` route
- Updated support login copy to better communicate the value of Bull Bitcoin's human support
- Removed redundant info banner from the support login screen

## Test plan
- [ ] Tap chat icon on Android while logged out → should see support login screen with updated copy
- [ ] Tap chat icon on iOS while logged out → should see same support login screen
- [ ] Tap "Login Or Sign up" → should navigate to exchange auth
- [ ] Back button returns to wallet home