### PR TITLE
feat: added skeleton loader for home screen fiat price

### DIFF
--- a/lib/features/bitcoin_price/presentation/bloc/bitcoin_price_bloc.dart
+++ b/lib/features/bitcoin_price/presentation/bloc/bitcoin_price_bloc.dart
@@ -60,6 +60,14 @@ class BitcoinPriceBloc extends Bloc<BitcoinPriceEvent, BitcoinPriceState> {
     log.info('FiatCurrenciesStarted');
 
     try {
+      emit(
+        state.copyWith(
+          loadingPrice: true,
+          startupFailed: false,
+          error: null,
+        ),
+      );
+
       final settings = await _getSettingsUsecase.execute();
       final currency = event.currency ?? settings.currencyCode;
       final availableCurrencies = await _getAvailableCurrenciesUsecase
@@ -69,6 +77,18 @@ class BitcoinPriceBloc extends Bloc<BitcoinPriceEvent, BitcoinPriceState> {
         currencyCode: currency,
       );
 
+      if (price <= 0) {
+        log.warning('Fiat rate invalid or zero for $currency');
+        emit(
+          state.copyWith(
+            loadingPrice: false,
+            startupFailed: true,
+            error: null,
+          ),
+        );
+        return;
+      }
+
       emit(
         BitcoinPriceState(
           currency: currency,
@@ -76,11 +96,18 @@ class BitcoinPriceBloc extends Bloc<BitcoinPriceEvent, BitcoinPriceState> {
           bitcoinPrice: price,
           startupFailed: false,
           error: null,
+          loadingPrice: false,
         ),
       );
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
-      emit(state.copyWith(error: e, startupFailed: true));
+      emit(
+        state.copyWith(
+          error: e,
+          startupFailed: true,
+          loadingPrice: false,
+        ),
+      );
     }
   }
 
@@ -98,7 +125,18 @@ class BitcoinPriceBloc extends Bloc<BitcoinPriceEvent, BitcoinPriceState> {
           currencyCode: currency,
         );
 
-        emit(state.copyWith(bitcoinPrice: price));
+        if (price <= 0) {
+          emit(state.copyWith(error: StateError('Invalid fiat rate')));
+          return;
+        }
+
+        emit(
+          state.copyWith(
+            bitcoinPrice: price,
+            error: null,
+            startupFailed: false,
+          ),
+        );
       }
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
@@ -119,19 +157,47 @@ class BitcoinPriceBloc extends Bloc<BitcoinPriceEvent, BitcoinPriceState> {
     log.info('BitcoinPriceCurrencyChanged to ${event.currencyCode}');
 
     try {
-      // The state should be in the success state, otherwise try to start the bloc
-      //  again with the new currency in the event.
-      // final successState = state as BitcoinPriceSuccess;
+      emit(state.copyWith(loadingPrice: true));
+
       final currency = event.currencyCode;
-      // Get the exchange rate for the new currency
       final price = await _convertSatsToCurrencyAmountUsecase.execute(
         currencyCode: currency,
       );
 
-      emit(state.copyWith(currency: currency, bitcoinPrice: price));
+      if (price <= 0) {
+        log.warning('Fiat rate invalid or zero after currency change to $currency');
+        emit(
+          state.copyWith(
+            bitcoinPrice: null,
+            currency: currency,
+            loadingPrice: false,
+            error: StateError('Invalid fiat rate'),
+            startupFailed: false,
+          ),
+        );
+        return;
+      }
+
+      emit(
+        state.copyWith(
+          currency: currency,
+          bitcoinPrice: price,
+          loadingPrice: false,
+          error: null,
+          startupFailed: false,
+        ),
+      );
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
-      emit(state.copyWith(error: e));
+      emit(
+        state.copyWith(
+          bitcoinPrice: null,
+          currency: event.currencyCode,
+          loadingPrice: false,
+          error: e,
+          startupFailed: false,
+        ),
+      );
     }
   }
 }

--- a/lib/features/bitcoin_price/presentation/bloc/bitcoin_price_state.dart
+++ b/lib/features/bitcoin_price/presentation/bloc/bitcoin_price_state.dart
@@ -13,8 +13,14 @@ sealed class BitcoinPriceState with _$BitcoinPriceState {
   }) = _BitcoinPriceState;
   const BitcoinPriceState._();
 
+  /// Fiat per 1 BTC from the API; must be positive to display converted amounts.
+  bool get hasValidFiatRate =>
+      currency != null &&
+      bitcoinPrice != null &&
+      bitcoinPrice! > 0;
+
   String? calculateFiatPrice(int satAmount) {
-    if (bitcoinPrice == null) return null;
+    if (!hasValidFiatRate) return null;
     final p = bitcoinPrice! * ConvertAmount.satsToBtc(satAmount);
     if (currency == null) return null;
     return '${_fiatFormatting(p.toStringAsFixed(2))} ${currency!}';

--- a/lib/features/wallet/ui/widgets/home_fiat_balance.dart
+++ b/lib/features/wallet/ui/widgets/home_fiat_balance.dart
@@ -1,7 +1,6 @@
 import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
-import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/price_input/price_input.dart';
 import 'package:bb_mobile/features/bitcoin_price/presentation/bloc/bitcoin_price_bloc.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
@@ -9,11 +8,19 @@ import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dar
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shimmer/shimmer.dart';
 
 class HomeFiatBalance extends StatelessWidget {
-  const HomeFiatBalance({super.key, required this.balanceSat});
+  const HomeFiatBalance({
+    super.key,
+    required this.balanceSat,
+    this.showBalanceLoading = false,
+  });
 
   final int balanceSat;
+
+  /// When true (e.g. wallet list still loading), avoids showing fiat from 0 sats.
+  final bool showBalanceLoading;
 
   Future<void> _openCurrencyBottomSheet(BuildContext context) async {
     List<String> availableCurrencies;
@@ -55,49 +62,22 @@ class HomeFiatBalance extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final startupFailed = context.select(
-      (BitcoinPriceBloc bitcoinPriceBloc) =>
-          bitcoinPriceBloc.state.startupFailed,
-    );
+    final priceState = context.select((BitcoinPriceBloc b) => b.state);
+    final loadingPrice = priceState.loadingPrice;
+    final hasValid = priceState.hasValidFiatRate;
 
-    final fiatPriceIsNull = context.select(
-      (BitcoinPriceBloc bitcoinPriceBloc) =>
-          bitcoinPriceBloc.state.bitcoinPrice == null,
-    );
+    // Only gate on balance/loading and whether we have a usable rate — not
+    // [startupFailed], or a successful currency change still shows skeleton.
+    final showSkeleton =
+        showBalanceLoading || loadingPrice || !hasValid;
 
-    if (startupFailed) {
+    if (showSkeleton) {
       return GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: () {
-          context.read<BitcoinPriceBloc>().add(const BitcoinPriceStarted());
-        },
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(4),
-            border: Border.all(
-              color: context.appColors.border.withValues(alpha: 0.3),
-            ),
-            color: context.appColors.border.withValues(alpha: 0.3),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.refresh, color: context.appColors.onPrimary, size: 16),
-              const SizedBox(width: 4),
-              Text(
-                context.loc.priceFailedToLoad,
-                style: context.font.bodyMedium?.copyWith(
-                  color: context.appColors.onPrimary,
-                ),
-              ),
-            ],
-          ),
-        ),
+        onTap: () => _openCurrencyBottomSheet(context),
+        child: const _HomeFiatBalanceSkeleton(),
       );
     }
-
-    if (fiatPriceIsNull) return const SizedBox.shrink();
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -116,6 +96,38 @@ class HomeFiatBalance extends StatelessWidget {
           showFiat: true,
           style: context.font.bodyLarge,
           color: context.appColors.onPrimary,
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeFiatBalanceSkeleton extends StatelessWidget {
+  const _HomeFiatBalanceSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(
+          color: context.appColors.border.withValues(alpha: 0.3),
+        ),
+        color: context.appColors.border.withValues(alpha: 0.3),
+      ),
+      child: Shimmer.fromColors(
+        baseColor: context.appColors.shimmerBase,
+        highlightColor: context.appColors.shimmerHighlight,
+        child: SizedBox(
+          width: 140,
+          height: 22,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: context.appColors.surface,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/widgets/cards/action_card.dart';
 import 'package:bb_mobile/features/bitcoin_price/presentation/cubit/price_chart_cubit.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/price_chart_widget.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/eye_toggle.dart';
@@ -13,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shimmer/shimmer.dart';
 
 class WalletHomeTopSection extends StatelessWidget {
   const WalletHomeTopSection({super.key});
@@ -130,9 +132,22 @@ class _BtcTotalAmt extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final btcTotal = context.select(
-      (WalletBloc bloc) => bloc.state.totalBalance(),
+    final walletState = context.select((WalletBloc bloc) => bloc.state);
+    final bitcoinUnit = context.select(
+      (SettingsCubit cubit) => cubit.state.bitcoinUnit,
     );
+
+    final showSkeleton =
+        walletState.status == WalletStatus.initial ||
+        walletState.status == WalletStatus.loading ||
+        walletState.isArkWalletLoading ||
+        bitcoinUnit == null;
+
+    if (showSkeleton) {
+      return const _WalletHomeBtcAmountSkeleton();
+    }
+
+    final btcTotal = walletState.totalBalance();
 
     return CurrencyText(
       btcTotal,
@@ -148,11 +163,38 @@ class _FiatAmt extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final totalBal = context.select(
-      (WalletBloc bloc) => bloc.state.totalBalance(),
-    );
+    final walletState = context.select((WalletBloc bloc) => bloc.state);
+    final showBalanceLoading =
+        walletState.status == WalletStatus.initial ||
+        walletState.status == WalletStatus.loading ||
+        walletState.isArkWalletLoading;
 
-    return HomeFiatBalance(balanceSat: totalBal);
+    return HomeFiatBalance(
+      balanceSat: walletState.totalBalance(),
+      showBalanceLoading: showBalanceLoading,
+    );
+  }
+}
+
+class _WalletHomeBtcAmountSkeleton extends StatelessWidget {
+  const _WalletHomeBtcAmountSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: context.appColors.shimmerBase,
+      highlightColor: context.appColors.shimmerHighlight,
+      child: SizedBox(
+        width: 200,
+        height: 40,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: context.appColors.surface,
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
Might close https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1409

Motivated by https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/1409#issuecomment-3971622177

Sometimes, when we try to fetch the price data, it either fails or takes a significant amount of time. Right now we display a 0 value if the fetch fails, which is inaccurate.

It makes sense to instead show a skeleton loader while we don't have the price data.

## Video of Fix
https://github.com/user-attachments/assets/917937e3-1b00-40a9-afcf-361ffed5c87a

