### PR TITLE
Solve splash spinner freezing

### DIFF
--- a/lib/core/seed/data/models/seed_model.dart
+++ b/lib/core/seed/data/models/seed_model.dart
@@ -50,17 +50,20 @@ sealed class SeedModel with _$SeedModel {
   }
 
   Seed toEntity() {
+    // Compute bytes and fingerprint once to avoid redundant PBKDF2 derivations
+    final seedBytes = Uint8List.fromList(bytes);
+    final fingerprint = Bip32Keys.fromSeed(seedBytes).fingerprint.toHexString();
     return switch (this) {
-      BytesSeedModel(:final bytes) => Seed.bytes(
-        bytes: Uint8List.fromList(bytes),
-        masterFingerprint: masterFingerprint,
+      BytesSeedModel() => Seed.bytes(
+        bytes: seedBytes,
+        masterFingerprint: fingerprint,
       ),
       MnemonicSeedModel(:final mnemonicWords, :final passphrase) =>
         Seed.mnemonic(
           mnemonicWords: mnemonicWords,
           passphrase: passphrase,
-          bytes: Uint8List.fromList(bytes),
-          masterFingerprint: masterFingerprint,
+          bytes: seedBytes,
+          masterFingerprint: fingerprint,
         ),
     };
   }

--- a/lib/core/seed/data/repository/seed_repository.dart
+++ b/lib/core/seed/data/repository/seed_repository.dart
@@ -48,7 +48,9 @@ class SeedRepository {
   Future<Seed> get(String fingerprint) async {
     try {
       final model = await _source.get(fingerprint);
-      return model.toEntity();
+      // Run toEntity() in isolate to avoid blocking UI with PBKDF2 + bip32
+      final entity = await compute(_toEntityInIsolate, model);
+      return entity;
     } catch (e, stackTrace) {
       log.info(
         'Failed to get seed with fingerprint $fingerprint: $e',
@@ -58,6 +60,9 @@ class SeedRepository {
       rethrow;
     }
   }
+
+  @pragma('vm:entry-point')
+  static Seed _toEntityInIsolate(SeedModel model) => model.toEntity();
 
   Future<bool> exists(String fingerprint) async {
     try {

--- a/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
+++ b/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
@@ -26,19 +26,23 @@ class CheckForExistingDefaultWalletsUsecase {
 
     if (defaultWallets.isNotEmpty) {
       log.fine('FINE: found default wallet');
-      for (final wallet in defaultWallets) {
-        try {
-          await _seedRepository.get(wallet.masterFingerprint);
-          log.fine('FINE: Seed Found');
-        } catch (e) {
-          log.severe(
-            message: 'Seed not found for default wallet ',
-            error: e,
-            trace: StackTrace.current,
-          );
-          rethrow;
-        }
-      }
+      // Check all seeds in parallel to avoid sequential keychain reads
+      // blocking the UI thread
+      await Future.wait(
+        defaultWallets.map((wallet) async {
+          try {
+            await _seedRepository.get(wallet.masterFingerprint);
+            log.fine('FINE: Seed Found');
+          } catch (e) {
+            log.severe(
+              message: 'Seed not found for default wallet ',
+              error: e,
+              trace: StackTrace.current,
+            );
+            rethrow;
+          }
+        }),
+      );
       return true;
     } else {
       log.fine('No default wallets found');


### PR DESCRIPTION
Various small optimisations were done regarding startup loading. 

The most important that solves the freezing of the spinning loader on the splash screen is the following:

- Moved toEntity() crypto (PBKDF2 + bip32) to background isolate so it never blocks the UI thread 

Two other small optimisations that slightly improve the startup loading time were included as well:

- Parallelized seed checks in CheckForExistingDefaultWalletsUsecase using Future.wait instead of sequential loop
- Fixed double PBKDF2 derivation in SeedModel.toEntity() — bytes and masterFingerprint getters each independently ran the full derivation