### PR TITLE
fix: label upsert UNIQUE constraint failure on exchange orders

### DIFF
--- a/lib/features/labels/adapters/labels_repository_adapter.dart
+++ b/lib/features/labels/adapters/labels_repository_adapter.dart
@@ -15,7 +15,10 @@ class DriftLabelsRepositoryAdapter implements LabelsRepositoryPort {
     final companion = LabelMapper.newLabelEntityToCompanion(newLabel);
     final id = await _database.into(_database.labels).insert(
       companion,
-      mode: InsertMode.insertOrIgnore,
+      onConflict: DoUpdate(
+        (old) => companion,
+        target: [_database.labels.label, _database.labels.reference],
+      ),
     );
 
     return LabelEntity(

--- a/lib/features/labels/adapters/labels_repository_adapter.dart
+++ b/lib/features/labels/adapters/labels_repository_adapter.dart
@@ -13,9 +13,10 @@ class DriftLabelsRepositoryAdapter implements LabelsRepositoryPort {
   @override
   Future<LabelEntity> store(NewLabel newLabel) async {
     final companion = LabelMapper.newLabelEntityToCompanion(newLabel);
-    final id = await _database
-        .into(_database.labels)
-        .insertOnConflictUpdate(companion);
+    final id = await _database.into(_database.labels).insert(
+      companion,
+      mode: InsertMode.insertOrIgnore,
+    );
 
     return LabelEntity(
       id: id,


### PR DESCRIPTION
## Summary
- `insertOnConflictUpdate` generates `ON CONFLICT(id) DO UPDATE`
  which only handles primary key collisions
- Since labels are inserted with auto-generated ids, there is
  never a conflict on `id` but the `(label, reference)` UNIQUE
  constraint can still be violated with no handler, causing
  SEVERE errors
- Changed to `insertOrIgnore` which covers all constraint
  violations and silently skips duplicates
