### PR TITLE
fix: dont dismiss auth webview before email is verified during sign-up

### DIFF
--- a/lib/features/exchange/ui/screens/exchange_auth_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_auth_screen.dart
@@ -115,6 +115,15 @@ class _ExchangeAuthScreenState extends State<ExchangeAuthScreen> {
             final url = change.url;
             if (url == null) return;
 
+            // During sign-up, the bb_session cookie is set before email
+            // verification. Skip processing on these paths so the WebView
+            // stays open and the user can complete email verification. Once
+            // done, the auth app navigates away and the API key is generated
+            // on the next URL change.
+            if (url.contains('/registration') || url.contains('/verification')) {
+              return;
+            }
+
             // Check if the URL contains the bb_session cookie
             final bbSessionCookie = await _tryGetBBSessionCookie(change.url!);
             // If no bb_session cookie is found, do nothing as the user is not


### PR DESCRIPTION
fixes https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1487

During sign-up, the bb_session cookie is set before email verification is complete. Skip API key generation on /registration and /verification paths so the auth WebView stays open and the user can verify their email naturally. Once verified, the auth app navigates away and the normal login flow proceeds, so the KYC screen no longer prompts for email verification again

I was looking for any /kyc/\<route\> that would allow users to go to the verification code entry page directly, but such a subroute doesn't exist. 

Kiran mentioned in BB-Exchange issue 733 that he "verified the latest fix on 05 on mobile browser, now observing verify email code directly", but that's because after signing up, the next page is the email verification page. So I used that same flow here as well. Let user verify email in the sign up flow before the API key is set