### PR TITLE
fix: closes #1872 and #1739

### DIFF
--- a/lib/core/widgets/qr_display_widget.dart
+++ b/lib/core/widgets/qr_display_widget.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -18,7 +19,7 @@ class QrDisplayWidget extends StatelessWidget {
       padding: const EdgeInsets.all(16),
       constraints: BoxConstraints(maxHeight: size, maxWidth: size),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: context.appColors.surfaceFixed,
         borderRadius: BorderRadius.circular(12),
       ),
       child: QrImageView(data: data),

--- a/lib/core/widgets/qr_display_widget.dart
+++ b/lib/core/widgets/qr_display_widget.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class QrDisplayWidget extends StatelessWidget {
+  const QrDisplayWidget({super.key, required this.data, this.size = 300});
+
+  final String data;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      constraints: BoxConstraints(maxHeight: size, maxWidth: size),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: data.isNotEmpty
+          ? QrImageView(data: data)
+          : const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/core/widgets/qr_display_widget.dart
+++ b/lib/core/widgets/qr_display_widget.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
@@ -9,6 +10,10 @@ class QrDisplayWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (data.isEmpty) {
+      return LoadingBoxContent(height: size, width: size);
+    }
+
     return Container(
       padding: const EdgeInsets.all(16),
       constraints: BoxConstraints(maxHeight: size, maxWidth: size),
@@ -16,9 +21,7 @@ class QrDisplayWidget extends StatelessWidget {
         color: Colors.white,
         borderRadius: BorderRadius.circular(12),
       ),
-      child: data.isNotEmpty
-          ? QrImageView(data: data)
-          : const SizedBox.shrink(),
+      child: QrImageView(data: data),
     );
   }
 }

--- a/lib/features/ark/ui/receive_page.dart
+++ b/lib/features/ark/ui/receive_page.dart
@@ -1,7 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/inputs/copy_input.dart';
-import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
@@ -83,9 +82,7 @@ class ReceiveQR extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 42),
-        child: qrData.isNotEmpty
-            ? QrDisplayWidget(data: qrData)
-            : const LoadingBoxContent(height: 200),
+        child: QrDisplayWidget(data: qrData),
       ),
     );
   }

--- a/lib/features/ark/ui/receive_page.dart
+++ b/lib/features/ark/ui/receive_page.dart
@@ -2,12 +2,12 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/inputs/copy_input.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 class ReceivePage extends StatefulWidget {
   const ReceivePage({super.key});
@@ -81,20 +81,10 @@ class ReceiveQR extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 42),
-        padding: const EdgeInsets.all(16),
-        constraints: const BoxConstraints(maxHeight: 300, maxWidth: 300),
-        decoration: BoxDecoration(
-          color: context.appColors.background,
-          borderRadius: BorderRadius.circular(12),
-        ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 42),
         child: qrData.isNotEmpty
-            ? QrImageView(
-                data: qrData,
-                // ignore: deprecated_member_use
-                foregroundColor: context.appColors.secondary,
-              )
+            ? QrDisplayWidget(data: qrData)
             : const LoadingBoxContent(height: 200),
       ),
     );

--- a/lib/features/fund_exchange/ui/screens/fund_exchange_canada_post_screen.dart
+++ b/lib/features/fund_exchange/ui/screens/fund_exchange_canada_post_screen.dart
@@ -1,6 +1,5 @@
 import 'package:bb_mobile/core/exchange/domain/entity/funding_details.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart';
@@ -72,10 +71,10 @@ class FundExchangeCanadaPostScreen extends StatelessWidget {
                         textAlign: .center,
                       ),
                       const Gap(8.0),
-                      if (details?.code == null)
-                        const LoadingBoxContent(height: 250.0, width: 250.0)
-                      else
-                        QrDisplayWidget(data: details!.code, size: 250),
+                      QrDisplayWidget(
+                        data: details?.code ?? '',
+                        size: 250,
+                      ),
                       const Gap(24.0),
                     ],
                   ),

--- a/lib/features/fund_exchange/ui/screens/fund_exchange_canada_post_screen.dart
+++ b/lib/features/fund_exchange/ui/screens/fund_exchange_canada_post_screen.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/exchange/domain/entity/funding_details.dart';
-import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart';
 import 'package:bb_mobile/features/fund_exchange/ui/widgets/fund_exchange_details_error_card.dart';
@@ -9,7 +9,6 @@ import 'package:bb_mobile/features/fund_exchange/ui/widgets/fund_exchange_done_b
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 class FundExchangeCanadaPostScreen extends StatelessWidget {
   const FundExchangeCanadaPostScreen({super.key});
@@ -76,19 +75,7 @@ class FundExchangeCanadaPostScreen extends StatelessWidget {
                       if (details?.code == null)
                         const LoadingBoxContent(height: 250.0, width: 250.0)
                       else
-                        Container(
-                          padding: const EdgeInsets.all(16),
-                          decoration: BoxDecoration(
-                            color: context.appColors.background,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: QrImageView(
-                            size: 250,
-                            data: details!.code,
-                            // ignore: deprecated_member_use
-                            foregroundColor: context.appColors.secondary,
-                          ),
-                        ),
+                        QrDisplayWidget(data: details!.code, size: 250),
                       const Gap(24.0),
                     ],
                   ),
@@ -101,5 +88,4 @@ class FundExchangeCanadaPostScreen extends StatelessWidget {
       bottomNavigationBar: const FundExchangeDoneBottomNavigationBar(),
     );
   }
-
 }

--- a/lib/features/pay/ui/widgets/pay_qr_bottom_sheet.dart
+++ b/lib/features/pay/ui/widgets/pay_qr_bottom_sheet.dart
@@ -1,10 +1,10 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 class PayQrBottomSheet extends StatelessWidget {
   const PayQrBottomSheet({super.key, required this.bip21InvoiceData});
@@ -56,32 +56,7 @@ class PayQrBottomSheet extends StatelessWidget {
             ],
           ),
           const Gap(24),
-          Center(
-            child: Container(
-              padding: const EdgeInsets.all(24),
-              decoration: BoxDecoration(
-                color: context.appColors.background,
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: context.appColors.overlay.withValues(alpha: 0.5),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-              ),
-              child: SizedBox(
-                width: 280,
-                height: 280,
-                child: QrImageView(
-                  data: bip21InvoiceData,
-                  size: 280,
-                  // ignore: deprecated_member_use
-                  foregroundColor: context.appColors.secondary,
-                ),
-              ),
-            ),
-          ),
+          Center(child: QrDisplayWidget(data: bip21InvoiceData, size: 280)),
           const Gap(16),
         ],
       ),

--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -4,7 +4,6 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/inputs/copy_input.dart';
-import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/bitbox/ui/bitbox_router.dart';
@@ -140,11 +139,7 @@ class ReceiveQRDetails extends StatelessWidget {
               ),
             ),
           const Gap(20),
-          Center(
-            child: qrData.isNotEmpty
-                ? QrDisplayWidget(data: qrData)
-                : const LoadingBoxContent(height: 200),
-          ),
+          Center(child: QrDisplayWidget(data: qrData)),
           if (isPayjoinAvailable) ...[
             const Gap(16),
             BBText(

--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -21,7 +21,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
-import 'package:qr_flutter/qr_flutter.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 
 class ReceiveQrPage extends StatelessWidget {
   const ReceiveQrPage({super.key, this.wallet});
@@ -141,21 +141,9 @@ class ReceiveQRDetails extends StatelessWidget {
             ),
           const Gap(20),
           Center(
-            child: Container(
-              padding: const EdgeInsets.all(16),
-              constraints: const BoxConstraints(maxHeight: 300, maxWidth: 300),
-              decoration: BoxDecoration(
-                color: context.appColors.background,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: qrData.isNotEmpty
-                  ? QrImageView(
-                      data: qrData,
-                      // ignore: deprecated_member_use
-                      foregroundColor: context.appColors.secondary,
-                    )
-                  : const LoadingBoxContent(height: 200),
-            ),
+            child: qrData.isNotEmpty
+                ? QrDisplayWidget(data: qrData)
+                : const LoadingBoxContent(height: 200),
           ),
           if (isPayjoinAvailable) ...[
             const Gap(16),

--- a/lib/features/sell/ui/widgets/sell_qr_bottom_sheet.dart
+++ b/lib/features/sell/ui/widgets/sell_qr_bottom_sheet.dart
@@ -1,10 +1,10 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 class SellQrBottomSheet extends StatelessWidget {
   const SellQrBottomSheet({super.key, required this.bip21InvoiceData});
@@ -56,32 +56,7 @@ class SellQrBottomSheet extends StatelessWidget {
             ],
           ),
           const Gap(24),
-          Center(
-            child: Container(
-              padding: const EdgeInsets.all(24),
-              decoration: BoxDecoration(
-                color: context.appColors.background,
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: context.appColors.overlay.withValues(alpha: 0.5),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
-              ),
-              child: SizedBox(
-                width: 280,
-                height: 280,
-                child: QrImageView(
-                  data: bip21InvoiceData,
-                  size: 280,
-                  // ignore: deprecated_member_use
-                  foregroundColor: context.appColors.secondary,
-                ),
-              ),
-            ),
-          ),
+          Center(child: QrDisplayWidget(data: bip21InvoiceData, size: 280)),
           const Gap(16),
         ],
       ),


### PR DESCRIPTION
Dark mode users cannot get their QR to be scanned by external devices since they mostly support white background with black dots