### PR TITLE
fix: import mnemonic passphrase and label input keyboard lag

### DIFF
--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -189,7 +189,7 @@ class MnemonicWord extends StatefulWidget {
 }
 
 class MnemonicWordState extends State<MnemonicWord> {
-  final _controller = TextEditingController();
+  late final _controller = TextEditingController(text: widget.word);
 
   String get displayIndex {
     final displayIndex = widget.index + 1;
@@ -197,9 +197,22 @@ class MnemonicWordState extends State<MnemonicWord> {
   }
 
   @override
+  void didUpdateWidget(MnemonicWord oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.word != widget.word && _controller.text != widget.word) {
+      _controller.text = widget.word;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isValidWord = widget.language.isValid(widget.word);
-    _controller.text = widget.word;
 
     return Container(
       padding: const EdgeInsets.all(3),
@@ -362,7 +375,9 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
       (word) => word.startsWith(widget.words[_focusedDisplayIndex]),
     );
 
-    if (widget.allowAutoFillWords && hints.length == 1) {
+    if (widget.allowAutoFillWords &&
+        hints.length == 1 &&
+        hints.first != widget.words[_focusedDisplayIndex]) {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => _onHintTap(hints.first),
       );

--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -189,7 +189,13 @@ class MnemonicWord extends StatefulWidget {
 }
 
 class MnemonicWordState extends State<MnemonicWord> {
-  late final _controller = TextEditingController(text: widget.word);
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.word;
+  }
 
   String get displayIndex {
     final displayIndex = widget.index + 1;


### PR DESCRIPTION
Fixes: #1867 (Keyboard Lag Issue on Wallet Import Screen)

- addPostFrameCallback guard (hints.first != widget.words[_focusedDisplayIndex])

When you finish typing a word and there's only one possible match, autofill fires: it schedules _onHintTap which sets the word and moves focus to the next field. That's the intended behaviour. But once all 12 words are complete and focus is still on the last word, hints always has exactly one match: the word that's already there. The old code scheduled _onHintTap unconditionally, which called onWordChanged -> parent setState -> rebuild -> scheduled _onHintTap again -> infinite loop. The guard breaks this: if the word is already set to the only matching hint, there's nothing to autofill, so don't schedule the callback.

- Controller text in didUpdateWidget instead of build()

_controller.text = widget.word was being called on every build(). TextEditingController's text setter calls notifyListeners(), which tells Android the text input has changed. With 12 word fields all doing this during a single rebuild, Android tries to reinitialize the IME 12 times - roughly 80ms each - adding up to 1 second of lag. Moving it to didUpdateWidget with a change check means the controller only notifies when the word actually changes for ex via autofill, not on every rebuild.