### PR TITLE
fix: use correct electrum URLs for testnet swaps

### DIFF
--- a/lib/core/swaps/domain/usecases/auto_swap_execution_usecase.dart
+++ b/lib/core/swaps/domain/usecases/auto_swap_execution_usecase.dart
@@ -132,11 +132,11 @@ class AutoSwapExecutionUsecase {
             as MnemonicSeed;
 
     final btcElectrumUrl = defaultBitcoinWallet.isTestnet
-        ? ApiServiceConstants.bbElectrumTestUrl
+        ? ApiServiceConstants.publicElectrumTestUrl
         : ApiServiceConstants.bbElectrumUrl;
 
     final lbtcElectrumUrl = defaultLiquidWallet.isTestnet
-        ? ApiServiceConstants.publicElectrumTestUrl
+        ? ApiServiceConstants.publicliquidElectrumTestUrlPath
         : ApiServiceConstants.bbLiquidElectrumUrlPath;
 
     debugPrint(

--- a/lib/core/swaps/domain/usecases/create_chain_swap_to_external_usecase.dart
+++ b/lib/core/swaps/domain/usecases/create_chain_swap_to_external_usecase.dart
@@ -43,12 +43,12 @@ class CreateChainSwapToExternalUsecase {
 
       final btcElectrumUrl =
           sendWallet.network.isTestnet
-              ? ApiServiceConstants.bbElectrumTestUrl
+              ? ApiServiceConstants.publicElectrumTestUrl
               : ApiServiceConstants.bbElectrumUrl;
 
       final lbtcElectrumUrl =
           sendWallet.network.isTestnet
-              ? ApiServiceConstants.publicElectrumTestUrl
+              ? ApiServiceConstants.publicliquidElectrumTestUrlPath
               : ApiServiceConstants.bbLiquidElectrumUrlPath;
 
       switch (type) {

--- a/lib/core/swaps/domain/usecases/create_chain_swap_usecase.dart
+++ b/lib/core/swaps/domain/usecases/create_chain_swap_usecase.dart
@@ -55,12 +55,12 @@ class CreateChainSwapUsecase {
 
       final btcElectrumUrl =
           bitcoinWallet.network.isTestnet
-              ? ApiServiceConstants.bbElectrumTestUrl
+              ? ApiServiceConstants.publicElectrumTestUrl
               : ApiServiceConstants.bbElectrumUrl;
 
       final lbtcElectrumUrl =
           liquidWallet.network.isTestnet
-              ? ApiServiceConstants.publicElectrumTestUrl
+              ? ApiServiceConstants.publicliquidElectrumTestUrlPath
               : ApiServiceConstants.bbLiquidElectrumUrlPath;
 
       switch (type) {

--- a/lib/features/receive/domain/usecases/create_receive_swap_use_case.dart
+++ b/lib/features/receive/domain/usecases/create_receive_swap_use_case.dart
@@ -69,11 +69,11 @@ class CreateReceiveSwapUsecase {
       }
 
       final btcElectrumUrl = wallet.network.isTestnet
-          ? ApiServiceConstants.bbElectrumTestUrl
+          ? ApiServiceConstants.publicElectrumTestUrl
           : ApiServiceConstants.bbElectrumUrl;
 
       final lbtcElectrumUrl = wallet.network.isTestnet
-          ? ApiServiceConstants.publicElectrumTestUrl
+          ? ApiServiceConstants.publicliquidElectrumTestUrlPath
           : ApiServiceConstants.bbLiquidElectrumUrlPath;
 
       final claimAddress = await _getReceiveAddressUsecase.execute(

--- a/lib/features/send/domain/usecases/create_send_swap_usecase.dart
+++ b/lib/features/send/domain/usecases/create_send_swap_usecase.dart
@@ -72,12 +72,12 @@ class CreateSendSwapUsecase {
 
       final btcElectrumUrl =
           wallet.network.isTestnet
-              ? ApiServiceConstants.bbElectrumTestUrl
+              ? ApiServiceConstants.publicElectrumTestUrl
               : ApiServiceConstants.bbElectrumUrl;
 
       final lbtcElectrumUrl =
           wallet.network.isTestnet
-              ? ApiServiceConstants.publicElectrumTestUrl
+              ? ApiServiceConstants.publicliquidElectrumTestUrlPath
               : ApiServiceConstants.bbLiquidElectrumUrlPath;
 
       switch (type) {


### PR DESCRIPTION
Fixes #1938 

All swap creation usecases were using the wrong URLs:

| Variable | Wrong | Correct |
|---|---|---|
| btcElectrumUrl | bbElectrumTestUrl (wes.bullbitcoin.com:60002) | publicElectrumTestUrl (ssl://blockstream.info:993) |
| lbtcElectrumUrl | publicElectrumTestUrl (ssl://blockstream.info:993) | publicliquidElectrumTestUrlPath (blockstream.info:465) |

Since these URLs are baked into the swap object at creation time, this caused all testnet swap claims and refunds to fail with connection errors