### PR TITLE
fix delete custom electrum server widget ui in dark mode

### DIFF
--- a/lib/features/electrum_settings/frameworks/ui/widgets/delete_custom_server_dialog.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/delete_custom_server_dialog.dart
@@ -14,7 +14,7 @@ class DeleteCustomServerDialog {
       context: context,
       builder:
           (BuildContext dialogContext) => AlertDialog(
-            backgroundColor: context.appColors.onPrimary,
+            backgroundColor: context.appColors.surfaceContainer,
             title: Text(context.loc.electrumDeleteServerTitle),
             content: Column(
               mainAxisSize: .min,


### PR DESCRIPTION
very small change that fixes the ui of the delete custom electrum server dialog in dark mode

before: 

<img src="https://github.com/user-attachments/assets/ef52077f-faef-486c-9ed8-b2d34b0de4a4" width="250px">

after:

<img src="https://github.com/user-attachments/assets/ab5684e1-34d7-49e4-bc37-609c442abcb2" width="250px">
