### PR TITLE
Fix Show Address Only switch overflow in receive

### DIFF
--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -619,11 +619,18 @@ class ReceiveCopyAddress extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16 + 12),
       child: Row(
         children: [
-          BBText(
-            context.loc.receiveCopyAddressOnly,
-            style: context.font.headlineSmall,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: .start,
+              children: [
+                Text(
+                  context.loc.receiveCopyAddressOnly,
+                  style: context.font.headlineSmall,
+                ),
+              ],
+            ),
           ),
-          const Spacer(),
+          const Gap(8),
           Switch(
             value: context.select<ReceiveBloc, bool>(
               (bloc) =>


### PR DESCRIPTION
- Use Expanded for the Text to take up as much space as possible without pushing the Switch out of the boundary
- Use Column so the Text can wrap to the next line if not enough space
- Add a Gap between the Text and Switch so the text is never completely pegged against the switch