### PR TITLE
fix exchange home kyc card in dark mode

### DIFF
--- a/lib/features/exchange/ui/widgets/exchange_home_kyc_card.dart
+++ b/lib/features/exchange/ui/widgets/exchange_home_kyc_card.dart
@@ -22,7 +22,7 @@ class ExchangeHomeKycCard extends StatelessWidget {
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-      tileColor: context.appColors.secondary,
+      tileColor: context.appColors.secondaryFixed,
       leading: Column(
         mainAxisAlignment: .center,
         children: [
@@ -35,12 +35,16 @@ class ExchangeHomeKycCard extends StatelessWidget {
           if (isKycLight)
             Text(
               context.loc.exchangeKycLevelLight,
-              style: theme.textTheme.labelLarge?.copyWith(color: context.appColors.surfaceFixed),
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: context.appColors.surfaceFixed,
+              ),
             ),
           if (isKycLimited)
             Text(
               context.loc.exchangeKycLevelLimited,
-              style: theme.textTheme.labelLarge?.copyWith(color: context.appColors.surfaceFixed),
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: context.appColors.surfaceFixed,
+              ),
             ),
         ],
       ),
@@ -55,7 +59,7 @@ class ExchangeHomeKycCard extends StatelessWidget {
       subtitle: Text(
         context.loc.exchangeKycCardSubtitle,
         style: theme.textTheme.bodyMedium?.copyWith(
-          color: context.appColors.surface,
+          color: context.appColors.onPrimaryFixed,
           fontWeight: .w500,
         ),
       ),
@@ -63,7 +67,11 @@ class ExchangeHomeKycCard extends StatelessWidget {
       onTap: () async {
         await context.pushNamed(ExchangeRoute.exchangeKyc.name);
       },
-      trailing: Icon(Icons.arrow_forward, color: context.appColors.surfaceFixed, size: 24),
+      trailing: Icon(
+        Icons.arrow_forward,
+        color: context.appColors.surfaceFixed,
+        size: 24,
+      ),
     );
   }
 }


### PR DESCRIPTION
fixes the kyc card colours in the dark mode

looked like this on dark mode

<img src="https://github.com/user-attachments/assets/eb41ece5-21c9-4383-a21d-a63d2b62a30f" width="250x">

now has a fixed colour scheme for both dark and light mode

<img src="https://github.com/user-attachments/assets/9fadec59-bf67-44f1-91eb-86630dda58d5" width="250x">
<img src="https://github.com/user-attachments/assets/55a0dee0-76b2-4693-95d4-e47f13f2cb19" width="250x">
