### PR TITLE
fix: recurrent no-api-key error spam when not logged in

### DIFF
--- a/lib/core/exchange/data/datasources/bullbitcoin_api_key_datasource.dart
+++ b/lib/core/exchange/data/datasources/bullbitcoin_api_key_datasource.dart
@@ -22,7 +22,7 @@ class BullbitcoinApiKeyDatasource {
       final jsonString = jsonEncode(apiKey.toJson());
       final key = isTestnet ? _apiKeyTestnetStorageKey : _apiKeyStorageKey;
       await _secureStorage.saveValue(key: key, value: jsonString);
-      log.fine('API key stored successfully');
+      log.fine('Exchange API key stored successfully');
     } catch (e) {
       log.severe(
         message: 'Error storing API key',

--- a/lib/core/exchange/data/datasources/bullbitcoin_api_key_datasource.dart
+++ b/lib/core/exchange/data/datasources/bullbitcoin_api_key_datasource.dart
@@ -39,7 +39,7 @@ class BullbitcoinApiKeyDatasource {
       final jsonString = await _secureStorage.getValue(key);
 
       if (jsonString == null || jsonString.isEmpty) {
-        log.warning('No API key found in storage');
+        log.warning('User not logged in exchange (no API key)');
         return null;
       }
 

--- a/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
+++ b/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
@@ -61,16 +61,8 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
         isTestnet: _isTestnet,
       );
 
-      if (apiKeyModel == null) {
-        throw ApiKeyException(
-          'API key not found. Please login to your Bull Bitcoin account.',
-        );
-      }
-
-      if (!apiKeyModel.isActive) {
-        throw ApiKeyException(
-          'API key is inactive. Please login again to your Bull Bitcoin account.',
-        );
+      if (apiKeyModel == null || !apiKeyModel.isActive) {
+        return null;
       }
 
       final orderModels = await _bullbitcoinApiDatasource.listOrderSummaries(
@@ -106,16 +98,8 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
         isTestnet: _isTestnet,
       );
 
-      if (apiKeyModel == null) {
-        throw ApiKeyException(
-          'API key not found. Please login to your Bull Bitcoin account.',
-        );
-      }
-
-      if (!apiKeyModel.isActive) {
-        throw ApiKeyException(
-          'API key is inactive. Please login again to your Bull Bitcoin account.',
-        );
+      if (apiKeyModel == null || !apiKeyModel.isActive) {
+        return [];
       }
 
       final orderModels = await _bullbitcoinApiDatasource.listOrderSummaries(
@@ -162,15 +146,11 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
 
       return orders;
     } catch (e) {
-      if (e is ApiKeyException) {
-        log.warning('Error fetching orders', error: e);
-      } else {
-        log.severe(
-          message: 'Error fetching orders',
-          error: e,
-          trace: StackTrace.current,
-        );
-      }
+      log.severe(
+        message: 'Error fetching orders',
+        error: e,
+        trace: StackTrace.current,
+      );
       return [];
     }
   }

--- a/lib/core/exchange/data/repository/exchange_user_repository_impl.dart
+++ b/lib/core/exchange/data/repository/exchange_user_repository_impl.dart
@@ -28,31 +28,19 @@ class ExchangeUserRepositoryImpl implements ExchangeUserRepository {
         isTestnet: _isTestnet,
       );
       if (apiKey == null) {
-        throw ApiKeyException(
-          'API key not found. Please login to your Bull Bitcoin account.',
-        );
+        return null;
       }
-      try {
-        final userSummaryModel = await _bullbitcoinApiDatasource.getUserSummary(
-          apiKey.key,
-        );
-        if (userSummaryModel == null) {
-          return null;
-        }
-        final userSummary = UserSummaryMapper.fromModelToEntity(
-          userSummaryModel,
-        );
 
-        return userSummary;
-      } catch (e) {
-        throw Exception('Failed to fetch user summary: $e');
+      final userSummaryModel = await _bullbitcoinApiDatasource.getUserSummary(
+        apiKey.key,
+      );
+      if (userSummaryModel == null) {
+        return null;
       }
+
+      return UserSummaryMapper.fromModelToEntity(userSummaryModel);
     } catch (e) {
-      if (e is ApiKeyException) {
-        rethrow;
-      } else {
-        throw Exception('Failed to fetch user summary: $e');
-      }
+      throw Exception('Failed to fetch user summary: $e');
     }
   }
 
@@ -123,28 +111,18 @@ class ExchangeUserRepositoryImpl implements ExchangeUserRepository {
         isTestnet: _isTestnet,
       );
       if (apiKey == null) {
-        throw ApiKeyException(
-          'API key not found. Please login to your Bull Bitcoin account.',
-        );
+        return [];
       }
-      try {
-        final announcementDataList =
-            await _bullbitcoinApiDatasource.listAnnouncements(
-          apiKey: apiKey.key,
-        );
-        final announcements = announcementDataList
-            .map((json) => AnnouncementModel.fromJson(json).toEntity())
-            .toList();
-        return announcements;
-      } catch (e) {
-        throw Exception('Failed to fetch announcements: $e');
-      }
+
+      final announcementDataList =
+          await _bullbitcoinApiDatasource.listAnnouncements(
+        apiKey: apiKey.key,
+      );
+      return announcementDataList
+          .map((json) => AnnouncementModel.fromJson(json).toEntity())
+          .toList();
     } catch (e) {
-      if (e is ApiKeyException) {
-        rethrow;
-      } else {
-        throw Exception('Failed to fetch announcements: $e');
-      }
+      throw Exception('Failed to fetch announcements: $e');
     }
   }
 }

--- a/lib/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart
+++ b/lib/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_user_repository.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
@@ -33,11 +32,6 @@ class GetExchangeUserSummaryUsecase {
 
       return userSummary;
     } catch (e) {
-      // TODO: Check if we really need a specific exception for this instead
-      // of just using GetEchangeUserSummaryException also for ApiKeyException
-      if (e is ApiKeyException) {
-        rethrow;
-      }
       throw GetExchangeUserSummaryException('$e');
     }
   }

--- a/lib/core/exchange/domain/usecases/save_exchange_api_key_usecase.dart
+++ b/lib/core/exchange/domain/usecases/save_exchange_api_key_usecase.dart
@@ -24,8 +24,6 @@ class SaveExchangeApiKeyUsecase {
         apiKeyResponseData,
         isTestnet: isTestnet,
       );
-
-      log.fine('API key saved successfully');
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
       throw SaveExchangeApiKeyException('$e');

--- a/lib/features/exchange/presentation/exchange_cubit.dart
+++ b/lib/features/exchange/presentation/exchange_cubit.dart
@@ -72,9 +72,7 @@ class ExchangeCubit extends Cubit<ExchangeState> {
 
   Future<void> fetchUserSummary({bool force = false}) async {
     try {
-      emit(
-        state.copyWith(apiKeyException: null, getUserSummaryException: null),
-      );
+      emit(state.copyWith(getUserSummaryException: null));
 
       final userSummary = await _getExchangeUserSummaryUsecase.execute();
 

--- a/lib/features/exchange/presentation/exchange_cubit.dart
+++ b/lib/features/exchange/presentation/exchange_cubit.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/notification_message.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/delete_exchange_api_key_usecase.dart';
 import 'package:bb_mobile/core/exchange/data/services/exchange_notification_service.dart';
@@ -92,15 +91,10 @@ class ExchangeCubit extends Cubit<ExchangeState> {
       }
 
       loadAnnouncements();
+    } on GetExchangeUserSummaryException catch (e) {
+      emit(state.copyWith(getUserSummaryException: e));
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
-      if (e is ApiKeyException) {
-        emit(state.copyWith(apiKeyException: e));
-        // Disconnect WebSocket if API key is invalid
-        disconnectWebSocket();
-      } else if (e is GetExchangeUserSummaryException) {
-        emit(state.copyWith(getUserSummaryException: e));
-      }
     }
   }
 

--- a/lib/features/exchange/presentation/exchange_state.dart
+++ b/lib/features/exchange/presentation/exchange_state.dart
@@ -1,4 +1,3 @@
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/announcement.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/delete_exchange_api_key_usecase.dart';
@@ -12,7 +11,6 @@ part 'exchange_state.freezed.dart';
 abstract class ExchangeState with _$ExchangeState {
   const factory ExchangeState({
     UserSummary? userSummary,
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
     SaveExchangeApiKeyException? saveApiKeyException,
     DeleteExchangeApiKeyException? deleteApiKeyException,
@@ -28,10 +26,8 @@ abstract class ExchangeState with _$ExchangeState {
   const ExchangeState._();
 
   bool get isFetchingUserSummary =>
-      userSummary == null &&
-      getUserSummaryException == null &&
-      apiKeyException == null;
-  bool get notLoggedIn => apiKeyException != null || !hasUser;
+      userSummary == null && getUserSummaryException == null;
+  bool get notLoggedIn => !hasUser;
   bool get hasUser => userSummary != null;
 
   bool get isFullyVerifiedKycLevel =>

--- a/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
@@ -32,8 +32,7 @@ class _WalletHomeAppBarState extends State<WalletHomeAppBar> {
       _hasTriggeredFetch = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         final cubit = context.read<ExchangeCubit>();
-        if (cubit.state.userSummary == null &&
-            cubit.state.apiKeyException == null) {
+        if (cubit.state.userSummary == null) {
           cubit.fetchUserSummary();
         }
       });


### PR DESCRIPTION
- Exchange repository read methods (getUserSummary, getOrders,
  getOrderByTxId, listAnnouncements) return empty results instead
  of throwing ApiKeyException when no API key is stored
- Simplified ExchangeCubit.fetchUserSummary() error handling
- Write/action methods (placeBuyOrder, saveUserPreference, etc.)
  still throw ApiKeyException as expected for login UI prompts
