### PR TITLE
Fixes throwing AppInitScreen for unhandled errors during app lifecycle

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -103,7 +103,6 @@ PODS:
   - permission_handler_apple (9.3.0):
     - Flutter
   - PromisesObjC (2.4.0)
-  - ScreenProtectorKit (1.3.1)
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -288,7 +287,6 @@ SPEC CHECKSUMS:
   payjoin_flutter: 6397d7b698cdad6453be4949ab6aca1863f6c5e5
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  ScreenProtectorKit: 83a6281b02c7a5902ee6eac4f5045f674e902ae4
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
   sentry_flutter: 841fa2fe08dc72eb95e2320b76e3f751f3400cf5

--- a/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
+++ b/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
@@ -119,7 +119,6 @@ class ExchangeNotificationDatasource {
         trace: StackTrace.current,
       );
       _handleDisconnect();
-      rethrow;
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,34 +109,49 @@ Future main() async {
   // Incase we error in the zoneGuarded block, we need to share logs on the error page.
   await Bull.initLogs();
 
-  await runZonedGuarded(
-    () async {
-      // Initialize the background tasks before anything else
-      await Workmanager().initialize(backgroundTasksHandler);
-      await Workmanager().cancelAll();
+  // Startup phase: errors here show the AppInitErrorScreen since the app
+  // cannot function without successful initialization.
+  try {
+    await Workmanager().initialize(backgroundTasksHandler);
+    await Workmanager().cancelAll();
 
-      await Bull.init();
+    await Bull.init();
 
-      await Workmanager().registerPeriodicTask(
-        BackgroundTask.logsPrune.id,
-        BackgroundTask.logsPrune.name,
-        frequency: const Duration(minutes: 15),
-        constraints: Constraints(
-          networkType: NetworkType.connected,
-          requiresBatteryNotLow: true,
-          requiresStorageNotLow: false,
-          requiresDeviceIdle: false,
-          requiresCharging: false,
-        ),
-      );
+    await Workmanager().registerPeriodicTask(
+      BackgroundTask.logsPrune.id,
+      BackgroundTask.logsPrune.name,
+      frequency: const Duration(minutes: 15),
+      constraints: Constraints(
+        networkType: NetworkType.connected,
+        requiresBatteryNotLow: true,
+        requiresStorageNotLow: false,
+        requiresDeviceIdle: false,
+        requiresCharging: false,
+      ),
+    );
+  } catch (error, stackTrace) {
+    log.severe(error: error, trace: stackTrace);
+    runApp(AppInitErrorScreen(error: error));
+    return;
+  }
 
-      runApp(const BullBitcoinWalletApp());
-    },
-    (error, stackTrace) async {
-      log.severe(error: error, trace: stackTrace);
-      runApp(AppInitErrorScreen(error: error));
-    },
-  );
+  FlutterError.onError = (details) {
+    log.severe(
+      message: 'Global Unhandled Error',
+      error: details.exception,
+      trace: details.stack ?? StackTrace.current,
+    );
+  };
+  PlatformDispatcher.instance.onError = (error, stackTrace) {
+    log.severe(
+      message: 'Global Unhandled Error',
+      error: error,
+      trace: stackTrace,
+    );
+    return true;
+  };
+
+  runApp(const BullBitcoinWalletApp());
 }
 
 class BullBitcoinWalletApp extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,13 +38,13 @@ import 'package:workmanager/workmanager.dart';
 
 class Bull {
   static Future<void> init() async {
+    await initLogs();
     await initFlutterRustBridgeDependencies();
-
     // The Locator setup might depend on the initialization of the libraries above
     //  so it's important to call it after the initialization
     await initLocator();
-
     await initErrorReporting();
+    await initWorkmanager();
   }
 
   static Future<void> initFlutterRustBridgeDependencies() async {
@@ -70,6 +70,22 @@ class Bull {
   static Future<void> initLocator() async {
     await AppLocator.setup(locator, SqliteDatabase());
     Bloc.observer = AppBlocObserver();
+  }
+
+  static Future<void> initWorkmanager() async {
+    await Workmanager().initialize(backgroundTasksHandler);
+    await Workmanager().cancelAll();
+    await Workmanager().registerPeriodicTask(
+      BackgroundTask.logsPrune.id,
+      BackgroundTask.logsPrune.name,
+      frequency: const Duration(minutes: 15),
+      constraints: Constraints(
+        requiresBatteryNotLow: true,
+        requiresStorageNotLow: false,
+        requiresDeviceIdle: false,
+        requiresCharging: false,
+      ),
+    );
   }
 
   static Future<void> initErrorReporting() async {
@@ -104,54 +120,26 @@ class Bull {
 }
 
 Future main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  // Should be initialized outside zone guarded
-  // Incase we error in the zoneGuarded block, we need to share logs on the error page.
-  await Bull.initLogs();
-
-  // Startup phase: errors here show the AppInitErrorScreen since the app
-  // cannot function without successful initialization.
-  try {
-    await Workmanager().initialize(backgroundTasksHandler);
-    await Workmanager().cancelAll();
-
-    await Bull.init();
-
-    await Workmanager().registerPeriodicTask(
-      BackgroundTask.logsPrune.id,
-      BackgroundTask.logsPrune.name,
-      frequency: const Duration(minutes: 15),
-      constraints: Constraints(
-        networkType: NetworkType.connected,
-        requiresBatteryNotLow: true,
-        requiresStorageNotLow: false,
-        requiresDeviceIdle: false,
-        requiresCharging: false,
-      ),
-    );
-  } catch (error, stackTrace) {
-    log.severe(error: error, trace: stackTrace);
-    runApp(AppInitErrorScreen(error: error));
-    return;
-  }
-
-  FlutterError.onError = (details) {
-    log.severe(
-      message: 'Global Unhandled Error',
-      error: details.exception,
-      trace: details.stack ?? StackTrace.current,
-    );
-  };
-  PlatformDispatcher.instance.onError = (error, stackTrace) {
-    log.severe(
-      message: 'Global Unhandled Error',
-      error: error,
-      trace: stackTrace,
-    );
-    return true;
-  };
-
-  runApp(const BullBitcoinWalletApp());
+  await runZonedGuarded(
+    () async {
+      try {
+        WidgetsFlutterBinding.ensureInitialized();
+        await Bull.init();
+      } catch (error, stackTrace) {
+        log.severe(error: error, trace: stackTrace);
+        runApp(AppInitErrorScreen(error: error));
+        return;
+      }
+      runApp(const BullBitcoinWalletApp());
+    },
+    (error, stackTrace) {
+      log.severe(
+        message: 'Global Unhandled Error',
+        error: error,
+        trace: stackTrace,
+      );
+    },
+  );
 }
 
 class BullBitcoinWalletApp extends StatefulWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -346,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1281,18 +1281,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -1873,26 +1873,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
Since runApp(BullBitcoinWalletApp) was inside the try block that had the catch with AppInitErrorScreen; the AppInitErrorScreen was being thrown for any unhandled error in the app. The main runApp is now outside this block and global error handlers are added to log as severe errors. 