### PR TITLE
fix: prevent same wallet selection in transfer dropdowns and add swap/flip button

### DIFF
--- a/lib/core/widgets/dropdown/bb_dropdown.dart
+++ b/lib/core/widgets/dropdown/bb_dropdown.dart
@@ -43,6 +43,7 @@ class BBDropdown<T> extends StatelessWidget {
             items: items.map((item) {
               return DropdownMenuItem<T>(
                 value: item.value,
+                enabled: item.enabled,
                 child: Container(
                   width: double.infinity,
                   alignment: Alignment.centerLeft,

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -242,23 +242,29 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
       return;
     }
 
-    if (newFromWallet.isLiquid == newToWallet.isLiquid) {
-      if (newFromWallet.isLiquid) {
-        return;
-      }
-    } else {
-      final isFromWalletChanged = newFromWallet != state.fromWallet;
-      if (isFromWalletChanged && newFromWallet.isLiquid) {
-        final bitcoinWallets = state.wallets.where((w) => !w.isLiquid).toList();
-        if (bitcoinWallets.isNotEmpty) {
-          newToWallet = bitcoinWallets.first;
+    final isSwap = newFromWallet.id == state.toWallet?.id &&
+        newToWallet.id == state.fromWallet?.id;
+
+    if (!isSwap) {
+      if (newFromWallet.isLiquid == newToWallet.isLiquid) {
+        if (newFromWallet.isLiquid) {
+          return;
         }
-      } else if (!isFromWalletChanged && newToWallet.isLiquid) {
-        final bitcoinWallets = state.wallets
-            .where((w) => !w.isLiquid && w.signsLocally)
-            .toList();
-        if (bitcoinWallets.isNotEmpty) {
-          newFromWallet = bitcoinWallets.first;
+      } else {
+        final isFromWalletChanged = newFromWallet != state.fromWallet;
+        if (isFromWalletChanged && newFromWallet.isLiquid) {
+          final bitcoinWallets =
+              state.wallets.where((w) => !w.isLiquid).toList();
+          if (bitcoinWallets.isNotEmpty) {
+            newToWallet = bitcoinWallets.first;
+          }
+        } else if (!isFromWalletChanged && newToWallet.isLiquid) {
+          final bitcoinWallets = state.wallets
+              .where((w) => !w.isLiquid && w.signsLocally)
+              .toList();
+          if (bitcoinWallets.isNotEmpty) {
+            newFromWallet = bitcoinWallets.first;
+          }
         }
       }
     }

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/errors/send_errors.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
@@ -146,15 +147,49 @@ class SwapPageState extends State<SwapPage> {
                   ),
                   const Gap(12),
                   const SwapFromWalletDropdown(),
-                  const Gap(12),
                   BlocSelector<TransferBloc, TransferState, bool>(
                     selector: (state) => state.sendToExternal,
                     builder: (context, sendToExternal) {
                       if (sendToExternal) {
-                        return const SwapExternalAddressInput();
-                      } else {
-                        return const SwapToWalletDropdown();
+                        return const Column(
+                          children: [Gap(12), SwapExternalAddressInput()],
+                        );
                       }
+                      return BlocSelector<
+                        TransferBloc,
+                        TransferState,
+                        (Wallet?, Wallet?)
+                      >(
+                        selector: (state) => (state.fromWallet, state.toWallet),
+                        builder: (context, wallets) {
+                          final (fromWallet, toWallet) = wallets;
+                          return Column(
+                            children: [
+                              Align(
+                                alignment: Alignment.centerRight,
+                                child: IconButton(
+                                  icon: Icon(
+                                    Icons.swap_vert,
+                                    color: context.appColors.primary,
+                                  ),
+                                  onPressed:
+                                      fromWallet != null && toWallet != null
+                                      ? () {
+                                          context.read<TransferBloc>().add(
+                                            TransferEvent.walletsChanged(
+                                              fromWallet: toWallet,
+                                              toWallet: fromWallet,
+                                            ),
+                                          );
+                                        }
+                                      : null,
+                                ),
+                              ),
+                              const SwapToWalletDropdown(),
+                            ],
+                          );
+                        },
+                      );
                     },
                   ),
                   const Gap(12),
@@ -185,7 +220,9 @@ class SwapPageState extends State<SwapPage> {
                     },
                   ),
                   BlocSelector<TransferBloc, TransferState, bool>(
-                    selector: (state) => state.shouldShowAdvancedOptions && !state.isSameChainTransfer,
+                    selector: (state) =>
+                        state.shouldShowAdvancedOptions &&
+                        !state.isSameChainTransfer,
                     builder: (context, showReceiveExactAmount) {
                       if (!showReceiveExactAmount) {
                         return const SizedBox.shrink();
@@ -201,7 +238,9 @@ class SwapPageState extends State<SwapPage> {
                                 builder: (context, receiveExactAmount) {
                                   return Text(
                                     receiveExactAmount
-                                        ? context.loc.swapReceiveExactAmountLabel
+                                        ? context
+                                              .loc
+                                              .swapReceiveExactAmountLabel
                                         : context.loc.swapSubtractFeesLabel,
                                     style: context.font.bodyLarge,
                                   );
@@ -214,7 +253,9 @@ class SwapPageState extends State<SwapPage> {
                                     value: receiveExactAmount,
                                     onChanged: (value) {
                                       context.read<TransferBloc>().add(
-                                        TransferEvent.receiveExactAmountToggled(value),
+                                        TransferEvent.receiveExactAmountToggled(
+                                          value,
+                                        ),
                                       );
                                     },
                                   );

--- a/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
@@ -17,6 +17,7 @@ class SwapFromWalletDropdown extends StatelessWidget {
     final selected = context.select(
       (TransferBloc bloc) => bloc.state.fromWallet,
     );
+    final toWallet = context.select((TransferBloc bloc) => bloc.state.toWallet);
     return Column(
       crossAxisAlignment: .start,
       children: [
@@ -26,27 +27,38 @@ class SwapFromWalletDropdown extends StatelessWidget {
           const LoadingLineContent()
         else
           BBDropdown<Wallet>(
-            items: wallets
-                .where((wallet) => wallet.signsLocally)
-                .map(
-                  (wallet) => DropdownMenuItem(
-                    value: wallet,
-                    child: Row(
-                      children: [
-                        Image.asset(
-                          wallet.isLiquid
-                              ? 'assets/logos/liquid.png'
-                              : 'assets/logos/bitcoin.png',
-                          width: 20,
-                          height: 20,
+            items:
+                [
+                      ...wallets.where(
+                        (w) => w.signsLocally && w.id != toWallet?.id,
+                      ),
+                      ...wallets.where(
+                        (w) => w.signsLocally && w.id == toWallet?.id,
+                      ),
+                    ]
+                    .map(
+                      (wallet) => DropdownMenuItem(
+                        value: wallet,
+                        enabled: wallet.id != toWallet?.id,
+                        child: Opacity(
+                          opacity: wallet.id != toWallet?.id ? 1.0 : 0.4,
+                          child: Row(
+                            children: [
+                              Image.asset(
+                                wallet.isLiquid
+                                    ? 'assets/logos/liquid.png'
+                                    : 'assets/logos/bitcoin.png',
+                                width: 20,
+                                height: 20,
+                              ),
+                              const Gap(8),
+                              Text(wallet.displayLabel(context)),
+                            ],
+                          ),
                         ),
-                        const Gap(8),
-                        Text(wallet.displayLabel(context)),
-                      ],
-                    ),
-                  ),
-                )
-                .toList(),
+                      ),
+                    )
+                    .toList(),
             value: selected,
             validator: (value) {
               if (value == null) {

--- a/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
@@ -15,6 +15,9 @@ class SwapToWalletDropdown extends StatelessWidget {
   Widget build(BuildContext context) {
     final wallets = context.select((TransferBloc bloc) => bloc.state.wallets);
     final selected = context.select((TransferBloc bloc) => bloc.state.toWallet);
+    final fromWallet = context.select(
+      (TransferBloc bloc) => bloc.state.fromWallet,
+    );
 
     return Column(
       crossAxisAlignment: .start,
@@ -25,26 +28,34 @@ class SwapToWalletDropdown extends StatelessWidget {
           const LoadingLineContent()
         else
           BBDropdown<Wallet>(
-            items: wallets
-                .map(
-                  (wallet) => DropdownMenuItem(
-                    value: wallet,
-                    child: Row(
-                      children: [
-                        Image.asset(
-                          wallet.isLiquid
-                              ? 'assets/logos/liquid.png'
-                              : 'assets/logos/bitcoin.png',
-                          width: 20,
-                          height: 20,
+            items:
+                [
+                      ...wallets.where((w) => w.id != fromWallet?.id),
+                      ...wallets.where((w) => w.id == fromWallet?.id),
+                    ]
+                    .map(
+                      (wallet) => DropdownMenuItem(
+                        value: wallet,
+                        enabled: wallet.id != fromWallet?.id,
+                        child: Opacity(
+                          opacity: wallet.id != fromWallet?.id ? 1.0 : 0.4,
+                          child: Row(
+                            children: [
+                              Image.asset(
+                                wallet.isLiquid
+                                    ? 'assets/logos/liquid.png'
+                                    : 'assets/logos/bitcoin.png',
+                                width: 20,
+                                height: 20,
+                              ),
+                              const Gap(8),
+                              Text(wallet.displayLabel(context)),
+                            ],
+                          ),
                         ),
-                        const Gap(8),
-                        Text(wallet.displayLabel(context)),
-                      ],
-                    ),
-                  ),
-                )
-                .toList(),
+                      ),
+                    )
+                    .toList(),
             value: selected,
             validator: (value) {
               if (value == null) {


### PR DESCRIPTION
Fixes #1939 

This PR

- disables and greys out the opposite wallet in from/to dropdowns
- sort disabled items to the bottom of each dropdown
- add swap/switch button between the from and to dropdowns
- fix wallet swap state corruption by detecting direct wallet swap in _onWalletsChanged

The transfer screen has a few pre-existing issues and a couple of new ones introduced by my changes

Pre-existing

- The Internal/External Transfer toggle also toggles the toggle below (Subtract fees from amount / Receive exact amount)
- Hardware wallets are hidden from the "from" dropdown. Probably done purposefully but the transfer page works identical to a send flow with/without swaps, so I don't understand why it was done this way
- I don't really get why External Transfer as it's implemented today. the "to" external address can be a Liquid address if the "from" is a Bitcoin wallet and vice versa, but "to" can be Secure Bitcoin and "from" can be another imported Bitcoin wallet when it's an internal transfer, so why disallow it in the external transfer flow?

New issues I introduced in this PR

- Instant Payments wallet is selected in "from" by default which means Secure Bitcoin is selected by default in "to" and it's greyed out in the "from" dropdown list. If a user wants to do the opposite, they'll have to click the swap/flip button, which is not very intuitive. We should instead probably keep the "to" option empty initially, and display all the from dropdown options, and once one is chosen, collapse it and give the option to choose the "to"

Issue my code introduced, but I haven't addressed yet

- Toggling it to be an external transfer still keeps some wallets greyed out from the "from" dropdown menu. The state should be cleared