### PR TITLE
allow pull to refresh from anywhere on wallet home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # About BULL Wallet
 
-BULL Wallet is a self-custodial Bitcoin and Liquid Network which offers non-custodial atomic swaps across Bitcoin, Lightning and Liquid. The wallet philosophy is to provide advanced features that give users the maximum control, while still being easy to use for beginners. Our goal is to make sure that anyone can take self-custody of their Bitcoin, even in a high fee environment. Our driving principle is to create a user experience which nudges the user into implementing best practices.
+BULL Wallet is a self-custodial Bitcoin and Liquid Network wallet which offers non-custodial atomic swaps across Bitcoin, Lightning and Liquid. The wallet philosophy is to provide advanced features that give users the maximum control, while still being easy to use for beginners. Our goal is to make sure that anyone can take self-custody of their Bitcoin, even in a high fee environment. Our driving principle is to create a user experience which nudges the user into implementing best practices.
 
-Following the cypherpunk ethos, the BULL Wallet wallet is fully open-source and trustless.
+Following the cypherpunk ethos, the BULL Wallet is fully open-source and trustless.
 
 ## Wallet basics
 

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -44,7 +44,7 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
           children: [
             Expanded(
               child: RefreshIndicator(
-                edgeOffset: MediaQuery.of(context).padding.top + 30,
+                edgeOffset: 30,
                 onRefresh: () async {
                   final bloc = context.read<WalletBloc>();
                   bloc.add(const WalletRefreshed());

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -42,9 +42,9 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
         onPopInvokedWithResult: (didPop, _) {},
         child: Column(
           children: [
-            const WalletHomeTopSection(),
             Expanded(
               child: RefreshIndicator(
+                edgeOffset: MediaQuery.of(context).padding.top + 30,
                 onRefresh: () async {
                   final bloc = context.read<WalletBloc>();
                   bloc.add(const WalletRefreshed());
@@ -55,6 +55,7 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
+                      const WalletHomeTopSection(),
                       const HomeWarnings(),
                       const AutoSwapFeeWarning(),
                       WalletCards(

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/themes/colors.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/auto_swap_fee_warning.dart';
@@ -41,43 +42,57 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
         canPop: false,
         onPopInvokedWithResult: (didPop, _) {},
         child: Column(
-          children: [
-            Expanded(
-              child: RefreshIndicator(
-                edgeOffset: 30,
-                onRefresh: () async {
-                  final bloc = context.read<WalletBloc>();
-                  bloc.add(const WalletRefreshed());
-                  await bloc.stream.firstWhere((state) => !state.isSyncing);
-                },
-                child: SingleChildScrollView(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      const WalletHomeTopSection(),
-                      const HomeWarnings(),
-                      const AutoSwapFeeWarning(),
-                      WalletCards(
-                        onTap: (w) {
-                          context.pushNamed(
-                            WalletRoute.walletDetail.name,
-                            pathParameters: {'walletId': w.id},
-                          );
-                        },
+            children: [
+              Expanded(
+                child: Stack(
+                  children: [
+                    // Black background visible only during iOS top overscroll
+                    Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      child: ColoredBox(
+                        color: AppColors.dark.background,
+                        child: const SizedBox(height: 300),
                       ),
-                    ],
+                    ),
+                    RefreshIndicator(
+                  edgeOffset: 30,
+                  onRefresh: () async {
+                    final bloc = context.read<WalletBloc>();
+                    bloc.add(const WalletRefreshed());
+                    await bloc.stream.firstWhere((state) => !state.isSyncing);
+                  },
+                  child: SingleChildScrollView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const WalletHomeTopSection(),
+                        const HomeWarnings(),
+                        const AutoSwapFeeWarning(),
+                        WalletCards(
+                          onTap: (w) {
+                            context.pushNamed(
+                              WalletRoute.walletDetail.name,
+                              pathParameters: {'walletId': w.id},
+                            );
+                          },
+                        ),
+                      ],
+                    ),
                   ),
+                  ),
+                  ],
                 ),
               ),
-            ),
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 13.0),
-              child: WalletBottomButtons(),
-            ),
-            const Gap(16),
-          ],
-        ),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 13.0),
+                child: WalletBottomButtons(),
+              ),
+              const Gap(16),
+            ],
+          ),
       ),
     );
   }


### PR DESCRIPTION
This allows a user to pull to refresh anywhere on the home screen. Previously, because `WalletHomeTopSection` was outside the widget containing the `RefreshIndicator`, you could only swipe below the buy/sell/pay/transfer buttons to refresh things like your balance or Electrum server status