### PR TITLE
fix: backup required before attempting to set up a PIN + theme color fix

### DIFF
--- a/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
+++ b/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
@@ -79,7 +79,7 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                           context.loc.appUnlockEnterPinMessage,
                           textAlign: .center,
                           style: context.font.headlineMedium?.copyWith(
-                            color: context.appColors.outline,
+                            color: context.appColors.onSurface,
                           ),
                           maxLines: 3,
                         ),
@@ -89,20 +89,25 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                           AppUnlockState,
                           (String, bool)
                         >(
-                          selector:
-                              (state) => (state.pinCode, state.obscurePinCode),
+                          selector: (state) =>
+                              (state.pinCode, state.obscurePinCode),
                           builder: (context, data) {
                             final (pinCode, obscurePinCode) = data;
                             return BBInputText(
                               value: pinCode,
                               obscure: obscurePinCode,
-                              onRightTap:
-                                  () => context.read<AppUnlockBloc>().add(
-                                    AppUnlockPinCodeObscureToggled(),
-                                  ),
-                              rightIcon: const Icon(
-                                Icons.visibility_off_outlined,
-                              ),
+                              onRightTap: () => context
+                                  .read<AppUnlockBloc>()
+                                  .add(AppUnlockPinCodeObscureToggled()),
+                              rightIcon: obscurePinCode
+                                  ? Icon(
+                                      Icons.visibility_off_outlined,
+                                      color: context.appColors.onSurface,
+                                    )
+                                  : Icon(
+                                      Icons.visibility_outlined,
+                                      color: context.appColors.onSurface,
+                                    ),
                               onlyNumbers: true,
                               onChanged: (value) {},
                             );
@@ -114,26 +119,23 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                           AppUnlockState,
                           (bool, int)
                         >(
-                          selector:
-                              (state) => (
-                                state.showError,
-                                state.failedAttempts,
-                              ),
+                          selector: (state) =>
+                              (state.showError, state.failedAttempts),
                           builder: (context, data) {
                             final (showError, failedAttempts) = data;
                             return showError && failedAttempts > 0
                                 ? Text(
-                                  context.loc.appUnlockIncorrectPinError(
-                                    failedAttempts,
-                                    failedAttempts == 1
-                                        ? context.loc.appUnlockAttemptSingular
-                                        : context.loc.appUnlockAttemptPlural,
-                                  ),
-                                  textAlign: .start,
-                                  style: context.font.labelSmall?.copyWith(
-                                    color: context.appColors.error,
-                                  ),
-                                )
+                                    context.loc.appUnlockIncorrectPinError(
+                                      failedAttempts,
+                                      failedAttempts == 1
+                                          ? context.loc.appUnlockAttemptSingular
+                                          : context.loc.appUnlockAttemptPlural,
+                                    ),
+                                    textAlign: .start,
+                                    style: context.font.labelSmall?.copyWith(
+                                      color: context.appColors.error,
+                                    ),
+                                  )
                                 : const SizedBox.shrink();
                           },
                         ),
@@ -147,14 +149,12 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                 child: DialPad(
                   disableFeedback: true,
                   onlyDigits: true,
-                  onNumberPressed:
-                      (value) => context.read<AppUnlockBloc>().add(
-                        AppUnlockPinCodeNumberAdded(int.parse(value)),
-                      ),
-                  onBackspacePressed:
-                      () => context.read<AppUnlockBloc>().add(
-                        const AppUnlockPinCodeNumberRemoved(),
-                      ),
+                  onNumberPressed: (value) => context.read<AppUnlockBloc>().add(
+                    AppUnlockPinCodeNumberAdded(int.parse(value)),
+                  ),
+                  onBackspacePressed: () => context.read<AppUnlockBloc>().add(
+                    const AppUnlockPinCodeNumberRemoved(),
+                  ),
                 ),
               ),
               const Gap(16),
@@ -176,11 +176,9 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                 return BBButton.big(
                   label: context.loc.appUnlockButton,
                   textStyle: context.font.headlineLarge,
-                  disabled: !canSubmit,
-                  bgColor:
-                      canSubmit
-                          ? context.appColors.secondary
-                          : context.appColors.outline,
+                  bgColor: canSubmit
+                      ? context.appColors.secondary
+                      : context.appColors.textMuted,
                   onPressed: () {
                     if (canSubmit) {
                       context.read<AppUnlockBloc>().add(
@@ -188,7 +186,9 @@ class PinCodeUnlockInputScreen extends StatelessWidget {
                       );
                     }
                   },
-                  textColor: context.appColors.onSecondary,
+                  textColor: canSubmit
+                      ? context.appColors.onSecondary
+                      : context.appColors.surface,
                 );
               },
             ),

--- a/lib/features/pin_code/pin_code_locator.dart
+++ b/lib/features/pin_code/pin_code_locator.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/features/pin_code/domain/usecases/delete_pin_code_usec
 import 'package:bb_mobile/features/pin_code/domain/usecases/is_pin_code_set_usecase.dart';
 import 'package:bb_mobile/features/pin_code/domain/usecases/set_pin_code_usecase.dart';
 import 'package:bb_mobile/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_backup_usecase.dart';
 import 'package:get_it/get_it.dart';
 
 class PinCodeLocator {
@@ -40,6 +41,7 @@ class PinCodeLocator {
         isPinCodeSetUsecase: locator<IsPinCodeSetUsecase>(),
         setPinCodeUsecase: locator<SetPinCodeUsecase>(),
         deletePinCodeUsecase: locator<DeletePinCodeUsecase>(),
+        checkBackupUsecase: locator<CheckBackupUsecase>(),
       ),
     );
   }

--- a/lib/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart
+++ b/lib/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bb_mobile/features/pin_code/domain/usecases/delete_pin_code_usecase.dart';
 import 'package:bb_mobile/features/pin_code/domain/usecases/is_pin_code_set_usecase.dart';
 import 'package:bb_mobile/features/pin_code/domain/usecases/set_pin_code_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_backup_usecase.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -17,11 +18,13 @@ class PinCodeSettingBloc
     required SetPinCodeUsecase setPinCodeUsecase,
     required DeletePinCodeUsecase deletePinCodeUsecase,
     required IsPinCodeSetUsecase isPinCodeSetUsecase,
+    required CheckBackupUsecase checkBackupUsecase,
     int minPinCodeLength = 4,
     int maxPinCodeLength = 8,
   }) : _setPinCodeUsecase = setPinCodeUsecase,
        _deletePinCodeUsecase = deletePinCodeUsecase,
        _isPinCodeSetUsecase = isPinCodeSetUsecase,
+       _checkBackupUsecase = checkBackupUsecase,
        super(
          PinCodeSettingState(
            choosePinKeyboardNumbers: List.generate(10, (i) => i)..shuffle(),
@@ -57,12 +60,12 @@ class PinCodeSettingBloc
   ) async {
     final isPinCodeSet = await _isPinCodeSetUsecase.execute();
     if (!isPinCodeSet) {
-      emit(
-        state.copyWith(
-          status: PinCodeSettingStatus.choose,
-          isPinCodeSet: false,
-        ),
-      );
+      var status = PinCodeSettingStatus.choose;
+
+      final hasBackup = await _checkBackupUsecase.execute();
+      if (!hasBackup) status = PinCodeSettingStatus.backupRequired;
+
+      emit(state.copyWith(status: status, isPinCodeSet: false));
     } else {
       emit(
         state.copyWith(status: PinCodeSettingStatus.unlock, isPinCodeSet: true),
@@ -73,6 +76,7 @@ class PinCodeSettingBloc
   final SetPinCodeUsecase _setPinCodeUsecase;
   final DeletePinCodeUsecase _deletePinCodeUsecase;
   final IsPinCodeSetUsecase _isPinCodeSetUsecase;
+  final CheckBackupUsecase _checkBackupUsecase;
 
   Future<void> _onStarted(
     PinCodeSettingStarted event,
@@ -91,7 +95,10 @@ class PinCodeSettingBloc
     PinCodeCreate event,
     Emitter<PinCodeSettingState> emit,
   ) async {
-    emit(state.copyWith(status: PinCodeSettingStatus.choose));
+    final hasBackup = await _checkBackupUsecase.execute();
+    var status = PinCodeSettingStatus.choose;
+    if (!hasBackup) status = PinCodeSettingStatus.backupRequired;
+    emit(state.copyWith(status: status));
   }
 
   Future<void> _onDeletePin(

--- a/lib/features/pin_code/presentation/bloc/pin_code_setting_state.dart
+++ b/lib/features/pin_code/presentation/bloc/pin_code_setting_state.dart
@@ -1,6 +1,7 @@
 part of 'pin_code_setting_bloc.dart';
 
 enum PinCodeSettingStatus {
+  backupRequired,
   initializing,
   unlock,
   settings,

--- a/lib/features/pin_code/ui/pin_code_setting_flow.dart
+++ b/lib/features/pin_code/ui/pin_code_setting_flow.dart
@@ -1,11 +1,14 @@
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/widgets/loading/status_screen.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/features/app_unlock/ui/pin_code_unlock_screen.dart';
 import 'package:bb_mobile/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart';
 import 'package:bb_mobile/features/pin_code/ui/screens/choose_pin_code_screen.dart';
 import 'package:bb_mobile/features/pin_code/ui/screens/confirm_pin_code_screen.dart';
 import 'package:bb_mobile/features/pin_code/ui/screens/pin_settings_screen.dart';
+import 'package:bb_mobile/features/settings/ui/settings_router.dart';
+import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -30,47 +33,56 @@ class PinCodeSettingFlow extends StatelessWidget {
             case PinCodeSettingStatus.deleted:
               log.info('Pin Code Deleted');
               context.pop();
+            case PinCodeSettingStatus.backupRequired:
+              log.warning('Backup required before setting PIN');
+              SnackBarUtils.showSnackBar(
+                context,
+                context.loc.pinCodeBackupRequiredWarning,
+              );
+              context.goNamed(WalletRoute.walletHome.name);
+              context.pushNamed(SettingsRoute.backupSettings.name);
             default:
               break;
           }
         },
-        child: BlocSelector<
-          PinCodeSettingBloc,
-          PinCodeSettingState,
-          PinCodeSettingStatus
-        >(
-          selector: (state) => state.status,
-          builder: (context, status) {
-            switch (status) {
-              case PinCodeSettingStatus.initializing:
-                return StatusScreen(
-                  title: context.loc.pinCodeLoading,
-                  description: context.loc.pinCodeCheckingStatus,
-                );
-              case PinCodeSettingStatus.unlock:
-                return PinCodeUnlockScreen(
-                  onSuccess:
-                      () => context.read<PinCodeSettingBloc>().add(
+        child:
+            BlocSelector<
+              PinCodeSettingBloc,
+              PinCodeSettingState,
+              PinCodeSettingStatus
+            >(
+              selector: (state) => state.status,
+              builder: (context, status) {
+                switch (status) {
+                  case PinCodeSettingStatus.initializing:
+                    return StatusScreen(
+                      title: context.loc.pinCodeLoading,
+                      description: context.loc.pinCodeCheckingStatus,
+                    );
+                  case PinCodeSettingStatus.unlock:
+                    return PinCodeUnlockScreen(
+                      onSuccess: () => context.read<PinCodeSettingBloc>().add(
                         const PinCodeSettingStarted(),
                       ),
-                  canPop: true,
-                );
-              case PinCodeSettingStatus.settings:
-                return const PinSettingsScreen();
-              case PinCodeSettingStatus.choose:
-                return const ChoosePinCodeScreen();
-              case PinCodeSettingStatus.confirm:
-                return const ConfirmPinCodeScreen();
-              case PinCodeSettingStatus.success:
-              case PinCodeSettingStatus.deleted:
-              case PinCodeSettingStatus.failure:
-                return StatusScreen(
-                  title: context.loc.pinCodeProcessing,
-                  description: context.loc.pinCodeSettingUp,
-                );
-            }
-          },
-        ),
+                      canPop: true,
+                    );
+                  case PinCodeSettingStatus.settings:
+                  case PinCodeSettingStatus.backupRequired:
+                    return const PinSettingsScreen();
+                  case PinCodeSettingStatus.choose:
+                    return const ChoosePinCodeScreen();
+                  case PinCodeSettingStatus.confirm:
+                    return const ConfirmPinCodeScreen();
+                  case PinCodeSettingStatus.success:
+                  case PinCodeSettingStatus.deleted:
+                  case PinCodeSettingStatus.failure:
+                    return StatusScreen(
+                      title: context.loc.pinCodeProcessing,
+                      description: context.loc.pinCodeSettingUp,
+                    );
+                }
+              },
+            ),
       ),
     );
   }

--- a/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
@@ -164,10 +164,9 @@ class _ConfirmButton extends StatelessWidget {
           return BBButton.big(
             label: context.loc.pinCodeContinue,
             textStyle: context.font.headlineLarge,
-            disabled: !isValidPinCode,
             bgColor: isValidPinCode
                 ? context.appColors.primary
-                : context.appColors.surfaceContainerHighest,
+                : context.appColors.textMuted,
             onPressed: () {
               if (isValidPinCode) {
                 context.read<PinCodeSettingBloc>().add(
@@ -177,7 +176,7 @@ class _ConfirmButton extends StatelessWidget {
             },
             textColor: isValidPinCode
                 ? context.appColors.onPrimary
-                : context.appColors.textMuted,
+                : context.appColors.surface,
           );
         },
       ),

--- a/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
@@ -49,7 +49,7 @@ class ConfirmPinCodeScreen extends StatelessWidget {
                           context.loc.pinCodeConfirmTitle,
                           textAlign: .center,
                           style: context.font.headlineMedium?.copyWith(
-                            color: context.appColors.outline,
+                            color: context.appColors.onSurface,
                           ),
                           maxLines: 3,
                         ),
@@ -59,26 +59,26 @@ class ConfirmPinCodeScreen extends StatelessWidget {
                           PinCodeSettingState,
                           (String, bool)
                         >(
-                          selector:
-                              (state) => (
-                                state.pinCodeConfirmation,
-                                state.obscurePinCode,
-                              ),
+                          selector: (state) =>
+                              (state.pinCodeConfirmation, state.obscurePinCode),
                           builder: (context, data) {
                             final (pinCode, obscurePinCode) = data;
                             return BBInputText(
                               value: pinCode,
                               obscure: obscurePinCode,
-                              onRightTap:
-                                  () => context.read<PinCodeSettingBloc>().add(
+                              onRightTap: () =>
+                                  context.read<PinCodeSettingBloc>().add(
                                     const PinCodeSettingPinCodeObscureToggled(),
                                   ),
-                              rightIcon:
-                                  obscurePinCode
-                                      ? const Icon(
-                                        Icons.visibility_off_outlined,
-                                      )
-                                      : const Icon(Icons.visibility_outlined),
+                              rightIcon: obscurePinCode
+                                  ? Icon(
+                                      Icons.visibility_off_outlined,
+                                      color: context.appColors.onSurface,
+                                    )
+                                  : Icon(
+                                      Icons.visibility_outlined,
+                                      color: context.appColors.onSurface,
+                                    ),
                               onlyNumbers: true,
                               onChanged: (value) {},
                             );
@@ -94,12 +94,12 @@ class ConfirmPinCodeScreen extends StatelessWidget {
                           builder: (context, showError) {
                             return showError
                                 ? Text(
-                                  context.loc.pinCodeMismatchError,
-                                  textAlign: .start,
-                                  style: context.font.labelSmall?.copyWith(
-                                    color: context.appColors.error,
-                                  ),
-                                )
+                                    context.loc.pinCodeMismatchError,
+                                    textAlign: .start,
+                                    style: context.font.labelSmall?.copyWith(
+                                      color: context.appColors.error,
+                                    ),
+                                  )
                                 : const SizedBox.shrink();
                           },
                         ),
@@ -113,14 +113,14 @@ class ConfirmPinCodeScreen extends StatelessWidget {
                 child: DialPad(
                   disableFeedback: true,
                   onlyDigits: true,
-                  onNumberPressed:
-                      (value) => context.read<PinCodeSettingBloc>().add(
+                  onNumberPressed: (value) =>
+                      context.read<PinCodeSettingBloc>().add(
                         PinCodeSettingPinCodeConfirmationNumberAdded(
                           int.parse(value),
                         ),
                       ),
-                  onBackspacePressed:
-                      () => context.read<PinCodeSettingBloc>().add(
+                  onBackspacePressed: () =>
+                      context.read<PinCodeSettingBloc>().add(
                         const PinCodeSettingPinCodeConfirmationNumberRemoved(),
                       ),
                 ),
@@ -159,17 +159,19 @@ class _ConfirmButton extends StatelessWidget {
           return BBButton.big(
             label: context.loc.pinCodeConfirm,
             textStyle: context.font.headlineLarge,
-            disabled: !canConfirm,
-            bgColor:
-                canConfirm
-                    ? context.appColors.secondary
-                    : context.appColors.outline,
+            bgColor: canConfirm
+                ? context.appColors.secondary
+                : context.appColors.textMuted,
             onPressed: () {
-              context.read<PinCodeSettingBloc>().add(
-                const PinCodeSettingPinCodeConfirmed(),
-              );
+              if (canConfirm) {
+                context.read<PinCodeSettingBloc>().add(
+                  const PinCodeSettingPinCodeConfirmed(),
+                );
+              }
             },
-            textColor: context.appColors.onSecondary,
+            textColor: canConfirm
+                ? context.appColors.onSecondary
+                : context.appColors.surface,
           );
         },
       ),

--- a/lib/features/pin_code/ui/screens/pin_settings_screen.dart
+++ b/lib/features/pin_code/ui/screens/pin_settings_screen.dart
@@ -40,14 +40,14 @@ class PinSettingsScreen extends StatelessWidget {
                     Text(
                       context.loc.pinCodeManageTitle,
                       style: context.font.headlineMedium?.copyWith(
-                        color: context.appColors.outlineVariant,
+                        color: context.appColors.onSurface,
                       ),
                     ),
                     const Gap(16),
                     Text(
                       context.loc.pinCodeCreateDescription,
                       style: context.font.bodyMedium?.copyWith(
-                        color: context.appColors.outline,
+                        color: context.appColors.textMuted,
                       ),
                     ),
                   ],
@@ -59,10 +59,9 @@ class PinSettingsScreen extends StatelessWidget {
               child: Column(
                 children: [
                   BBButton.big(
-                    label:
-                        isPinCodeSet
-                            ? context.loc.pinCodeChangeButton
-                            : context.loc.pinCodeCreateButton,
+                    label: isPinCodeSet
+                        ? context.loc.pinCodeChangeButton
+                        : context.loc.pinCodeCreateButton,
                     onPressed: () => bloc.add(const PinCodeCreate()),
                     bgColor: context.appColors.secondary,
                     textColor: context.appColors.onSecondary,
@@ -72,8 +71,8 @@ class PinSettingsScreen extends StatelessWidget {
                     BBButton.big(
                       label: context.loc.pinCodeRemoveButton,
                       onPressed: () => bloc.add(const PinCodeDelete()),
-                      bgColor: context.appColors.errorContainer,
-                      textColor: context.appColors.onSecondary,
+                      bgColor: context.appColors.error,
+                      textColor: context.appColors.onError,
                     ),
                   const Gap(24),
                 ],

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -9461,6 +9461,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "يرجى إكمال نسخة احتياطية للمحفظة قبل تعيين رمز PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "تحتاج إلى زيادة معدل الرسوم على الأقل 1 سات/فبيت بالمقارنة مع الصفقة الأصلية",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -52,5 +52,6 @@
   "deleteAccountSuccessClose": "Close",
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
-  }
+  },
+  "pinCodeBackupRequiredWarning": "PIN ছেট কৰাৰ আগতে অনুগ্ৰহ কৰি এটা ৱালেট বেকআপ সম্পূৰ্ণ কৰক"
 }

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -7659,6 +7659,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "Моля, завършете резервно копие на портфейла, преди да зададете PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "Трябва да увеличите таксата с поне 1 сат/байт спрямо оригиналната транзакция.",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -9890,6 +9890,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "PIN সেট করার আগে অনুগ্রহ করে একটি ওয়ালেট ব্যাকআপ সম্পন্ন করুন",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "মূল ট্রান্স্যাকশনটির তুলনায় ফি রেট অন্তত 1 sat/vbyte বেশি করতে হবে",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -219,6 +219,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "Před nastavením PIN dokončete zálohu peněženky",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "settingsCurrencyTitle": "Čeština",
   "@settingsCurrencyTitle": {
     "description": "Title for the currency settings section in the settings menu"

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -3288,6 +3288,7 @@
   "exchangeBitcoinWalletsLiquidAddressLabel": "Liquid-Adresse",
   "backupWalletSuccessTestButton": "Backup testen",
   "pinCodeSettingUp": "PIN einrichten",
+  "pinCodeBackupRequiredWarning": "Bitte schließen Sie eine Wallet-Sicherung ab, bevor Sie eine PIN festlegen",
   "replaceByFeeErrorFeeRateTooLow": "Sie müssen den Gebührensatz um mindestens 1 sat/vbyte gegenüber der ursprünglichen Transaktion erhöhen",
   "payPriority": "Priorität",
   "fundExchangeCostaRicaMethodIbanCrcSubtitle": "Überweisung in Costa-Ricanischem Colón (CRC)",

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -8308,6 +8308,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "Παρακαλώ ολοκληρώστε ένα αντίγραφο ασφαλείας πορτοφολιού πριν ορίσετε PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "Πρέπει να αυξήσετε το ποσοστό χρέωσης κατά τουλάχιστον 1 sat/vbyte σε σύγκριση με την αρχική συναλλαγή",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -336,6 +336,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "Please complete a wallet backup before setting a PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "settingsCurrencyTitle": "Currency",
   "@settingsCurrencyTitle": {
     "description": "Title for the currency settings section in the settings menu"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -107,6 +107,7 @@
   "pinCodeCheckingStatus": "Verificando estado del PIN",
   "pinCodeProcessing": "Procesando",
   "pinCodeSettingUp": "Configurando su código PIN",
+  "pinCodeBackupRequiredWarning": "Por favor, completa una copia de seguridad de la billetera antes de establecer un PIN",
   "settingsCurrencyTitle": "Moneda",
   "settingsAppSettingsTitle": "Configuración de la aplicación",
   "settingsTermsOfServiceTitle": "Términos de servicio",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -9605,6 +9605,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "لطفاً قبل از تنظیم PIN، یک پشتیبان‌گیری از کیف پول انجام دهید",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "شما نیاز به افزایش نرخ هزینه با حداقل 1 نشست/vbyte در مقایسه با معامله اصلی",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -69,6 +69,7 @@
   "pinCodeCheckingStatus": "Tarkistetaan PIN-tilaa",
   "pinCodeProcessing": "Käsitellään",
   "pinCodeSettingUp": "PIN-koodin käyttöönotto",
+  "pinCodeBackupRequiredWarning": "Suorita lompakkosi varmuuskopiointi ennen PIN-koodin asettamista",
   "settingsCurrencyTitle": "Valuutta",
   "settingsAppSettingsTitle": "Sovellusasetukset",
   "settingsTermsOfServiceTitle": "Käyttöehdot",

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -107,6 +107,7 @@
   "pinCodeCheckingStatus": "Vérification du statut du code PIN",
   "pinCodeProcessing": "Traitement",
   "pinCodeSettingUp": "Configuration de votre code PIN",
+  "pinCodeBackupRequiredWarning": "Veuillez effectuer une sauvegarde du portefeuille avant de définir un code PIN",
   "settingsCurrencyTitle": "Devise",
   "settingsAppSettingsTitle": "Paramètres de l'application",
   "settingsTermsOfServiceTitle": "Conditions d'utilisation",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -10120,6 +10120,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "PIN सेट करने से पहले कृपया एक वॉलेट बैकअप पूरा करें",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "आपको मूल लेन-देन की तुलना में कम से कम 1 sat/vbyte द्वारा शुल्क दर बढ़ाने की आवश्यकता है",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -53,5 +53,6 @@
   "deleteAccountSuccessClose": "Close",
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
-  }
+  },
+  "pinCodeBackupRequiredWarning": "Խնդրում ենք ավարտել դրամապանակի կրկնօրինակումը PIN-ը սահմանելուց առաջ"
 }

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -3332,6 +3332,7 @@
   "exchangeBitcoinWalletsLiquidAddressLabel": "Indirizzo liquido",
   "backupWalletSuccessTestButton": "Test di backup",
   "pinCodeSettingUp": "Impostazione del codice PIN",
+  "pinCodeBackupRequiredWarning": "Completa un backup del portafoglio prima di impostare un PIN",
   "replaceByFeeErrorFeeRateTooLow": "È necessario aumentare il tasso di tassa di almeno 1 sat/vbyte rispetto alla transazione originale",
   "payPriority": "Priorità",
   "fundExchangeCostaRicaMethodIbanCrcSubtitle": "Fondi di trasferimento in Costa Rica Colón (CRC)",

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -265,5 +265,6 @@
   "deleteAccountSuccessClose": "Close",
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
-  }
+  },
+  "pinCodeBackupRequiredWarning": "გთხოვთ, PIN-ის დაყენებამდე შეასრულოთ საფულის სარეზერვო ასლი"
 }

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -10120,6 +10120,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "PIN을 설정하기 전에 지갑 백업을 완료해 주세요",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "원래 거래에 비해 최소 1 sat/vbyte로 수수료율을 늘릴 필요가 있습니다",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -3309,6 +3309,7 @@
   "exchangeBitcoinWalletsLiquidAddressLabel": "Endereço líquido",
   "backupWalletSuccessTestButton": "Teste de backup",
   "pinCodeSettingUp": "Configurando seu código PIN",
+  "pinCodeBackupRequiredWarning": "Por favor, conclua uma cópia de segurança da carteira antes de definir um PIN",
   "replaceByFeeErrorFeeRateTooLow": "Você precisa aumentar a taxa de taxa em pelo menos 1 sat/vbyte em comparação com a transação original",
   "payPriority": "Prioridade",
   "fundExchangeCostaRicaMethodIbanCrcSubtitle": "Transferir fundos em Costa Rican Colón (CRC)",

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -10256,6 +10256,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "Por favor, conclua um backup da carteira antes de definir um PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "bitboxScreenActionFailed": "{action}",
   "@bitboxScreenActionFailed": {
     "description": "Main text when action fails",

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -3330,6 +3330,7 @@
   "exchangeBitcoinWalletsLiquidAddressLabel": "Liquid адрес",
   "backupWalletSuccessTestButton": "Проверка",
   "pinCodeSettingUp": "Настройка PIN-кода",
+  "pinCodeBackupRequiredWarning": "Пожалуйста, выполните резервное копирование кошелька перед установкой PIN-кода",
   "replaceByFeeErrorFeeRateTooLow": "Вы должны увеличить ставку сбора как минимум на 1 атт/вбайт по сравнению с первоначальной транзакцией",
   "payPriority": "Приоритет",
   "fundExchangeCostaRicaMethodIbanCrcSubtitle": "Перевод средств в Коста-Рике",

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -73,5 +73,6 @@
   "deleteAccountSuccessClose": "Close",
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
-  }
+  },
+  "pinCodeBackupRequiredWarning": "Tafadhali kamilisha nakala rudufu ya pochi kabla ya kuweka PIN"
 }

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -10112,6 +10112,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "กรุณาสำรองข้อมูลกระเป๋าเงินก่อนตั้ง PIN",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "คุณต้องเพิ่มค่าธรรมเนียมภายในอย่างน้อย 1 คืน / Vbyte",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -10041,6 +10041,10 @@
   "@pinCodeSettingUp": {
     "description": "Status screen description while setting up PIN"
   },
+  "pinCodeBackupRequiredWarning": "PIN ayarlamadan önce lütfen bir cüzdan yedeklemesi tamamlayın",
+  "@pinCodeBackupRequiredWarning": {
+    "description": "Warning shown when user tries to set a PIN without having tested their wallet backup"
+  },
   "replaceByFeeErrorFeeRateTooLow": "Ücret oranını en az 1 do /vbay tarafından orijinal işlemle kıyaslamanız gerekir",
   "@replaceByFeeErrorFeeRateTooLow": {
     "description": "Error message when new fee rate is not high enough"

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -191,6 +191,7 @@
   "pinCodeCheckingStatus": "Перевірка стану PIN",
   "pinCodeProcessing": "Переробка",
   "pinCodeSettingUp": "Налаштування коду PIN",
+  "pinCodeBackupRequiredWarning": "Будь ласка, виконайте резервне копіювання гаманця перед встановленням PIN-коду",
   "settingsCurrencyTitle": "Ціна",
   "settingsAppSettingsTitle": "Налаштування додатків",
   "settingsTermsOfServiceTitle": "Умови надання послуг",

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -53,5 +53,6 @@
   "deleteAccountSuccessClose": "Close",
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
-  }
+  },
+  "pinCodeBackupRequiredWarning": "Vui lòng hoàn tất sao lưu ví trước khi đặt PIN"
 }

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -3333,6 +3333,7 @@
   "exchangeBitcoinWalletsLiquidAddressLabel": "流动资金",
   "backupWalletSuccessTestButton": "退约",
   "pinCodeSettingUp": "1. 制定您的《个人资料》",
+  "pinCodeBackupRequiredWarning": "请在设置PIN之前完成钱包备份",
   "replaceByFeeErrorFeeRateTooLow": "您需要将收费率提高到至少1分之一的CO/vbyte,而不是原来的交易",
   "payPriority": "优先程度",
   "fundExchangeCostaRicaMethodIbanCrcSubtitle": "哥斯达黎加哥伦的转移资金",


### PR DESCRIPTION

1. Require backup before setting PIN –> redirect to wallet backup
2. Unreadable light theme text and button fixed

[video.webm](https://github.com/user-attachments/assets/77115d9e-dd62-4af1-88ba-3ef9661f5c42)
