### PR TITLE
refactor: split Report.versionChange into log.shout + commitVersion

### DIFF
--- a/lib/core/utils/report.dart
+++ b/lib/core/utils/report.dart
@@ -91,19 +91,14 @@ class Report {
     consent = enabled;
   }
 
-  /// Emits the install/upgrade milestone, then advances the persisted
-  /// `_lastVersionKey` marker. No-op on a normal launch (versions
-  /// match). The marker write is deferred until after the event
-  /// dispatches so a crash between the two retries the event on the
-  /// next launch.
-  static Future<void> versionChange() async {
+  /// Advances the persisted `_lastVersionKey` marker. Caller emits the
+  /// install/upgrade milestone via `log.shout` first so a crash between
+  /// the two retries the event on the next launch.
+  static Future<void> commitVersion() async {
     final to = toVersion;
     if (to == null) return;
-    if (migrationType != null) {
-      await critical(message: migrationType!.name);
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_lastVersionKey, to);
-    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastVersionKey, to);
   }
 
   /// Consent-gated error capture. Dropped by `beforeSend` when the user

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,11 @@ class Bull {
     await initWorkmanager();
     // Emits the install/upgrade transition event (no-op on a normal
     // launch) and advances the persisted version marker.
-    await Report.versionChange();
+    final type = Report.migrationType;
+    if (type != null) {
+      log.shout(message: type.name);
+      await Report.commitVersion();
+    }
   }
 
   static Future<void> initFlutterRustBridgeDependencies() async {


### PR DESCRIPTION
Caller now emits the install/upgrade milestone explicitly via `log.shout` and advances the persisted version marker via `Report.commitVersion`. Preserves the crash-between-events retry property since the log fires before the marker write.