### PR TITLE
fix: exclude payjoins from swaps filter and swaps from payjoin filter

### DIFF
--- a/lib/features/transactions/presentation/blocs/transactions_state.dart
+++ b/lib/features/transactions/presentation/blocs/transactions_state.dart
@@ -183,9 +183,9 @@ abstract class TransactionsState with _$TransactionsState {
           TransactionsFilter.send => tx.isOutgoing,
           TransactionsFilter.receive => tx.isIncoming,
           TransactionsFilter.swap =>
-            tx.isSwap && !shouldFilterOutgoingChainSwap,
+            tx.isSwap && !tx.isPayjoin && !shouldFilterOutgoingChainSwap,
           TransactionsFilter.payjoin =>
-            tx.isPayjoin && !shouldFilterOutgoingChainSwap,
+            tx.isPayjoin && !tx.isSwap && !shouldFilterOutgoingChainSwap,
           TransactionsFilter.sell => tx.isSellOrder,
           TransactionsFilter.buy => tx.isBuyOrder,
           TransactionsFilter.withdraw => tx.isWithdrawOrder,

--- a/lib/features/transactions/ui/widgets/tx_list.dart
+++ b/lib/features/transactions/ui/widgets/tx_list.dart
@@ -16,9 +16,19 @@ class TxList extends StatelessWidget {
       (TransactionsCubit cubit) => cubit.state.ongoingSwaps,
     );
 
+    final filter = context.select(
+      (TransactionsCubit cubit) => cubit.state.filter,
+    );
+
+    // Ongoing swaps are only relevant when browsing all transactions or
+    // filtering by swap — hide them under unrelated filters (payjoin, send,
+    // receive, sell, buy, …) so they don't bleed into the wrong category.
+    final showOngoingSwaps =
+        filter == TransactionsFilter.all || filter == TransactionsFilter.swap;
+
     return TransactionsByDayList(
       transactionsByDay: txsByDay,
-      ongoingSwaps: ongoingSwaps,
+      ongoingSwaps: showOngoingSwaps ? ongoingSwaps : [],
     );
   }
 }


### PR DESCRIPTION
It appears that some swaps appear in payjoin filter, this PR should fix it.

Not tested, please if you experience such weird swaps give me the feedback