### PR TITLE
fix: cargokit to be able to pin a rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ARG JVM_TARGET=21
 ARG ANDROID_API_LEVEL=36
 ARG ANDROID_BUILD_TOOLS=36.0.0
 ARG ANDROID_NDK=29.0.14206865
+ARG RUST_VERSION=1.95.0
+
 
 ENV ANDROID_HOME=/opt/android-sdk
 ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
@@ -38,10 +40,9 @@ RUN adduser $USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER $USER
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup.sh
-RUN sh /tmp/rustup.sh -y
-RUN rm /tmp/rustup.sh
+# Install Rust (pinned for reproducible builds; cargokit defaults to 'stable' for
+# plugins without cargokit.yaml, so this version determines their output)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain ${RUST_VERSION}
 ENV PATH="/home/$USER/.cargo/bin:${PATH}"
 
 # Add Android Rust targets

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,8 +53,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: b48601c2df25032888a300f67d6a5dc7b2520c44
-      resolved-ref: b48601c2df25032888a300f67d6a5dc7b2520c44
+      ref: f3264ce66c8fec8438a0f9670da3eccfde757b9e
+      resolved-ref: f3264ce66c8fec8438a0f9670da3eccfde757b9e
       url: "https://github.com/SatoshiPortal/ark-wallet-dart"
     source: git
     version: "0.0.1"
@@ -151,8 +151,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
-      resolved-ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
+      ref: "23f91b6e708e853358a0b03774d0f8033aa82502"
+      resolved-ref: "23f91b6e708e853358a0b03774d0f8033aa82502"
       url: "https://github.com/SatoshiPortal/bitbox-dart"
     source: git
     version: "0.1.0"
@@ -209,8 +209,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: a33984312dcc6e181641469868ede9fb435b800a
-      resolved-ref: a33984312dcc6e181641469868ede9fb435b800a
+      ref: "42c03082d5d97764fbfedc43a72125963f54dba6"
+      resolved-ref: "42c03082d5d97764fbfedc43a72125963f54dba6"
       url: "https://github.com/SatoshiPortal/boltz-dart.git"
     source: git
     version: "0.2.1"
@@ -482,8 +482,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
-      resolved-ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
+      ref: c7831bfa2059c01650940b4f2d99eef9931119eb
+      resolved-ref: c7831bfa2059c01650940b4f2d99eef9931119eb
       url: "https://github.com/SatoshiPortal/bbqr-dart"
     source: git
     version: "0.0.1"
@@ -1282,8 +1282,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5bd93986abb86cb13c108184ee44df7fe62d3f60"
-      resolved-ref: "5bd93986abb86cb13c108184ee44df7fe62d3f60"
+      ref: "40287f063fc87293625b15f653290d4be2f5acc5"
+      resolved-ref: "40287f063fc87293625b15f653290d4be2f5acc5"
       url: "https://github.com/SatoshiPortal/lwk-dart"
     source: git
     version: "0.2.2"
@@ -1483,8 +1483,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec"
-      resolved-ref: "028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec"
+      ref: e939cf5128b61d02aefca725f6de80cbb8818e09
+      resolved-ref: e939cf5128b61d02aefca725f6de80cbb8818e09
       url: "https://github.com/SatoshiPortal/payjoin-dart"
     source: git
     version: "0.23.0"
@@ -1669,8 +1669,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "99c3b045c8e80c9429cf1c35bb662fff8a598841"
-      resolved-ref: "99c3b045c8e80c9429cf1c35bb662fff8a598841"
+      ref: df6e385d30eb266242099883fed06c462a159b3e
+      resolved-ref: df6e385d30eb266242099883fed06c462a159b3e
       url: "https://github.com/SatoshiPortal/dart-satoshifier"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,8 +53,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "847342ecd4a2d70bea5a0755e4152d1cb7e68493"
-      resolved-ref: "847342ecd4a2d70bea5a0755e4152d1cb7e68493"
+      ref: b48601c2df25032888a300f67d6a5dc7b2520c44
+      resolved-ref: b48601c2df25032888a300f67d6a5dc7b2520c44
       url: "https://github.com/SatoshiPortal/ark-wallet-dart"
     source: git
     version: "0.0.1"
@@ -94,20 +94,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ebf4a6675ede8f7337ab18121157717dc9dc9751
-      resolved-ref: ebf4a6675ede8f7337ab18121157717dc9dc9751
+      ref: "76695446cd57f94802327f6ab50392f651c49b63"
+      resolved-ref: "76695446cd57f94802327f6ab50392f651c49b63"
       url: "https://github.com/ethicnology/bdk-dart"
     source: git
     version: "2.3.0-alpha.0"
-  bdk_flutter:
-    dependency: transitive
-    description:
-      path: "."
-      ref: "3024b3452b4b0e5982d737f82ff461024a881ae7"
-      resolved-ref: "3024b3452b4b0e5982d737f82ff461024a881ae7"
-      url: "https://github.com/SatoshiPortal/bdk-flutter"
-    source: git
-    version: "0.31.3"
   bech32:
     dependency: transitive
     description:
@@ -160,8 +151,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d44d96983a39896fdc02a2d320036a5ef340e5eb
-      resolved-ref: d44d96983a39896fdc02a2d320036a5ef340e5eb
+      ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
+      resolved-ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
       url: "https://github.com/SatoshiPortal/bitbox-dart"
     source: git
     version: "0.1.0"
@@ -218,8 +209,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "80d6f1a4b307717bc8eb1ad110d85f0a2ee5e5a4"
-      resolved-ref: "80d6f1a4b307717bc8eb1ad110d85f0a2ee5e5a4"
+      ref: a33984312dcc6e181641469868ede9fb435b800a
+      resolved-ref: a33984312dcc6e181641469868ede9fb435b800a
       url: "https://github.com/SatoshiPortal/boltz-dart.git"
     source: git
     version: "0.2.1"
@@ -355,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -491,8 +482,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "170873e1d59a0b037f2dfac4d26bf900cd539532"
-      resolved-ref: "170873e1d59a0b037f2dfac4d26bf900cd539532"
+      ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
+      resolved-ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
       url: "https://github.com/SatoshiPortal/bbqr-dart"
     source: git
     version: "0.0.1"
@@ -780,8 +771,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_secure_storage
-      ref: 01ed2ee04192f4ecda8bbf68198baceb6386f1e6
-      resolved-ref: 01ed2ee04192f4ecda8bbf68198baceb6386f1e6
+      ref: "01ed2ee04192f4ecda8bbf68198baceb6386f1e6"
+      resolved-ref: "01ed2ee04192f4ecda8bbf68198baceb6386f1e6"
       url: "https://github.com/SatoshiPortal/flutter_secure_storage_legacy"
     source: git
     version: "9.2.3"
@@ -789,8 +780,8 @@ packages:
     dependency: transitive
     description:
       path: flutter_secure_storage_platform_interface
-      ref: 01ed2ee04192f4ecda8bbf68198baceb6386f1e6
-      resolved-ref: 01ed2ee04192f4ecda8bbf68198baceb6386f1e6
+      ref: "01ed2ee04192f4ecda8bbf68198baceb6386f1e6"
+      resolved-ref: "01ed2ee04192f4ecda8bbf68198baceb6386f1e6"
       url: "https://github.com/SatoshiPortal/flutter_secure_storage_legacy"
     source: git
     version: "1.1.2"
@@ -1291,8 +1282,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2e10deb2fbaa76e888bda7be6a2128ce2c05173d"
-      resolved-ref: "2e10deb2fbaa76e888bda7be6a2128ce2c05173d"
+      ref: "5bd93986abb86cb13c108184ee44df7fe62d3f60"
+      resolved-ref: "5bd93986abb86cb13c108184ee44df7fe62d3f60"
       url: "https://github.com/SatoshiPortal/lwk-dart"
     source: git
     version: "0.2.2"
@@ -1300,18 +1291,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
@@ -1492,8 +1483,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "913812dba120703ce9738fa330c5203e1d11f2fa"
-      resolved-ref: "913812dba120703ce9738fa330c5203e1d11f2fa"
+      ref: "028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec"
+      resolved-ref: "028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec"
       url: "https://github.com/SatoshiPortal/payjoin-dart"
     source: git
     version: "0.23.0"
@@ -1678,8 +1669,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: c1dd6d76639eaa79a8e6c40ff1c05c78e9c4bae5
-      resolved-ref: c1dd6d76639eaa79a8e6c40ff1c05c78e9c4bae5
+      ref: "99c3b045c8e80c9429cf1c35bb662fff8a598841"
+      resolved-ref: "99c3b045c8e80c9429cf1c35bb662fff8a598841"
       url: "https://github.com/SatoshiPortal/dart-satoshifier"
     source: git
     version: "0.0.1"
@@ -1956,26 +1947,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   bdk_dart:
     git:
       url: https://github.com/ethicnology/bdk-dart
-      ref: ebf4a6675ede8f7337ab18121157717dc9dc9751
+      ref: 76695446cd57f94802327f6ab50392f651c49b63
   flutter_bloc: ^9.1.1
   freezed: ^3.2.3
   get_it: ^9.1.1
@@ -34,7 +34,7 @@ dependencies:
   payjoin_flutter:
     git:
       url: https://github.com/SatoshiPortal/payjoin-dart
-      ref: 913812dba120703ce9738fa330c5203e1d11f2fa
+      ref: 028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec
   qr_flutter: ^4.1.0
   dio: ^5.9.0
   timeago: ^3.7.1
@@ -45,7 +45,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/SatoshiPortal/bitbox-dart
-      ref: d44d96983a39896fdc02a2d320036a5ef340e5eb
+      ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
   hex: ^0.2.0
   auto_size_text: ^3.0.0
   no_screenshot: ^0.3.1
@@ -58,11 +58,11 @@ dependencies:
   boltz:
     git:
       url: https://github.com/SatoshiPortal/boltz-dart.git
-      ref: 80d6f1a4b307717bc8eb1ad110d85f0a2ee5e5a4
+      ref: a33984312dcc6e181641469868ede9fb435b800a
   lwk:
     git:
       url: https://github.com/SatoshiPortal/lwk-dart
-      ref: 2e10deb2fbaa76e888bda7be6a2128ce2c05173d
+      ref: 5bd93986abb86cb13c108184ee44df7fe62d3f60
   json_annotation: ^4.9.0
   flutter_localizations:
     sdk: flutter
@@ -104,13 +104,13 @@ dependencies:
   dart_bbqr:
     git:
       url: https://github.com/SatoshiPortal/bbqr-dart
-      ref: 170873e1d59a0b037f2dfac4d26bf900cd539532
+      ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
   sliver_tools: ^0.2.12
   logging_colorful: ^1.3.2
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/dart-satoshifier
-      ref: c1dd6d76639eaa79a8e6c40ff1c05c78e9c4bae5
+      ref: 99c3b045c8e80c9429cf1c35bb662fff8a598841
   flutter_nfc_kit: ^3.6.1
   ledger_bitcoin:
     git:
@@ -127,7 +127,7 @@ dependencies:
   ark_wallet:
     git:
       url: https://github.com/SatoshiPortal/ark-wallet-dart
-      ref: 847342ecd4a2d70bea5a0755e4152d1cb7e68493
+      ref: b48601c2df25032888a300f67d6a5dc7b2520c44
   socks5_proxy: ^2.1.1
   tor:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   payjoin_flutter:
     git:
       url: https://github.com/SatoshiPortal/payjoin-dart
-      ref: 028a85f73b5a68c0c86ee4ddeacdab888b5ef1ec
+      ref: e939cf5128b61d02aefca725f6de80cbb8818e09
   qr_flutter: ^4.1.0
   dio: ^5.9.0
   timeago: ^3.7.1
@@ -45,7 +45,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/SatoshiPortal/bitbox-dart
-      ref: f65b2288c025bc6643c8cd5bfa00c0ec6aec808c
+      ref: 23f91b6e708e853358a0b03774d0f8033aa82502
   hex: ^0.2.0
   auto_size_text: ^3.0.0
   no_screenshot: ^0.3.1
@@ -58,11 +58,11 @@ dependencies:
   boltz:
     git:
       url: https://github.com/SatoshiPortal/boltz-dart.git
-      ref: a33984312dcc6e181641469868ede9fb435b800a
+      ref: 42c03082d5d97764fbfedc43a72125963f54dba6
   lwk:
     git:
       url: https://github.com/SatoshiPortal/lwk-dart
-      ref: 5bd93986abb86cb13c108184ee44df7fe62d3f60
+      ref: 40287f063fc87293625b15f653290d4be2f5acc5
   json_annotation: ^4.9.0
   flutter_localizations:
     sdk: flutter
@@ -104,13 +104,13 @@ dependencies:
   dart_bbqr:
     git:
       url: https://github.com/SatoshiPortal/bbqr-dart
-      ref: c1bb2f43a560b53666838bbcd3f27e9c23cce997
+      ref: c7831bfa2059c01650940b4f2d99eef9931119eb
   sliver_tools: ^0.2.12
   logging_colorful: ^1.3.2
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/dart-satoshifier
-      ref: 99c3b045c8e80c9429cf1c35bb662fff8a598841
+      ref: df6e385d30eb266242099883fed06c462a159b3e
   flutter_nfc_kit: ^3.6.1
   ledger_bitcoin:
     git:
@@ -127,7 +127,7 @@ dependencies:
   ark_wallet:
     git:
       url: https://github.com/SatoshiPortal/ark-wallet-dart
-      ref: b48601c2df25032888a300f67d6a5dc7b2520c44
+      ref: f3264ce66c8fec8438a0f9670da3eccfde757b9e
   socks5_proxy: ^2.1.1
   tor:
     git:


### PR DESCRIPTION
Bumps every git ref in `pubspec.yaml` to new `reproducibility/6.9.1` branches in each fork. Each of those branches contains three changes:

1. **`rust/cargokit.yaml`** — `toolchain: 1.95.0` for both `debug` and `release`. Drops the previous `nightly` + `-Z build-std=panic_abort,std` combo (was producing slightly smaller release binaries but required nightly, defeating reproducibility).
2. **`rust/rust-toolchain.toml`** — redundant backup for non-cargokit invocations (CI scripts, `cargo check` from terminal).
3. **`cargokit/` (vendored)** — patched `build_tool/lib/src/options.dart` to accept any rustup-compatible toolchain name (version strings like `1.95.0`, dated nightlies like `nightly-2025-10-01`). Also updates `rustup.dart`'s installed-toolchain filter and `builder.dart`'s nightly detection. Unit tests added.

bdk_dart** (ethicnology/bdk-dart) — `ebf4a66` → `7669544`
  https://github.com/ethicnology/bdk-dart/compare/ebf4a6675ede8f7337ab18121157717dc9dc9751...76695446cd57f94802327f6ab50392f651c49b63

- **payjoin_flutter** (SatoshiPortal/payjoin-dart) — `913812d` → `e939cf5`
  https://github.com/SatoshiPortal/payjoin-dart/compare/913812dba120703ce9738fa330c5203e1d11f2fa...e939cf5128b61d02aefca725f6de80cbb8818e09

- **bitbox_flutter** (SatoshiPortal/bitbox-dart) — `d44d969` → `23f91b6`
  https://github.com/SatoshiPortal/bitbox-dart/compare/d44d96983a39896fdc02a2d320036a5ef340e5eb...23f91b6e708e853358a0b03774d0f8033aa82502

- **dart_bbqr** (SatoshiPortal/bbqr-dart) — `170873e` → `c7831bf`
  https://github.com/SatoshiPortal/bbqr-dart/compare/170873e1d59a0b037f2dfac4d26bf900cd539532...c7831bfa2059c01650940b4f2d99eef9931119eb

- **ark_wallet** (SatoshiPortal/ark-wallet-dart) — `847342e` → `f3264ce`
  https://github.com/SatoshiPortal/ark-wallet-dart/compare/847342ecd4a2d70bea5a0755e4152d1cb7e68493...f3264ce66c8fec8438a0f9670da3eccfde757b9e

- **boltz** (SatoshiPortal/boltz-dart) — `80d6f1a` → `42c0308`
  https://github.com/SatoshiPortal/boltz-dart/compare/80d6f1a4b307717bc8eb1ad110d85f0a2ee5e5a4...42c03082d5d97764fbfedc43a72125963f54dba6

- **lwk** (SatoshiPortal/lwk-dart) — `2e10deb` → `40287f0`
  https://github.com/SatoshiPortal/lwk-dart/compare/2e10deb2fbaa76e888bda7be6a2128ce2c05173d...40287f063fc87293625b15f653290d4be2f5acc5

- **satoshifier** (SatoshiPortal/dart-satoshifier) — `c1dd6d7` → `df6e385`
  https://github.com/SatoshiPortal/dart-satoshifier/compare/c1dd6d76639eaa79a8e6c40ff1c05c78e9c4bae5...df6e385d30eb266242099883fed06c462a159b3e