### PR TITLE
add .debug suffix to application id for debug builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,10 +56,10 @@ android {
 
     signingConfigs {
         debug {
-            storeFile file("debug.keystore")
-            storePassword "android"
             keyAlias "androiddebugkey"
             keyPassword "android"
+            storeFile file("debug.keystore")
+            storePassword "android"
         }
         release {
             keyAlias keystoreProperties['keyAlias']
@@ -74,6 +74,7 @@ android {
             minifyEnabled false
             shrinkResources false
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".debug"
         }
         release {        
             minifyEnabled false


### PR DESCRIPTION
Fixes issue #1950 (Setup Flutter flavours)

Instead of setting up Flutter flavours using productFlavors like the issue suggested which will produce 4 different build variants (`debug x dev`, `debug x prod`, `release x dev`, `release x prod`), which doesn't really make sense, this PR has a simpler solution of just adding a .debug suffix to the applicationId when the app is in debug mode

This still allows anyone to have the release and debug builds as two different apps on their phone for example

The other changes to `signingConfigs` are just cosmetic (moves some lines around)