### PR TITLE
fix: random OHTTP relay to prevent network-layer fingerprinting

### DIFF
--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
@@ -47,11 +48,16 @@ class AssetConstants {
 }
 
 class PayjoinConstants {
-  static const List<String> ohttpRelayUrls = [
-    'https://ohttp.achow101.com',
-    'https://pj.bobspacebkk.com',
-    'https://ohttp.cakewallet.com',
-  ];
+  static List<String> get ohttpRelayUrls {
+    final list = [
+      'https://ohttp.achow101.com',
+      'https://pj.bobspacebkk.com',
+      'https://ohttp.cakewallet.com',
+    ];
+    list.shuffle(Random.secure());
+    return list;
+  }
+
   static const String directoryUrl = 'https://payjo.in';
   static const directoryPollingInterval = 5;
   static const defaultExpireAfterSec = 60 * 60 * 24; // 24 hours


### PR DESCRIPTION
Changes `ohttpRelayUrls` from a `const` to a getter that shuffles the list on each call using `Random.secure()`, so relay selection is randomized across all 5 calls in `pdk_payjoin_datasource.dart`, matching the approach already used by Cake Wallet and recommended in payjoin/rust-payjoin#1328.

Closes #1906