### PR TITLE
feat: SamRock Protocol support for BTCPay Server

### DIFF
--- a/lib/features/samrock/data/datasources/samrock_api_datasource.dart
+++ b/lib/features/samrock/data/datasources/samrock_api_datasource.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:http/http.dart' as http;
+
+class SamrockApiDatasource {
+  final http.Client _client;
+
+  SamrockApiDatasource({http.Client? client})
+      : _client = client ?? http.Client();
+
+  Future<SamrockSetupResponse> submitSetup({
+    required SamrockSetupRequest request,
+    required Map<String, dynamic> descriptorPayload,
+  }) async {
+    final url = Uri.parse(request.setupUrl);
+
+    if (url.scheme != 'https') {
+      throw Exception('SamRock setup requires HTTPS');
+    }
+
+    final jsonString = jsonEncode(descriptorPayload);
+    final body = 'json=${Uri.encodeComponent(jsonString)}';
+
+    final response = await _client.post(
+      url,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body,
+    );
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      try {
+        final responseBody =
+            jsonDecode(response.body) as Map<String, dynamic>;
+        final success = responseBody['Success'] as bool? ?? true;
+        final message =
+            responseBody['Message'] as String? ?? 'Setup completed';
+        return SamrockSetupResponse(
+          success: success,
+          message: message,
+          statusCode: response.statusCode,
+        );
+      } catch (_) {
+        // If response isn't JSON, treat 2xx as success
+        return SamrockSetupResponse(
+          success: true,
+          message: 'Setup completed successfully',
+          statusCode: response.statusCode,
+        );
+      }
+    } else {
+      String message;
+      try {
+        final responseBody =
+            jsonDecode(response.body) as Map<String, dynamic>;
+        message = responseBody['Message'] as String? ??
+            responseBody['Error'] as String? ??
+            'Server error: ${response.statusCode}';
+      } catch (_) {
+        message = 'Server returned ${response.statusCode}: ${response.body}';
+      }
+
+      return SamrockSetupResponse(
+        success: false,
+        message: message,
+        statusCode: response.statusCode,
+      );
+    }
+  }
+}

--- a/lib/features/samrock/data/repositories/samrock_repository_impl.dart
+++ b/lib/features/samrock/data/repositories/samrock_repository_impl.dart
@@ -1,0 +1,21 @@
+import 'package:bb_mobile/features/samrock/data/datasources/samrock_api_datasource.dart';
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:bb_mobile/features/samrock/domain/repositories/samrock_repository.dart';
+
+class SamrockRepositoryImpl implements SamrockRepository {
+  final SamrockApiDatasource _datasource;
+
+  SamrockRepositoryImpl({required SamrockApiDatasource datasource})
+      : _datasource = datasource;
+
+  @override
+  Future<SamrockSetupResponse> submitSetup({
+    required SamrockSetupRequest request,
+    required Map<String, dynamic> descriptorPayload,
+  }) async {
+    return _datasource.submitSetup(
+      request: request,
+      descriptorPayload: descriptorPayload,
+    );
+  }
+}

--- a/lib/features/samrock/domain/entities/samrock_setup.dart
+++ b/lib/features/samrock/domain/entities/samrock_setup.dart
@@ -10,10 +10,13 @@ enum SamrockPaymentMethod {
   factory SamrockPaymentMethod.fromString(String value) {
     switch (value.toLowerCase()) {
       case 'btc':
+      case 'btc-chain':
         return SamrockPaymentMethod.btc;
       case 'lbtc':
+      case 'liquid-chain':
         return SamrockPaymentMethod.lbtc;
       case 'btcln':
+      case 'btc-ln':
         return SamrockPaymentMethod.btcln;
       default:
         throw ArgumentError('Unknown payment method: $value');

--- a/lib/features/samrock/domain/entities/samrock_setup.dart
+++ b/lib/features/samrock/domain/entities/samrock_setup.dart
@@ -1,0 +1,105 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'samrock_setup.freezed.dart';
+
+enum SamrockPaymentMethod {
+  btc,
+  lbtc,
+  btcln;
+
+  factory SamrockPaymentMethod.fromString(String value) {
+    switch (value.toLowerCase()) {
+      case 'btc':
+        return SamrockPaymentMethod.btc;
+      case 'lbtc':
+        return SamrockPaymentMethod.lbtc;
+      case 'btcln':
+        return SamrockPaymentMethod.btcln;
+      default:
+        throw ArgumentError('Unknown payment method: $value');
+    }
+  }
+
+  String get displayName {
+    switch (this) {
+      case SamrockPaymentMethod.btc:
+        return 'Bitcoin On-chain';
+      case SamrockPaymentMethod.lbtc:
+        return 'Liquid';
+      case SamrockPaymentMethod.btcln:
+        return 'Lightning (via Boltz)';
+    }
+  }
+}
+
+@freezed
+abstract class SamrockSetupRequest with _$SamrockSetupRequest {
+  const factory SamrockSetupRequest({
+    required String serverUrl,
+    required String storeId,
+    required List<SamrockPaymentMethod> paymentMethods,
+    required String otp,
+  }) = _SamrockSetupRequest;
+
+  const SamrockSetupRequest._();
+
+  String get setupUrl =>
+      '$serverUrl/plugins/$storeId/samrock/protocol?setup=${paymentMethods.map((m) => m.name).join(',')}&otp=$otp';
+
+  String get serverHost => Uri.parse(serverUrl).host;
+
+  static SamrockSetupRequest? tryParse(String url) {
+    try {
+      final uri = Uri.parse(url);
+
+      if (uri.scheme != 'https') return null;
+
+      // Match path: /plugins/<storeId>/samrock/protocol
+      final pathSegments = uri.pathSegments;
+      if (pathSegments.length < 4) return null;
+
+      final pluginsIndex = pathSegments.indexOf('plugins');
+      if (pluginsIndex == -1) return null;
+      if (pluginsIndex + 3 >= pathSegments.length) return null;
+      if (pathSegments[pluginsIndex + 2] != 'samrock') return null;
+      if (pathSegments[pluginsIndex + 3] != 'protocol') return null;
+
+      final storeId = pathSegments[pluginsIndex + 1];
+
+      final setupParam = uri.queryParameters['setup'];
+      final otp = uri.queryParameters['otp'];
+
+      if (setupParam == null || setupParam.isEmpty) return null;
+      if (otp == null || otp.isEmpty) return null;
+
+      final methods = setupParam
+          .split(',')
+          .map((m) => m.trim())
+          .where((m) => m.isNotEmpty)
+          .map(SamrockPaymentMethod.fromString)
+          .toList();
+
+      if (methods.isEmpty) return null;
+
+      final serverUrl = '${uri.scheme}://${uri.host}${uri.hasPort ? ':${uri.port}' : ''}';
+
+      return SamrockSetupRequest(
+        serverUrl: serverUrl,
+        storeId: storeId,
+        paymentMethods: methods,
+        otp: otp,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+@freezed
+abstract class SamrockSetupResponse with _$SamrockSetupResponse {
+  const factory SamrockSetupResponse({
+    required bool success,
+    @Default('') String message,
+    @Default(0) int statusCode,
+  }) = _SamrockSetupResponse;
+}

--- a/lib/features/samrock/domain/repositories/samrock_repository.dart
+++ b/lib/features/samrock/domain/repositories/samrock_repository.dart
@@ -1,0 +1,8 @@
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+
+abstract class SamrockRepository {
+  Future<SamrockSetupResponse> submitSetup({
+    required SamrockSetupRequest request,
+    required Map<String, dynamic> descriptorPayload,
+  });
+}

--- a/lib/features/samrock/domain/usecases/complete_samrock_setup_usecase.dart
+++ b/lib/features/samrock/domain/usecases/complete_samrock_setup_usecase.dart
@@ -1,0 +1,81 @@
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:bb_mobile/features/samrock/domain/repositories/samrock_repository.dart';
+
+class CompleteSamrockSetupUsecase {
+  final WalletRepository _walletRepository;
+  final SamrockRepository _samrockRepository;
+
+  CompleteSamrockSetupUsecase({
+    required WalletRepository walletRepository,
+    required SamrockRepository samrockRepository,
+  })  : _walletRepository = walletRepository,
+        _samrockRepository = samrockRepository;
+
+  Future<SamrockSetupResponse> execute(SamrockSetupRequest request) async {
+    final payload = await _buildPayload(request.paymentMethods);
+    return _samrockRepository.submitSetup(
+      request: request,
+      descriptorPayload: payload,
+    );
+  }
+
+  Future<Map<String, dynamic>> _buildPayload(
+    List<SamrockPaymentMethod> methods,
+  ) async {
+    final payload = <String, dynamic>{};
+
+    String? btcDescriptor;
+    String? liquidDescriptor;
+
+    if (methods.contains(SamrockPaymentMethod.btc) ||
+        methods.contains(SamrockPaymentMethod.lbtc) ||
+        methods.contains(SamrockPaymentMethod.btcln)) {
+      // Get default wallets
+      final defaultWallets = await _walletRepository.getWallets(
+        onlyDefaults: true,
+      );
+
+      for (final wallet in defaultWallets) {
+        if (wallet.isBitcoin && wallet.isDefault) {
+          btcDescriptor = wallet.externalPublicDescriptor;
+        }
+        if (wallet.isLiquid && wallet.isDefault) {
+          liquidDescriptor = wallet.externalPublicDescriptor;
+        }
+      }
+    }
+
+    if (methods.contains(SamrockPaymentMethod.btc)) {
+      if (btcDescriptor == null || btcDescriptor.isEmpty) {
+        throw Exception('No default Bitcoin wallet found');
+      }
+      payload['BTC'] = {
+        'Descriptor': btcDescriptor,
+      };
+    }
+
+    if (methods.contains(SamrockPaymentMethod.lbtc)) {
+      if (liquidDescriptor == null || liquidDescriptor.isEmpty) {
+        throw Exception('No default Liquid wallet found');
+      }
+      payload['LBTC'] = {
+        'Descriptor': liquidDescriptor,
+      };
+    }
+
+    if (methods.contains(SamrockPaymentMethod.btcln)) {
+      if (liquidDescriptor == null || liquidDescriptor.isEmpty) {
+        throw Exception('No default Liquid wallet found for Lightning setup');
+      }
+      payload['BTCLN'] = {
+        'Type': 'Boltz',
+        'LBTC': {
+          'Descriptor': liquidDescriptor,
+        },
+      };
+    }
+
+    return payload;
+  }
+}

--- a/lib/features/samrock/presentation/bloc/samrock_cubit.dart
+++ b/lib/features/samrock/presentation/bloc/samrock_cubit.dart
@@ -1,0 +1,51 @@
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:bb_mobile/features/samrock/domain/usecases/complete_samrock_setup_usecase.dart';
+import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SamrockCubit extends Cubit<SamrockState> {
+  final CompleteSamrockSetupUsecase _completeSamrockSetupUsecase;
+
+  SamrockCubit({
+    required CompleteSamrockSetupUsecase completeSamrockSetupUsecase,
+  })  : _completeSamrockSetupUsecase = completeSamrockSetupUsecase,
+        super(const SamrockState.initial());
+
+  void parseUrl(String url) {
+    final request = SamrockSetupRequest.tryParse(url);
+    if (request == null) {
+      emit(const SamrockState.error(message: 'Invalid SamRock setup URL'));
+      return;
+    }
+    emit(SamrockState.parsed(request: request));
+  }
+
+  Future<void> confirmSetup() async {
+    final currentState = state;
+    if (currentState is! SamrockParsed) return;
+
+    final request = currentState.request;
+    emit(SamrockState.loading(request: request));
+
+    try {
+      final response = await _completeSamrockSetupUsecase.execute(request);
+      if (response.success) {
+        emit(SamrockState.success(request: request, response: response));
+      } else {
+        emit(SamrockState.error(
+          message: response.message,
+          request: request,
+        ));
+      }
+    } catch (e) {
+      emit(SamrockState.error(
+        message: e.toString(),
+        request: request,
+      ));
+    }
+  }
+
+  void reset() {
+    emit(const SamrockState.initial());
+  }
+}

--- a/lib/features/samrock/presentation/bloc/samrock_state.dart
+++ b/lib/features/samrock/presentation/bloc/samrock_state.dart
@@ -1,0 +1,27 @@
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'samrock_state.freezed.dart';
+
+@freezed
+abstract class SamrockState with _$SamrockState {
+  const factory SamrockState.initial() = SamrockInitial;
+
+  const factory SamrockState.parsed({
+    required SamrockSetupRequest request,
+  }) = SamrockParsed;
+
+  const factory SamrockState.loading({
+    required SamrockSetupRequest request,
+  }) = SamrockLoading;
+
+  const factory SamrockState.success({
+    required SamrockSetupRequest request,
+    required SamrockSetupResponse response,
+  }) = SamrockSuccess;
+
+  const factory SamrockState.error({
+    required String message,
+    SamrockSetupRequest? request,
+  }) = SamrockError;
+}

--- a/lib/features/samrock/samrock_locator.dart
+++ b/lib/features/samrock/samrock_locator.dart
@@ -1,0 +1,38 @@
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/features/samrock/data/datasources/samrock_api_datasource.dart';
+import 'package:bb_mobile/features/samrock/data/repositories/samrock_repository_impl.dart';
+import 'package:bb_mobile/features/samrock/domain/repositories/samrock_repository.dart';
+import 'package:bb_mobile/features/samrock/domain/usecases/complete_samrock_setup_usecase.dart';
+import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_cubit.dart';
+import 'package:get_it/get_it.dart';
+
+class SamrockLocator {
+  static void setup(GetIt locator) {
+    // Datasources
+    locator.registerLazySingleton<SamrockApiDatasource>(
+      () => SamrockApiDatasource(),
+    );
+
+    // Repositories
+    locator.registerLazySingleton<SamrockRepository>(
+      () => SamrockRepositoryImpl(
+        datasource: locator<SamrockApiDatasource>(),
+      ),
+    );
+
+    // Usecases
+    locator.registerFactory<CompleteSamrockSetupUsecase>(
+      () => CompleteSamrockSetupUsecase(
+        walletRepository: locator<WalletRepository>(),
+        samrockRepository: locator<SamrockRepository>(),
+      ),
+    );
+
+    // Blocs
+    locator.registerFactory<SamrockCubit>(
+      () => SamrockCubit(
+        completeSamrockSetupUsecase: locator<CompleteSamrockSetupUsecase>(),
+      ),
+    );
+  }
+}

--- a/lib/features/samrock/samrock_router.dart
+++ b/lib/features/samrock/samrock_router.dart
@@ -1,0 +1,24 @@
+import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_cubit.dart';
+import 'package:bb_mobile/features/samrock/ui/samrock_setup_page.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+enum SamrockRoute {
+  samrockSetup('/samrock-setup');
+
+  const SamrockRoute(this.path);
+
+  final String path;
+}
+
+class SamrockRouter {
+  static final route = GoRoute(
+    name: SamrockRoute.samrockSetup.name,
+    path: SamrockRoute.samrockSetup.path,
+    builder: (context, state) => BlocProvider(
+      create: (_) => locator<SamrockCubit>(),
+      child: const SamrockSetupPage(),
+    ),
+  );
+}

--- a/lib/features/samrock/ui/samrock_confirmation_widget.dart
+++ b/lib/features/samrock/ui/samrock_confirmation_widget.dart
@@ -1,0 +1,108 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+class SamrockConfirmationWidget extends StatelessWidget {
+  final SamrockSetupRequest request;
+
+  const SamrockConfirmationWidget({
+    super.key,
+    required this.request,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          BBText(
+            'Connect to BTCPay Server',
+            style: context.font.headlineMedium,
+          ),
+          const Gap(16),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: context.appColors.surface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: context.appColors.border),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                BBText(
+                  'Server',
+                  style: context.font.labelSmall,
+                  color: context.appColors.textMuted,
+                ),
+                const Gap(4),
+                BBText(
+                  request.serverHost,
+                  style: context.font.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+          const Gap(16),
+          BBText(
+            'Payment methods to configure:',
+            style: context.font.bodyMedium,
+            color: context.appColors.textMuted,
+          ),
+          const Gap(8),
+          ...request.paymentMethods.map(
+            (method) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                children: [
+                  Icon(
+                    _iconForMethod(method),
+                    size: 20,
+                    color: context.appColors.primary,
+                  ),
+                  const Gap(8),
+                  BBText(
+                    method.displayName,
+                    style: context.font.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const Gap(16),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: context.appColors.surface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: context.appColors.border),
+            ),
+            child: BBText(
+              'This will share your public wallet descriptors with the server so it can generate receive addresses for your store.',
+              style: context.font.bodySmall,
+              color: context.appColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _iconForMethod(SamrockPaymentMethod method) {
+    switch (method) {
+      case SamrockPaymentMethod.btc:
+        return Icons.currency_bitcoin;
+      case SamrockPaymentMethod.lbtc:
+        return Icons.water_drop_outlined;
+      case SamrockPaymentMethod.btcln:
+        return Icons.flash_on;
+    }
+  }
+}

--- a/lib/features/samrock/ui/samrock_confirmation_widget.dart
+++ b/lib/features/samrock/ui/samrock_confirmation_widget.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
-import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
 import 'package:flutter/material.dart';

--- a/lib/features/samrock/ui/samrock_setup_page.dart
+++ b/lib/features/samrock/ui/samrock_setup_page.dart
@@ -1,0 +1,253 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
+import 'package:bb_mobile/core/widgets/qr_scanner_widget.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_cubit.dart';
+import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_state.dart';
+import 'package:bb_mobile/features/samrock/ui/samrock_confirmation_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+
+class SamrockSetupPage extends StatelessWidget {
+  const SamrockSetupPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SamrockCubit, SamrockState>(
+      builder: (context, state) {
+        return state.when(
+          initial: () => _buildScannerView(context),
+          parsed: (request) => _buildConfirmationView(context, state),
+          loading: (request) => _buildLoadingView(context),
+          success: (request, response) =>
+              _buildSuccessView(context, request, response),
+          error: (message, request) =>
+              _buildErrorView(context, message, request),
+        );
+      },
+    );
+  }
+
+  Widget _buildScannerView(BuildContext context) {
+    final cubit = context.read<SamrockCubit>();
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          QrScannerWidget(
+            onScanned: cubit.parseUrl,
+          ),
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 8,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: BBText(
+                'Scan SamRock QR Code',
+                style: context.font.labelMedium,
+                color: context.appColors.onPrimary,
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: MediaQuery.of(context).size.height * 0.02,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: IconButton(
+                onPressed: () => context.pop(),
+                icon: Icon(
+                  CupertinoIcons.xmark_circle,
+                  color: context.appColors.onPrimary,
+                  size: 64,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildConfirmationView(BuildContext context, SamrockState state) {
+    final cubit = context.read<SamrockCubit>();
+    final request = (state as SamrockParsed).request;
+
+    return Scaffold(
+      appBar: AppBar(
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        flexibleSpace: TopBar(
+          title: 'SamRock Setup',
+          onBack: () => cubit.reset(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            SamrockConfirmationWidget(request: request),
+            const Gap(24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: BBButton.big(
+                      label: 'Cancel',
+                      bgColor: context.appColors.surface,
+                      textColor: context.appColors.text,
+                      onPressed: () => cubit.reset(),
+                    ),
+                  ),
+                  const Gap(16),
+                  Expanded(
+                    child: BBButton.big(
+                      label: 'Confirm',
+                      bgColor: context.appColors.primary,
+                      textColor: context.appColors.onPrimary,
+                      onPressed: cubit.confirmSetup,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Gap(32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingView(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        flexibleSpace: const TopBar(title: 'SamRock Setup'),
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircularProgressIndicator(),
+            Gap(16),
+            Text('Submitting wallet descriptors...'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSuccessView(
+    BuildContext context,
+    dynamic request,
+    dynamic response,
+  ) {
+    return Scaffold(
+      appBar: AppBar(
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        flexibleSpace: const TopBar(title: 'SamRock Setup'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.check_circle_outline,
+                size: 80,
+                color: context.appColors.primary,
+              ),
+              const Gap(16),
+              BBText(
+                'Setup Complete!',
+                style: context.font.headlineMedium,
+              ),
+              const Gap(8),
+              BBText(
+                'Your BTCPay Server store is now configured to receive payments to your Bull Bitcoin wallet.',
+                style: context.font.bodyMedium,
+                color: context.appColors.textMuted,
+                textAlign: TextAlign.center,
+              ),
+              const Gap(32),
+              BBButton.big(
+                label: 'Done',
+                bgColor: context.appColors.primary,
+                textColor: context.appColors.onPrimary,
+                onPressed: () => context.pop(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorView(
+    BuildContext context,
+    String message,
+    dynamic request,
+  ) {
+    final cubit = context.read<SamrockCubit>();
+    return Scaffold(
+      appBar: AppBar(
+        forceMaterialTransparency: true,
+        automaticallyImplyLeading: false,
+        flexibleSpace: TopBar(
+          title: 'SamRock Setup',
+          onBack: () => cubit.reset(),
+        ),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.error_outline,
+                size: 80,
+                color: context.appColors.error,
+              ),
+              const Gap(16),
+              BBText(
+                'Setup Failed',
+                style: context.font.headlineMedium,
+              ),
+              const Gap(8),
+              BBText(
+                message,
+                style: context.font.bodyMedium,
+                color: context.appColors.error,
+                textAlign: TextAlign.center,
+              ),
+              const Gap(32),
+              if (request != null)
+                BBButton.big(
+                  label: 'Try Again',
+                  bgColor: context.appColors.primary,
+                  textColor: context.appColors.onPrimary,
+                  onPressed: cubit.confirmSetup,
+                ),
+              const Gap(16),
+              BBButton.big(
+                label: 'Scan Again',
+                bgColor: context.appColors.surface,
+                textColor: context.appColors.text,
+                onPressed: () => cubit.reset(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/samrock/ui/samrock_setup_page.dart
+++ b/lib/features/samrock/ui/samrock_setup_page.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
+import 'package:bb_mobile/core/widgets/inputs/paste_input.dart';
 import 'package:bb_mobile/core/widgets/qr_scanner_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/samrock/presentation/bloc/samrock_cubit.dart';
@@ -51,6 +52,16 @@ class SamrockSetupPage extends StatelessWidget {
                 style: context.font.labelMedium,
                 color: context.appColors.onPrimary,
               ),
+            ),
+          ),
+          Positioned(
+            bottom: MediaQuery.of(context).size.height * 0.12,
+            left: 16,
+            right: 16,
+            child: PasteInput(
+              text: '',
+              hint: 'Paste SamRock URL',
+              onChanged: cubit.parseUrl,
             ),
           ),
           Positioned(

--- a/lib/features/samrock/ui/samrock_setup_page.dart
+++ b/lib/features/samrock/ui/samrock_setup_page.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
-import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/qr_scanner_widget.dart';

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_support_chat/ui/exchange_support_chat_router.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/samrock/samrock_router.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/router.dart';
@@ -124,6 +125,13 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
                   },
                 ),
 
+                SettingsEntryItem(
+                  icon: Icons.link,
+                  title: 'SamRock',
+                  onTap: () {
+                    context.pushNamed(SamrockRoute.samrockSetup.name);
+                  },
+                ),
                 SettingsEntryItem(
                   icon: Icons.description,
                   title: context.loc.settingsTermsOfServiceTitle,

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -38,6 +38,7 @@ import 'package:bb_mobile/features/test_wallet_backup/test_wallet_backup_locator
 import 'package:bb_mobile/features/tor_settings/tor_settings_locator.dart';
 import 'package:bb_mobile/features/transactions/transactions_locator.dart';
 import 'package:bb_mobile/features/wallet/wallet_locator.dart';
+import 'package:bb_mobile/features/samrock/samrock_locator.dart';
 import 'package:bb_mobile/features/withdraw/withdraw_locator.dart';
 import 'package:get_it/get_it.dart';
 
@@ -105,5 +106,6 @@ class AppLocator {
     RecipientsLocator.setup(locator);
     BitBoxLocator.setup(locator);
     ArkCoreLocator.setup(locator);
+    SamrockLocator.setup(locator);
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -37,6 +37,7 @@ import 'package:bb_mobile/features/status_check/router.dart';
 import 'package:bb_mobile/features/swap/ui/swap_router.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
+import 'package:bb_mobile/features/samrock/samrock_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/backup_warning_overlay.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_home_app_bar.dart';
 import 'package:bb_mobile/features/withdraw/ui/withdraw_router.dart';
@@ -166,6 +167,7 @@ class AppRouter {
       RecoverBullGoogleDriveRouter.route,
       LabelsRouter.route,
       StatusCheckRouter.route,
+      SamrockRouter.route,
     ],
     errorBuilder: (context, state) => const RouteErrorScreen(),
   );

--- a/test/features/samrock/domain/entities/samrock_setup_test.dart
+++ b/test/features/samrock/domain/entities/samrock_setup_test.dart
@@ -1,0 +1,167 @@
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SamrockSetupRequest.tryParse', () {
+    test('parses valid SamRock URL with all methods', () {
+      const url =
+          'https://btcpay.example.com/plugins/abc123/samrock/protocol?setup=btc,lbtc,btcln&otp=token456';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNotNull);
+      expect(result!.serverUrl, 'https://btcpay.example.com');
+      expect(result.storeId, 'abc123');
+      expect(result.otp, 'token456');
+      expect(result.paymentMethods, [
+        SamrockPaymentMethod.btc,
+        SamrockPaymentMethod.lbtc,
+        SamrockPaymentMethod.btcln,
+      ]);
+    });
+
+    test('parses valid URL with only btc', () {
+      const url =
+          'https://server.com/plugins/store1/samrock/protocol?setup=btc&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNotNull);
+      expect(result!.paymentMethods, [SamrockPaymentMethod.btc]);
+    });
+
+    test('parses valid URL with port', () {
+      const url =
+          'https://server.com:8443/plugins/store1/samrock/protocol?setup=lbtc&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNotNull);
+      expect(result!.serverUrl, 'https://server.com:8443');
+    });
+
+    test('returns null for HTTP (non-HTTPS) URL', () {
+      const url =
+          'http://server.com/plugins/store1/samrock/protocol?setup=btc&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for missing otp', () {
+      const url =
+          'https://server.com/plugins/store1/samrock/protocol?setup=btc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for missing setup param', () {
+      const url =
+          'https://server.com/plugins/store1/samrock/protocol?otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for wrong path', () {
+      const url =
+          'https://server.com/api/v1/samrock/protocol?setup=btc&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for non-samrock path', () {
+      const url =
+          'https://server.com/plugins/store1/other/protocol?setup=btc&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for unknown payment method', () {
+      const url =
+          'https://server.com/plugins/store1/samrock/protocol?setup=unknown&otp=abc';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNull);
+    });
+
+    test('returns null for empty string', () {
+      final result = SamrockSetupRequest.tryParse('');
+      expect(result, isNull);
+    });
+
+    test('returns null for random string', () {
+      final result = SamrockSetupRequest.tryParse('not a url at all');
+      expect(result, isNull);
+    });
+
+    test('generates correct setupUrl', () {
+      const url =
+          'https://btcpay.example.com/plugins/abc123/samrock/protocol?setup=btc,lbtc&otp=token456';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result, isNotNull);
+      expect(
+        result!.setupUrl,
+        'https://btcpay.example.com/plugins/abc123/samrock/protocol?setup=btc,lbtc&otp=token456',
+      );
+    });
+
+    test('serverHost returns just the hostname', () {
+      const url =
+          'https://btcpay.example.com/plugins/abc123/samrock/protocol?setup=btc&otp=token';
+
+      final result = SamrockSetupRequest.tryParse(url);
+
+      expect(result!.serverHost, 'btcpay.example.com');
+    });
+  });
+
+  group('SamrockPaymentMethod', () {
+    test('fromString parses all valid methods', () {
+      expect(SamrockPaymentMethod.fromString('btc'), SamrockPaymentMethod.btc);
+      expect(
+        SamrockPaymentMethod.fromString('lbtc'),
+        SamrockPaymentMethod.lbtc,
+      );
+      expect(
+        SamrockPaymentMethod.fromString('btcln'),
+        SamrockPaymentMethod.btcln,
+      );
+    });
+
+    test('fromString is case-insensitive', () {
+      expect(SamrockPaymentMethod.fromString('BTC'), SamrockPaymentMethod.btc);
+      expect(
+        SamrockPaymentMethod.fromString('LBTC'),
+        SamrockPaymentMethod.lbtc,
+      );
+      expect(
+        SamrockPaymentMethod.fromString('BTCLN'),
+        SamrockPaymentMethod.btcln,
+      );
+    });
+
+    test('displayName returns correct strings', () {
+      expect(
+        SamrockPaymentMethod.btc.displayName,
+        'Bitcoin On-chain',
+      );
+      expect(SamrockPaymentMethod.lbtc.displayName, 'Liquid');
+      expect(
+        SamrockPaymentMethod.btcln.displayName,
+        'Lightning (via Boltz)',
+      );
+    });
+  });
+}

--- a/test/features/samrock/domain/usecases/payload_construction_test.dart
+++ b/test/features/samrock/domain/usecases/payload_construction_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/features/samrock/domain/entities/samrock_setup.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Payload construction', () {
+    test('BTC payload has correct structure', () {
+      const btcDescriptor =
+          "wpkh([abcdef01/84h/0h/0h]xpub6CUGRUo.../0/*)#checksum";
+
+      final payload = <String, dynamic>{
+        'BTC': {
+          'Descriptor': btcDescriptor,
+        },
+      };
+
+      expect(payload['BTC'], isA<Map>());
+      expect(payload['BTC']['Descriptor'], btcDescriptor);
+    });
+
+    test('LBTC payload has correct structure', () {
+      const liquidDescriptor =
+          "ct(slip77(abcdef),elwpkh([abcdef01/84h/1776h/0h]xpub6CUGRUo.../0/*))";
+
+      final payload = <String, dynamic>{
+        'LBTC': {
+          'Descriptor': liquidDescriptor,
+        },
+      };
+
+      expect(payload['LBTC'], isA<Map>());
+      expect(payload['LBTC']['Descriptor'], liquidDescriptor);
+    });
+
+    test('BTCLN payload has Boltz type and LBTC descriptor', () {
+      const liquidDescriptor =
+          "ct(slip77(abcdef),elwpkh([abcdef01/84h/1776h/0h]xpub6CUGRUo.../0/*))";
+
+      final payload = <String, dynamic>{
+        'BTCLN': {
+          'Type': 'Boltz',
+          'LBTC': {
+            'Descriptor': liquidDescriptor,
+          },
+        },
+      };
+
+      expect(payload['BTCLN']['Type'], 'Boltz');
+      expect(payload['BTCLN']['LBTC']['Descriptor'], liquidDescriptor);
+    });
+
+    test('full payload with all methods serializes to valid JSON', () {
+      const btcDescriptor =
+          "wpkh([abcdef01/84h/0h/0h]xpub6CUGRUo.../0/*)#checksum";
+      const liquidDescriptor =
+          "ct(slip77(abcdef),elwpkh([abcdef01/84h/1776h/0h]xpub6CUGRUo.../0/*))";
+
+      final payload = <String, dynamic>{
+        'BTC': {
+          'Descriptor': btcDescriptor,
+        },
+        'LBTC': {
+          'Descriptor': liquidDescriptor,
+        },
+        'BTCLN': {
+          'Type': 'Boltz',
+          'LBTC': {
+            'Descriptor': liquidDescriptor,
+          },
+        },
+      };
+
+      final jsonString = jsonEncode(payload);
+      final decoded = jsonDecode(jsonString) as Map<String, dynamic>;
+
+      expect(decoded['BTC']['Descriptor'], btcDescriptor);
+      expect(decoded['LBTC']['Descriptor'], liquidDescriptor);
+      expect(decoded['BTCLN']['Type'], 'Boltz');
+      expect(decoded['BTCLN']['LBTC']['Descriptor'], liquidDescriptor);
+    });
+
+    test('form-encoded body has correct format', () {
+      final payload = <String, dynamic>{
+        'BTC': {
+          'Descriptor': 'wpkh([fp/84h/0h/0h]xpub.../0/*)',
+        },
+      };
+
+      final jsonString = jsonEncode(payload);
+      final body = 'json=${Uri.encodeComponent(jsonString)}';
+
+      expect(body, startsWith('json='));
+      // Decode it back
+      final decoded = Uri.decodeComponent(body.substring(5));
+      final map = jsonDecode(decoded) as Map<String, dynamic>;
+      expect(map['BTC']['Descriptor'], 'wpkh([fp/84h/0h/0h]xpub.../0/*)');
+    });
+
+    test('payment methods map correctly from setup param', () {
+      const setupParam = 'btc,lbtc,btcln';
+      final methods = setupParam
+          .split(',')
+          .map((m) => SamrockPaymentMethod.fromString(m.trim()))
+          .toList();
+
+      expect(methods.length, 3);
+      expect(methods[0], SamrockPaymentMethod.btc);
+      expect(methods[1], SamrockPaymentMethod.lbtc);
+      expect(methods[2], SamrockPaymentMethod.btcln);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add SamRock Protocol integration allowing BTCPay Server to generate payment addresses from the user's Bull Bitcoin wallet descriptor
- Accept both BTCPay Server (`btc-chain`, `liquid-chain`, `btc-ln`) and Aqua (`btc`, `lbtc`, `btcln`) URL formats
- Add SamRock entry in Settings screen
- Add paste input alongside QR scanner for URL entry

## Test plan
- [x] Tested with live BTCPay Server at btcpay.bitcoinbutlers.com
- [x] Verified invoice payment address matches Bull Bitcoin wallet receive address
- [x] All 16 unit tests pass