### PR TITLE
Handle lwk database corruptions due to parallel updates

### DIFF
--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -60,7 +60,8 @@ class LwkWalletDatasource {
       return balance;
     } catch (e) {
       if (e is lwk.LwkError) {
-        if (e.msg.contains('UpdateOnDifferentStatus')) {
+        if (e.toString().contains('UpdateOnDifferentStatus') ||
+            e.msg.contains('UpdateOnDifferentStatus')) {
           await delete(wallet: wallet);
         }
         throw e.msg;

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -380,6 +380,19 @@ class WalletRepository {
     await _walletMetadataDatasource.delete(walletId);
   }
 
+  // used only to delete lwk db - required for UpdateOnDifferentStatusError
+  Future<void> deleteLwkDb() async {
+    final metadatas = await _walletMetadataDatasource.fetchAll();
+
+    final liquidDefaultWallets = metadatas.where(
+      (metadata) => metadata.isDefault && metadata.isLiquid,
+    );
+
+    for (final metadata in liquidDefaultWallets) {
+      await _lwkWallet.delete(wallet: WalletModel.fromMetadata(metadata));
+    }
+  }
+
   Stream<String> get _walletSyncStartedStream => StreamGroup.merge([
     _bdkWallet.walletSyncStartedStream,
     _lwkWallet.walletSyncStartedStream,

--- a/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
+++ b/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
@@ -19,7 +19,7 @@ class CheckForExistingDefaultWalletsUsecase {
   Future<bool> execute() async {
     final settings = await _settingsRepository.fetch();
     final environment = settings.environment;
-    
+
     late final List defaultWallets;
     try {
       defaultWallets = await _walletRepository.getWallets(
@@ -29,6 +29,7 @@ class CheckForExistingDefaultWalletsUsecase {
     } catch (e) {
       if (e.toString().contains('UpdateOnDifferentStatus')) {
         log.fine('UpdateOnDifferentStatus error, retrying getWallets');
+        await _walletRepository.deleteLwkDb();
         defaultWallets = await _walletRepository.getWallets(
           onlyDefaults: true,
           environment: environment,


### PR DESCRIPTION
UpdateOnDifferentStatus errors from lwk can only be recovered by deleting the lwk db and resyncing it. This issue deletes wallet on the balance and sync method if the error is detected.

The reason for doing it in the balance method is because it is called on app startup and reading the db at this time can cause an app startup failure.
