### PR TITLE
fix: redirect to exchange login when not logged in on buy/sell/withdraw

### DIFF
--- a/lib/core/exchange/data/repository/exchange_user_repository_impl.dart
+++ b/lib/core/exchange/data/repository/exchange_user_repository_impl.dart
@@ -114,10 +114,8 @@ class ExchangeUserRepositoryImpl implements ExchangeUserRepository {
         return [];
       }
 
-      final announcementDataList =
-          await _bullbitcoinApiDatasource.listAnnouncements(
-        apiKey: apiKey.key,
-      );
+      final announcementDataList = await _bullbitcoinApiDatasource
+          .listAnnouncements(apiKey: apiKey.key);
       return announcementDataList
           .map((json) => AnnouncementModel.fromJson(json).toEntity())
           .toList();

--- a/lib/features/buy/presentation/buy_bloc.dart
+++ b/lib/features/buy/presentation/buy_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/errors/buy_error.dart';
@@ -98,7 +97,6 @@ class BuyBloc extends Bloc<BuyEvent, BuyState> {
       emit(
         state.copyWith(
           userSummary: summary,
-          apiKeyException: null,
           getUserSummaryException: null,
           currencyInput: currencyInput,
           bitcoinUnit: settings.bitcoinUnit,
@@ -131,10 +129,6 @@ class BuyBloc extends Bloc<BuyEvent, BuyState> {
       }
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
-      if (e is ApiKeyException) {
-        // If the API key is invalid, we should not proceed with the buy flow.
-        emit(state.copyWith(apiKeyException: e));
-      }
       if (e is GetExchangeUserSummaryException) {
         emit(state.copyWith(getUserSummaryException: e));
       } else if (e is GetWalletsException) {

--- a/lib/features/buy/presentation/buy_state.dart
+++ b/lib/features/buy/presentation/buy_state.dart
@@ -5,7 +5,6 @@ sealed class BuyState with _$BuyState {
   const factory BuyState({
     @Default(false) bool isStarted,
     UserSummary? userSummary,
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
     @Default({}) Map<String, double> balances,
     @Default('') String amountInput,

--- a/lib/features/buy/ui/buy_router.dart
+++ b/lib/features/buy/ui/buy_router.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/features/buy/ui/screens/buy_accelerate_success_screen.
 import 'package:bb_mobile/features/buy/ui/screens/buy_confirm_screen.dart';
 import 'package:bb_mobile/features/buy/ui/screens/buy_input_screen.dart';
 import 'package:bb_mobile/features/buy/ui/screens/buy_success_screen.dart';
+import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -34,27 +35,18 @@ class BuyRouter {
         GoRoute(
           name: BuyRoute.buy.name,
           path: BuyRoute.buy.path,
+          redirect: (context, state) {
+            final notLoggedIn = context.read<ExchangeCubit>().state.notLoggedIn;
+            if (notLoggedIn) return ExchangeRoute.exchangeHome.path;
+            return null;
+          },
           builder: (context, state) {
-            return MultiBlocListener(
-              listeners: [
-                BlocListener<BuyBloc, BuyState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous.apiKeyException == null &&
-                          current.apiKeyException != null,
-                  listener: (context, state) {
-                    context.goNamed(ExchangeRoute.exchangeHome.name);
-                  },
-                ),
-                BlocListener<BuyBloc, BuyState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous.buyOrder == null && current.buyOrder != null,
-                  listener: (context, state) {
-                    context.pushNamed(BuyRoute.buyConfirmation.name);
-                  },
-                ),
-              ],
+            return BlocListener<BuyBloc, BuyState>(
+              listenWhen: (previous, current) =>
+                  previous.buyOrder == null && current.buyOrder != null,
+              listener: (context, state) {
+                context.pushNamed(BuyRoute.buyConfirmation.name);
+              },
               child: const BuyInputScreen(),
             );
           },
@@ -64,10 +56,9 @@ class BuyRouter {
               path: BuyRoute.buyConfirmation.path,
               builder: (context, state) {
                 return BlocListener<BuyBloc, BuyState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous.buyOrder?.isPayinCompleted != true &&
-                          current.buyOrder?.isPayinCompleted == true,
+                  listenWhen: (previous, current) =>
+                      previous.buyOrder?.isPayinCompleted != true &&
+                      current.buyOrder?.isPayinCompleted == true,
                   listener: (context, state) {
                     context.goNamed(
                       BuyRoute.buySuccess.name,
@@ -97,15 +88,13 @@ class BuyRouter {
       builder: (context, state) {
         final orderId = state.pathParameters['orderId']!;
         return BlocProvider(
-          create:
-              (context) =>
-                  locator<BuyBloc>()
-                    ..add(BuyEvent.accelerateTransactionPressed(orderId)),
+          create: (context) =>
+              locator<BuyBloc>()
+                ..add(BuyEvent.accelerateTransactionPressed(orderId)),
           child: BlocListener<BuyBloc, BuyState>(
-            listenWhen:
-                (previous, current) =>
-                    previous.buyOrder?.unbatchedBuyOnchainFees == null &&
-                    current.buyOrder?.unbatchedBuyOnchainFees != null,
+            listenWhen: (previous, current) =>
+                previous.buyOrder?.unbatchedBuyOnchainFees == null &&
+                current.buyOrder?.unbatchedBuyOnchainFees != null,
             listener: (context, state) {
               context.pushReplacementNamed(
                 BuyRoute.buyAccelerateSuccess.name,
@@ -124,10 +113,8 @@ class BuyRouter {
         final orderId = state.pathParameters['orderId']!;
 
         return BlocProvider(
-          create:
-              (context) =>
-                  locator<BuyBloc>()
-                    ..add(BuyEvent.refreshOrder(orderId: orderId)),
+          create: (context) =>
+              locator<BuyBloc>()..add(BuyEvent.refreshOrder(orderId: orderId)),
           child: const BuyAccelerateSuccessScreen(),
         );
       },

--- a/lib/features/dca/presentation/dca_bloc.dart
+++ b/lib/features/dca/presentation/dca_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
@@ -46,8 +45,6 @@ class DcaBloc extends Bloc<DcaEvent, DcaState> {
           defaultLightningAddress: startData.lightningAddress,
         ),
       );
-    } on ApiKeyException catch (e) {
-      emit(DcaState.initial(apiKeyException: e));
     } on GetExchangeUserSummaryException catch (e) {
       emit(DcaState.initial(getUserSummaryException: e));
     }

--- a/lib/features/dca/presentation/dca_state.dart
+++ b/lib/features/dca/presentation/dca_state.dart
@@ -3,7 +3,6 @@ part of 'dca_bloc.dart';
 @freezed
 sealed class DcaState with _$DcaState {
   const factory DcaState.initial({
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
   }) = DcaInitialState;
   const factory DcaState.buyInput({
@@ -39,7 +38,7 @@ sealed class DcaState with _$DcaState {
 
   String? get defaultLightningAddress {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => null,
+      initial: (getUserSummaryException) => null,
       buyInput:
           (defaultLightningAddress, balances, currency) =>
               defaultLightningAddress,
@@ -179,7 +178,7 @@ sealed class DcaState with _$DcaState {
 
   FiatCurrency? get currency {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => null,
+      initial: (getUserSummaryException) => null,
       buyInput: (defaultLightningAddress, balances, currency) => currency,
       walletSelection:
           (defaultLightningAddress, balances, amount, currency, frequency) =>
@@ -203,7 +202,7 @@ sealed class DcaState with _$DcaState {
   }
 
   List<UserBalance> get balances => when(
-    initial: (apiKeyException, getUserSummaryException) => [],
+    initial: (getUserSummaryException) => [],
     buyInput: (defaultLightningAddress, balances, currency) => balances,
     walletSelection:
         (defaultLightningAddress, balances, amount, currency, frequency) =>

--- a/lib/features/fund_exchange/fund_exchange_router.dart
+++ b/lib/features/fund_exchange/fund_exchange_router.dart
@@ -91,14 +91,6 @@ class FundExchangeRouter {
                 ..add(const FundExchangeEvent.started()),
           child: MultiBlocListener(
             listeners: [
-              BlocListener<FundExchangeBloc, FundExchangeState>(
-                listenWhen: (previous, current) =>
-                    previous.apiKeyException == null &&
-                    current.apiKeyException != null,
-                listener: (context, state) {
-                  context.goNamed(ExchangeRoute.exchangeHome.name);
-                },
-              ),
               // Navigate to COP input screen once institutions are loaded.
               // Uses pushNamed to avoid rebuilding the parent /fund-exchange
               // route (which would dispose the BLoC passed via extra).

--- a/lib/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart
+++ b/lib/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart
@@ -1,4 +1,3 @@
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/features/fund_exchange/application/fund_exchange_application_error.dart';
@@ -55,8 +54,6 @@ class FundExchangeBloc extends Bloc<FundExchangeEvent, FundExchangeState> {
     try {
       final summary = await _getExchangeUserSummaryUsecase.execute();
       emit(state.copyWith(userSummary: summary));
-    } on ApiKeyException catch (e) {
-      emit(state.copyWith(apiKeyException: e));
     } on GetExchangeUserSummaryException catch (e) {
       emit(state.copyWith(getUserSummaryException: e));
     } finally {

--- a/lib/features/fund_exchange/presentation/bloc/fund_exchange_state.dart
+++ b/lib/features/fund_exchange/presentation/bloc/fund_exchange_state.dart
@@ -5,7 +5,6 @@ sealed class FundExchangeState with _$FundExchangeState {
   const factory FundExchangeState({
     @Default(false) bool isStarted,
     UserSummary? userSummary,
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
     @Default(false) bool isLoadingFundingInstitutions,
     List<FundingInstitution>? fundingInstitutions,

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
@@ -117,14 +116,6 @@ class PayBloc extends Bloc<PayEvent, PayState> {
       final userSummary = await _getExchangeUserSummaryUsecase.execute();
 
       emit(recipientSelectionState.copyWith(userSummary: userSummary));
-    } on ApiKeyException catch (e) {
-      // Handle API key error by showing error in current state
-
-      emit(
-        recipientSelectionState.copyWith(
-          error: PayError.unexpected(message: e.message),
-        ),
-      );
     } on GetExchangeUserSummaryException catch (e) {
       emit(
         recipientSelectionState.copyWith(

--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
@@ -132,8 +131,6 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           bitcoinUnit: settings.bitcoinUnit,
         ),
       );
-    } on ApiKeyException catch (e) {
-      emit(SellState.initial(apiKeyException: e));
     } on GetExchangeUserSummaryException catch (e) {
       emit(SellState.initial(getUserSummaryException: e));
     }

--- a/lib/features/sell/presentation/bloc/sell_state.dart
+++ b/lib/features/sell/presentation/bloc/sell_state.dart
@@ -3,7 +3,6 @@ part of 'sell_bloc.dart';
 @freezed
 sealed class SellState with _$SellState {
   const factory SellState.initial({
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
   }) = SellInitialState;
   const factory SellState.amountInput({
@@ -160,7 +159,7 @@ sealed class SellState with _$SellState {
 
   FiatCurrency get fiatCurrency {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => FiatCurrency.cad,
+      initial: (getUserSummaryException) => FiatCurrency.cad,
       amountInput:
           (userSummary, bitcoinUnit) =>
               FiatCurrency.fromCode(userSummary.currency ?? 'CAD'),
@@ -198,7 +197,7 @@ sealed class SellState with _$SellState {
 
   BitcoinUnit? get bitcoinUnit {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => null,
+      initial: (getUserSummaryException) => null,
       amountInput: (userSummary, bitcoinUnit) => bitcoinUnit,
       walletSelection:
           (
@@ -232,7 +231,7 @@ sealed class SellState with _$SellState {
 
   bool get isLimitedKycLevel {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => false,
+      initial: (getUserSummaryException) => false,
       amountInput: (userSummary, bitcoinUnit) => userSummary.isLimitedKycLevel,
       walletSelection:
           (
@@ -268,7 +267,7 @@ sealed class SellState with _$SellState {
 
   bool get isLightKycLevel {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => false,
+      initial: (getUserSummaryException) => false,
       amountInput: (userSummary, bitcoinUnit) => userSummary.isLightKycLevel,
       walletSelection:
           (
@@ -304,7 +303,7 @@ sealed class SellState with _$SellState {
 
   bool get isFullyVerifiedKycLevel {
     return when(
-      initial: (apiKeyException, getUserSummaryException) => false,
+      initial: (getUserSummaryException) => false,
       amountInput:
           (userSummary, bitcoinUnit) => userSummary.isFullyVerifiedKycLevel,
       walletSelection:

--- a/lib/features/sell/ui/sell_router.dart
+++ b/lib/features/sell/ui/sell_router.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:bb_mobile/features/sell/ui/screens/sell_external_wallet_network_selection_screen.dart';
@@ -35,97 +36,74 @@ class SellRouter {
       GoRoute(
         name: SellRoute.sell.name,
         path: SellRoute.sell.path,
-        builder:
-            (context, state) => MultiBlocListener(
-              listeners: [
-                BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellInitialState &&
-                          previous.apiKeyException == null &&
-                          current is SellInitialState &&
-                          current.apiKeyException != null,
-                  listener: (context, state) {
-                    // Redirect to exchange home if API key exception occurs which means the user is not authenticated
-                    context.goNamed(ExchangeRoute.exchangeHome.name);
-                  },
-                ),
-                BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellAmountInputState &&
-                          current is SellWalletSelectionState,
-                  listener: (context, state) {
-                    context.pushNamed(SellRoute.sellWalletSelection.name);
-                  },
-                ),
-              ],
-              child: const SellScreen(),
-            ),
+        redirect: (context, state) {
+          final notLoggedIn = context.read<ExchangeCubit>().state.notLoggedIn;
+          if (notLoggedIn) return ExchangeRoute.exchangeHome.path;
+          return null;
+        },
+        builder: (context, state) => BlocListener<SellBloc, SellState>(
+          listenWhen: (previous, current) =>
+              previous is SellAmountInputState &&
+              current is SellWalletSelectionState,
+          listener: (context, state) {
+            context.pushNamed(SellRoute.sellWalletSelection.name);
+          },
+          child: const SellScreen(),
+        ),
         routes: [
           GoRoute(
             name: SellRoute.sellWalletSelection.name,
             path: SellRoute.sellWalletSelection.path,
-            builder:
-                (context, state) => BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellWalletSelectionState &&
-                          current is SellPaymentState &&
-                          current.selectedWallet != null,
-                  listener: (context, state) {
-                    context.pushNamed(SellRoute.sellSendPayment.name);
-                  },
-                  child: const SellWalletSelectionScreen(),
-                ),
+            builder: (context, state) => BlocListener<SellBloc, SellState>(
+              listenWhen: (previous, current) =>
+                  previous is SellWalletSelectionState &&
+                  current is SellPaymentState &&
+                  current.selectedWallet != null,
+              listener: (context, state) {
+                context.pushNamed(SellRoute.sellSendPayment.name);
+              },
+              child: const SellWalletSelectionScreen(),
+            ),
           ),
           GoRoute(
             name: SellRoute.sellSendPayment.name,
             path: SellRoute.sellSendPayment.path,
-            builder:
-                (context, state) => BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellPaymentState &&
-                          current is SellSuccessState,
-                  listener: (context, state) {
-                    context.pushNamed(SellRoute.sellSuccess.name);
-                  },
-                  child: const SellSendPaymentScreen(),
-                ),
+            builder: (context, state) => BlocListener<SellBloc, SellState>(
+              listenWhen: (previous, current) =>
+                  previous is SellPaymentState && current is SellSuccessState,
+              listener: (context, state) {
+                context.pushNamed(SellRoute.sellSuccess.name);
+              },
+              child: const SellSendPaymentScreen(),
+            ),
           ),
           GoRoute(
             name: SellRoute.sellExternalWalletNetworkSelection.name,
             path: SellRoute.sellExternalWalletNetworkSelection.path,
-            builder:
-                (context, state) => BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellWalletSelectionState &&
-                          current is SellPaymentState &&
-                          current.selectedWallet == null,
-                  listener: (context, state) {
-                    context.pushNamed(
-                      SellRoute.sellExternalWalletReceivePayment.name,
-                    );
-                  },
-                  child: const SellExternalWalletNetworkSelectionScreen(),
-                ),
+            builder: (context, state) => BlocListener<SellBloc, SellState>(
+              listenWhen: (previous, current) =>
+                  previous is SellWalletSelectionState &&
+                  current is SellPaymentState &&
+                  current.selectedWallet == null,
+              listener: (context, state) {
+                context.pushNamed(
+                  SellRoute.sellExternalWalletReceivePayment.name,
+                );
+              },
+              child: const SellExternalWalletNetworkSelectionScreen(),
+            ),
           ),
           GoRoute(
             name: SellRoute.sellExternalWalletReceivePayment.name,
             path: SellRoute.sellExternalWalletReceivePayment.path,
-            builder:
-                (context, state) => BlocListener<SellBloc, SellState>(
-                  listenWhen:
-                      (previous, current) =>
-                          previous is SellPaymentState &&
-                          current is SellSuccessState,
-                  listener: (context, state) {
-                    context.pushNamed(SellRoute.sellSuccess.name);
-                  },
-                  child: const SellReceivePaymentScreen(),
-                ),
+            builder: (context, state) => BlocListener<SellBloc, SellState>(
+              listenWhen: (previous, current) =>
+                  previous is SellPaymentState && current is SellSuccessState,
+              listener: (context, state) {
+                context.pushNamed(SellRoute.sellSuccess.name);
+              },
+              child: const SellReceivePaymentScreen(),
+            ),
           ),
           GoRoute(
             name: SellRoute.sellSuccess.name,

--- a/lib/features/withdraw/presentation/withdraw_bloc.dart
+++ b/lib/features/withdraw/presentation/withdraw_bloc.dart
@@ -1,4 +1,3 @@
-import 'package:bb_mobile/core/errors/exchange_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/errors/withdraw_error.dart';
@@ -48,18 +47,11 @@ class WithdrawBloc extends Bloc<WithdrawEvent, WithdrawState> {
       } else {
         initialState = const WithdrawInitialState();
       }
-      emit(
-        initialState.copyWith(
-          apiKeyException: null,
-          getUserSummaryException: null,
-        ),
-      );
+      emit(initialState.copyWith(getUserSummaryException: null));
 
       final userSummary = await _getExchangeUserSummaryUsecase.execute();
 
       emit(initialState.toAmountInputState(userSummary: userSummary));
-    } on ApiKeyException catch (e) {
-      emit(WithdrawState.initial(apiKeyException: e));
     } on GetExchangeUserSummaryException catch (e) {
       emit(WithdrawState.initial(getUserSummaryException: e));
     }

--- a/lib/features/withdraw/presentation/withdraw_state.dart
+++ b/lib/features/withdraw/presentation/withdraw_state.dart
@@ -3,7 +3,6 @@ part of 'withdraw_bloc.dart';
 @freezed
 sealed class WithdrawState with _$WithdrawState {
   const factory WithdrawState.initial({
-    ApiKeyException? apiKeyException,
     GetExchangeUserSummaryException? getUserSummaryException,
   }) = WithdrawInitialState;
   const factory WithdrawState.amountInput({required UserSummary userSummary}) =
@@ -40,7 +39,7 @@ sealed class WithdrawState with _$WithdrawState {
 
   FiatCurrency get currency {
     return when(
-      initial: (_, _) => FiatCurrency.cad,
+      initial: (_) => FiatCurrency.cad,
       amountInput: (userSummary) => userSummary.currency != null
           ? FiatCurrency.fromCode(userSummary.currency!)
           : FiatCurrency.cad,

--- a/lib/features/withdraw/ui/withdraw_router.dart
+++ b/lib/features/withdraw/ui/withdraw_router.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/withdraw/presentation/withdraw_bloc.dart';
 import 'package:bb_mobile/features/withdraw/ui/screens/withdraw_amount_screen.dart';
@@ -23,23 +24,17 @@ class WithdrawRouter {
   static final route = GoRoute(
     path: WithdrawRoute.withdraw.path,
     name: WithdrawRoute.withdraw.name,
+    redirect: (context, state) {
+      final notLoggedIn = context.read<ExchangeCubit>().state.notLoggedIn;
+      if (notLoggedIn) return ExchangeRoute.exchangeHome.path;
+      return null;
+    },
     builder: (context, state) {
       return BlocProvider(
         create: (_) =>
             locator<WithdrawBloc>()..add(const WithdrawEvent.started()),
         child: MultiBlocListener(
           listeners: [
-            BlocListener<WithdrawBloc, WithdrawState>(
-              listenWhen: (previous, current) =>
-                  previous is WithdrawInitialState &&
-                  previous.apiKeyException == null &&
-                  current is WithdrawInitialState &&
-                  current.apiKeyException != null,
-              listener: (context, state) {
-                // Redirect to exchange home if API key exception occurs which means the user is not authenticated
-                context.goNamed(ExchangeRoute.exchangeHome.name);
-              },
-            ),
             BlocListener<WithdrawBloc, WithdrawState>(
               listenWhen: (previous, current) =>
                   previous is WithdrawAmountInputState &&


### PR DESCRIPTION
Routers now check `ExchangeCubit.notLoggedIn` via go_router redirect instead of listening for `ApiKeyException`, which stopped firing in 6e626abc4 when read paths were made silent. 

Removes dead `apiKeyException` fields/branches across buy, sell, dca, withdraw, fund_exchange, pay.