### PR TITLE
refactor: prevents users from using uppercase letters in mnemonic words

### DIFF
--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -82,7 +82,7 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
   }
 
   void updateMnemonic(({int index, String word}) value) {
-    words[value.index] = value.word;
+    words[value.index] = value.word.toLowerCase().trim();
     setState(() {});
   }
 


### PR DESCRIPTION
This PR prevents users from using uppercase letters in mnemonic words.

<img width="166" height="105" alt="image" src="https://github.com/user-attachments/assets/8a978150-8938-4e4e-9f1f-898d6bcf57ad" />
