### PR TITLE
Create automated script for testing bull bitcoin mobile against payjoin-cli

### DIFF
--- a/integration_test/payjoin_cli_receive_integration_test.dart
+++ b/integration_test/payjoin_cli_receive_integration_test.dart
@@ -1,0 +1,253 @@
+/// End-to-End Interoperability Test: Bull Bitcoin Mobile <-> payjoin-cli
+///
+/// This test verifies that the mobile app's payjoin sender implementation is
+/// spec-compliant and interoperable with payjoin-cli, the reference
+/// implementation from the rust-payjoin project.
+///
+/// This test is NOT run directly — it is orchestrated by a shell script that
+/// starts payjoin-cli and passes the BIP21 pjURI to this test via an env var:
+///
+///   scripts/payjoin_cli_receive_test.sh
+///
+/// Scenario: payjoin-cli as RECEIVER, mobile as SENDER
+///
+///   1. payjoin-cli `receive <sats>` is started by the script, which prints the
+///      BIP21 pjURI and long-polls the directory for a request.
+///   2. This test reads the pjURI from PJ_BIP21_URI, builds a PSBT with the
+///      mobile wallet, and starts a mobile sender session.
+///   3. payjoin-cli picks up the request, processes it, and posts a proposal
+///      back to the directory.
+///   4. The mobile sender polls, picks up the proposal, signs and broadcasts
+///      the final tx, reaching PayjoinStatus.completed.
+///
+/// Prerequisites:
+///   - Mobile wallet funded with testnet3 tBTC (TEST_ALICE_MNEMONIC in .env)
+///   - payjoin-cli receiver already running (managed by the shell script)
+///
+/// Environment variables:
+///   TEST_ALICE_MNEMONIC   Mobile wallet mnemonic (needs testnet3 tBTC)
+///   PJ_BIP21_URI          BIP21 pjURI from payjoin-cli (set by script)
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bb_mobile/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart';
+import 'package:bb_mobile/core/blockchain/domain/ports/electrum_server_port.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/datasources/pdk_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:bb_mobile/main.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:payjoin_flutter/send.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:test/test.dart';
+
+// Compile-time defines passed via --dart-define (required for device-based tests
+// where Platform.environment is unavailable, e.g. Android).
+const _dartDefines = <String, String>{
+  'PJ_BIP21_URI': String.fromEnvironment('PJ_BIP21_URI'),
+  'TEST_ALICE_MNEMONIC': String.fromEnvironment('TEST_ALICE_MNEMONIC'),
+  'TEST_BOB_MNEMONIC': String.fromEnvironment('TEST_BOB_MNEMONIC'),
+  'PAYJOIN_CLI_SEND_AMOUNT_SAT':
+      String.fromEnvironment('PAYJOIN_CLI_SEND_AMOUNT_SAT'),
+};
+
+String _env(String key, {String? fallback}) {
+  final dartVal = _dartDefines[key];
+  final val = (dartVal != null && dartVal.isNotEmpty)
+      ? dartVal
+      : Platform.environment[key] ?? dotenv.env[key];
+  if (val != null && val.isNotEmpty) return val;
+  if (fallback != null) return fallback;
+  throw Exception('Required environment variable $key is not set');
+}
+
+Future<void> main({bool isInitialized = false}) async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  // NOTE: Bull.init() and locator<> calls are deferred to setUpAll() so that
+  // the flutter-test VM "loading" pre-check can call main() on the Linux host
+  // without trying to dlopen libark_wallet.so (which only exists on Android).
+
+  late String mobileWalletMnemonic;
+  late String pjBip21Uri;
+  late int amountSat;
+  const networkFeesSatPerVb = 2.0;
+
+  late WalletRepository walletRepository;
+  late WalletAddressRepository addressRepository;
+  late PayjoinRepository payjoinRepository;
+  late SendWithPayjoinUsecase sendWithPayjoinUsecase;
+  late PrepareBitcoinSendUsecase prepareBitcoinSendUsecase;
+
+  late Wallet mobileWallet;
+
+  setUpAll(() async {
+    if (!isInitialized) await Bull.init();
+
+    mobileWalletMnemonic = _env('TEST_ALICE_MNEMONIC');
+    pjBip21Uri = _env('PJ_BIP21_URI');
+    amountSat =
+        int.parse(_env('PAYJOIN_CLI_SEND_AMOUNT_SAT', fallback: '2000'));
+
+    walletRepository = locator<WalletRepository>();
+    addressRepository = locator<WalletAddressRepository>();
+    payjoinRepository = locator<PayjoinRepository>();
+    sendWithPayjoinUsecase = locator<SendWithPayjoinUsecase>();
+    prepareBitcoinSendUsecase = locator<PrepareBitcoinSendUsecase>();
+
+    await locator<SetEnvironmentUsecase>().execute(Environment.testnet);
+
+    final seed = await locator<SeedRepository>().createFromMnemonic(
+      mnemonicWords: mobileWalletMnemonic.split(' '),
+    );
+    mobileWallet = await walletRepository.createWallet(
+      seed: seed,
+      network: Network.bitcoinTestnet,
+      scriptType: ScriptType.bip84,
+    );
+    debugPrint('[integration] Mobile wallet id: ${mobileWallet.id}');
+  });
+
+  setUp(() async {
+    await walletRepository.getWallets(sync: true);
+    mobileWallet = (await walletRepository.getWallet(mobileWallet.id))!;
+    debugPrint('[integration] Balance: ${mobileWallet.balanceSat} sat');
+  });
+
+  test(
+    'mobile sender can pay to payjoin-cli receiver',
+    () async {
+      if (mobileWallet.balanceSat == BigInt.zero) {
+        final addr = await addressRepository.generateNewReceiveAddress(
+          walletId: mobileWallet.id,
+        );
+        fail(
+          'Mobile wallet has no funds. '
+          'Send testnet3 tBTC to ${addr.address} and retry.',
+        );
+      }
+
+      debugPrint('[integration] Using pjURI: $pjBip21Uri');
+      expect(pjBip21Uri, contains('pj='));
+
+      final parsedUri = Uri.parse(pjBip21Uri);
+      final recipientAddress = parsedUri.path;
+
+      final senderCompletedCompleter = Completer<bool>();
+      final payjoinSub = payjoinRepository.payjoinStream.listen((payjoin) {
+        debugPrint(
+          '[integration] Payjoin event ${payjoin.id}: ${payjoin.status}',
+        );
+        if (payjoin is PayjoinSender &&
+            payjoin.status == PayjoinStatus.completed &&
+            !senderCompletedCompleter.isCompleted) {
+          senderCompletedCompleter.complete(true);
+        }
+      });
+
+      final localDatasource = locator<LocalPayjoinDatasource>();
+      final bitcoinWalletRepository = locator<BitcoinWalletRepository>();
+      final blockchain = locator<BdkBitcoinBlockchainDatasource>();
+      final dio = Dio();
+      const electrumServer = ElectrumServer(
+        url: ApiServiceConstants.publicElectrumTestUrlTwo,
+        priority: 1,
+        retry: 5,
+        timeout: 5,
+        stopGap: 20,
+        validateDomain: true,
+        isCustom: false,
+      );
+
+      try {
+        final preparedSend = await prepareBitcoinSendUsecase.execute(
+          walletId: mobileWallet.id,
+          address: recipientAddress,
+          amountSat: amountSat,
+          networkFee: const NetworkFee.relative(networkFeesSatPerVb),
+          ignoreUnspendableInputs: false,
+        );
+
+        final sender = await sendWithPayjoinUsecase.execute(
+          walletId: mobileWallet.id,
+          isTestnet: mobileWallet.isTestnet,
+          bip21: pjBip21Uri,
+          unsignedOriginalPsbt: preparedSend.unsignedPsbt,
+          amountSat: amountSat,
+          networkFeesSatPerVb: networkFeesSatPerVb,
+        );
+        debugPrint('[integration] Mobile sender created: ${sender.id}');
+        expect(sender.status, PayjoinStatus.requested);
+
+        // --- Step 1: post the original PSBT to the directory ---
+        final senderModel = await localDatasource.fetchSender(sender.id);
+        expect(senderModel, isNotNull, reason: 'Sender model not found in DB');
+        final payjoinSender = Sender.fromJson(json: senderModel!.sender);
+
+        debugPrint('[integration] Posting payjoin request to directory...');
+        final getContext = await PdkPayjoinDatasource.request(
+          sender: payjoinSender,
+          dio: dio,
+        );
+        debugPrint('[integration] Request posted, polling for CLI proposal...');
+
+        // --- Step 2: poll until the CLI receiver posts a proposal ---
+        String? proposalPsbt;
+        for (int i = 0; i < 18; i++) {
+          proposalPsbt = await PdkPayjoinDatasource.getProposalPsbt(
+            context: getContext,
+            dio: dio,
+          );
+          if (proposalPsbt != null) break;
+          debugPrint(
+              '[integration] No proposal yet, retrying (${i + 1}/18)...');
+          await Future.delayed(
+            const Duration(seconds: PayjoinConstants.directoryPollingInterval),
+          );
+        }
+        expect(
+          proposalPsbt,
+          isNotNull,
+          reason: 'CLI did not post a payjoin proposal in time',
+        );
+        debugPrint('[integration] Received CLI proposal, signing...');
+
+        // --- Step 3: sign the proposal PSBT and broadcast ---
+        final signedProposalPsbt = await bitcoinWalletRepository.signPsbt(
+          proposalPsbt!,
+          walletId: mobileWallet.id,
+        );
+        debugPrint('[integration] Proposal signed, broadcasting...');
+
+        final txId = await blockchain.broadcastPsbt(
+          signedProposalPsbt,
+          electrumServer: electrumServer,
+        );
+        debugPrint('[integration] Payjoin tx broadcast: $txId');
+        expect(txId, isNotEmpty, reason: 'Broadcast returned empty txId');
+      } finally {
+        await payjoinSub.cancel();
+        dio.close();
+      }
+    },
+    timeout: const Timeout(
+      Duration(seconds: PayjoinConstants.directoryPollingInterval * 20),
+    ),
+  );
+}

--- a/integration_test/payjoin_cli_receive_integration_test.dart
+++ b/integration_test/payjoin_cli_receive_integration_test.dart
@@ -17,33 +17,29 @@
 ///      mobile wallet, and starts a mobile sender session.
 ///   3. payjoin-cli picks up the request, processes it, and posts a proposal
 ///      back to the directory.
-///   4. The mobile sender polls, picks up the proposal, signs and broadcasts
-///      the final tx, reaching PayjoinStatus.completed.
+///   4. The mobile sender's automatic poll loop picks up the proposal, signs
+///      and broadcasts the final tx, reaching PayjoinStatus.completed.
 ///
 /// Prerequisites:
-///   - Mobile wallet funded with testnet3 tBTC (TEST_ALICE_MNEMONIC in .env)
+///   - Mobile wallet funded with testnet3 tBTC (TEST_ALICE_MNEMONIC)
 ///   - payjoin-cli receiver already running (managed by the shell script)
 ///
-/// Environment variables:
-///   TEST_ALICE_MNEMONIC   Mobile wallet mnemonic (needs testnet3 tBTC)
-///   PJ_BIP21_URI          BIP21 pjURI from payjoin-cli (set by script)
+/// Environment variables (passed via --dart-define / --dart-define-from-file):
+///   TEST_ALICE_MNEMONIC          Mobile wallet mnemonic (needs testnet3 tBTC)
+///   PJ_BIP21_URI                 BIP21 pjURI from payjoin-cli (set by script)
+///   PAYJOIN_CLI_SEND_AMOUNT_SAT  Amount in sat (default: 2000)
 library;
 
 import 'dart:async';
 import 'dart:io';
 
-import 'package:bb_mobile/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart';
-import 'package:bb_mobile/core/blockchain/domain/ports/electrum_server_port.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
-import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
-import 'package:bb_mobile/core/payjoin/data/datasources/pdk_payjoin_datasource.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
@@ -51,19 +47,13 @@ import 'package:bb_mobile/features/send/domain/usecases/prepare_bitcoin_send_use
 import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/main.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:payjoin_flutter/send.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:test/test.dart';
 
-// Compile-time defines passed via --dart-define (required for device-based tests
-// where Platform.environment is unavailable, e.g. Android).
 const _dartDefines = <String, String>{
   'PJ_BIP21_URI': String.fromEnvironment('PJ_BIP21_URI'),
   'TEST_ALICE_MNEMONIC': String.fromEnvironment('TEST_ALICE_MNEMONIC'),
-  'TEST_BOB_MNEMONIC': String.fromEnvironment('TEST_BOB_MNEMONIC'),
   'PAYJOIN_CLI_SEND_AMOUNT_SAT':
       String.fromEnvironment('PAYJOIN_CLI_SEND_AMOUNT_SAT'),
 };
@@ -72,7 +62,7 @@ String _env(String key, {String? fallback}) {
   final dartVal = _dartDefines[key];
   final val = (dartVal != null && dartVal.isNotEmpty)
       ? dartVal
-      : Platform.environment[key] ?? dotenv.env[key];
+      : Platform.environment[key];
   if (val != null && val.isNotEmpty) return val;
   if (fallback != null) return fallback;
   throw Exception('Required environment variable $key is not set');
@@ -80,9 +70,6 @@ String _env(String key, {String? fallback}) {
 
 Future<void> main({bool isInitialized = false}) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  // NOTE: Bull.init() and locator<> calls are deferred to setUpAll() so that
-  // the flutter-test VM "loading" pre-check can call main() on the Linux host
-  // without trying to dlopen libark_wallet.so (which only exists on Android).
 
   late String mobileWalletMnemonic;
   late String pjBip21Uri;
@@ -146,9 +133,6 @@ Future<void> main({bool isInitialized = false}) async {
       debugPrint('[integration] Using pjURI: $pjBip21Uri');
       expect(pjBip21Uri, contains('pj='));
 
-      final parsedUri = Uri.parse(pjBip21Uri);
-      final recipientAddress = parsedUri.path;
-
       final senderCompletedCompleter = Completer<bool>();
       final payjoinSub = payjoinRepository.payjoinStream.listen((payjoin) {
         debugPrint(
@@ -161,24 +145,10 @@ Future<void> main({bool isInitialized = false}) async {
         }
       });
 
-      final localDatasource = locator<LocalPayjoinDatasource>();
-      final bitcoinWalletRepository = locator<BitcoinWalletRepository>();
-      final blockchain = locator<BdkBitcoinBlockchainDatasource>();
-      final dio = Dio();
-      const electrumServer = ElectrumServer(
-        url: ApiServiceConstants.publicElectrumTestUrlTwo,
-        priority: 1,
-        retry: 5,
-        timeout: 5,
-        stopGap: 20,
-        validateDomain: true,
-        isCustom: false,
-      );
-
       try {
         final preparedSend = await prepareBitcoinSendUsecase.execute(
           walletId: mobileWallet.id,
-          address: recipientAddress,
+          address: Uri.parse(pjBip21Uri).path,
           amountSat: amountSat,
           networkFee: const NetworkFee.relative(networkFeesSatPerVb),
           ignoreUnspendableInputs: false,
@@ -195,59 +165,25 @@ Future<void> main({bool isInitialized = false}) async {
         debugPrint('[integration] Mobile sender created: ${sender.id}');
         expect(sender.status, PayjoinStatus.requested);
 
-        // --- Step 1: post the original PSBT to the directory ---
-        final senderModel = await localDatasource.fetchSender(sender.id);
-        expect(senderModel, isNotNull, reason: 'Sender model not found in DB');
-        final payjoinSender = Sender.fromJson(json: senderModel!.sender);
-
-        debugPrint('[integration] Posting payjoin request to directory...');
-        final getContext = await PdkPayjoinDatasource.request(
-          sender: payjoinSender,
-          dio: dio,
+        // Sender's background poll loop posts the original PSBT, picks up the
+        // CLI's proposal, signs it, and broadcasts — all driven by the
+        // PdkPayjoinDatasource session loop. We just wait for completion.
+        final completed = await senderCompletedCompleter.future.timeout(
+          Duration(seconds: PayjoinConstants.directoryPollingInterval * 20),
+          onTimeout: () => false,
         );
-        debugPrint('[integration] Request posted, polling for CLI proposal...');
-
-        // --- Step 2: poll until the CLI receiver posts a proposal ---
-        String? proposalPsbt;
-        for (int i = 0; i < 18; i++) {
-          proposalPsbt = await PdkPayjoinDatasource.getProposalPsbt(
-            context: getContext,
-            dio: dio,
-          );
-          if (proposalPsbt != null) break;
-          debugPrint(
-              '[integration] No proposal yet, retrying (${i + 1}/18)...');
-          await Future.delayed(
-            const Duration(seconds: PayjoinConstants.directoryPollingInterval),
-          );
-        }
         expect(
-          proposalPsbt,
-          isNotNull,
-          reason: 'CLI did not post a payjoin proposal in time',
+          completed,
+          isTrue,
+          reason: 'Mobile sender did not reach completed status — '
+              'CLI receiver may not have posted a proposal in time',
         );
-        debugPrint('[integration] Received CLI proposal, signing...');
-
-        // --- Step 3: sign the proposal PSBT and broadcast ---
-        final signedProposalPsbt = await bitcoinWalletRepository.signPsbt(
-          proposalPsbt!,
-          walletId: mobileWallet.id,
-        );
-        debugPrint('[integration] Proposal signed, broadcasting...');
-
-        final txId = await blockchain.broadcastPsbt(
-          signedProposalPsbt,
-          electrumServer: electrumServer,
-        );
-        debugPrint('[integration] Payjoin tx broadcast: $txId');
-        expect(txId, isNotEmpty, reason: 'Broadcast returned empty txId');
       } finally {
         await payjoinSub.cancel();
-        dio.close();
       }
     },
     timeout: const Timeout(
-      Duration(seconds: PayjoinConstants.directoryPollingInterval * 20),
+      Duration(seconds: PayjoinConstants.directoryPollingInterval * 25),
     ),
   );
 }

--- a/integration_test/payjoin_cli_send_integration_test.dart
+++ b/integration_test/payjoin_cli_send_integration_test.dart
@@ -1,0 +1,190 @@
+/// End-to-End Interoperability Test: Bull Bitcoin Mobile <-> payjoin-cli
+///
+/// This test verifies that the mobile app's payjoin receiver implementation is
+/// spec-compliant and interoperable with payjoin-cli, the reference
+/// implementation from the rust-payjoin project.
+///
+/// This test is NOT run directly — it is orchestrated by a shell script that
+/// reads the BIP21 pjURI printed by this test and passes it to payjoin-cli:
+///
+///   scripts/payjoin_cli_send_test.sh
+///
+/// Scenario: mobile as RECEIVER, payjoin-cli as SENDER
+///
+///   1. This test creates a mobile payjoin receiver, prints the BIP21 pjURI
+///      to stdout (prefixed with "PJ_URI:"), then polls for completion.
+///   2. The shell script picks up the URI and runs `payjoin-cli send <uri>`.
+///   3. payjoin-cli builds an original PSBT and posts it to the directory.
+///   4. The mobile receiver's background isolate picks up the request,
+///      processes it, contributes inputs, and posts a proposal back.
+///   5. payjoin-cli picks up the proposal, signs, and broadcasts.
+///   6. This test detects PayjoinStatus.proposed and passes.
+///
+/// Prerequisites:
+///   - Mobile wallet funded with testnet3 tBTC (TEST_ALICE_MNEMONIC in .env)
+///   - payjoin-cli wallet funded with testnet3 tBTC (managed by bitcoind)
+///
+/// Environment variables:
+///   TEST_ALICE_MNEMONIC          Mobile wallet mnemonic (needs testnet3 tBTC)
+///   PAYJOIN_CLI_SEND_AMOUNT_SAT  Amount in sat (default: 2000)
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:bb_mobile/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:test/test.dart';
+
+const _dartDefines = <String, String>{
+  'TEST_ALICE_MNEMONIC': String.fromEnvironment('TEST_ALICE_MNEMONIC'),
+  'PAYJOIN_CLI_SEND_AMOUNT_SAT':
+      String.fromEnvironment('PAYJOIN_CLI_SEND_AMOUNT_SAT'),
+};
+
+String _env(String key, {String? fallback}) {
+  final dartVal = _dartDefines[key];
+  final val = (dartVal != null && dartVal.isNotEmpty)
+      ? dartVal
+      : Platform.environment[key] ?? dotenv.env[key];
+  if (val != null && val.isNotEmpty) return val;
+  if (fallback != null) return fallback;
+  throw Exception('Required environment variable $key is not set');
+}
+
+Future<void> main({bool isInitialized = false}) async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late String mobileWalletMnemonic;
+  late int amountSat;
+
+  late WalletRepository walletRepository;
+  late WalletAddressRepository addressRepository;
+  late PayjoinRepository payjoinRepository;
+  late ReceiveWithPayjoinUsecase receiveWithPayjoinUsecase;
+
+  late Wallet mobileWallet;
+
+  setUpAll(() async {
+    if (!isInitialized) await Bull.init();
+
+    mobileWalletMnemonic = _env('TEST_ALICE_MNEMONIC');
+    amountSat =
+        int.parse(_env('PAYJOIN_CLI_SEND_AMOUNT_SAT', fallback: '2000'));
+
+    walletRepository = locator<WalletRepository>();
+    addressRepository = locator<WalletAddressRepository>();
+    payjoinRepository = locator<PayjoinRepository>();
+    receiveWithPayjoinUsecase = locator<ReceiveWithPayjoinUsecase>();
+
+    await locator<SetEnvironmentUsecase>().execute(Environment.testnet);
+
+    final seed = await locator<SeedRepository>().createFromMnemonic(
+      mnemonicWords: mobileWalletMnemonic.split(' '),
+    );
+    mobileWallet = await walletRepository.createWallet(
+      seed: seed,
+      network: Network.bitcoinTestnet,
+      scriptType: ScriptType.bip84,
+    );
+    debugPrint('[integration] Mobile wallet id: ${mobileWallet.id}');
+  });
+
+  setUp(() async {
+    await walletRepository.getWallets(sync: true);
+    mobileWallet = (await walletRepository.getWallet(mobileWallet.id))!;
+    debugPrint('[integration] Balance: ${mobileWallet.balanceSat} sat');
+  });
+
+  test(
+    'mobile receiver can accept payjoin from payjoin-cli sender',
+    () async {
+      if (mobileWallet.balanceSat == BigInt.zero) {
+        final addr = await addressRepository.generateNewReceiveAddress(
+          walletId: mobileWallet.id,
+        );
+        fail(
+          'Mobile wallet has no funds (needs UTXOs to contribute to payjoin). '
+          'Send testnet3 tBTC to ${addr.address} and retry.',
+        );
+      }
+
+      // --- Step 1: create a mobile payjoin receiver ---
+      final address = await addressRepository.generateNewReceiveAddress(
+        walletId: mobileWallet.id,
+      );
+      debugPrint('[integration] Receive address: ${address.address}');
+
+      final receiver = await receiveWithPayjoinUsecase.execute(
+        walletId: mobileWallet.id,
+        address: address.address,
+      );
+      debugPrint('[integration] Receiver created: ${receiver.id}');
+      expect(receiver.status, PayjoinStatus.started);
+
+      final pjUri = receiver.pjUri;
+      debugPrint('[integration] pjUri: $pjUri');
+      expect(pjUri, contains('pj='));
+
+      // Print the URI on its own line so the shell script can grep for it.
+      // ignore: avoid_print
+      print('PJ_URI:$pjUri');
+
+      // --- Step 2: wait for the background receiver flow to complete ---
+      // The mobile receiver's background isolate automatically:
+      //   - polls the directory for the CLI sender's original PSBT
+      //   - processes the request, contributes inputs, creates a proposal
+      //   - posts the proposal back to the directory
+      // We just need to listen for the status change.
+      final proposedCompleter = Completer<bool>();
+      final payjoinSub = payjoinRepository.payjoinStream.listen((payjoin) {
+        debugPrint(
+          '[integration] Payjoin event ${payjoin.id}: ${payjoin.status}',
+        );
+        if (payjoin is PayjoinReceiver &&
+            payjoin.id == receiver.id &&
+            payjoin.status == PayjoinStatus.proposed &&
+            !proposedCompleter.isCompleted) {
+          proposedCompleter.complete(true);
+        }
+      });
+
+      try {
+        debugPrint(
+          '[integration] Waiting for CLI sender to post request and '
+          'mobile receiver to propose...',
+        );
+        final proposed = await proposedCompleter.future.timeout(
+          Duration(seconds: PayjoinConstants.directoryPollingInterval * 40),
+          onTimeout: () => false,
+        );
+        expect(
+          proposed,
+          isTrue,
+          reason:
+              'Mobile receiver did not reach proposed status — '
+              'CLI sender may not have posted a request in time',
+        );
+        debugPrint('[integration] Mobile receiver proposed payjoin!');
+      } finally {
+        await payjoinSub.cancel();
+      }
+    },
+    timeout: Timeout(
+      Duration(seconds: PayjoinConstants.directoryPollingInterval * 45),
+    ),
+  );
+}

--- a/integration_test/payjoin_cli_send_integration_test.dart
+++ b/integration_test/payjoin_cli_send_integration_test.dart
@@ -45,7 +45,6 @@ import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usec
 import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/main.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:test/test.dart';
 
@@ -59,7 +58,7 @@ String _env(String key, {String? fallback}) {
   final dartVal = _dartDefines[key];
   final val = (dartVal != null && dartVal.isNotEmpty)
       ? dartVal
-      : Platform.environment[key] ?? dotenv.env[key];
+      : Platform.environment[key];
   if (val != null && val.isNotEmpty) return val;
   if (fallback != null) return fallback;
   throw Exception('Required environment variable $key is not set');

--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
@@ -33,6 +34,7 @@ Future<void> main({bool isInitialized = false}) async {
   final addressRepository = locator<WalletAddressRepository>();
   final utxoRepository = locator<WalletUtxoRepository>();
   final payjoinRepository = locator<PayjoinRepository>();
+  final localPayjoinDatasource = locator<LocalPayjoinDatasource>();
   final receiveWithPayjoinUsecase = locator<ReceiveWithPayjoinUsecase>();
   final sendWithPayjoinUsecase = locator<SendWithPayjoinUsecase>();
   final prepareBitcoinSendUsecase = locator<PrepareBitcoinSendUsecase>();
@@ -49,6 +51,34 @@ Future<void> main({bool isInitialized = false}) async {
 
   setUpAll(() async {
     await locator<SetEnvironmentUsecase>().execute(Environment.testnet);
+
+    // Drain any persisted payjoin state so the test starts clean. Ongoing
+    // payjoins left behind by a previous (possibly crashed) run keep their
+    // inputs frozen via getUtxosFrozenByOngoingPayjoins(), which would starve
+    // the sender wallet. _resumePayjoins in PayjoinRepositoryImpl's
+    // constructor runs unawaited and writes its own updates concurrently, so
+    // we expire + recheck until the ongoing set stays empty for several polls.
+    const pollInterval = Duration(milliseconds: 500);
+    const requiredStableChecks = 3;
+    const maxIterations = 40;
+    var stableChecks = 0;
+    for (var i = 0; i < maxIterations; i++) {
+      final ongoing = await localPayjoinDatasource.fetchAll(
+        onlyUnfinished: true,
+      );
+      if (ongoing.isEmpty) {
+        stableChecks++;
+        if (stableChecks >= requiredStableChecks) break;
+      } else {
+        stableChecks = 0;
+        for (final payjoin in ongoing) {
+          await localPayjoinDatasource.update(
+            payjoin.copyWith(isExpired: true),
+          );
+        }
+      }
+      await Future.delayed(pollInterval);
+    }
 
     final receiverSeed = await seedRepository.createFromMnemonic(
       mnemonicWords: receiverMnemonic.split(' '),

--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
-import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
@@ -16,7 +16,6 @@ import 'package:bb_mobile/features/send/domain/usecases/prepare_bitcoin_send_use
 import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/main.dart';
-import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
@@ -30,6 +29,7 @@ Future<void> main({bool isInitialized = false}) async {
   late Wallet senderWallet;
 
   final walletRepository = locator<WalletRepository>();
+  final seedRepository = locator<SeedRepository>();
   final addressRepository = locator<WalletAddressRepository>();
   final utxoRepository = locator<WalletUtxoRepository>();
   final payjoinRepository = locator<PayjoinRepository>();
@@ -37,32 +37,32 @@ Future<void> main({bool isInitialized = false}) async {
   final sendWithPayjoinUsecase = locator<SendWithPayjoinUsecase>();
   final prepareBitcoinSendUsecase = locator<PrepareBitcoinSendUsecase>();
 
-  final receiverMnemonic = Platform.environment['TEST_ALICE_MNEMONIC'];
-  final senderMnemonic = Platform.environment['TEST_BOB_MNEMONIC'];
+  const receiverMnemonic = String.fromEnvironment('TEST_ALICE_MNEMONIC');
+  const senderMnemonic = String.fromEnvironment('TEST_BOB_MNEMONIC');
 
-  if (receiverMnemonic == null || receiverMnemonic.isEmpty) {
+  if (receiverMnemonic.isEmpty) {
     throw Exception('TEST_ALICE_MNEMONIC environment variable is not set');
   }
-  if (senderMnemonic == null || senderMnemonic.isEmpty) {
+  if (senderMnemonic.isEmpty) {
     throw Exception('TEST_BOB_MNEMONIC environment variable is not set');
   }
 
   setUpAll(() async {
     await locator<SetEnvironmentUsecase>().execute(Environment.testnet);
 
-    final receiverSeedModel = SeedModel.mnemonic(
+    final receiverSeed = await seedRepository.createFromMnemonic(
       mnemonicWords: receiverMnemonic.split(' '),
     );
-    final senderSeedModel = SeedModel.mnemonic(
+    final senderSeed = await seedRepository.createFromMnemonic(
       mnemonicWords: senderMnemonic.split(' '),
     );
     receiverWallet = await walletRepository.createWallet(
-      seed: receiverSeedModel.toEntity(),
+      seed: receiverSeed,
       network: Network.bitcoinTestnet,
       scriptType: ScriptType.bip84,
     );
     senderWallet = await walletRepository.createWallet(
-      seed: senderSeedModel.toEntity(),
+      seed: senderSeed,
       network: Network.bitcoinTestnet,
       scriptType: ScriptType.bip84,
     );

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -99,7 +99,9 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - payjoin_flutter (0.20.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
   - PromisesObjC (2.4.0)
@@ -175,7 +177,7 @@ DEPENDENCIES:
   - lwk (from `.symlinks/plugins/lwk/ios`)
   - no_screenshot (from `.symlinks/plugins/no_screenshot/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - payjoin_flutter (from `.symlinks/plugins/payjoin_flutter/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -239,8 +241,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/no_screenshot/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  payjoin_flutter:
-    :path: ".symlinks/plugins/payjoin_flutter/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sentry_flutter:
@@ -267,46 +269,46 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  ark_wallet: cb7a2af0c3a711d488709b7b91b6e639cfd441b1
+  ark_wallet: f985745c06c7cf93f368c61218c51ac56b46c71e
   boltz: 6388ec2412f3753b63a9e65c97f87ea26f43bddc
-  camera_avfoundation: 5675ca25298b6f81fa0a325188e7df62cc217741
-  dart_bbqr: bfd89cc8a74538d94ef6d87d11e4a2ad55578e7d
+  camera_avfoundation: 281867ff09f1da66f031a184ecfbc6f2e625c9f5
+  dart_bbqr: 10143a83ef3919f9ac06974e3bbe23cac4abc39b
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
-  flutter_nfc_kit: e1b71583eafd2c9650bc86844a7f2d185fb414f6
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_secure_storage_legacy: 2b1517bd98433d760370884d3e2cc3ed8eeb2538
-  flutter_zxing: e8bcc43bd3056c70c271b732ed94e7a16fd62f93
-  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
+  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
+  flutter_nfc_kit: 3985c93f749b9cb4747479205c2f10bd2f877a11
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_secure_storage_legacy: a315f1c83d88e9490f44a269454281a2c9b2c160
+  flutter_zxing: d527c3ff9c7f3606dd29a7ec8c4055f7daa088c5
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   lwk: 22e06bc5664247d6b2dac91cfe209b63b70dd580
-  no_screenshot: 5e345998c43ffcad5d6834f249590483fcc037bd
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  payjoin_flutter: 6397d7b698cdad6453be4949ab6aca1863f6c5e5
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  no_screenshot: e91f3e7a771bf761b087c575028bb1b24a7ca33d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   Sentry: 958d9619ceccf6abb8c4736003fa336dac1a80a7
-  sentry_flutter: bdfd7a7b8931c4ecefa37fde9e44a15cd0af30b1
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sentry_flutter: 9bde8d71f013f0e807c424017de923f0ee489e9a
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
-  sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
+  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  tor: 767208930250ef7be241963b75568c55c0a81890
-  universal_ble: 45519b2aeafe62761e2c6309f8927edb5288b914
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  webview_cookie_manager: d63a76cabdf42a7ea3d92768ac67d4853a1367f8
-  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
-  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
+  tor: 662a9f5b980b5c86decb8ba611de9bcd4c8286eb
+  universal_ble: 65e1257dffc557cc7991a93d253beeddc7c1dc92
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  webview_cookie_manager: eaf920722b493bd0f7611b5484771ca53fed03f7
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
+  workmanager_apple: 7bac258335c310689a641e2d66e88d4845d372e9
 
 PODFILE CHECKSUM: b9aa080c2a42d4d61d216015adddd3850778d844
 

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -751,53 +751,6 @@ class PdkPayjoinDatasource {
   }
 }
 
-class InMemoryReceiverPersister {
-  final Map<String, Receiver> _store = {};
-
-  Future<ReceiverToken> save({required Receiver receiver}) async {
-    final token = receiver.key();
-    _store[token.toBytes().toString()] = receiver;
-    return token;
-  }
-
-  Future<Receiver> load({required ReceiverToken token}) async {
-    logger.log.info('LOADING RECEIVER');
-    final receiver = _store[token.toBytes().toString()];
-    if (receiver == null) {
-      throw Exception('Receiver not found for the provided token.');
-    }
-    return receiver;
-  }
-}
-
-class InMemorySenderPersister implements DartSenderPersister {
-  final Map<String, Sender> _store = {};
-
-  Future<SenderToken> save({required Sender sender}) async {
-    final token = sender.key();
-    logger.log.info('TOKEN SAVE}');
-    _store[token.toBytes().toString()] = sender;
-    return token;
-  }
-
-  Future<Sender> load({required SenderToken token}) async {
-    logger.log.info('TOKEN LOAD}');
-    final sender = _store[token.toBytes().toString()];
-    if (sender == null) {
-      throw Exception('Sender not found for the provided token.');
-    }
-    return sender;
-  }
-
-  @override
-  void dispose() {
-    _store.clear();
-  }
-
-  @override
-  bool get isDisposed => _store.isEmpty;
-}
-
 class PayjoinNotFoundException extends BullException {
   PayjoinNotFoundException(super.message);
 }

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -644,28 +644,34 @@ class PdkPayjoinDatasource {
       final receiverModel = PayjoinReceiverModel.fromJson(
         data as Map<String, dynamic>,
       );
-      final receiver = Receiver.fromJson(json: receiverModel.receiver);
 
       // Start checking for a payjoin request from the sender periodically
       Timer.periodic(const Duration(seconds: PayjoinConstants.directoryPollingInterval), (
         Timer timer,
       ) async {
-        log(
-          '[Receivers Isolate] Checking for request in receivers isolate for '
-          '${receiver.id()}',
-        );
+        log('[Receivers Isolate] Checking for request for ${receiverModel.id}');
         try {
-          final request = await getRequest(receiver: receiver, dio: dio);
-          if (request != null) {
-            requests.putIfAbsent(receiver.id(), () async {
-              log(
-                '[Receivers Isolate] Request found in receivers isolate for '
-                '${receiver.id()}',
-              );
+          final persister = InMemoryJsonReceiverSessionPersister.fromJson(
+            receiverModel.receiver,
+          );
+          final state = replayReceiverEventLog(persister: persister).state();
+          if (state is! InitializedReceiveSession) return;
+
+          final unchecked = await _getUncheckedOriginalPayload(
+            state.inner,
+            persister,
+            dio,
+          );
+          if (unchecked != null) {
+            requests.putIfAbsent(receiverModel.id, () async {
+              log('[Receivers Isolate] Request found for ${receiverModel.id}');
+              final maybeInputsOwned = unchecked
+                  .assumeInteractiveReceiver()
+                  .save(persister: persister);
               // The original tx bytes are needed in the main isolate for
-              //  further processing so extract them here and pass them through
-              //  the model
-              final originalTxBytes = await request
+              //  further processing so extract them here and pass them
+              //  through the model
+              final originalTxBytes = maybeInputsOwned
                   .extractTxToScheduleBroadcast();
               final originalTx = await BitcoinTx.fromBytes(originalTxBytes);
               final originalTxId = originalTx.txid;
@@ -675,12 +681,12 @@ class PdkPayjoinDatasource {
               );
               log(
                 '[Receivers Isolate] Request original Tx ID: $originalTxId and amount: $amountSat for '
-                '${receiver.id()}',
+                '${receiverModel.id}',
               );
               final updatedModel = receiverModel.copyWith(
-                receiver: receiver.toJson(),
+                receiver: persister.toJson(),
                 originalTxBytes: originalTxBytes,
-                originalTxId: originalTxId,
+                originalTxId: originalTx.txid,
                 amountSat: amountSat,
               );
 
@@ -689,23 +695,22 @@ class PdkPayjoinDatasource {
 
               // Cancel the timer since the request has been received
               log(
-                '[Receivers Isolate] cancelling timer in receivers isolate for ${receiver.id()}',
+                '[Receivers Isolate] cancelling timer in receivers isolate for ${receiverModel.id}',
               );
               timer.cancel();
               log(
-                '[Receivers Isolate] timer cancelled in receivers isolate for ${receiver.id()}',
+                '[Receivers Isolate] timer cancelled in receivers isolate for ${receiverModel.id}',
               );
             });
           } else {
             log(
               '[Receivers Isolate] No valid request found in receivers isolate for '
-              '${receiver.id()}',
+              '${receiverModel.id}',
             );
           }
         } catch (e) {
           log(
-            '[Receivers Isolate] periodic timer get request exception: $e for '
-            '${receiver.id()}',
+            '[Receivers Isolate] periodic timer get request exception: $e for ${receiverModel.id}',
           );
           if (e is PayjoinExpiredException) {
             // If the request returns an expiry error, mark the receiver as
@@ -788,66 +793,40 @@ class PdkPayjoinDatasource {
     });
   }
 
-  static Future<UncheckedProposal?> getRequest({
-    required Receiver receiver,
-    required Dio dio,
-  }) async {
-    // The use of ffiError here is a hack, we should change it once payjoin-flutter
-    //  exposes different exceptions for specific errors
-    Object? ffiError;
-    try {
-      receiver.id();
-      (Request, ClientResponse)? request;
-      for (final ohttpRelay in PayjoinConstants.ohttpRelayUrls) {
-        try {
-          request = await receiver.extractReq(ohttpRelay: ohttpRelay);
-          ffiError = null;
-          log('[${receiver.id()}] receiver extractReq success');
-          break;
-        } catch (e) {
-          log('[${receiver.id()}] receiver extractReq exception: $e');
-          ffiError = e;
-          continue;
-        }
-      }
-
-      if (request == null) {
-        if (ffiError != null) {
-          throw ffiError;
-        }
-        throw PayjoinNotFoundException(
-          '[${receiver.id()}] No payjoin request found',
+  static Future<UncheckedOriginalPayload?> _getUncheckedOriginalPayload(
+    Initialized initialized,
+    InMemoryJsonReceiverSessionPersister persister,
+    Dio dio,
+  ) async {
+    Object? lastError;
+    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+      try {
+        final poll = initialized.createPollRequest(ohttpRelay: relay);
+        final body = await _postBytes(
+          dio,
+          poll.request.url,
+          poll.request.body,
+          poll.request.contentType,
         );
+        final outcome = initialized
+            .processResponse(body: body, ctx: poll.clientResponse)
+            .save(persister: persister);
+        if (outcome is StasisInitializedTransitionOutcome) return null;
+        return (outcome as ProgressInitializedTransitionOutcome).inner;
+      } on ReceiverException catch (e) {
+        if (_isExpiredString(e)) {
+          throw PayjoinExpiredException('Payjoin receiver expired: $e');
+        }
+        log('receiver createPollRequest via $relay failed: $e');
+        lastError = e;
+        continue;
+      } catch (e) {
+        log('receiver poll via $relay failed: $e');
+        lastError = e;
+        continue;
       }
-
-      log('[${receiver.id()}] request != null');
-      final (req, context) = request;
-      final ohttpResponse = await dio.post(
-        req.url.asString(),
-        data: req.body,
-        options: Options(
-          headers: {'Content-Type': req.contentType},
-          responseType: ResponseType.bytes,
-        ),
-      );
-      log('[${receiver.id()}] processing request...');
-      final proposal = await receiver.processRes(
-        body: ohttpResponse.data as List<int>,
-        ctx: context,
-      );
-      log('[${receiver.id()}] request processed');
-      return proposal;
-    } catch (e) {
-      log('[${receiver.id()}] getRequest exception: $e');
-      if (e == ffiError) {
-        // TODO: Check for the correct error.
-        //  We just assume the error is an expired error for now.
-        throw PayjoinExpiredException(
-          'Payjoin receiver $receiver.id() expired',
-        );
-      }
-      return null;
     }
+    throw PayjoinNotFoundException('Failed to poll receiver: $lastError');
   }
 
   static Future<String?> getProposalPsbt({
@@ -908,6 +887,11 @@ class PdkPayjoinDatasource {
       return null;
     }
   }
+
+  // "Expired" variants aren't exposed publicly as a distinct subtype.
+  // Tighten to a typed check if the payjoin bindings start exposing variants.
+  static bool _isExpiredString(Object error) =>
+      error.toString().toLowerCase().contains('expired');
 
   static Future<Uint8List> _postBytes(
     Dio dio,

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -817,3 +817,71 @@ class PayjoinExpiredException extends BullException {
 class OhttpRelaysUnavailableException extends BullException {
   OhttpRelaysUnavailableException(super.message);
 }
+
+class InMemoryJsonReceiverSessionPersister
+    implements JsonReceiverSessionPersister {
+  final List<String> _events;
+  bool _closed;
+
+  InMemoryJsonReceiverSessionPersister([List<String>? initial])
+    : _events = [...?initial],
+      _closed = false;
+
+  factory InMemoryJsonReceiverSessionPersister.fromJson(String? raw) {
+    return InMemoryJsonReceiverSessionPersister(_decodeEvents(raw));
+  }
+
+  List<String> get events => List.unmodifiable(_events);
+
+  bool get isClosed => _closed;
+
+  String toJson() => jsonEncode(_events);
+
+  @override
+  void save(String event) => _events.add(event);
+
+  @override
+  List<String> load() => List<String>.from(_events);
+
+  @override
+  void close() => _closed = true;
+}
+
+class InMemoryJsonSenderSessionPersister implements JsonSenderSessionPersister {
+  final List<String> _events;
+  bool _closed;
+
+  InMemoryJsonSenderSessionPersister([List<String>? initial])
+    : _events = [...?initial],
+      _closed = false;
+
+  factory InMemoryJsonSenderSessionPersister.fromJson(String? raw) {
+    return InMemoryJsonSenderSessionPersister(_decodeEvents(raw));
+  }
+
+  List<String> get events => List.unmodifiable(_events);
+
+  bool get isClosed => _closed;
+
+  String toJson() => jsonEncode(_events);
+
+  @override
+  void save(String event) => _events.add(event);
+
+  @override
+  List<String> load() => List<String>.from(_events);
+
+  @override
+  void close() => _closed = true;
+}
+
+List<String> _decodeEvents(String? raw) {
+  if (raw == null || raw.isEmpty) return const [];
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is List) {
+      return decoded.cast<String>();
+    }
+  } catch (_) {}
+  return const [];
+}

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
-import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/errors/bull_exception.dart';
@@ -22,13 +21,9 @@ class PdkPayjoinDatasource {
   final StreamController<PayjoinSenderModel> _proposalSentController;
   final StreamController<PayjoinModel> _expiredController;
 
-  // Background processing
-  Isolate? _receiversIsolate;
-  Isolate? _sendersIsolate;
-  SendPort? _receiversIsolatePort;
-  SendPort? _sendersIsolatePort;
-  final Completer _receiversIsolateReady;
-  final Completer _sendersIsolateReady;
+  // Per-session polling timers keyed by session id
+  final Map<String, Timer> _receiverTimers = {};
+  final Map<String, Timer> _senderTimers = {};
 
   PdkPayjoinDatasource({
     String payjoinDirectoryUrl = PayjoinConstants.directoryUrl,
@@ -37,9 +32,7 @@ class PdkPayjoinDatasource {
        _dio = dio,
        _payjoinRequestedController = StreamController.broadcast(),
        _proposalSentController = StreamController.broadcast(),
-       _expiredController = StreamController.broadcast(),
-       _receiversIsolateReady = Completer(),
-       _sendersIsolateReady = Completer();
+       _expiredController = StreamController.broadcast();
 
   Stream<PayjoinReceiverModel> get requestsForReceivers =>
       _payjoinRequestedController.stream;
@@ -114,8 +107,8 @@ class PdkPayjoinDatasource {
               )
               as PayjoinReceiverModel;
 
-      // Start listening for a payjoin request from the sender in an isolate
-      await startListeningForRequest(model);
+      // Start listening for a payjoin request from the sender
+      startListeningForRequest(model);
 
       return model;
     } catch (e) {
@@ -173,8 +166,8 @@ class PdkPayjoinDatasource {
             )
             as PayjoinSenderModel;
 
-    // Start listening for a payjoin proposal from the receiver in an isolate
-    await startListeningForProposal(model);
+    // Start listening for a payjoin proposal from the receiver
+    startListeningForProposal(model);
 
     return model;
   }
@@ -262,7 +255,9 @@ class PdkPayjoinDatasource {
   }) async {
     switch (state) {
       case InitializedReceiveSession():
-        throw StateError('Original PSBT is retrieved in the receiver isolate');
+        throw StateError(
+          'Original PSBT is retrieved in startListeningForRequest',
+        );
       case UncheckedOriginalPayloadReceiveSession():
         return _checkProposal(
           state.inner,
@@ -546,267 +541,138 @@ class PdkPayjoinDatasource {
     );
   }
 
-  Future<void> startListeningForRequest(PayjoinReceiverModel payjoin) async {
-    if (_receiversIsolate == null) {
-      // Start the isolate if it is not running yet
-      await _spawnReceiversIsolate();
-    }
-    await _receiversIsolateReady.future;
-    _receiversIsolatePort?.send(payjoin.toJson());
-  }
-
-  Future<void> startListeningForProposal(PayjoinSenderModel payjoin) async {
-    if (_sendersIsolate == null) {
-      // Start the isolate if it is not running yet
-      await _spawnSendersIsolate();
-    }
-    await _sendersIsolateReady.future;
-    _sendersIsolatePort?.send(payjoin.toJson());
-  }
-
-  /// Starts the isolate to listen for payjoin requests.
-  Future<void> _spawnReceiversIsolate() async {
-    // Receive isolate
-    final receivePort = ReceivePort();
-
-    // Listen to messages from the receive isolate
-    receivePort.listen((message) {
-      if (message is SendPort) {
-        _receiversIsolatePort = message;
-        _receiversIsolateReady.complete();
-      } else if (message is Map<String, dynamic>) {
-        logger.log.info(
-          'Received message of found payjoin request in main isolate: $message',
-        );
-        final model = PayjoinReceiverModel.fromJson(message);
-
-        // Send the updated payjoin model to the higher repository layers so it
-        //  can be stored locally and processed further
-        if (model.isExpired) {
-          _expiredController.add(model);
-        } else {
-          // If not expired, it means a request was received
-          _payjoinRequestedController.add(model);
-        }
-      }
-    });
-
-    logger.log.info('Spawning receivers isolate');
-    // Spawn the isolate
-    _receiversIsolate = await Isolate.spawn(
-      _receiversIsolateEntryPoint,
-      receivePort.sendPort,
+  void startListeningForRequest(PayjoinReceiverModel payjoin) {
+    _receiverTimers[payjoin.id]?.cancel();
+    _receiverTimers[payjoin.id] = Timer.periodic(
+      const Duration(seconds: PayjoinConstants.directoryPollingInterval),
+      (timer) => _pollReceiverOnce(payjoin, timer),
     );
   }
 
-  /// Starts the isolate to request and listen for payjoin proposals.
-  Future<void> _spawnSendersIsolate() async {
-    // Senders isolate
-    final receivePort = ReceivePort();
-
-    // Listen for messages from the senders isolate
-    receivePort.listen((message) {
-      if (message is SendPort) {
-        _sendersIsolatePort = message;
-        _sendersIsolateReady.complete();
-      } else if (message is Map<String, dynamic>) {
-        final model = PayjoinSenderModel.fromJson(message);
-
-        // Send the updated payjoin model to the higher repository layers for
-        //  processing and notification to the user
-        if (model.isExpired) {
-          _expiredController.add(model);
-        } else {
-          // If not expired, it means a proposal was received
-          _proposalSentController.add(model);
-        }
-      }
-    });
-
-    logger.log.info('Spawning senders isolate');
-    _sendersIsolate = await Isolate.spawn(
-      _sendersIsolateEntryPoint,
-      receivePort.sendPort,
+  void startListeningForProposal(PayjoinSenderModel payjoin) {
+    _senderTimers[payjoin.id]?.cancel();
+    _senderTimers[payjoin.id] = Timer.periodic(
+      const Duration(seconds: PayjoinConstants.directoryPollingInterval),
+      (timer) => _pollSenderOnce(payjoin, timer),
     );
   }
 
-  static Future<void> _receiversIsolateEntryPoint(SendPort sendPort) async {
-    log('[Receivers Isolate] Started _receiversIsolateEntryPoint');
-
-    final receivePort = ReceivePort();
-    sendPort.send(receivePort.sendPort);
-    final dio = Dio();
-    final requests = <String, Future<void>>{};
-
-    // Listen for and register new receivers sent from the main isolate
-    receivePort.listen((data) {
-      log('[Receivers Isolate] Received data in receivers isolate: $data');
-      final receiverModel = PayjoinReceiverModel.fromJson(
-        data as Map<String, dynamic>,
+  Future<void> _pollReceiverOnce(
+    PayjoinReceiverModel receiverModel,
+    Timer timer,
+  ) async {
+    log('[receiver poll] checking for request for ${receiverModel.id}');
+    try {
+      final persister = InMemoryJsonReceiverSessionPersister.fromJson(
+        receiverModel.receiver,
       );
-
-      // Start checking for a payjoin request from the sender periodically
-      Timer.periodic(const Duration(seconds: PayjoinConstants.directoryPollingInterval), (
-        Timer timer,
-      ) async {
-        log('[Receivers Isolate] Checking for request for ${receiverModel.id}');
-        try {
-          final persister = InMemoryJsonReceiverSessionPersister.fromJson(
-            receiverModel.receiver,
-          );
-          final state = replayReceiverEventLog(persister: persister).state();
-          if (state is! InitializedReceiveSession) return;
-
-          final unchecked = await _getUncheckedOriginalPayload(
-            state.inner,
-            persister,
-            dio,
-          );
-          if (unchecked != null) {
-            requests.putIfAbsent(receiverModel.id, () async {
-              log('[Receivers Isolate] Request found for ${receiverModel.id}');
-              final maybeInputsOwned = unchecked
-                  .assumeInteractiveReceiver()
-                  .save(persister: persister);
-              // The original tx bytes are needed in the main isolate for
-              //  further processing so extract them here and pass them
-              //  through the model
-              final originalTxBytes = maybeInputsOwned
-                  .extractTxToScheduleBroadcast();
-              final originalTx = await BitcoinTx.fromBytes(originalTxBytes);
-              final originalTxId = originalTx.txid;
-              final amountSat = await originalTx.getAmountReceived(
-                address: receiverModel.address,
-                isTestnet: receiverModel.isTestnet,
-              );
-              log(
-                '[Receivers Isolate] Request original Tx ID: $originalTxId and amount: $amountSat for '
-                '${receiverModel.id}',
-              );
-              final updatedModel = receiverModel.copyWith(
-                receiver: persister.toJson(),
-                originalTxBytes: originalTxBytes,
-                originalTxId: originalTx.txid,
-                amountSat: amountSat,
-              );
-
-              // Notify the main isolate so it can be processed further
-              sendPort.send(updatedModel.toJson());
-
-              // Cancel the timer since the request has been received
-              log(
-                '[Receivers Isolate] cancelling timer in receivers isolate for ${receiverModel.id}',
-              );
-              timer.cancel();
-              log(
-                '[Receivers Isolate] timer cancelled in receivers isolate for ${receiverModel.id}',
-              );
-            });
-          } else {
-            log(
-              '[Receivers Isolate] No valid request found in receivers isolate for '
-              '${receiverModel.id}',
-            );
-          }
-        } catch (e) {
-          log(
-            '[Receivers Isolate] periodic timer get request exception: $e for ${receiverModel.id}',
-          );
-          if (e is PayjoinExpiredException) {
-            // If the request returns an expiry error, mark the receiver as
-            //  expired and notify the main isolate so it stops polling
-            final updatedModel = receiverModel.copyWith(isExpired: true);
-            sendPort.send(updatedModel.toJson());
-            timer.cancel();
-          }
-        }
-      });
-    });
-  }
-
-  static Future<void> _sendersIsolateEntryPoint(SendPort sendPort) async {
-    log('[Senders Isolate] Started _sendersIsolateEntryPoint');
-
-    final receivePort = ReceivePort();
-    sendPort.send(receivePort.sendPort);
-
-    final dio = Dio();
-    // Listen for and register new senders sent from the main isolate
-    receivePort.listen((data) async {
+      final ReceiveSession state;
       try {
-        log('[Senders Isolate] Received data in senders isolate: $data');
-        final senderModel = PayjoinSenderModel.fromJson(
-          data as Map<String, dynamic>,
-        );
-
-        // Periodically check for a proposal from the receiver
-        Timer.periodic(
-          const Duration(seconds: PayjoinConstants.directoryPollingInterval),
-          (Timer timer) async {
-            log('[Senders Isolate]Checking for proposal in senders isolate');
-            try {
-              final persister = InMemoryJsonSenderSessionPersister.fromJson(
-                senderModel.sender,
-              );
-              final state = pj
-                  .replaySenderEventLog(persister: persister)
-                  .state();
-              if (state is! PollingForProposalSendSession) return;
-
-              final proposalPsbt = await _getProposalPsbt(
-                state.inner,
-                persister,
-                dio,
-              );
-
-              if (proposalPsbt != null) {
-                log('[Senders Isolate] Proposal found in senders isolate');
-                final txId = (await BitcoinTx.fromPsbt(proposalPsbt)).txid;
-                // The proposal psbt is needed in the main isolate for
-                //  further processing so send it through the model as well as
-                //  its txId.
-                final updatedModel = senderModel.copyWith(
-                  sender: persister.toJson(),
-                  proposalPsbt: proposalPsbt,
-                  txId: txId,
-                );
-
-                // Notify the main isolate so the payjoin can be processed further
-                sendPort.send(updatedModel.toJson());
-
-                // Cancel the timer
-                timer.cancel();
-              }
-            } catch (e) {
-              log('[Senders Isolate] periodic timer exception: $e');
-              if (e is PayjoinExpiredException) {
-                // If the request returns an expiry error, mark the receiver as
-                //  expired and notify the main isolate so it stops polling
-                final updatedModel = senderModel.copyWith(isExpired: true);
-                sendPort.send(updatedModel.toJson());
-                timer.cancel();
-              }
-            }
-          },
-        );
-      } catch (e) {
-        log('[Senders Isolate] Error in listener: $e');
-        // Optionally notify the main isolate of the failure
+        state = replayReceiverEventLog(persister: persister).state();
+      } on ReceiverReplayException catch (e) {
+        if (_isExpiredString(e)) {
+          throw PayjoinExpiredException('Payjoin receiver expired: $e');
+        }
+        rethrow;
       }
-    });
+      if (state is! InitializedReceiveSession) return;
+
+      final unchecked = await _getUncheckedOriginalPayload(
+        state.inner,
+        persister,
+      );
+      if (unchecked == null) {
+        log('[receiver poll] no request yet for ${receiverModel.id}');
+        return;
+      }
+
+      timer.cancel();
+      _receiverTimers.remove(receiverModel.id);
+
+      final maybeInputsOwned = unchecked.assumeInteractiveReceiver().save(
+        persister: persister,
+      );
+      final originalTxBytes = maybeInputsOwned.extractTxToScheduleBroadcast();
+      final originalTx = await BitcoinTx.fromBytes(originalTxBytes);
+      final amountSat = await originalTx.getAmountReceived(
+        address: receiverModel.address,
+        isTestnet: receiverModel.isTestnet,
+      );
+      log(
+        '[receiver poll] request found for ${receiverModel.id}: '
+        'txid=${originalTx.txid} amount=$amountSat',
+      );
+      final updatedModel = receiverModel.copyWith(
+        receiver: persister.toJson(),
+        originalTxBytes: originalTxBytes,
+        originalTxId: originalTx.txid,
+        amountSat: amountSat,
+      );
+      _payjoinRequestedController.add(updatedModel);
+    } on PayjoinExpiredException catch (e) {
+      logger.log.info('[receiver poll] expired for ${receiverModel.id}: $e');
+      timer.cancel();
+      _receiverTimers.remove(receiverModel.id);
+      _expiredController.add(receiverModel.copyWith(isExpired: true));
+    } catch (e) {
+      logger.log.info('[receiver poll] ${receiverModel.id}: $e');
+    }
   }
 
-  static Future<UncheckedOriginalPayload?> _getUncheckedOriginalPayload(
+  Future<void> _pollSenderOnce(
+    PayjoinSenderModel senderModel,
+    Timer timer,
+  ) async {
+    log('[sender poll] checking for proposal for ${senderModel.id}');
+    try {
+      final persister = InMemoryJsonSenderSessionPersister.fromJson(
+        senderModel.sender,
+      );
+      final SendSession state;
+      try {
+        state = replaySenderEventLog(persister: persister).state();
+      } on SenderReplayException catch (e) {
+        if (_isExpiredString(e)) {
+          throw PayjoinExpiredException('Payjoin sender expired: $e');
+        }
+        rethrow;
+      }
+      if (state is! PollingForProposalSendSession) return;
+
+      final proposalPsbt = await _getProposalPsbt(state.inner, persister);
+      if (proposalPsbt == null) return;
+
+      timer.cancel();
+      _senderTimers.remove(senderModel.id);
+
+      log('[sender poll] proposal found for ${senderModel.id}');
+      final txId = (await BitcoinTx.fromPsbt(proposalPsbt)).txid;
+      final updatedModel = senderModel.copyWith(
+        sender: persister.toJson(),
+        proposalPsbt: proposalPsbt,
+        txId: txId,
+      );
+      _proposalSentController.add(updatedModel);
+    } on PayjoinExpiredException catch (e) {
+      logger.log.info('[sender poll] expired for ${senderModel.id}: $e');
+      timer.cancel();
+      _senderTimers.remove(senderModel.id);
+      _expiredController.add(senderModel.copyWith(isExpired: true));
+    } catch (e) {
+      logger.log.info('[sender poll] ${senderModel.id}: $e');
+    }
+  }
+
+  Future<UncheckedOriginalPayload?> _getUncheckedOriginalPayload(
     Initialized initialized,
     InMemoryJsonReceiverSessionPersister persister,
-    Dio dio,
   ) async {
     Object? lastError;
     for (final relay in PayjoinConstants.ohttpRelayUrls) {
       try {
         final poll = initialized.createPollRequest(ohttpRelay: relay);
         final body = await _postBytes(
-          dio,
+          _dio,
           poll.request.url,
           poll.request.body,
           poll.request.contentType,
@@ -832,17 +698,16 @@ class PdkPayjoinDatasource {
     throw PayjoinNotFoundException('Failed to poll receiver: $lastError');
   }
 
-  static Future<String?> _getProposalPsbt(
+  Future<String?> _getProposalPsbt(
     PollingForProposal polling,
     InMemoryJsonSenderSessionPersister persister,
-    Dio dio,
   ) async {
     Object? lastError;
     for (final relay in PayjoinConstants.ohttpRelayUrls) {
       try {
         final poll = polling.createPollRequest(ohttpRelay: relay);
         final body = await _postBytes(
-          dio,
+          _dio,
           poll.request.url,
           poll.request.body,
           poll.request.contentType,

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -87,42 +87,32 @@ class PdkPayjoinDatasource {
         throw Exception('All OHTTP relays failed');
       }
 
-      final newReceiver = NewReceiver.create(
-        address: address,
-        network: isTestnet ? Network.testnet : Network.bitcoin,
-        directory: _payjoinDirectoryUrl,
-        ohttpKeys: ohttpKeys,
-        expireAfter: BigInt.from(expireAfterSec),
-      );
+      var receiverBuilder =
+          ReceiverBuilder(
+                address: address,
+                directory: _payjoinDirectoryUrl,
+                ohttpKeys: ohttpKeys,
+              )
+              .withExpiration(expirationSecs: expireAfterSec)
+              .withMaxFeeRate(
+                maxEffectiveFeeRateSatPerVb: maxFeeRateSatPerVb.toInt(),
+              );
 
-      final imp = InMemoryReceiverPersister();
-      final noOpPersister = DartReceiverPersister(
-        save: (receiver) async {
-          logger.log.info('SAVING RECEIVER');
-          final token = await imp.save(receiver: receiver);
-          return token;
-        },
-        load: (token) async {
-          final receiver = await imp.load(token: token);
-          return receiver;
-        },
-      );
-      final token = await newReceiver.persist(persister: noOpPersister);
-
-      final receiver = await Receiver.load(
-        token: token,
-        persister: noOpPersister,
-      );
+      final persister = InMemoryJsonReceiverSessionPersister();
+      final initialized = receiverBuilder.build().save(persister: persister);
+      final pjUri = initialized.pjUri().asString();
+      // Derive the receiver ID from pjUri
+      final id = sha256.convert(utf8.encode(pjUri)).toString().substring(0, 16);
 
       // Create and store the model to keep track of the payjoin session
       final model =
           PayjoinModel.receiver(
-                id: receiver.id(),
+                id: id,
                 address: address,
                 isTestnet: isTestnet,
-                receiver: receiver.toJson(),
+                receiver: persister.toJson(),
                 walletId: walletId,
-                pjUri: (await receiver.pjUri()).asString(),
+                pjUri: pjUri,
                 maxFeeRateSatPerVb: maxFeeRateSatPerVb,
                 createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
                 expireAfterSec: expireAfterSec,

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -214,105 +214,336 @@ class PdkPayjoinDatasource {
 
   Future<PayjoinReceiverModel> proposePayjoin({
     required PayjoinReceiverModel receiverModel,
-    required FutureOr<bool> Function(Uint8List) hasOwnedInputs,
-    required FutureOr<bool> Function(Uint8List) hasReceiverOutput,
+    required bool Function(Uint8List) hasOwnedInputs,
+    required bool Function(Uint8List) hasReceiverOutput,
     required List<PayjoinInputPairModel> inputPairs,
-    required FutureOr<String> Function(String) processPsbt,
+    required String Function(String) processPsbt,
   }) async {
-    final receiver = Receiver.fromJson(json: receiverModel.receiver);
-    final request = await getRequest(receiver: receiver, dio: _dio);
-
-    if (request == null) {
-      throw Exception('No request found');
-    }
-
-    final interactiveReceiver = await request.assumeInteractiveReceiver();
-    final inputsNotOwned = await interactiveReceiver.checkInputsNotOwned(
-      isOwned: hasOwnedInputs,
+    final persister = InMemoryJsonReceiverSessionPersister.fromJson(
+      receiverModel.receiver,
     );
-    final inputsNotSeen = await inputsNotOwned.checkNoInputsSeenBefore(
-      isKnown: (_) =>
-          false, // Assume the wallet has not seen the inputs since it is an interactive wallet
-    );
-    final receiverOutputs = await inputsNotSeen.identifyReceiverOutputs(
-      isReceiverOutput: hasReceiverOutput,
-    );
-    final committedOutputs = await receiverOutputs.commitOutputs();
+    final state = replayReceiverEventLog(persister: persister).state();
 
-    final candidateInputs = await Future.wait(
-      inputPairs.map(
-        (input) async => await InputPair.newInstance(
-          txin: TxIn(
-            previousOutput: OutPoint(txid: input.txId, vout: input.vout),
-            scriptSig: await Script.newInstance(
-              rawOutputScript: input.scriptSigRawOutputScript,
-            ),
-            sequence: input.sequence,
-            witness: input.witness,
-          ),
-          psbtin: PsbtInput(
-            witnessUtxo: TxOut(
-              value: input.value!,
-              scriptPubkey: input.scriptPubkey,
-            ),
-            redeemScript: input.redeemScriptRawOutputScript.isEmpty
-                ? null
-                : await Script.newInstance(
-                    rawOutputScript: input.redeemScriptRawOutputScript,
-                  ),
-            witnessScript: input.witnessScriptRawOutputScript.isEmpty
-                ? null
-                : await Script.newInstance(
-                    rawOutputScript: input.witnessScriptRawOutputScript,
-                  ),
-          ),
-        ),
-      ),
-    );
-
-    // Try to select a privacy preserving input pair, else just stick with the
-    //  first possible input pair.
-    InputPair inputPair = candidateInputs.first;
-    try {
-      inputPair = await committedOutputs.tryPreservingPrivacy(
-        candidateInputs: candidateInputs,
-      );
-    } catch (e) {
-      logger.log.severe(
-        message: 'Failed to preserve privacy: Using first input pair.',
-        error: e,
-        trace: StackTrace.current,
-      );
-    }
-
-    final inputsContributed = await committedOutputs.contributeInputs(
-      replacementInputs: [inputPair],
-    );
-    final inputsCommitted = await inputsContributed.commitInputs();
-    final proposal = await inputsCommitted.finalizeProposal(
+    final result = await processReceiveSession(
+      state: state,
+      persister: persister,
+      hasOwnedInputs: hasOwnedInputs,
+      hasReceiverOutput: hasReceiverOutput,
+      inputPairs: inputPairs,
+      receiverModel: receiverModel,
       processPsbt: processPsbt,
-      maxFeeRateSatPerVb: receiverModel.maxFeeRateSatPerVb,
     );
-
-    // Now that the request is processed and the proposal is ready, send it to
-    //  the sender through the payjoin directory
-    await _sendPayjoinProposal(proposal);
 
     // Update the model with the proposal psbt so it can be known a proposal has
     //  been sent
-    final proposalPsbt = await proposal.psbt();
+    final proposalPsbt = result.psbt;
 
     final updatedModel = receiverModel.copyWith(
-      receiver: receiver.toJson(),
+      receiver: persister.toJson(),
       proposalPsbt: proposalPsbt,
       txId: (await BitcoinTx.fromPsbt(proposalPsbt)).txid,
     );
 
     logger.log.info(
-      'Payjoin request processed and proposal sent for ${receiver.id()}: $proposalPsbt',
+      'Payjoin request processed and proposal sent for ${receiverModel.id}: $proposalPsbt',
     );
 
     return updatedModel;
+  }
+
+  Future<({Monitor monitor, String psbt})> processReceiveSession({
+    required ReceiveSession state,
+    required InMemoryJsonReceiverSessionPersister persister,
+    required bool Function(Uint8List) hasOwnedInputs,
+    required bool Function(Uint8List) hasReceiverOutput,
+    required List<PayjoinInputPairModel> inputPairs,
+    required PayjoinReceiverModel receiverModel,
+    required String Function(String) processPsbt,
+  }) async {
+    switch (state) {
+      case InitializedReceiveSession():
+        throw StateError('Original PSBT is retrieved in the receiver isolate');
+      case UncheckedOriginalPayloadReceiveSession():
+        return _checkProposal(
+          state.inner,
+          persister,
+          hasOwnedInputs,
+          hasReceiverOutput,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case MaybeInputsOwnedReceiveSession():
+        return _checkInputsNotOwned(
+          state.inner,
+          persister,
+          hasOwnedInputs,
+          hasReceiverOutput,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case MaybeInputsSeenReceiveSession():
+        return _checkNoInputsSeenBefore(
+          state.inner,
+          persister,
+          hasReceiverOutput,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case OutputsUnknownReceiveSession():
+        return _identifyReceiverOutputs(
+          state.inner,
+          persister,
+          hasReceiverOutput,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case WantsOutputsReceiveSession():
+        return _commitOutputs(
+          state.inner,
+          persister,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case WantsInputsReceiveSession():
+        return _contributeInputs(
+          state.inner,
+          persister,
+          inputPairs,
+          receiverModel,
+          processPsbt,
+        );
+      case WantsFeeRangeReceiveSession():
+        return _applyFeeRange(
+          state.inner,
+          persister,
+          receiverModel,
+          processPsbt,
+        );
+      case ProvisionalProposalReceiveSession():
+        return _finalizeProposal(state.inner, persister, processPsbt);
+      case PayjoinProposalReceiveSession():
+        return _sendPayjoinProposal(state.inner, persister);
+      case HasReplyableExceptionReceiveSession():
+        throw StateError('Receive session has a replyable exception');
+      case MonitorReceiveSession():
+        throw StateError(
+          'Receive session is monitoring; proposal already sent',
+        );
+      case ClosedReceiveSession():
+        throw StateError('Receive session is closed');
+      default:
+        throw StateError('Unexpected receive session state: $state');
+    }
+  }
+
+  Future<({Monitor monitor, String psbt})> _checkProposal(
+    UncheckedOriginalPayload inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    bool Function(Uint8List) hasOwnedInputs,
+    bool Function(Uint8List) hasReceiverOutput,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner.assumeInteractiveReceiver().save(persister: persister);
+    return _checkInputsNotOwned(
+      next,
+      persister,
+      hasOwnedInputs,
+      hasReceiverOutput,
+      inputPairs,
+      receiverModel,
+      processPsbt,
+    );
+  }
+
+  Future<({Monitor monitor, String psbt})> _checkInputsNotOwned(
+    MaybeInputsOwned inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    bool Function(Uint8List) hasOwnedInputs,
+    bool Function(Uint8List) hasReceiverOutput,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner
+        .checkInputsNotOwned(isOwned: _IsScriptOwned(hasOwnedInputs))
+        .save(persister: persister);
+    return _checkNoInputsSeenBefore(
+      next,
+      persister,
+      hasReceiverOutput,
+      inputPairs,
+      receiverModel,
+      processPsbt,
+    );
+  }
+
+  Future<({Monitor monitor, String psbt})> _checkNoInputsSeenBefore(
+    MaybeInputsSeen inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    bool Function(Uint8List) hasReceiverOutput,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner
+        .checkNoInputsSeenBefore(isKnown: _AssumeUnseen())
+        .save(persister: persister);
+    return _identifyReceiverOutputs(
+      next,
+      persister,
+      hasReceiverOutput,
+      inputPairs,
+      receiverModel,
+      processPsbt,
+    );
+  }
+
+  Future<({Monitor monitor, String psbt})> _identifyReceiverOutputs(
+    OutputsUnknown inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    bool Function(Uint8List) hasReceiverOutput,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner
+        .identifyReceiverOutputs(
+          isReceiverOutput: _IsScriptOwned(hasReceiverOutput),
+        )
+        .save(persister: persister);
+    return _commitOutputs(
+      next,
+      persister,
+      inputPairs,
+      receiverModel,
+      processPsbt,
+    );
+  }
+
+  Future<({Monitor monitor, String psbt})> _commitOutputs(
+    WantsOutputs inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner.commitOutputs().save(persister: persister);
+    return _contributeInputs(
+      next,
+      persister,
+      inputPairs,
+      receiverModel,
+      processPsbt,
+    );
+  }
+
+  Future<({Monitor monitor, String psbt})> _contributeInputs(
+    WantsInputs inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    List<PayjoinInputPairModel> inputPairs,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final candidates = inputPairs.map(_buildInputPair).toList();
+    InputPair? chosen;
+    try {
+      chosen = inner.tryPreservingPrivacy(candidateInputs: candidates);
+    } catch (e) {
+      throw StateError('No inputs available to contribute to payjoin');
+    }
+    final next = inner
+        .contributeInputs(replacementInputs: [chosen])
+        .commitInputs()
+        .save(persister: persister);
+    return _applyFeeRange(next, persister, receiverModel, processPsbt);
+  }
+
+  Future<({Monitor monitor, String psbt})> _applyFeeRange(
+    WantsFeeRange inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    PayjoinReceiverModel receiverModel,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner
+        .applyFeeRange(
+          minFeeRateSatPerVb: null,
+          maxEffectiveFeeRateSatPerVb: receiverModel.maxFeeRateSatPerVb.toInt(),
+        )
+        .save(persister: persister);
+    return _finalizeProposal(next, persister, processPsbt);
+  }
+
+  Future<({Monitor monitor, String psbt})> _finalizeProposal(
+    ProvisionalProposal inner,
+    InMemoryJsonReceiverSessionPersister persister,
+    String Function(String) processPsbt,
+  ) async {
+    final next = inner
+        .finalizeProposal(processPsbt: _ProcessPsbt(processPsbt))
+        .save(persister: persister);
+    return _sendPayjoinProposal(next, persister);
+  }
+
+  Future<({Monitor monitor, String psbt})> _sendPayjoinProposal(
+    PayjoinProposal proposal,
+    InMemoryJsonReceiverSessionPersister persister,
+  ) async {
+    Object? lastError;
+    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+      try {
+        final req = proposal.createPostRequest(ohttpRelay: relay);
+        final body = await _postBytes(
+          _dio,
+          req.request.url,
+          req.request.body,
+          req.request.contentType,
+        );
+        // Capture the proposal PSBT here, as it's not available on the monitor typestate.
+        final psbt = proposal.psbt();
+        final monitor = proposal
+            .processResponse(body: body, ohttpContext: req.clientResponse)
+            .save(persister: persister);
+        return (monitor: monitor, psbt: psbt);
+      } catch (e) {
+        log('proposal post via $relay failed: $e');
+        lastError = e;
+        continue;
+      }
+    }
+    throw PayjoinNotFoundException(
+      'Failed to post payjoin proposal: $lastError',
+    );
+  }
+
+  InputPair _buildInputPair(PayjoinInputPairModel input) {
+    return InputPair(
+      txin: TxIn(
+        previousOutput: OutPoint(txid: input.txId, vout: input.vout),
+        scriptSig: Uint8List.fromList(input.scriptSigRawOutputScript),
+        sequence: input.sequence,
+        witness: input.witness,
+      ),
+      psbtin: PsbtInput(
+        witnessUtxo: TxOut(
+          valueSat: (input.value ?? BigInt.zero).toInt(),
+          scriptPubkey: input.scriptPubkey,
+        ),
+        redeemScript: input.redeemScriptRawOutputScript.isEmpty
+            ? null
+            : Uint8List.fromList(input.redeemScriptRawOutputScript),
+        witnessScript: input.witnessScriptRawOutputScript.isEmpty
+            ? null
+            : Uint8List.fromList(input.witnessScriptRawOutputScript),
+      ),
+      expectedWeight: null,
+    );
   }
 
   Future<void> startListeningForRequest(PayjoinReceiverModel payjoin) async {
@@ -617,36 +848,6 @@ class PdkPayjoinDatasource {
       }
       return null;
     }
-  }
-
-  Future<void> _sendPayjoinProposal(PayjoinProposal proposal) async {
-    (Request, ClientResponse)? request;
-    for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrls) {
-      try {
-        request = await proposal.extractReq(ohttpRelay: ohttpRelayUrl);
-        break;
-      } catch (e) {
-        log('proposal extractReq exception: $e with relay $ohttpRelayUrl');
-        continue;
-      }
-    }
-    if (request == null) {
-      throw PayjoinNotFoundException('No payjoin proposal found');
-    }
-
-    final (req, ohttpCtx) = request;
-    final res = await _dio.post(
-      req.url.asString(),
-      data: req.body,
-      options: Options(
-        headers: {'Content-Type': req.contentType},
-        responseType: ResponseType.bytes,
-      ),
-    );
-    await proposal.processRes(
-      res: res.data as List<int>,
-      ohttpContext: ohttpCtx,
-    );
   }
 
   static Future<String?> getProposalPsbt({

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -133,43 +133,37 @@ class PdkPayjoinDatasource {
     int? expireAfterSec,
   }) async {
     final expirySec = expireAfterSec ?? PayjoinConstants.defaultExpireAfterSec;
-    final uri = await Uri.fromStr(bip21);
 
     PjUri pjUri;
+    final Uri parsedUri;
     try {
-      pjUri = uri.checkPjSupported();
+      parsedUri = Uri.parse(uri: bip21);
+      pjUri = parsedUri.checkPjSupported();
     } catch (e) {
       throw NoValidPayjoinBip21Exception(e.toString());
     }
 
-    final minFeeRateSatPerKwu = BigInt.from(networkFeesSatPerVb * 250);
-    final senderBuilder = await SenderBuilder.fromPsbtAndUri(
-      psbtBase64: originalPsbt,
-      pjUri: pjUri,
-    );
-    final newSender = await senderBuilder.buildRecommended(
-      minFeeRate: minFeeRateSatPerKwu,
-    );
-    final imp = InMemorySenderPersister();
-    final persister = DartSenderPersister(
-      save: (sender) async {
-        return await imp.save(sender: sender);
-      },
-      load: (token) async {
-        return await imp.load(token: token);
-      },
-    );
-    final token = await newSender.persist(persister: persister);
-    final sender = await Sender.load(token: token, persister: persister);
-    final senderJson = sender.toJson();
+    var sendBuilder = SenderBuilder(psbt: originalPsbt, uri: pjUri);
+    final persister = InMemoryJsonSenderSessionPersister();
+    final minFeeRateSatPerKwu = (networkFeesSatPerVb * 250).round();
+    WithReplyKey? withReplyKey;
+    try {
+      withReplyKey = sendBuilder
+          .buildRecommended(minFeeRateSatPerKwu: minFeeRateSatPerKwu)
+          .save(persister: persister);
+    } catch (e) {
+      throw SendCreationException(e.toString());
+    }
+
+    await postOriginalProposal(withReplyKey, persister);
 
     // Create and store the model with the data needed to keep track of the
-    //  payjoin session
+    // payjoin session
     final model =
         PayjoinModel.sender(
-              uri: uri.asString(),
+              uri: parsedUri.asString(),
               isTestnet: isTestnet,
-              sender: senderJson,
+              sender: persister.toJson(),
               walletId: walletId,
               originalPsbt: originalPsbt,
               originalTxId: (await BitcoinTx.fromPsbt(originalPsbt)).txid,
@@ -183,6 +177,39 @@ class PdkPayjoinDatasource {
     await startListeningForProposal(model);
 
     return model;
+  }
+
+  Future<void> postOriginalProposal(
+    WithReplyKey withReplyKey,
+    InMemoryJsonSenderSessionPersister persister,
+  ) async {
+    Object? lastError;
+    var posted = false;
+    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+      try {
+        final reqCtx = withReplyKey.createV2PostRequest(ohttpRelay: relay);
+        final body = await _postBytes(
+          _dio,
+          reqCtx.request.url,
+          reqCtx.request.body,
+          reqCtx.request.contentType,
+        );
+        withReplyKey
+            .processResponse(response: body, postCtx: reqCtx.ohttpCtx)
+            .save(persister: persister);
+        posted = true;
+        break;
+      } catch (e) {
+        log('sender v2 post via $relay failed: $e');
+        lastError = e;
+        continue;
+      }
+    }
+    if (!posted) {
+      throw SendCreationException(
+        'Failed to post original PSBT to any OHTTP relay: $lastError',
+      );
+    }
   }
 
   Future<PayjoinReceiverModel> proposePayjoin({
@@ -620,56 +647,6 @@ class PdkPayjoinDatasource {
       res: res.data as List<int>,
       ohttpContext: ohttpCtx,
     );
-  }
-
-  static Future<V2GetContext> request({
-    required Sender sender,
-    required Dio dio,
-  }) async {
-    (Request, V2PostContext)? result;
-
-    for (final ohttpProxyUrl in PayjoinConstants.ohttpRelayUrls) {
-      try {
-        log(
-          '[Senders Isolate] Extracting V2 request from sender with relay: $ohttpProxyUrl',
-        );
-        result = await sender.extractV2(
-          ohttpProxyUrl: await Url.fromStr(ohttpProxyUrl),
-        );
-        break;
-      } catch (e) {
-        final msg = (e as dynamic).msg ?? e.toString();
-        log('[Senders Isolate] request error: $msg');
-        log('[Senders Isolate] Continuing to next OHTTP relay');
-        continue;
-      }
-    }
-
-    if (result == null) {
-      log('[Senders Isolate] All OHTTP relays failed');
-      throw Exception('All OHTTP relays failed');
-    }
-
-    final (req, context) = result;
-
-    log('[Senders Isolate] Sending V2 request to ${req.url.asString()}');
-    final res = await dio.post(
-      req.url.asString(),
-      data: req.body,
-      options: Options(
-        headers: {'Content-Type': req.contentType},
-        responseType: ResponseType.bytes,
-      ),
-    );
-    log('[Senders Isolate] Received response from ${req.url.asString()}');
-
-    final getCtx = await context.processResponse(
-      response: res.data as List<int>,
-    );
-
-    log('[Senders Isolate] Processed response for V2 request: $getCtx');
-
-    return getCtx;
   }
 
   static Future<String?> getProposalPsbt({

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -13,7 +13,8 @@ import 'package:bb_mobile/core/utils/logger.dart' as logger;
 import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:payjoin/payjoin.dart';
-import 'package:payjoin_flutter/bitcoin_ffi.dart';
+import 'package:payjoin/http.dart' show fetchOhttpKeys;
+import 'packapayjoin_flutter/bitcoin_ffi.dart';
 import 'package:payjoin_flutter/common.dart';
 import 'package:payjoin_flutter/receive.dart';
 import 'package:payjoin_flutter/send.dart';
@@ -53,25 +54,21 @@ class PdkPayjoinDatasource {
 
   Stream<PayjoinModel> get expiredPayjoins => _expiredController.stream;
 
-  Future<(OhttpKeys?, Url?)> fetchOhttpKeyAndRelay({
+  Future<(OhttpKeys?, String?)> fetchOhttpKeyAndRelay({
     required String payjoinDirectory,
   }) async {
-    Url? ohttpRelay;
-    OhttpKeys? ohttpKeys;
     for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrls) {
       try {
-        final relay = await Url.fromStr(ohttpRelayUrl);
-        ohttpKeys = await fetchOhttpKeys(
-          ohttpRelay: ohttpRelayUrl,
-          payjoinDirectory: payjoinDirectory,
+        final ohttpKeys = await fetchOhttpKeys(
+          ohttpRelayUrl: ohttpRelayUrl,
+          directoryUrl: payjoinDirectory,
         );
-        ohttpRelay = relay;
-        break;
+        return (ohttpKeys, ohttpRelayUrl);
       } catch (e) {
         continue;
       }
     }
-    return (ohttpKeys, ohttpRelay);
+    return (null, null);
   }
 
   Future<PayjoinReceiverModel> createReceiver({

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -14,11 +14,6 @@ import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:payjoin/payjoin.dart';
 import 'package:payjoin/http.dart' show fetchOhttpKeys;
-import 'packapayjoin_flutter/bitcoin_ffi.dart';
-import 'package:payjoin_flutter/common.dart';
-import 'package:payjoin_flutter/receive.dart';
-import 'package:payjoin_flutter/send.dart';
-import 'package:payjoin_flutter/uri.dart';
 
 class PdkPayjoinDatasource {
   final String _payjoinDirectoryUrl;
@@ -379,8 +374,6 @@ class PdkPayjoinDatasource {
 
   static Future<void> _receiversIsolateEntryPoint(SendPort sendPort) async {
     log('[Receivers Isolate] Started _receiversIsolateEntryPoint');
-    // Initialize core library in the isolate too for the native pdk library
-    await PConfig.initializeApp();
 
     final receivePort = ReceivePort();
     sendPort.send(receivePort.sendPort);
@@ -470,8 +463,6 @@ class PdkPayjoinDatasource {
 
   static Future<void> _sendersIsolateEntryPoint(SendPort sendPort) async {
     log('[Senders Isolate] Started _sendersIsolateEntryPoint');
-    // Initialize core library in the isolate too for the native pdk library
-    await PConfig.initializeApp();
 
     final receivePort = ReceivePort();
     sendPort.send(receivePort.sendPort);

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -731,20 +731,13 @@ class PdkPayjoinDatasource {
     sendPort.send(receivePort.sendPort);
 
     final dio = Dio();
-    // Listen for and register new receivers sent from the main isolate
+    // Listen for and register new senders sent from the main isolate
     receivePort.listen((data) async {
       try {
         log('[Senders Isolate] Received data in senders isolate: $data');
         final senderModel = PayjoinSenderModel.fromJson(
           data as Map<String, dynamic>,
         );
-        final sender = Sender.fromJson(json: senderModel.sender);
-        log('[Senders Isolate] Requesting payjoin...');
-        final context = await PdkPayjoinDatasource.request(
-          sender: sender,
-          dio: dio,
-        );
-        log('[Senders Isolate] Payjoin requested.');
 
         // Periodically check for a proposal from the receiver
         Timer.periodic(
@@ -752,9 +745,18 @@ class PdkPayjoinDatasource {
           (Timer timer) async {
             log('[Senders Isolate]Checking for proposal in senders isolate');
             try {
-              final proposalPsbt = await PdkPayjoinDatasource.getProposalPsbt(
-                context: context,
-                dio: dio,
+              final persister = InMemoryJsonSenderSessionPersister.fromJson(
+                senderModel.sender,
+              );
+              final state = pj
+                  .replaySenderEventLog(persister: persister)
+                  .state();
+              if (state is! PollingForProposalSendSession) return;
+
+              final proposalPsbt = await _getProposalPsbt(
+                state.inner,
+                persister,
+                dio,
               );
 
               if (proposalPsbt != null) {
@@ -764,6 +766,7 @@ class PdkPayjoinDatasource {
                 //  further processing so send it through the model as well as
                 //  its txId.
                 final updatedModel = senderModel.copyWith(
+                  sender: persister.toJson(),
                   proposalPsbt: proposalPsbt,
                   txId: txId,
                 );
@@ -829,63 +832,43 @@ class PdkPayjoinDatasource {
     throw PayjoinNotFoundException('Failed to poll receiver: $lastError');
   }
 
-  static Future<String?> getProposalPsbt({
-    required V2GetContext context,
-    required Dio dio,
-  }) async {
-    // The use of ffiError here is a hack, we should change it once payjoin-flutter
-    //  exposes different exceptions for specific errors
-    Object? ffiError;
-    try {
-      (Request, ClientResponse)? result;
-      for (final ohttpRelay in PayjoinConstants.ohttpRelayUrls) {
-        try {
-          result = await context.extractReq(ohttpRelay: ohttpRelay);
-          ffiError = null;
-          log(
-            'context extract request success: $result with relay $ohttpRelay',
-          );
-          break;
-        } catch (e) {
-          log('context extract request exception: $e with relay $ohttpRelay');
-          ffiError = e;
-          continue;
+  static Future<String?> _getProposalPsbt(
+    PollingForProposal polling,
+    InMemoryJsonSenderSessionPersister persister,
+    Dio dio,
+  ) async {
+    Object? lastError;
+    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+      try {
+        final poll = polling.createPollRequest(ohttpRelay: relay);
+        final body = await _postBytes(
+          dio,
+          poll.request.url,
+          poll.request.body,
+          poll.request.contentType,
+        );
+        final outcome = polling
+            .processResponse(response: body, ohttpCtx: poll.ohttpCtx)
+            .save(persister: persister);
+        if (outcome is StasisPollingForProposalTransitionOutcome) {
+          return null;
         }
-      }
-
-      if (result == null) {
-        if (ffiError != null) {
-          throw ffiError;
+        return (outcome as ProgressPollingForProposalTransitionOutcome)
+            .psbtBase64;
+      } on CreateRequestException catch (e) {
+        if (_isExpiredString(e)) {
+          throw PayjoinExpiredException('Payjoin sender expired: $e');
         }
-        throw Exception('All OHTTP relays failed');
+        log('sender createPollRequest via $relay failed: $e');
+        lastError = e;
+        continue;
+      } catch (e) {
+        log('sender poll via $relay failed: $e');
+        lastError = e;
+        continue;
       }
-
-      final (req, reqCtx) = result;
-
-      final res = await dio.post(
-        req.url.asString(),
-        data: req.body,
-        options: Options(
-          headers: {'Content-Type': req.contentType},
-          responseType: ResponseType.bytes,
-        ),
-      );
-
-      final proposalPsbt = await context.processResponse(
-        response: res.data as List<int>,
-        ohttpCtx: reqCtx,
-      );
-
-      return proposalPsbt;
-    } catch (e) {
-      log('getProposalPsbt exception: $e');
-      if (e == ffiError) {
-        // TODO: Check for the correct error.
-        //  We just assume the error is an expired error for now.
-        throw PayjoinExpiredException('Payjoin sender expired');
-      }
-      return null;
     }
+    throw PayjoinNotFoundException('Failed to poll sender: $lastError');
   }
 
   // "Expired" variants aren't exposed publicly as a distinct subtype.

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:isolate';
 import 'dart:typed_data';
@@ -9,7 +10,9 @@ import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart' as logger;
+import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
+import 'package:payjoin/payjoin.dart';
 import 'package:payjoin_flutter/bitcoin_ffi.dart';
 import 'package:payjoin_flutter/common.dart';
 import 'package:payjoin_flutter/receive.dart';
@@ -749,6 +752,23 @@ class PdkPayjoinDatasource {
       return null;
     }
   }
+
+  static Future<Uint8List> _postBytes(
+    Dio dio,
+    String url,
+    Uint8List body,
+    String contentType,
+  ) async {
+    final response = await dio.post<List<int>>(
+      url,
+      data: body,
+      options: Options(
+        headers: {'Content-Type': contentType},
+        responseType: ResponseType.bytes,
+      ),
+    );
+    return Uint8List.fromList(response.data ?? const []);
+  }
 }
 
 class PayjoinNotFoundException extends BullException {
@@ -769,6 +789,32 @@ class PayjoinExpiredException extends BullException {
 
 class OhttpRelaysUnavailableException extends BullException {
   OhttpRelaysUnavailableException(super.message);
+}
+
+class SendCreationException extends BullException {
+  SendCreationException(super.message);
+}
+
+class _IsScriptOwned implements IsScriptOwned {
+  final bool Function(Uint8List) _fn;
+  _IsScriptOwned(this._fn);
+
+  @override
+  bool callback(Uint8List script) => _fn(script);
+}
+
+/// Assume the wallet has not seen the inputs since it is an interactive wallet
+class _AssumeUnseen implements IsOutputKnown {
+  @override
+  bool callback(OutPoint outpoint) => false;
+}
+
+class _ProcessPsbt implements ProcessPsbt {
+  final String Function(String) _sign;
+  _ProcessPsbt(this._sign);
+
+  @override
+  String callback(String psbt) => _sign(psbt);
 }
 
 class InMemoryJsonReceiverSessionPersister

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -18,7 +18,6 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/constants.dart' show PayjoinConstants;
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
@@ -498,16 +497,14 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       );
       if (freshModel == null) throw Exception('Payjoin receiver not found');
 
-      final bdkWallet = await BdkFacade.createWallet(wallet);
-
+      final isMineSync = await _bdkWallet.createIsMineChecker(wallet: wallet);
+      final signPsbtSync = await _bdkWallet.createPsbtSigner(wallet: wallet);
       final updatedModel = await _pdkPayjoinDatasource.proposePayjoin(
         receiverModel: freshModel,
-        hasOwnedInputs: (script) =>
-            _bdkWallet.isMine(script, wallet: wallet, bdkWallet: bdkWallet),
-        hasReceiverOutput: (script) =>
-            _bdkWallet.isMine(script, wallet: wallet, bdkWallet: bdkWallet),
+        hasOwnedInputs: isMineSync,
+        hasReceiverOutput: isMineSync,
         inputPairs: inputPairs,
-        processPsbt: (psbt) => _bdkWallet.signPsbt(psbt, wallet: wallet),
+        processPsbt: signPsbtSync,
       );
 
       await _localPayjoinDatasource.update(updatedModel);

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -436,7 +436,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         if (model.originalTxBytes == null) {
           // If the original tx bytes are not present, it means the receiver
           //  needs to listen for a payjoin request from the sender.
-          await _pdkPayjoinDatasource.startListeningForRequest(model);
+          _pdkPayjoinDatasource.startListeningForRequest(model);
         } else if (model.proposalPsbt == null) {
           // If the original tx bytes are present but the proposal psbt is not,
           //  it means the receiver has already received a payjoin request and
@@ -449,7 +449,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         if (model.proposalPsbt == null) {
           // If the proposal psbt is not present, it means the sender needs to
           //  listen for a payjoin proposal from the receiver.
-          await _pdkPayjoinDatasource.startListeningForProposal(model);
+          _pdkPayjoinDatasource.startListeningForProposal(model);
         } else {
           // If the proposal psbt is present, it means a payjoin proposal was
           //  already received  and it should be processed.

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -51,9 +51,10 @@ class AssetConstants {
 class PayjoinConstants {
   static List<String> get ohttpRelayUrls {
     final list = [
-      'https://ohttp.achow101.com',
+      // 'https://ohttp.achow101.com',
+      // 'https://ohttp.cakewallet.com',
       'https://pj.bobspacebkk.com',
-      'https://ohttp.cakewallet.com',
+      'https://pj.benalleng.com'
     ];
     list.shuffle(Random.secure());
     return list;

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -86,6 +86,7 @@ class ApiServiceConstants {
   // BB test currently not operational
   static const bbElectrumTestUrl = 'ssl://wes.bullbitcoin.com:60002';
   static const publicElectrumTestUrl = 'ssl://blockstream.info:993';
+  static const publicElectrumTestUrlTwo = 'ssl://testnet.aranguren.org:51002';
 
   // Liquid Electrum servers - lwk does not accept ssl:// prefix
   static const bbLiquidElectrumUrlPath = 'les.bullbitcoin.com:995';

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -85,6 +85,7 @@ class ApiServiceConstants {
   // BB test currently not operational
   static const bbElectrumTestUrl = 'ssl://wes.bullbitcoin.com:60002';
   static const publicElectrumTestUrl = 'ssl://blockstream.info:993';
+  static const publicElectrumTestUrlTwo = 'ssl://testnet.aranguren.org:51002';
 
   // Liquid Electrum servers - lwk does not accept ssl:// prefix
   static const bbLiquidElectrumUrlPath = 'les.bullbitcoin.com:995';

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -50,9 +50,10 @@ class AssetConstants {
 class PayjoinConstants {
   static List<String> get ohttpRelayUrls {
     final list = [
-      'https://ohttp.achow101.com',
+      // 'https://ohttp.achow101.com',
+      // 'https://ohttp.cakewallet.com',
       'https://pj.bobspacebkk.com',
-      'https://ohttp.cakewallet.com',
+      'https://pj.benalleng.com'
     ];
     list.shuffle(Random.secure());
     return list;

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -141,6 +141,38 @@ class BdkWalletDatasource {
     return w.isMine(script: bdk.Script(rawOutputScript: scriptBytes));
   }
 
+  /// Returns a synchronous `isMine` check bound to a pre-loaded bdk wallet.
+  Future<bool Function(Uint8List)> createIsMineChecker({
+    required WalletModel wallet,
+  }) async {
+    final bdkWallet = await BdkFacade.createWallet(wallet);
+    return (Uint8List scriptBytes) =>
+        bdkWallet.isMine(script: bdk.Script(rawOutputScript: scriptBytes));
+  }
+
+  /// Returns a synchronous PSBT signer bound to a pre-loaded private bdk
+  /// wallet.
+  Future<String Function(String)> createPsbtSigner({
+    required PrivateBdkWalletModel wallet,
+  }) async {
+    final bdkWallet = await BdkFacade.createPrivateWallet(wallet);
+    return (String psbtBase64) {
+      final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+      bdkWallet.sign(
+        psbt: psbt,
+        signOptions: bdk.SignOptions(
+          trustWitnessUtxo: true,
+          assumeHeight: null,
+          allowAllSighashes: true,
+          tryFinalize: true,
+          signWithTapInternalKey: false,
+          allowGrinding: true,
+        ),
+      );
+      return psbt.serialize();
+    };
+  }
+
   Future<bool> isAddressMine(
     String address, {
     required WalletModel wallet,

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -750,7 +750,12 @@ Future<void> _performFullScan(_SyncParams params) async {
   );
 
   final bdkWallet = await BdkFacade.createWallet(wallet);
-  final blockchain = bdk.ElectrumClient(
+  // Guard against a rustls CryptoProvider install race across concurrent
+  // sync isolates. electrum-client's install_default check+install is not
+  // atomic, so two isolates can both see "not installed" and the loser
+  // fails. On retry the provider is already installed and the check
+  // short-circuits.
+  bdk.ElectrumClient buildClient() => bdk.ElectrumClient(
     url: params.electrumUrl,
     socks5: params.electrumSocks5?.isNotEmpty == true
         ? params.electrumSocks5
@@ -759,6 +764,16 @@ Future<void> _performFullScan(_SyncParams params) async {
     retry: params.electrumRetry.clamp(0, 255),
     validateDomain: params.electrumValidateDomain,
   );
+  bdk.ElectrumClient blockchain;
+  try {
+    blockchain = buildClient();
+  } on bdk.CouldNotCreateConnectionElectrumException catch (e) {
+    if (e.errorMessage.contains('Failed to install CryptoProvider')) {
+      blockchain = buildClient();
+    } else {
+      rethrow;
+    }
+  }
   final scanRequest = bdkWallet.startFullScan().build();
   final update = blockchain.fullScan(
     request: scanRequest,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,8 +36,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lwk/lwk.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:payjoin_flutter/common.dart';
-
 import 'package:workmanager/workmanager.dart';
 
 class Bull {
@@ -70,7 +68,6 @@ class Bull {
     final initTasks = [
       LibLwk.init(),
       BoltzCore.init(),
-      PConfig.initializeApp(),
       LibBbqr.init(),
       LibArk.init(),
       if (Platform.isAndroid) BitBoxFlutterApi.initialize(),

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all setup clean deps build-runner translations hooks ios-pod-update drift-migrations devcontainer docker-build apk verify test unit-test integration-test fvm-check
+.PHONY: all setup clean deps build-runner translations hooks ios-pod-update drift-migrations devcontainer docker-build apk verify test unit-test integration-test payjoin-test payjoin-cli-receive-test payjoin-cli-send-test fvm-check
 
 fvm-check:
 	@echo "🔍 Checking FVM"
@@ -115,3 +115,17 @@ unit-test:
 integration-test:
 	@echo "🧪 integration tests"
 	@fvm flutter test integration_test/ --reporter=compact
+
+payjoin-test: payjoin-internal-test payjoin-cli-receive-test payjoin-cli-send-test
+
+payjoin-internal-test:
+	@echo "🧪 internal payjoin integration test"
+	@fvm flutter test integration_test/payjoin_test.dart --dart-define-from-file=.env --reporter=compact
+
+payjoin-cli-receive-test:                                                                
+	@echo "🧪 payjoin-cli receiver <-> mobile sender"
+	@bash scripts/payjoin_cli_receive_test.sh
+
+payjoin-cli-send-test:                                                                   
+	@echo "🧪 payjoin-cli sender <-> mobile receiver"
+	@bash scripts/payjoin_cli_send_test.sh

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -398,14 +398,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -932,10 +924,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "08b742eef4f71c9df5af543751cd0b7f1c679c4088488f4223ecaddc1a813b79"
+      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.2"
+    version: "17.2.3"
   google_cloud:
     dependency: transitive
     description:
@@ -1335,14 +1327,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mockito:
-    dependency: transitive
-    description:
-      name: mockito
-      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.6.4"
   mocktail:
     dependency: "direct dev"
     description:
@@ -1351,14 +1335,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   native_toolchain_rust:
     dependency: transitive
     description:
@@ -1399,14 +1375,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   package_config:
     dependency: transitive
     description:
@@ -1467,10 +1435,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1495,15 +1463,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  payjoin_flutter:
+  payjoin:
     dependency: "direct main"
     description:
-      path: "."
-      ref: e939cf5128b61d02aefca725f6de80cbb8818e09
-      resolved-ref: e939cf5128b61d02aefca725f6de80cbb8818e09
-      url: "https://github.com/SatoshiPortal/payjoin-dart"
-    source: git
-    version: "0.23.0"
+      name: payjoin
+      sha256: a2047b2f2ecb40543f1a8b0d5ea93cf377151ac72463df4096aa73a443cef42e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -2347,5 +2314,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,10 +32,7 @@ dependencies:
       path: flutter_secure_storage
   path_provider: ^2.1.5
   shared_preferences: ^2.3.0
-  payjoin_flutter:
-    git:
-      url: https://github.com/SatoshiPortal/payjoin-dart
-      ref: e939cf5128b61d02aefca725f6de80cbb8818e09
+  payjoin: ^0.1.1
   qr_flutter: ^4.1.0
   dio: ^5.9.0
   timeago: ^3.7.1

--- a/scripts/payjoin_cli_example.config.toml
+++ b/scripts/payjoin_cli_example.config.toml
@@ -1,0 +1,29 @@
+# NOTE: payjoin-cli does NOT require a config.toml for the e2e test.
+# All arguments are passed directly on the command line by the Dart test.
+# This file is kept as a reference only.
+#
+# If you want to use payjoin-cli manually (outside of the automated test),
+# copy this to a directory and rename it config.toml, then run payjoin-cli
+# from that directory.
+#
+# Reference: https://github.com/payjoin/rust-payjoin
+
+[bitcoind]
+# testnet3 default (must match the network the mobile app uses)
+rpchost = "http://127.0.0.1:18332/wallet/payjoin-test"
+# Use either cookie file:
+# cookie = "/home/<user>/.bitcoin/testnet3/.cookie"
+# Or rpcuser / rpcpassword:
+cookie = "/home/user/.bitcoin/testnet3/.cookie"
+
+# rpcuser = "your_rpc_user"
+# rpcpassword = "your_rpc_password"
+
+[v2]
+# Must match PayjoinConstants in lib/core/utils/constants.dart
+pj_directory = "https://payjo.in"
+ohttp_relays = [
+    "https://ohttp.achow101.com",
+    "https://pj.bobspacebkk.com",
+    "https://pj.benalleng.com",
+]

--- a/scripts/payjoin_cli_receive_test.sh
+++ b/scripts/payjoin_cli_receive_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Orchestrates the payjoin-cli receiver <-> mobile sender integration test.
+#
+# Steps:
+#   1. Start payjoin-cli as a receiver — it prints a BIP21 pjURI to stdout
+#   2. Wait for that URI to appear
+#   3. Pass the URI to `flutter test` as PJ_BIP21_URI
+#   4. Clean up the CLI process on exit
+#
+# Required env / .env variables:
+#   PAYJOIN_CLI_SOURCE_DIR   Path to the payjoin-cli Cargo crate
+#   PAYJOIN_CLI_RPCHOST      bitcoind RPC URL  (e.g. http://localhost:18332/wallet/test)
+#   PAYJOIN_CLI_COOKIE_FILE  Path to bitcoind .cookie  — OR use RPCUSER + RPCPASSWORD
+#   PAYJOIN_CLI_RPCUSER
+#   PAYJOIN_CLI_RPCPASSWORD
+#
+# Optional:
+#   CARGO_PATH               Full path to cargo binary (default: cargo)
+#   PAYJOIN_CLI_OHTTP_RELAY  OHTTP relay URL
+#   PAYJOIN_CLI_PJ_DIRECTORY Payjoin directory URL
+#   PAYJOIN_CLI_SEND_AMOUNT_SAT  Amount in sat for the CLI to receive (default: 2000)
+#   BIP21_WAIT_SECS          Seconds to wait for BIP21 URI (default: 120 — first run compiles)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env from repo root
+if [ -f "$REPO_DIR/.env" ]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/.env"
+  set +o allexport
+fi
+
+# --- Config ---
+CARGO_PATH="${CARGO_PATH:-cargo}"
+RUST_TOOLCHAIN="${PAYJOIN_CLI_RUST_TOOLCHAIN:-1.85.0}"
+CLI_SOURCE_DIR="${PAYJOIN_CLI_SOURCE_DIR:?PAYJOIN_CLI_SOURCE_DIR must be set}"
+RPCHOST="${PAYJOIN_CLI_RPCHOST:?PAYJOIN_CLI_RPCHOST must be set}"
+OHTTP_RELAY="${PAYJOIN_CLI_OHTTP_RELAY:-https://pj.benalleng.com}"
+PJ_DIRECTORY="${PAYJOIN_CLI_PJ_DIRECTORY:-https://payjo.in}"
+AMOUNT_SAT="${PAYJOIN_CLI_SEND_AMOUNT_SAT:-2000}"
+BIP21_WAIT_SECS="${BIP21_WAIT_SECS:-120}"
+
+# Pin the Rust toolchain for payjoin-cli builds
+export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
+
+# --- Print Rust version ---
+echo "[script] Using cargo: $CARGO_PATH (toolchain: $RUST_TOOLCHAIN)"
+"$CARGO_PATH" --version
+rustc --version
+
+# --- Temp files ---
+TMPDIR_WORK="$(mktemp -d)"
+DB_PATH="$CLI_SOURCE_DIR/payjoin-test/payjoin.sqlite"
+CLI_LOG="$TMPDIR_WORK/cli.log"
+CLI_PID=""
+
+cleanup() {
+  if [ -n "$CLI_PID" ]; then
+    echo "[script] Killing payjoin-cli (PID $CLI_PID)..."
+    kill "$CLI_PID" 2>/dev/null || true
+  fi
+  echo "[script] === payjoin-cli output ==="
+  cat "$CLI_LOG" 2>/dev/null || true
+  echo "[script] === end payjoin-cli output ==="
+  rm -rf "$TMPDIR_WORK"
+}
+trap cleanup EXIT
+
+# --- Build RPC args ---
+RPC_ARGS=(--rpchost "$RPCHOST")
+COOKIE_FILE="${PAYJOIN_CLI_COOKIE_FILE:-}"
+if [ -n "$COOKIE_FILE" ]; then
+  RPC_ARGS+=(--cookie-file "$COOKIE_FILE")
+else
+  RPC_ARGS+=(
+    --rpcuser "${PAYJOIN_CLI_RPCUSER:?PAYJOIN_CLI_RPCUSER or PAYJOIN_CLI_COOKIE_FILE must be set}"
+    --rpcpassword "${PAYJOIN_CLI_RPCPASSWORD:?PAYJOIN_CLI_RPCPASSWORD must be set}"
+  )
+fi
+
+# --- Start payjoin-cli receiver ---
+echo "[script] Starting payjoin-cli receiver (amount: ${AMOUNT_SAT} sat)..."
+"$CARGO_PATH" run \
+  --manifest-path "$CLI_SOURCE_DIR/Cargo.toml" \
+  -- \
+  "${RPC_ARGS[@]}" \
+  --db-path "$DB_PATH" \
+  --ohttp-relays "$OHTTP_RELAY" \
+  --pj-directory "$PJ_DIRECTORY" \
+  receive "$AMOUNT_SAT" \
+  > "$CLI_LOG" 2>&1 &
+CLI_PID=$!
+
+# --- Wait for BIP21 URI ---
+echo "[script] Waiting up to ${BIP21_WAIT_SECS}s for BIP21 URI (first run compiles Rust — this may take a while)..."
+BIP21_URI=""
+for _ in $(seq 1 "$BIP21_WAIT_SECS"); do
+  if grep -qm1 "^bitcoin:" "$CLI_LOG" 2>/dev/null; then
+    BIP21_URI="$(grep -m1 "^bitcoin:" "$CLI_LOG")"
+    break
+  fi
+  # Exit early if the CLI process died
+  if ! kill -0 "$CLI_PID" 2>/dev/null; then
+    echo "[script] ERROR: payjoin-cli exited unexpectedly. Output:"
+    cat "$CLI_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [ -z "$BIP21_URI" ]; then
+  echo "[script] ERROR: payjoin-cli did not print a BIP21 URI within ${BIP21_WAIT_SECS}s. Output:"
+  cat "$CLI_LOG"
+  exit 1
+fi
+
+# --- Patch fragment separator: payjoin-cli v1.x uses '-' but payjoin-flutter v0.23 expects '+' ---
+# The pj= URL's fragment (after %23) uses '-' between params; the mobile lib expects '+'
+if [[ "$BIP21_URI" == *"%23"* ]]; then
+  PREFIX="${BIP21_URI%%\%23*}"
+  SUFFIX="${BIP21_URI#*%23}"
+  SUFFIX="${SUFFIX//-/+}"
+  BIP21_URI="${PREFIX}%23${SUFFIX}"
+  echo "[script] Patched BIP21 fragment separators (- -> +)"
+fi
+echo "[script] BIP21 URI: $BIP21_URI"
+
+# --- Run Flutter integration test ---
+echo "[script] Running flutter integration test..."
+cd "$REPO_DIR"
+DEVICE_ID="${ANDROID_DEVICE_ID:-$(adb devices | awk 'NR>1 && $2=="device"{print $1; exit}')}"
+if [ -z "$DEVICE_ID" ]; then
+  echo "[script] ERROR: No Android device/emulator found. Start an emulator and retry."
+  exit 1
+fi
+echo "[script] Using device: $DEVICE_ID"
+
+fvm flutter test \
+  --device-id="$DEVICE_ID" \
+  --dart-define="PJ_BIP21_URI=$BIP21_URI" \
+  integration_test/payjoin_cli_receive_integration_test.dart \
+  --reporter=compact
+
+echo "[script] Done."

--- a/scripts/payjoin_cli_receive_test.sh
+++ b/scripts/payjoin_cli_receive_test.sh
@@ -141,6 +141,7 @@ echo "[script] Using device: $DEVICE_ID"
 
 fvm flutter test \
   --device-id="$DEVICE_ID" \
+  --dart-define-from-file=.env \
   --dart-define="PJ_BIP21_URI=$BIP21_URI" \
   integration_test/payjoin_cli_receive_integration_test.dart \
   --reporter=compact

--- a/scripts/payjoin_cli_send_test.sh
+++ b/scripts/payjoin_cli_send_test.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Orchestrates the payjoin-cli sender <-> mobile receiver integration test.
+#
+# Steps:
+#   1. Start the Flutter integration test — it creates a mobile receiver,
+#      prints the BIP21 pjURI to stdout, then polls the directory for the
+#      CLI's original PSBT.
+#   2. Wait for that URI to appear in the test output.
+#   3. Run payjoin-cli `send <bip21>` — it builds a PSBT and posts it.
+#   4. The Flutter test picks up the request, processes it, creates a proposal,
+#      and sends it back via the directory.  payjoin-cli picks it up and broadcasts.
+#   5. Clean up on exit.
+#
+# Required env / .env variables:
+#   PAYJOIN_CLI_SOURCE_DIR   Path to the payjoin-cli Cargo crate
+#   PAYJOIN_CLI_RPCHOST      bitcoind RPC URL  (e.g. http://localhost:18332/wallet/test)
+#   PAYJOIN_CLI_COOKIE_FILE  Path to bitcoind .cookie  — OR use RPCUSER + RPCPASSWORD
+#   PAYJOIN_CLI_RPCUSER
+#   PAYJOIN_CLI_RPCPASSWORD
+#   TEST_ALICE_MNEMONIC      Mobile wallet mnemonic (needs testnet3 tBTC)
+#
+# Optional:
+#   CARGO_PATH               Full path to cargo binary (default: cargo)
+#   PAYJOIN_CLI_OHTTP_RELAY  OHTTP relay URL
+#   PAYJOIN_CLI_PJ_DIRECTORY Payjoin directory URL
+#   PAYJOIN_CLI_SEND_AMOUNT_SAT  Amount in sat for the mobile to receive (default: 2000)
+#   PAYJOIN_CLI_FEE_RATE     Fee rate in sat/vB for payjoin-cli send (default: 2)
+#   BIP21_WAIT_SECS          Seconds to wait for BIP21 URI from mobile (default: 180)
+
+# NOTE: We intentionally do NOT use `set -e`. Errors are handled explicitly so
+# that we always reach the results section and print clear PASS/FAIL output.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env from repo root
+if [ -f "$REPO_DIR/.env" ]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/.env"
+  set +o allexport
+fi
+
+# --- Config ---
+CARGO_PATH="${CARGO_PATH:-cargo}"
+RUST_TOOLCHAIN="${PAYJOIN_CLI_RUST_TOOLCHAIN:-1.85.0}"
+CLI_SOURCE_DIR="${PAYJOIN_CLI_SOURCE_DIR:?PAYJOIN_CLI_SOURCE_DIR must be set}"
+RPCHOST="${PAYJOIN_CLI_RPCHOST:?PAYJOIN_CLI_RPCHOST must be set}"
+OHTTP_RELAY="${PAYJOIN_CLI_OHTTP_RELAY:-https://pj.benalleng.com}"
+PJ_DIRECTORY="${PAYJOIN_CLI_PJ_DIRECTORY:-https://payjo.in}"
+AMOUNT_SAT="${PAYJOIN_CLI_SEND_AMOUNT_SAT:-2000}"
+FEE_RATE="${PAYJOIN_CLI_FEE_RATE:-2}"
+BIP21_WAIT_SECS="${BIP21_WAIT_SECS:-180}"
+CLI_TIMEOUT_SECS="${CLI_TIMEOUT_SECS:-300}"
+
+# Pin the Rust toolchain for payjoin-cli builds
+export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
+
+# --- Print Rust version ---
+echo "[script] Using cargo: $CARGO_PATH (toolchain: $RUST_TOOLCHAIN)"
+"$CARGO_PATH" --version
+rustc --version
+
+# --- Temp files ---
+TMPDIR_WORK="$(mktemp -d)"
+DB_PATH="$CLI_SOURCE_DIR/payjoin-test/payjoin.sqlite"
+CLI_LOG="$TMPDIR_WORK/cli.log"
+FLUTTER_LOG="$TMPDIR_WORK/flutter.log"
+FLUTTER_PID=""
+CLI_PID=""
+
+echo "[script] Logs: $TMPDIR_WORK"
+
+cleanup() {
+  local exit_code=$?
+  if [ -n "$FLUTTER_PID" ]; then
+    echo "[cleanup] Killing Flutter test (PID $FLUTTER_PID)..."
+    kill "$FLUTTER_PID" 2>/dev/null || true
+  fi
+  if [ -n "$CLI_PID" ]; then
+    echo "[cleanup] Killing payjoin-cli (PID $CLI_PID)..."
+    kill "$CLI_PID" 2>/dev/null || true
+  fi
+  # Stop the app on the device/emulator
+  adb -s "${DEVICE_ID:-emulator-5554}" shell am force-stop com.bullbitcoin.mobile 2>/dev/null || true
+
+  echo ""
+  echo "========================================"
+  echo "  LOGS"
+  echo "========================================"
+  echo "--- Flutter test output ---"
+  cat "$FLUTTER_LOG" 2>/dev/null || echo "(empty)"
+  echo ""
+  echo "--- payjoin-cli output ---"
+  cat "$CLI_LOG" 2>/dev/null || echo "(empty)"
+  echo "========================================"
+  echo ""
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "[cleanup] Preserving logs in $TMPDIR_WORK for inspection"
+  else
+    rm -rf "$TMPDIR_WORK"
+  fi
+}
+trap cleanup EXIT
+
+# --- Build RPC args ---
+RPC_ARGS=(--rpchost "$RPCHOST")
+COOKIE_FILE="${PAYJOIN_CLI_COOKIE_FILE:-}"
+if [ -n "$COOKIE_FILE" ]; then
+  RPC_ARGS+=(--cookie-file "$COOKIE_FILE")
+else
+  RPC_ARGS+=(
+    --rpcuser "${PAYJOIN_CLI_RPCUSER:?PAYJOIN_CLI_RPCUSER or PAYJOIN_CLI_COOKIE_FILE must be set}"
+    --rpcpassword "${PAYJOIN_CLI_RPCPASSWORD:?PAYJOIN_CLI_RPCPASSWORD must be set}"
+  )
+fi
+
+# --- Find Android device ---
+cd "$REPO_DIR"
+DEVICE_ID="${ANDROID_DEVICE_ID:-$(adb devices | awk 'NR>1 && $2=="device"{print $1; exit}')}"
+if [ -z "$DEVICE_ID" ]; then
+  echo "[script] ERROR: No Android device/emulator found. Start an emulator and retry."
+  exit 1
+fi
+echo "[script] Using device: $DEVICE_ID"
+
+# --- Start Flutter integration test in background ---
+echo "[script] Starting Flutter integration test (mobile receiver)..."
+fvm flutter test \
+  --device-id="$DEVICE_ID" \
+  --dart-define="PAYJOIN_CLI_SEND_AMOUNT_SAT=$AMOUNT_SAT" \
+  integration_test/payjoin_cli_send_integration_test.dart \
+  --reporter=compact \
+  > "$FLUTTER_LOG" 2>&1 &
+FLUTTER_PID=$!
+echo "[script] Flutter PID: $FLUTTER_PID"
+
+# --- Wait for BIP21 URI from Flutter test ---
+echo "[script] Waiting up to ${BIP21_WAIT_SECS}s for mobile receiver BIP21 URI..."
+BIP21_URI=""
+for _ in $(seq 1 "$BIP21_WAIT_SECS"); do
+  if grep -qm1 "PJ_URI:" "$FLUTTER_LOG" 2>/dev/null; then
+    # The compact reporter may wrap long lines. Collapse continuations and
+    # extract the full URI. Only match characters valid in a BIP21 URI
+    # (letters, digits, and the set: % + ? & = : / . @ _ # -) so we stop
+    # cleanly when the next log line (e.g. "[integration]") begins.
+    BIP21_URI="$(tr -d '\r\n' < "$FLUTTER_LOG" | grep -oP 'PJ_URI:\Kbitcoin:[A-Za-z0-9%+?&=:/.@_#-]+' || true)"
+    # Fallback: try simpler extraction if perl-style grep not available
+    if [ -z "$BIP21_URI" ]; then
+      BIP21_URI="$(tr -d '\r\n' < "$FLUTTER_LOG" | sed -n 's/.*PJ_URI:\(bitcoin:[A-Za-z0-9%+?&=:\/.@_#-]*\).*/\1/p')"
+    fi
+    break
+  fi
+  # Exit early if the Flutter test died
+  if ! kill -0 "$FLUTTER_PID" 2>/dev/null; then
+    echo "[script] ERROR: Flutter test exited before printing a BIP21 URI."
+    exit 1
+  fi
+  sleep 1
+done
+
+if [ -z "$BIP21_URI" ]; then
+  echo "[script] ERROR: Flutter test did not print a BIP21 URI within ${BIP21_WAIT_SECS}s."
+  exit 1
+fi
+
+echo "[script] Extracted BIP21 URI (${#BIP21_URI} chars):"
+echo "  $BIP21_URI"
+
+# --- Append amount to URI if missing (payjoin-cli send requires it) ---
+if [[ "$BIP21_URI" != *"amount="* ]]; then
+  AMOUNT_BTC="$(awk -v sat="$AMOUNT_SAT" 'BEGIN { printf "%.8f", sat / 100000000 }')"
+  if [ -z "$AMOUNT_BTC" ] || [ "$AMOUNT_BTC" = "0.00000000" ]; then
+    echo "[script] ERROR: Failed to compute BTC amount from ${AMOUNT_SAT} sat (got: '${AMOUNT_BTC}')"
+    exit 1
+  fi
+  BIP21_URI="${BIP21_URI}&amount=${AMOUNT_BTC}"
+  echo "[script] Appended amount=${AMOUNT_BTC} BTC (${AMOUNT_SAT} sat) to URI"
+fi
+
+echo "[script] Final URI: $BIP21_URI"
+
+# --- Run payjoin-cli send ---
+echo "[script] Starting payjoin-cli send (fee-rate: ${FEE_RATE} sat/vB)..."
+echo "[script] Full command: cargo run --manifest-path $CLI_SOURCE_DIR/Cargo.toml -- ${RPC_ARGS[*]} --db-path $DB_PATH --ohttp-relays $OHTTP_RELAY --pj-directory $PJ_DIRECTORY send --fee-rate $FEE_RATE \"$BIP21_URI\""
+
+"$CARGO_PATH" run \
+  --manifest-path "$CLI_SOURCE_DIR/Cargo.toml" \
+  -- \
+  "${RPC_ARGS[@]}" \
+  --db-path "$DB_PATH" \
+  --ohttp-relays "$OHTTP_RELAY" \
+  --pj-directory "$PJ_DIRECTORY" \
+  send --fee-rate "$FEE_RATE" "$BIP21_URI" \
+  > "$CLI_LOG" 2>&1 &
+CLI_PID=$!
+echo "[script] payjoin-cli PID: $CLI_PID"
+
+# --- Wait for both processes to finish ---
+echo "[script] Waiting up to ${CLI_TIMEOUT_SECS}s for both processes..."
+
+ELAPSED=0
+FLUTTER_DONE=false
+CLI_DONE=false
+FLUTTER_EXIT=""
+CLI_EXIT=""
+
+while [ "$ELAPSED" -lt "$CLI_TIMEOUT_SECS" ]; do
+  if [ "$FLUTTER_DONE" = false ] && ! kill -0 "$FLUTTER_PID" 2>/dev/null; then
+    wait "$FLUTTER_PID" 2>/dev/null
+    FLUTTER_EXIT=$?
+    FLUTTER_DONE=true
+    FLUTTER_PID=""
+    echo "[script] Flutter test exited with code $FLUTTER_EXIT (${ELAPSED}s elapsed)"
+  fi
+  if [ "$CLI_DONE" = false ] && ! kill -0 "$CLI_PID" 2>/dev/null; then
+    wait "$CLI_PID" 2>/dev/null
+    CLI_EXIT=$?
+    CLI_DONE=true
+    CLI_PID=""
+    echo "[script] payjoin-cli exited with code $CLI_EXIT (${ELAPSED}s elapsed)"
+    # If the CLI exits before the Flutter test, the receiver has no sender to
+    # interact with — kill Flutter immediately instead of waiting for its timeout.
+    if [ "$FLUTTER_DONE" = false ]; then
+      echo "[script] CLI exited early — killing Flutter test (no point waiting)."
+      kill "$FLUTTER_PID" 2>/dev/null || true
+      FLUTTER_PID=""
+      FLUTTER_EXIT="killed"
+      FLUTTER_DONE=true
+    fi
+  fi
+
+  # Print periodic status while waiting
+  if [ $((ELAPSED % 30)) -eq 0 ] && [ "$ELAPSED" -gt 0 ]; then
+    echo -n "[script] Still waiting (${ELAPSED}s):"
+    [ "$FLUTTER_DONE" = false ] && echo -n " flutter" || true
+    [ "$CLI_DONE" = false ] && echo -n " cli" || true
+    echo ""
+    # Tail the CLI log to show progress
+    if [ "$CLI_DONE" = false ] && [ -s "$CLI_LOG" ]; then
+      echo "  [cli tail] $(tail -1 "$CLI_LOG")"
+    fi
+  fi
+
+  if [ "$FLUTTER_DONE" = true ] && [ "$CLI_DONE" = true ]; then
+    break
+  fi
+  sleep 1
+  ELAPSED=$((ELAPSED + 1))
+done
+
+# Kill any stragglers if we timed out
+if [ "$FLUTTER_DONE" = false ]; then
+  echo "[script] TIMEOUT: Flutter test did not finish within ${CLI_TIMEOUT_SECS}s"
+  kill "$FLUTTER_PID" 2>/dev/null || true
+  FLUTTER_PID=""
+  FLUTTER_EXIT="timeout"
+fi
+if [ "$CLI_DONE" = false ]; then
+  echo "[script] TIMEOUT: payjoin-cli did not finish within ${CLI_TIMEOUT_SECS}s"
+  kill "$CLI_PID" 2>/dev/null || true
+  CLI_PID=""
+  CLI_EXIT="timeout"
+fi
+
+# --- Verify results ---
+echo ""
+echo "========================================"
+echo "  TEST RESULTS"
+echo "========================================"
+
+PASS=true
+
+# Check Flutter test result
+if [ "$FLUTTER_EXIT" = "0" ]; then
+  echo "  [PASS] Flutter integration test (mobile receiver)"
+else
+  echo "  [FAIL] Flutter integration test (exit code: ${FLUTTER_EXIT:-unknown})"
+  PASS=false
+fi
+
+# Check payjoin-cli result
+if [ "$CLI_EXIT" = "0" ]; then
+  echo "  [PASS] payjoin-cli send (exit code 0)"
+else
+  echo "  [FAIL] payjoin-cli send (exit code: ${CLI_EXIT:-unknown})"
+  PASS=false
+fi
+
+# Check CLI log for broadcast confirmation (payjoin-cli prints the txid on success)
+if [ -s "$CLI_LOG" ]; then
+  TXID="$(grep -oE '[0-9a-f]{64}' "$CLI_LOG" | tail -1 || true)"
+  if [ -n "$TXID" ]; then
+    echo "  [PASS] Transaction broadcast: $TXID"
+  elif grep -qiE '(broadcast|sent|success)' "$CLI_LOG" 2>/dev/null; then
+    echo "  [INFO] CLI mentions success but no txid found in output"
+  else
+    echo "  [WARN] No broadcast confirmation in CLI output"
+    if [ "$CLI_EXIT" != "0" ]; then
+      PASS=false
+    fi
+  fi
+else
+  echo "  [FAIL] payjoin-cli produced no output (was it started?)"
+  PASS=false
+fi
+
+echo "========================================"
+
+if [ "$PASS" = true ]; then
+  echo "[script] TEST PASSED"
+  exit 0
+else
+  echo "[script] TEST FAILED — logs preserved in $TMPDIR_WORK"
+  exit 1
+fi

--- a/scripts/payjoin_cli_send_test.sh
+++ b/scripts/payjoin_cli_send_test.sh
@@ -53,6 +53,7 @@ AMOUNT_SAT="${PAYJOIN_CLI_SEND_AMOUNT_SAT:-2000}"
 FEE_RATE="${PAYJOIN_CLI_FEE_RATE:-2}"
 BIP21_WAIT_SECS="${BIP21_WAIT_SECS:-180}"
 CLI_TIMEOUT_SECS="${CLI_TIMEOUT_SECS:-300}"
+CLI_BROADCAST_GRACE_SECS="${CLI_BROADCAST_GRACE_SECS:-60}"
 
 # Pin the Rust toolchain for payjoin-cli builds
 export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
@@ -186,7 +187,7 @@ echo "[script] Final URI: $BIP21_URI"
 echo "[script] Starting payjoin-cli send (fee-rate: ${FEE_RATE} sat/vB)..."
 echo "[script] Full command: cargo run --manifest-path $CLI_SOURCE_DIR/Cargo.toml -- ${RPC_ARGS[*]} --db-path $DB_PATH --ohttp-relays $OHTTP_RELAY --pj-directory $PJ_DIRECTORY send --fee-rate $FEE_RATE \"$BIP21_URI\""
 
-"$CARGO_PATH" run \
+RUST_LOG=trace "$CARGO_PATH" run \
   --manifest-path "$CLI_SOURCE_DIR/Cargo.toml" \
   -- \
   "${RPC_ARGS[@]}" \
@@ -244,6 +245,18 @@ while [ "$ELAPSED" -lt "$CLI_TIMEOUT_SECS" ]; do
     fi
   fi
 
+  # When Flutter finishes first, give the CLI a grace period to complete
+  # its broadcast (sendrawtransaction RPC) before the loop times out.
+  if [ "$FLUTTER_DONE" = true ] && [ "$CLI_DONE" = false ]; then
+    if [ -z "${CLI_GRACE_DEADLINE:-}" ]; then
+      CLI_GRACE_DEADLINE=$((ELAPSED + CLI_BROADCAST_GRACE_SECS))
+      echo "[script] Flutter done — giving CLI ${CLI_BROADCAST_GRACE_SECS}s grace period to finish broadcast..."
+    elif [ "$ELAPSED" -ge "$CLI_GRACE_DEADLINE" ]; then
+      echo "[script] CLI grace period expired (${CLI_BROADCAST_GRACE_SECS}s) — checking for raw tx in log..."
+      break
+    fi
+  fi
+
   if [ "$FLUTTER_DONE" = true ] && [ "$CLI_DONE" = true ]; then
     break
   fi
@@ -298,9 +311,7 @@ if [ -s "$CLI_LOG" ]; then
     echo "  [INFO] CLI mentions success but no txid found in output"
   else
     echo "  [WARN] No broadcast confirmation in CLI output"
-    if [ "$CLI_EXIT" != "0" ]; then
-      PASS=false
-    fi
+    PASS=false
   fi
 else
   echo "  [FAIL] payjoin-cli produced no output (was it started?)"

--- a/scripts/payjoin_cli_send_test.sh
+++ b/scripts/payjoin_cli_send_test.sh
@@ -131,6 +131,7 @@ echo "[script] Using device: $DEVICE_ID"
 echo "[script] Starting Flutter integration test (mobile receiver)..."
 fvm flutter test \
   --device-id="$DEVICE_ID" \
+  --dart-define-from-file=.env \
   --dart-define="PAYJOIN_CLI_SEND_AMOUNT_SAT=$AMOUNT_SAT" \
   integration_test/payjoin_cli_send_integration_test.dart \
   --reporter=compact \


### PR DESCRIPTION
This creates a script to automate the integration test between the payjoin-cli and bull bitcoin. This first test is using bull bitcoin as the sender and payjoin-cli as the receiver.

Claude Opus had a heavy hand in porting over the payjoin_test.dart to work with this new format

Blocked until #2041 is merged. Though this is also working with the current payjoin-flutter sdk I think it is probably more useful to wait until it is merged.