### PR TITLE
fix(send): persist transaction labels and auto-populate from invoice labels (#1173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Bull Bitcoin Mobile will be documented in this file.
 
+## [X.X.X] - To be released
+
+### Bug Fixes
+- **Transaction note now saved to database** ([#1173](https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1173)): Fixed an issue where notes added during a send were stored in state but never persisted. Notes embedded in Bolt11 invoice descriptions or BIP21 label parameters are also automatically pre-populated if the user has not set one manually
+
+---
+
 ## [6.8.0] - 2026-03-17
 
 ### New Features

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -41,12 +41,15 @@ import 'package:bb_mobile/features/send/domain/usecases/select_best_wallet_useca
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_usecase.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/labels/new_label.dart';
 import 'package:bb_mobile/features/send/presentation/bloc/send_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SendCubit extends Cubit<SendState> {
   SendCubit({
     Wallet? wallet,
+    required LabelsFacade labelsFacade,
     required SelectBestWalletUsecase bestWalletUsecase,
     required DetectBitcoinStringUsecase detectBitcoinStringUsecase,
     required GetSettingsUsecase getSettingsUsecase,
@@ -80,6 +83,7 @@ class SendCubit extends Cubit<SendState> {
     required UpdateSendSwapLockupFeesUsecase updateSendSwapLockupFeesUsecase,
     required VerifyChainSwapAmountSendUsecase verifyChainSwapAmountSendUsecase,
   }) : _wallet = wallet,
+       _labelsFacade = labelsFacade,
        _getSettingsUsecase = getSettingsUsecase,
        _convertSatsToCurrencyAmountUsecase = convertSatsToCurrencyAmountUsecase,
        _getAvailableCurrenciesUsecase = getAvailableCurrenciesUsecase,
@@ -114,6 +118,7 @@ class SendCubit extends Cubit<SendState> {
 
   // ignore: unused_field
   final Wallet? _wallet;
+  final LabelsFacade _labelsFacade;
   final SelectBestWalletUsecase _bestWalletUsecase;
   final DetectBitcoinStringUsecase _detectBitcoinStringUsecase;
   final GetAvailableCurrenciesUsecase _getAvailableCurrenciesUsecase;
@@ -317,6 +322,17 @@ class SendCubit extends Cubit<SendState> {
           });
 
       final sendType = SendType.from(state.paymentRequest!);
+
+      // Pre-populate label from the embedded invoice description or BIP21 label
+      // if the user hasn't manually set one already.
+      final embeddedLabel = switch (state.paymentRequest!) {
+        Bolt11PaymentRequest(description: final d) when d.isNotEmpty => d,
+        Bip21PaymentRequest(label: final l) when l.isNotEmpty => l,
+        _ => null,
+      };
+      if (embeddedLabel != null && state.label.isEmpty) {
+        emit(state.copyWith(label: embeddedLabel));
+      }
 
       emit(state.copyWith(selectedWallet: wallet, sendType: sendType));
       await loadFees();
@@ -1484,6 +1500,16 @@ class SendCubit extends Cubit<SendState> {
           network: state.selectedWallet!.network,
           absoluteFees:
               0, // TODO (ishi): removed until server fees are implemented
+        );
+      }
+
+      if (state.label.isNotEmpty) {
+        await _labelsFacade.store(
+          NewLabel.tx(
+            transactionId: state.txId!,
+            label: state.label,
+            origin: state.selectedWallet!.id,
+          ),
         );
       }
 

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -42,7 +42,7 @@ import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_usecase.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
-import 'package:bb_mobile/features/labels/new_label.dart';
+
 import 'package:bb_mobile/features/send/presentation/bloc/send_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
@@ -144,6 +145,7 @@ class SendLocator {
     locator.registerFactoryParam<SendCubit, Wallet?, void>(
       (wallet, _) => SendCubit(
         wallet: wallet,
+        labelsFacade: locator<LabelsFacade>(),
         bestWalletUsecase: locator<SelectBestWalletUsecase>(),
         detectBitcoinStringUsecase: locator<DetectBitcoinStringUsecase>(),
         getSettingsUsecase: locator<GetSettingsUsecase>(),


### PR DESCRIPTION
**Fixes #1173**

## What was broken
When sending a transaction, any note you added in the send flow but was never actually written to the database. Same story for invoices that already carry a label (Bolt11 `description` field, BIP21 `label` param) 

## Tested
- Bitcoin
- Liquid
- Lightning invoice from Wallet of Satoshis
