### PR TITLE
Swap wallet autoselect

### DIFF
--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -242,23 +242,55 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
       return;
     }
 
-    if (newFromWallet.isLiquid == newToWallet.isLiquid) {
-      if (newFromWallet.isLiquid) {
-        return;
-      }
-    } else {
-      final isFromWalletChanged = newFromWallet != state.fromWallet;
-      if (isFromWalletChanged && newFromWallet.isLiquid) {
-        final bitcoinWallets = state.wallets.where((w) => !w.isLiquid).toList();
-        if (bitcoinWallets.isNotEmpty) {
-          newToWallet = bitcoinWallets.first;
+    final isFromWalletChanged = newFromWallet != state.fromWallet;
+
+    // Prevent selecting the same wallet for both from and to
+    if (newFromWallet.id == newToWallet.id) {
+      if (isFromWalletChanged) {
+        final opposite = state.wallets
+            .where((w) => w.isLiquid != newFromWallet.isLiquid && w.isDefault)
+            .firstOrNull;
+        if (opposite != null) {
+          newToWallet = opposite;
+        } else {
+          return;
         }
-      } else if (!isFromWalletChanged && newToWallet.isLiquid) {
-        final bitcoinWallets = state.wallets
-            .where((w) => !w.isLiquid && w.signsLocally)
-            .toList();
-        if (bitcoinWallets.isNotEmpty) {
-          newFromWallet = bitcoinWallets.first;
+      } else {
+        final opposite = state.wallets
+            .where(
+              (w) =>
+                  w.isLiquid != newToWallet.isLiquid &&
+                  w.isDefault &&
+                  w.signsLocally,
+            )
+            .firstOrNull;
+        if (opposite != null) {
+          newFromWallet = opposite;
+        } else {
+          return;
+        }
+      }
+    }
+
+    // Prevent Liquid-to-Liquid transfers (not supported)
+    if (newFromWallet.isLiquid && newToWallet.isLiquid) {
+      if (isFromWalletChanged) {
+        final btcWallet = state.wallets
+            .where((w) => !w.isLiquid && w.isDefault)
+            .firstOrNull;
+        if (btcWallet != null) {
+          newToWallet = btcWallet;
+        } else {
+          return;
+        }
+      } else {
+        final btcWallet = state.wallets
+            .where((w) => !w.isLiquid && w.isDefault && w.signsLocally)
+            .firstOrNull;
+        if (btcWallet != null) {
+          newFromWallet = btcWallet;
+        } else {
+          return;
         }
       }
     }

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/errors/send_errors.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
@@ -146,15 +147,53 @@ class SwapPageState extends State<SwapPage> {
                   ),
                   const Gap(12),
                   const SwapFromWalletDropdown(),
-                  const Gap(12),
                   BlocSelector<TransferBloc, TransferState, bool>(
                     selector: (state) => state.sendToExternal,
                     builder: (context, sendToExternal) {
                       if (sendToExternal) {
-                        return const SwapExternalAddressInput();
-                      } else {
-                        return const SwapToWalletDropdown();
+                        return const Column(
+                          children: [Gap(12), SwapExternalAddressInput()],
+                        );
                       }
+                      return BlocSelector<
+                        TransferBloc,
+                        TransferState,
+                        (Wallet?, Wallet?)
+                      >(
+                        selector: (state) =>
+                            (state.fromWallet, state.toWallet),
+                        builder: (context, wallets) {
+                          final (fromWallet, toWallet) = wallets;
+                          return Column(
+                            children: [
+                              Align(
+                                alignment: Alignment.centerRight,
+                                child: IconButton(
+                                  icon: Icon(
+                                    Icons.swap_vert,
+                                    color: context.appColors.primary,
+                                  ),
+                                  onPressed:
+                                      fromWallet != null && toWallet != null
+                                          ? () {
+                                              context
+                                                  .read<TransferBloc>()
+                                                  .add(
+                                                    TransferEvent
+                                                        .walletsChanged(
+                                                      fromWallet: toWallet,
+                                                      toWallet: fromWallet,
+                                                    ),
+                                                  );
+                                            }
+                                          : null,
+                                ),
+                              ),
+                              const SwapToWalletDropdown(),
+                            ],
+                          );
+                        },
+                      );
                     },
                   ),
                   const Gap(12),

--- a/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
@@ -58,26 +58,6 @@ class SwapFromWalletDropdown extends StatelessWidget {
               if (value != null) {
                 final bloc = context.read<TransferBloc>();
                 final currentToWallet = bloc.state.toWallet;
-
-                // If Liquid wallet selected in From, ensure To is Bitcoin
-                if (value.isLiquid &&
-                    currentToWallet != null &&
-                    currentToWallet.isLiquid) {
-                  // Find Secure Bitcoin (default Bitcoin wallet)
-                  final secureBitcoin = wallets
-                      .where((w) => !w.isLiquid && w.isDefault)
-                      .firstOrNull;
-                  if (secureBitcoin != null) {
-                    bloc.add(
-                      TransferWalletsChanged(
-                        fromWallet: value,
-                        toWallet: secureBitcoin,
-                      ),
-                    );
-                    return;
-                  }
-                }
-
                 if (currentToWallet != null) {
                   bloc.add(
                     TransferWalletsChanged(

--- a/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
@@ -56,26 +56,6 @@ class SwapToWalletDropdown extends StatelessWidget {
               if (value != null) {
                 final bloc = context.read<TransferBloc>();
                 final currentFromWallet = bloc.state.fromWallet;
-
-                // If Liquid wallet selected in To, ensure From is Bitcoin
-                if (value.isLiquid &&
-                    currentFromWallet != null &&
-                    currentFromWallet.isLiquid) {
-                  // Find Secure Bitcoin (default Bitcoin wallet)
-                  final secureBitcoin = wallets
-                      .where((w) => !w.isLiquid && w.isDefault)
-                      .firstOrNull;
-                  if (secureBitcoin != null) {
-                    bloc.add(
-                      TransferWalletsChanged(
-                        fromWallet: secureBitcoin,
-                        toWallet: value,
-                      ),
-                    );
-                    return;
-                  }
-                }
-
                 if (currentFromWallet != null) {
                   bloc.add(
                     TransferWalletsChanged(


### PR DESCRIPTION
## Summary
- Prevent selecting the same wallet for both from and to in the transfer/swap screen — auto-switches to the default wallet on the opposite chain
- Prevent Liquid-to-Liquid transfers (not supported) — auto-switches to a Bitcoin wallet
- Bitcoin-to-Bitcoin transfers between different wallets remain allowed
- Move wallet selection logic from dropdown widgets into the bloc (single source of truth)
- Add swap/flip button between from and to wallet dropdowns

## Test plan
- [x] Open transfer/swap screen
- [x] Select the same wallet in both from and to — verify the other auto-switches to opposite chain
- [x] Select two Liquid wallets — verify one auto-switches to Bitcoin
- [x] Select two different Bitcoin wallets — verify this is allowed
- [x] Tap the swap button between dropdowns — verify from and to wallets flip
- [x] Verify swap button is disabled when wallets are loading