### PR TITLE
fix: guard ServiceStatusCubit emits with isClosed

### DIFF
--- a/lib/features/status_check/presentation/cubit.dart
+++ b/lib/features/status_check/presentation/cubit.dart
@@ -27,6 +27,7 @@ class ServiceStatusCubit extends Cubit<ServiceStatusState> {
         network: network,
       );
 
+      if (isClosed) return;
       emit(state.copyWith(serviceStatus: serviceStatus, isLoading: false));
     } catch (e) {
       log.severe(
@@ -34,6 +35,7 @@ class ServiceStatusCubit extends Cubit<ServiceStatusState> {
         error: e,
         trace: StackTrace.current,
       );
+      if (isClosed) return;
       emit(state.copyWith(isLoading: false, error: e.toString()));
     }
   }


### PR DESCRIPTION
Pulling-to-refresh and navigating away mid-check raced the post- await emits, throwing "Cannot emit new states after calling close". Background pings still complete (acceptable for status checks, no critical work to cancel).

Polluting the logs if moving out of service status before emit ended
```logs
I/flutter ( 5666): 2026-04-30T11:50:46.969937	SEVERE	[ServiceStatusCubit] Failed to check service status	Bad state: Cannot emit new states after calling close	#0      ServiceStatusCubit.checkStatus (package:bb_mobile/features/status_check/presentation/cubit.dart:35:27)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): #1      _ServiceStatusPageState.build.<anonymous closure>.<anonymous closure> (package:bb_mobile/features/status_check/service_status_page.dart:40:36)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): #2      RefreshIndicatorState._show.<anonymous closure>.<anonymous closure> (package:flutter/src/material/refresh_indicator.dart:579:40)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): 
I/flutter ( 5666): 2026-04-30T11:50:46.972926	SEVERE	Global Unhandled Error	Bad state: Cannot emit new states after calling close	#0      BlocBase.emit (package:bloc/src/bloc_base.dart:100:9)
I/flutter ( 5666): #1      ServiceStatusCubit.checkStatus (package:bb_mobile/features/status_check/presentation/cubit.dart:37:7)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): #2      _ServiceStatusPageState.build.<anonymous closure>.<anonymous closure> (package:bb_mobile/features/status_check/service_status_page.dart:40:36)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): #3      RefreshIndicatorState._show.<anonymous closure>.<anonymous closure> (package:flutter/src/material/refresh_indicator.dart:579:40)
I/flutter ( 5666): <asynchronous suspension>
I/flutter ( 5666): 

```