### PR TITLE
check self spent before doing payjoin send

### DIFF
--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -144,6 +144,21 @@ class BdkWalletDatasource {
     return isMine;
   }
 
+  Future<bool> isAddressMine(
+    String address, {
+    required WalletModel wallet,
+  }) async {
+    final bdkWallet = await BdkFacade.createWallet(wallet);
+    final bdkAddress = await bdk.Address.fromString(
+      s: address,
+      network: wallet.isTestnet ? bdk.Network.testnet : bdk.Network.bitcoin,
+    );
+    final script = bdkAddress.scriptPubkey();
+    final isMine = bdkWallet.isMine(script: script);
+
+    return isMine;
+  }
+
   Future<String> buildPsbt({
     required String address,
     required NetworkFee networkFee,

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -58,8 +58,9 @@ class BitcoinWalletRepository {
       networkFee: networkFee,
       drain: drain,
       unspendable: unspendable,
-      selected:
-          selected?.map((utxo) => WalletUtxoMapper.fromEntity(utxo)).toList(),
+      selected: selected
+          ?.map((utxo) => WalletUtxoMapper.fromEntity(utxo))
+          .toList(),
       replaceByFee: replaceByFee ?? false,
     );
 
@@ -96,6 +97,37 @@ class BitcoinWalletRepository {
             as PublicBdkWalletModel;
 
     final isFromWallet = await _bdkWallet.isMine(script, wallet: wallet);
+
+    return isFromWallet;
+  }
+
+  Future<bool> isAddressOfWallet(
+    String address, {
+    required String walletId,
+  }) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+
+    if (metadata == null) {
+      throw Exception('Wallet metadata not found for walletId: $walletId');
+    }
+
+    if (!metadata.isBitcoin) {
+      throw Exception('Wallet $walletId is not a Bitcoin wallet');
+    }
+
+    final wallet =
+        WalletModel.publicBdk(
+              externalDescriptor: metadata.externalPublicDescriptor,
+              internalDescriptor: metadata.internalPublicDescriptor,
+              isTestnet: metadata.isTestnet,
+              id: metadata.id,
+            )
+            as PublicBdkWalletModel;
+
+    final isFromWallet = await _bdkWallet.isAddressMine(
+      address,
+      wallet: wallet,
+    );
 
     return isFromWallet;
   }

--- a/lib/features/send/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -16,7 +16,7 @@ class PrepareBitcoinSendUsecase {
   }) : _payjoin = payjoinRepository,
        _bitcoinWalletRepository = bitcoinWalletRepository;
 
-  Future<({String unsignedPsbt, int txSize})> execute({
+  Future<({String unsignedPsbt, int txSize, bool isToSelf})> execute({
     required String walletId,
     required String address,
     required NetworkFee networkFee,
@@ -51,7 +51,11 @@ class PrepareBitcoinSendUsecase {
         replaceByFee: replaceByFee,
       );
       final size = await _bitcoinWalletRepository.getTxSize(psbt: psbt);
-      return (unsignedPsbt: psbt, txSize: size);
+      final isToSelf = await _bitcoinWalletRepository.isAddressOfWallet(
+        address,
+        walletId: walletId,
+      );
+      return (unsignedPsbt: psbt, txSize: size, isToSelf: isToSelf);
     } on NoSpendableUtxoException {
       rethrow;
     } catch (e) {

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -1173,7 +1173,7 @@ class SendCubit extends Cubit<SendState> {
           );
         }
       } else {
-        final unsignedPsbtAndTxSize = await _prepareBitcoinSendUsecase.execute(
+        final txPreparation = await _prepareBitcoinSendUsecase.execute(
           walletId: state.selectedWallet!.id,
           address: address,
           networkFee: state.selectedFee!,
@@ -1186,7 +1186,7 @@ class SendCubit extends Cubit<SendState> {
 
         if (state.chainSwap != null) {
           await _verifyChainSwapAmountSendUsecase.execute(
-            psbtOrPset: unsignedPsbtAndTxSize.unsignedPsbt,
+            psbtOrPset: txPreparation.unsignedPsbt,
             swap: state.chainSwap!,
             walletId: state.selectedWallet!.id,
           );
@@ -1195,14 +1195,15 @@ class SendCubit extends Cubit<SendState> {
         if (state.selectedWallet!.signsRemotely) {
           emit(
             state.copyWith(
-              unsignedPsbt: unsignedPsbtAndTxSize.unsignedPsbt,
-              bitcoinTxSize: unsignedPsbtAndTxSize.txSize,
+              unsignedPsbt: txPreparation.unsignedPsbt,
+              bitcoinTxSize: txPreparation.txSize,
+              isToSelf: txPreparation.isToSelf,
               buildingTransaction: false,
             ),
           );
         } else {
           final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
-            psbt: unsignedPsbtAndTxSize.unsignedPsbt,
+            psbt: txPreparation.unsignedPsbt,
             walletId: state.selectedWallet!.id,
           );
           final bitcoinAbsoluteFeesSat =
@@ -1221,9 +1222,10 @@ class SendCubit extends Cubit<SendState> {
             );
             emit(
               state.copyWith(
-                unsignedPsbt: unsignedPsbtAndTxSize.unsignedPsbt,
+                unsignedPsbt: txPreparation.unsignedPsbt,
                 signedBitcoinPsbt: signedPsbtAndTxSize.signedPsbt,
                 bitcoinTxSize: signedPsbtAndTxSize.txSize,
+                isToSelf: txPreparation.isToSelf,
                 chainSwap: updatedSwap as ChainSwap,
                 buildingTransaction: false,
               ),
@@ -1240,9 +1242,10 @@ class SendCubit extends Cubit<SendState> {
             );
             emit(
               state.copyWith(
-                unsignedPsbt: unsignedPsbtAndTxSize.unsignedPsbt,
+                unsignedPsbt: txPreparation.unsignedPsbt,
                 signedBitcoinPsbt: signedPsbtAndTxSize.signedPsbt,
                 bitcoinTxSize: signedPsbtAndTxSize.txSize,
+                isToSelf: txPreparation.isToSelf,
                 lightningSwap: updatedSwap as LnSendSwap,
                 buildingTransaction: false,
               ),
@@ -1250,9 +1253,10 @@ class SendCubit extends Cubit<SendState> {
           } else {
             emit(
               state.copyWith(
-                unsignedPsbt: unsignedPsbtAndTxSize.unsignedPsbt,
+                unsignedPsbt: txPreparation.unsignedPsbt,
                 signedBitcoinPsbt: signedPsbtAndTxSize.signedPsbt,
                 bitcoinTxSize: signedPsbtAndTxSize.txSize,
+                isToSelf: txPreparation.isToSelf,
                 buildingTransaction: false,
               ),
             );
@@ -1321,7 +1325,8 @@ class SendCubit extends Cubit<SendState> {
         );
       } else {
         final paymentRequest = state.paymentRequest;
-        if (paymentRequest != null &&
+        if (state.isToSelf != true &&
+            paymentRequest != null &&
             paymentRequest is Bip21PaymentRequest &&
             paymentRequest.pj.isNotEmpty) {
           final payjoinSender = await _sendWithPayjoinUsecase.execute(
@@ -1408,7 +1413,8 @@ class SendCubit extends Cubit<SendState> {
         emit(state.copyWith(txId: txId));
       } else {
         final paymentRequest = state.paymentRequest;
-        if (paymentRequest != null &&
+        if (state.isToSelf != true &&
+            paymentRequest != null &&
             paymentRequest is Bip21PaymentRequest &&
             paymentRequest.pj.isNotEmpty) {
           emit(state.copyWith(broadcastingTransaction: false));

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -67,6 +67,7 @@ abstract class SendState with _$SendState {
     PaymentRequest? paymentRequest,
     @Default([]) List<Wallet> wallets,
     Wallet? selectedWallet,
+    bool? isToSelf,
     @Default('') String amount,
     int? confirmedAmountSat,
     BitcoinUnit? bitcoinUnit,

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -859,6 +859,9 @@ class _OnchainSendInfoSection extends StatelessWidget {
     final formattedAbsoluteFees = context.select(
       (SendCubit cubit) => cubit.state.formattedAbsoluteFees,
     );
+    final isToSelf = context.select(
+      (SendCubit cubit) => cubit.state.isToSelf == true,
+    );
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Column(
@@ -913,6 +916,20 @@ class _OnchainSendInfoSection extends StatelessWidget {
             //   ),
             // ),
           ),
+          if (isToSelf) ...[
+            _divider(context),
+            InfoRow(
+              title: context.loc.sendSelfTransfer,
+              details: Align(
+                alignment: Alignment.centerRight,
+                child: Icon(
+                  Icons.check,
+                  color: context.appColors.secondary,
+                  size: 20,
+                ),
+              ),
+            ),
+          ],
           _divider(context),
           InfoRow(
             title: context.loc.sendAmount,

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -3693,6 +3693,7 @@
   "fundExchangeWarningTactic8": "Sie drängen Sie zur Eile",
   "encryptedVaultStatusLabel": "Ihr verschlüsseltes Backup",
   "sendConfirmSend": "Senden bestätigen",
+  "sendSelfTransfer": "Eigenüberweisung",
   "fundExchangeBankTransfer": "Banküberweisung",
   "importQrDeviceButtonInstructions": "Anweisungen",
   "buyLevel3Limit": "Stufe 3 – Limit: {amount}",

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -7060,6 +7060,10 @@
   "@sendConfirmSend": {
     "description": "Title for send confirmation screen"
   },
+  "sendSelfTransfer": "Self-transfer",
+  "@sendSelfTransfer": {
+    "description": "Label shown when the transaction is sending to the same wallet"
+  },
   "sendSending": "Sending",
   "@sendSending": {
     "description": "Title shown while transaction is being sent"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -2128,6 +2128,7 @@
   "sendReceiveNetworkFee": "Comisión de red de recepción",
   "sendServerNetworkFees": "Comisiones de red del servidor",
   "sendConfirmSend": "Confirmar envío",
+  "sendSelfTransfer": "Autotransferencia",
   "sendSending": "Enviando",
   "sendBroadcastingTransaction": "Transmitiendo la transacción.",
   "sendSwapInProgressInvoice": "El intercambio está en curso. La factura se pagará en unos segundos.",

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -2078,6 +2078,7 @@
   "sendReceiveNetworkFee": "Vastaanoton verkkokulu",
   "sendServerNetworkFees": "Palvelimen verkkokulut",
   "sendConfirmSend": "Vahvista lähetys",
+  "sendSelfTransfer": "Siirto itselle",
   "sendSending": "Lähetetään",
   "sendBroadcastingTransaction": "Lähetetään transaktiota.",
   "sendSwapInProgressInvoice": "Swap on käynnissä. Lasku maksetaan muutamassa sekunnissa.",

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -2128,6 +2128,7 @@
   "sendReceiveNetworkFee": "Frais de réseau de réception",
   "sendServerNetworkFees": "Frais de réseau du serveur",
   "sendConfirmSend": "Confirmer l'envoi",
+  "sendSelfTransfer": "Auto-transfert",
   "sendSending": "Envoi en cours",
   "sendBroadcastingTransaction": "Diffusion de la transaction.",
   "sendSwapInProgressInvoice": "L'échange est en cours. La facture sera payée dans quelques secondes.",

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -3741,6 +3741,7 @@
   "fundExchangeWarningTactic8": "Ti stanno pressando per agire rapidamente",
   "encryptedVaultStatusLabel": "Vault crittografato",
   "sendConfirmSend": "Conferma Invia",
+  "sendSelfTransfer": "Trasferimento a sé",
   "fundExchangeBankTransfer": "Trasferimento bancario",
   "importQrDeviceButtonInstructions": "Istruzioni",
   "buyLevel3Limit": "Limite di livello 3: {amount}",

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -3717,6 +3717,7 @@
   "fundExchangeWarningTactic8": "Eles estão pressionando você para agir rapidamente",
   "encryptedVaultStatusLabel": "Vault criptografado",
   "sendConfirmSend": "Enviar",
+  "sendSelfTransfer": "Autotransferência",
   "fundExchangeBankTransfer": "Transferência bancária",
   "importQrDeviceButtonInstructions": "Instruções",
   "buyLevel3Limit": "Limite de nível 3: {amount}",

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -3739,6 +3739,7 @@
   "fundExchangeWarningTactic8": "Они заставляют вас действовать быстро",
   "encryptedVaultStatusLabel": "Зашифрованное хранилище",
   "sendConfirmSend": "Добавить",
+  "sendSelfTransfer": "Перевод себе",
   "fundExchangeBankTransfer": "Банковский перевод",
   "importQrDeviceButtonInstructions": "Инструкции",
   "buyLevel3Limit": "Предел уровня 3: {amount}",

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -3819,6 +3819,7 @@
   "autoswapSaveButton": "Зберегти",
   "importWatchOnlyDisclaimerDescription": "Переконайтеся, що шлях деривативації ви обираєтеся відповідати одному, який виготовив даний xpub, перевіривши першу адресу, отриману з гаманця перед використанням. Використання неправильного шляху може призвести до втрати коштів",
   "sendConfirmSend": "Підтвердження",
+  "sendSelfTransfer": "Переказ собі",
   "fundExchangeBankTransfer": "Банківський переказ",
   "importQrDeviceButtonInstructions": "Інструкції",
   "buyLevel3Limit": "Рівень 3 ліміт: {amount}",

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -3741,6 +3741,7 @@
   "fundExchangeWarningTactic8": "他们正在敦促你迅速采取行动",
   "encryptedVaultStatusLabel": "加密违约",
   "sendConfirmSend": "Confirm Send",
+  "sendSelfTransfer": "自转账",
   "fundExchangeBankTransfer": "银行转账",
   "importQrDeviceButtonInstructions": "指示",
   "buyLevel3Limit": "3级限制:{amount}",


### PR DESCRIPTION
Added a check for a self-spent in the Bitcoin transaction preparation phase, which is then stored in the Cubit state and used further in the cubit at transaction confirmation and broadcasting to skip any payjoin handling if it is a self-spent.

As a little extra, since we have it in the state now, I added the Self-transfer row to the confirmation screen (see screenshot below) in case it is a self-spent, so the user is aware and it is not by mistake. Nothing is shown if it is not a self-spent.

Translations of the "Self-transfer" label in all languages are done by Claude, so not sure about all of them. Let me know if I should remove them or if it's ok?

<img width="314" height="668" alt="Screenshot 2026-03-04 at 21 28 49" src="https://github.com/user-attachments/assets/d00d2b51-dd8c-4293-bd9d-e80645da58a4" />
