### PR TITLE
fix: center pull-to-refresh loader and enable full-screen gesture

### DIFF
--- a/lib/core/widgets/bb_refresh_indicator.dart
+++ b/lib/core/widgets/bb_refresh_indicator.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Pull-to-refresh wrapper that centers the spinner on the screen so it
+/// never overlaps the AppBar. Behavior parity is the goal — every screen
+/// using this widget gets the same gesture feel and indicator placement.
+///
+/// To make the gesture work across the full screen (including footer
+/// buttons), the [child] must be a single scrollable that fills the
+/// viewport. Two patterns are supported per screen layout:
+///
+/// 1. Sliver layouts: `CustomScrollView` with a
+///    `SliverFillRemaining(hasScrollBody: false)` hosting the bottom
+///    widgets.
+/// 2. Box layouts: `LayoutBuilder` + `SingleChildScrollView` +
+///    `ConstrainedBox(minHeight)` + `IntrinsicHeight` + `Spacer` to push
+///    the bottom widgets down inside the scroll view.
+///
+/// Either way, the pull gesture is accepted from anywhere on the screen
+/// because the entire viewport belongs to the scroll view.
+class BBRefreshIndicator extends StatelessWidget {
+  const BBRefreshIndicator({
+    super.key,
+    this.indicatorKey,
+    required this.onRefresh,
+    required this.child,
+  });
+
+  /// Forwarded to the inner [RefreshIndicator]. Use a
+  /// `GlobalKey<RefreshIndicatorState>` to call `.show()` programmatically.
+  final Key? indicatorKey;
+  final RefreshCallback onRefresh;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // Position the spinner around the upper third of the actual scroll
+    // area (not the full screen — MediaQuery would include the bottom
+    // nav and bias the indicator toward the bottom of the body).
+    // 60 = default RefreshIndicator displacement (40) + half indicator
+    // height (~20). The displacement is left at its native value to
+    // preserve drag feel.
+    return LayoutBuilder(
+      builder: (context, constraints) => RefreshIndicator(
+        key: indicatorKey,
+        edgeOffset: constraints.maxHeight * 0.4 - 60,
+        onRefresh: onRefresh,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/features/ark/ui/ark_wallet_detail_page.dart
+++ b/lib/features/ark/ui/ark_wallet_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:bb_mobile/features/ark/router.dart';
@@ -38,77 +39,55 @@ class ArkWalletDetailPage extends StatelessWidget {
         ],
       ),
       body: SafeArea(
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: RefreshIndicator(
-                onRefresh: () async => await cubit.load(),
-                child: SingleChildScrollView(
-                  // Needed to allow pull-to-refresh even if content is too short
-                  //  to be scrollable
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  padding: const EdgeInsets.only(bottom: 160.0),
-                  child: Column(
-                    children: [
-                      ArkBalanceDetailWidget(arkBalance: state.arkBalance),
-                      if (state.isLoading)
-                        LinearProgressIndicator(
-                          backgroundColor: context.appColors.surface,
-                          color: context.appColors.primary,
-                        ),
-                      const Gap(16.0),
-                      TransactionHistoryWidget(
-                        transactions: state.transactions,
-                        isLoading: state.isLoading,
-                      ),
-                    ],
+        child: BBRefreshIndicator(
+          onRefresh: () async => await cubit.load(),
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverToBoxAdapter(
+                child: ArkBalanceDetailWidget(arkBalance: state.arkBalance),
+              ),
+              if (state.isLoading)
+                SliverToBoxAdapter(
+                  child: LinearProgressIndicator(
+                    backgroundColor: context.appColors.surface,
+                    color: context.appColors.primary,
                   ),
                 ),
+              const SliverToBoxAdapter(child: Gap(16.0)),
+              SliverToBoxAdapter(
+                child: TransactionHistoryWidget(
+                  transactions: state.transactions,
+                  isLoading: state.isLoading,
+                ),
               ),
-            ),
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Column(
-                mainAxisSize: .min,
-                children: [
-                  Builder(
-                    builder: (context) {
-                      /*final unsettledCount =
-                          state.transactions
-                              .whereType<ark_wallet.Transaction_Redeem>()
-                              .where((tx) => !tx.isSettled)
-                              .length;
-
-                      if (unsettledCount == 0) {
-                        return const SizedBox.shrink();
-                      }*/
-
-                      return Padding(
-                        padding: const EdgeInsets.all(13.0),
-                        child: BBButton.big(
-                          label: context.loc.arkSettleTransactions,
-                          onPressed:
-                              () => SettleBottomSheet.show(context, cubit),
-                          bgColor: context.appColors.primary,
-                          textColor: context.appColors.onPrimary,
-                        ),
-                      );
-                    },
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.only(
-                      left: 13.0,
-                      right: 13.0,
-                      bottom: 40.0,
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  children: [
+                    const Spacer(),
+                    Padding(
+                      padding: const EdgeInsets.all(13.0),
+                      child: BBButton.big(
+                        label: context.loc.arkSettleTransactions,
+                        onPressed: () => SettleBottomSheet.show(context, cubit),
+                        bgColor: context.appColors.primary,
+                        textColor: context.appColors.onPrimary,
+                      ),
                     ),
-                    child: ArkWalletBottomButtons(),
-                  ),
-                ],
+                    const Padding(
+                      padding: EdgeInsets.only(
+                        left: 13.0,
+                        right: 13.0,
+                        bottom: 40.0,
+                      ),
+                      child: ArkWalletBottomButtons(),
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
+++ b/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/features/electrum_settings/frameworks/ui/widgets/draggable_server_list.dart';
@@ -27,76 +28,77 @@ class ElectrumSettingsScreen extends StatelessWidget {
         // Create a reusable app bar with a loading indicator at the bottom
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(3),
-          child:
-              isLoading
-                  ? FadingLinearProgress(
-                    height: 3,
-                    trigger: isLoading,
-                    backgroundColor: context.appColors.surface,
-                    foregroundColor: context.appColors.primary,
-                  )
-                  : const SizedBox(height: 3),
+          child: isLoading
+              ? FadingLinearProgress(
+                  height: 3,
+                  trigger: isLoading,
+                  backgroundColor: context.appColors.surface,
+                  foregroundColor: context.appColors.primary,
+                )
+              : const SizedBox(height: 3),
         ),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              child: RefreshIndicator(
-                onRefresh: () async {
-                  context.read<ElectrumSettingsBloc>().add(
-                    ElectrumSettingsLoaded(isLiquid: isLiquid),
-                  );
-                },
-                child: SingleChildScrollView(
-                  // Needed to allow pull-to-refresh even if content is too short
-                  //  to be scrollable
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: Column(
-                      children: [
-                        const Gap(16),
-                        BBSegmentFull(
-                          items: {
-                            context.loc.electrumNetworkBitcoin,
-                            context.loc.electrumNetworkLiquid,
-                          },
-                          initialValue:
-                              isLiquid
-                                  ? context.loc.electrumNetworkLiquid
-                                  : context.loc.electrumNetworkBitcoin,
-                          onSelected: (value) {
-                            context.read<ElectrumSettingsBloc>().add(
-                              ElectrumSettingsLoaded(
-                                isLiquid:
-                                    value == context.loc.electrumNetworkLiquid,
-                              ),
-                            );
-                          },
-                        ),
-                        const TorProxyErrorBanner(),
-                        const Gap(16),
-                        const DraggableServerList(),
-                      ],
+        child: BBRefreshIndicator(
+          onRefresh: () async {
+            context.read<ElectrumSettingsBloc>().add(
+              ElectrumSettingsLoaded(isLiquid: isLiquid),
+            );
+          },
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    const Gap(16),
+                    BBSegmentFull(
+                      items: {
+                        context.loc.electrumNetworkBitcoin,
+                        context.loc.electrumNetworkLiquid,
+                      },
+                      initialValue: isLiquid
+                          ? context.loc.electrumNetworkLiquid
+                          : context.loc.electrumNetworkBitcoin,
+                      onSelected: (value) {
+                        context.read<ElectrumSettingsBloc>().add(
+                          ElectrumSettingsLoaded(
+                            isLiquid:
+                                value == context.loc.electrumNetworkLiquid,
+                          ),
+                        );
+                      },
                     ),
-                  ),
+                    const TorProxyErrorBanner(),
+                    const Gap(16),
+                    const DraggableServerList(),
+                  ]),
                 ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: TextButton(
-                onPressed: () => SetAdvancedOptionsBottomSheet.show(context),
-                child: Text(
-                  context.loc.electrumAdvancedOptions,
-                  style: context.font.bodyMedium?.copyWith(
-                    color: context.appColors.primary,
-                  ),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Column(
+                  children: [
+                    const Spacer(),
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: TextButton(
+                        onPressed: () =>
+                            SetAdvancedOptionsBottomSheet.show(context),
+                        child: Text(
+                          context.loc.electrumAdvancedOptions,
+                          style: context.font.bodyMedium?.copyWith(
+                            color: context.appColors.primary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/exchange/ui/screens/exchange_home_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar_bull_logo.dart';
 import 'package:bb_mobile/features/bitcoin_price/presentation/cubit/price_chart_cubit.dart';
@@ -42,208 +43,190 @@ class ExchangeHomeScreen extends StatelessWidget {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return RefreshIndicator(
-      edgeOffset: 30,
+    return BBRefreshIndicator(
       onRefresh: () async {
         await context.read<ExchangeCubit>().fetchUserSummary();
       },
-      child: Stack(
-        children: [
-          CustomScrollView(
-            slivers: [
-              SliverStack(
-                children: [
-                  SliverList(
-                    delegate: SliverChildListDelegate([
-                      const ExchangeHomeTopSection(),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        child: Column(
-                          children: [
-                            const Gap(12),
-                            if (!isFullyVerified) const ExchangeHomeKycCard(),
-                            const Gap(12),
-                            DcaListTile(hasDcaActive: hasDcaActive, dca: dca),
-                            const Gap(12),
-                            if (!notLoggedIn) const AnnouncementBanner(),
-                            /*
-                            SwitchListTile(
-                              value: false,
-                              onChanged: (value) {},
-                              title: const Text('Activate auto-buy'),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverStack(
+            children: [
+              SliverList(
+                delegate: SliverChildListDelegate([
+                  const ExchangeHomeTopSection(),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: Column(
+                      children: [
+                        const Gap(12),
+                        if (!isFullyVerified) const ExchangeHomeKycCard(),
+                        const Gap(12),
+                        DcaListTile(hasDcaActive: hasDcaActive, dca: dca),
+                        const Gap(12),
+                        if (!notLoggedIn) const AnnouncementBanner(),
+                      ],
+                    ),
+                  ),
+                ]),
+              ),
+              BlocBuilder<PriceChartCubit, PriceChartState>(
+                builder: (context, priceChartState) {
+                  final showChart = priceChartState.showChart;
+
+                  return SliverAppBar(
+                    backgroundColor: Colors.transparent,
+                    floating: true,
+                    pinned: true,
+                    elevation: 0,
+                    centerTitle: true,
+                    title: showChart ? null : const TopBarBullLogo(),
+                    leading: Padding(
+                      padding: const EdgeInsets.only(left: 16.0),
+                      child: showChart
+                          ? IconButton(
+                              icon: Icon(
+                                Icons.arrow_back,
+                                color: context.appColors.onPrimary,
+                                size: 24,
+                              ),
+                              onPressed: () {
+                                context.read<PriceChartCubit>().hideChart();
+                              },
+                            )
+                          : SizedBox(
+                              width: 96,
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  IconButton(
+                                    padding: EdgeInsets.zero,
+                                    constraints: const BoxConstraints(),
+                                    visualDensity: VisualDensity.compact,
+                                    icon: Icon(
+                                      Icons.show_chart,
+                                      color: context.appColors.onPrimary,
+                                      size: 24,
+                                    ),
+                                    onPressed: () {
+                                      context
+                                          .read<PriceChartCubit>()
+                                          .showChart();
+                                    },
+                                  ),
+                                  IconButton(
+                                    padding: EdgeInsets.zero,
+                                    constraints: const BoxConstraints(),
+                                    visualDensity: VisualDensity.compact,
+                                    icon: Icon(
+                                      Icons.chat_bubble_outline,
+                                      color: context.appColors.onPrimary,
+                                      size: 24,
+                                    ),
+                                    onPressed: () {
+                                      final notLoggedIn = context
+                                          .read<ExchangeCubit>()
+                                          .state
+                                          .notLoggedIn;
+                                      if (notLoggedIn) {
+                                        context.pushNamed(
+                                          ExchangeRoute
+                                              .exchangeLoginForSupport
+                                              .name,
+                                        );
+                                      } else {
+                                        context.pushNamed(
+                                          ExchangeSupportChatRoute
+                                              .supportChat
+                                              .name,
+                                        );
+                                      }
+                                    },
+                                  ),
+                                ],
+                              ),
                             ),
-
-                        const Gap(12),
-                        ListTile(
-                          title: const Text('View auto-sell address'),
-                          onTap: () {},
-                          trailing: const Icon(Icons.arrow_forward),
-                        ),
-                        const Gap(12),
-                        */
-                            // Add bottom padding to account for fixed button bar
-                            const Gap(100),
+                    ),
+                    leadingWidth: showChart ? 56 : 112,
+                    actionsIconTheme: IconThemeData(
+                      color: context.appColors.onPrimary,
+                      size: 24,
+                    ),
+                    actionsPadding: const EdgeInsets.only(right: 16),
+                    actions: showChart
+                        ? null
+                        : [
+                            IconButton(
+                              onPressed: () {
+                                context.pushNamed(
+                                  TransactionsRoute.transactions.name,
+                                );
+                              },
+                              visualDensity: VisualDensity.compact,
+                              color: context.appColors.onPrimary,
+                              iconSize: 32,
+                              icon: const Icon(Icons.history),
+                            ),
+                            const Gap(16),
+                            InkWell(
+                              onTap: () => context.pushNamed(
+                                SettingsRoute.settings.name,
+                              ),
+                              child: Image.asset(
+                                Assets.icons.settingsLine.path,
+                                width: 32,
+                                height: 32,
+                                color: context.appColors.onPrimary,
+                              ),
+                            ),
                           ],
-                        ),
-                      ), // Bottom-aligned button
-                    ]),
-                  ),
-                  BlocBuilder<PriceChartCubit, PriceChartState>(
-                    builder: (context, priceChartState) {
-                      final showChart = priceChartState.showChart;
-
-                      return SliverAppBar(
-                        backgroundColor: Colors.transparent,
-                        floating: true,
-                        pinned: true,
-                        elevation: 0,
-                        centerTitle: true,
-                        title: showChart ? null : const TopBarBullLogo(),
-                        leading: Padding(
-                          padding: const EdgeInsets.only(left: 16.0),
-                          child: showChart
-                              ? IconButton(
-                                  icon: Icon(
-                                    Icons.arrow_back,
-                                    color: context.appColors.onPrimary,
-                                    size: 24,
-                                  ),
-                                  onPressed: () {
-                                    context.read<PriceChartCubit>().hideChart();
-                                  },
-                                )
-                              : SizedBox(
-                                  width: 96,
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      IconButton(
-                                        padding: EdgeInsets.zero,
-                                        constraints: const BoxConstraints(),
-                                        visualDensity: VisualDensity.compact,
-                                        icon: Icon(
-                                          Icons.show_chart,
-                                          color: context.appColors.onPrimary,
-                                          size: 24,
-                                        ),
-                                        onPressed: () {
-                                          context
-                                              .read<PriceChartCubit>()
-                                              .showChart();
-                                        },
-                                      ),
-                                      IconButton(
-                                        padding: EdgeInsets.zero,
-                                        constraints: const BoxConstraints(),
-                                        visualDensity: VisualDensity.compact,
-                                        icon: Icon(
-                                          Icons.chat_bubble_outline,
-                                          color: context.appColors.onPrimary,
-                                          size: 24,
-                                        ),
-                                        onPressed: () {
-                                          final notLoggedIn = context
-                                              .read<ExchangeCubit>()
-                                              .state
-                                              .notLoggedIn;
-                                          if (notLoggedIn) {
-                                            context.pushNamed(
-                                              ExchangeRoute
-                                                  .exchangeLoginForSupport
-                                                  .name,
-                                            );
-                                          } else {
-                                            context.pushNamed(
-                                              ExchangeSupportChatRoute
-                                                  .supportChat
-                                                  .name,
-                                            );
-                                          }
-                                        },
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                        ),
-                        leadingWidth: showChart ? 56 : 112,
-                        actionsIconTheme: IconThemeData(
-                          color: context.appColors.onPrimary,
-                          size: 24,
-                        ),
-                        actionsPadding: const EdgeInsets.only(right: 16),
-                        actions: showChart
-                            ? null
-                            : [
-                                IconButton(
-                                  onPressed: () {
-                                    context.pushNamed(
-                                      TransactionsRoute.transactions.name,
-                                    );
-                                  },
-                                  visualDensity: VisualDensity.compact,
-                                  color: context.appColors.onPrimary,
-                                  iconSize: 32,
-                                  icon: const Icon(Icons.history),
-                                ),
-                                const Gap(16),
-                                InkWell(
-                                  onTap: () => context.pushNamed(
-                                    SettingsRoute.settings.name,
-                                  ),
-                                  child: Image.asset(
-                                    Assets.icons.settingsLine.path,
-                                    width: 32,
-                                    height: 32,
-                                    color: context.appColors.onPrimary,
-                                  ),
-                                ),
-                              ],
-                      );
-                    },
-                  ),
-                ],
+                  );
+                },
               ),
             ],
           ),
-          Positioned(
-            child: Align(
-              alignment: Alignment.bottomCenter,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: BBButton.big(
-                        iconData: Icons.arrow_downward,
-                        label: context.loc.exchangeHomeDepositButton,
-                        iconFirst: true,
-                        onPressed: () => context.pushNamed(
-                          FundExchangeRoute.fundExchange.name,
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Column(
+              children: [
+                const Spacer(),
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: BBButton.big(
+                          iconData: Icons.arrow_downward,
+                          label: context.loc.exchangeHomeDepositButton,
+                          iconFirst: true,
+                          onPressed: () => context.pushNamed(
+                            FundExchangeRoute.fundExchange.name,
+                          ),
+                          bgColor: context.appColors.secondaryFixed,
+                          textColor: context.appColors.onSecondaryFixed,
+                          outlined: true,
+                          borderColor: context.appColors.onSecondaryFixed,
                         ),
-                        bgColor: context.appColors.secondaryFixed,
-                        textColor: context.appColors.onSecondaryFixed,
-                        outlined: true,
-                        borderColor: context.appColors.onSecondaryFixed,
                       ),
-                    ),
-                    const Gap(4),
-                    Expanded(
-                      child: BBButton.big(
-                        iconData: Icons.arrow_upward,
-                        label: context.loc.exchangeHomeWithdrawButton,
-                        iconFirst: true,
-                        disabled: false,
-                        onPressed: () =>
-                            context.pushNamed(WithdrawRoute.withdraw.name),
-                        bgColor: context.appColors.secondaryFixed,
-                        textColor: context.appColors.onSecondaryFixed,
-                        outlined: true,
-                        borderColor: context.appColors.onSecondaryFixed,
+                      const Gap(4),
+                      Expanded(
+                        child: BBButton.big(
+                          iconData: Icons.arrow_upward,
+                          label: context.loc.exchangeHomeWithdrawButton,
+                          iconFirst: true,
+                          disabled: false,
+                          onPressed: () =>
+                              context.pushNamed(WithdrawRoute.withdraw.name),
+                          bgColor: context.appColors.secondaryFixed,
+                          textColor: context.appColors.onSecondaryFixed,
+                          outlined: true,
+                          borderColor: context.appColors.onSecondaryFixed,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
+              ],
             ),
           ),
         ],

--- a/lib/features/status_check/service_status_page.dart
+++ b/lib/features/status_check/service_status_page.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/status/domain/entity/service_status.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/presentation/state.dart';
@@ -35,8 +36,8 @@ class _ServiceStatusPageState extends State<ServiceStatusPage> {
           final serviceStatus = state.serviceStatus;
           final cubit = context.read<ServiceStatusCubit>();
 
-          return RefreshIndicator(
-            key: _refreshIndicatorKey,
+          return BBRefreshIndicator(
+            indicatorKey: _refreshIndicatorKey,
             onRefresh: () async => await cubit.checkStatus(),
             child: SingleChildScrollView(
               physics: const AlwaysScrollableScrollPhysics(),

--- a/lib/features/transactions/ui/screens/transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/transactions_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transactions_cubit.dart';
@@ -58,7 +59,7 @@ class _Screen extends StatelessWidget {
           ),
         const Gap(16.0),
         Expanded(
-          child: RefreshIndicator(
+          child: BBRefreshIndicator(
             onRefresh: () async {
               final bloc = context.read<WalletBloc>();
               bloc.add(const WalletRefreshed());

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -48,41 +49,45 @@ class WalletDetailScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: Stack(
-        alignment: Alignment.bottomCenter,
-        children: [
-          if (wallet == null)
-            const LoadingBoxContent(height: 100)
-          else
-            BlocProvider<TransactionsCubit>(
+      body: wallet == null
+          ? const LoadingBoxContent(height: 100)
+          : BlocProvider<TransactionsCubit>(
               create: (_) =>
                   locator<TransactionsCubit>(param1: walletId)..loadTxs(),
-              child: RefreshIndicator(
+              child: BBRefreshIndicator(
                 onRefresh: () async {
                   final bloc = context.read<WalletBloc>();
                   bloc.add(const WalletRefreshed());
                   await bloc.stream.firstWhere((state) => !state.isSyncing);
                 },
-                child: Column(
-                  children: [
-                    WalletDetailBalanceCard(
-                      balanceSat: wallet.balanceSat.toInt(),
-                      isLiquid: wallet.isLiquid,
-                      signer: wallet.signer,
+                child: LayoutBuilder(
+                  builder: (context, constraints) => SingleChildScrollView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    child: SizedBox(
+                      height: constraints.maxHeight,
+                      child: Column(
+                        children: [
+                          WalletDetailBalanceCard(
+                            balanceSat: wallet.balanceSat.toInt(),
+                            isLiquid: wallet.isLiquid,
+                            signer: wallet.signer,
+                          ),
+                          const Gap(16),
+                          const Expanded(child: WalletDetailTxsList()),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 13.0,
+                              vertical: 40,
+                            ),
+                            child: WalletBottomButtons(wallet: wallet),
+                          ),
+                        ],
+                      ),
                     ),
-                    const Gap(16.0),
-                    const WalletDetailTxsList(),
-                    const Gap(96),
-                  ],
+                  ),
                 ),
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 13.0, vertical: 40),
-            child: WalletBottomButtons(wallet: wallet),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/themes/colors.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/auto_swap_fee_warning.dart';
@@ -41,58 +42,58 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
       child: PopScope(
         canPop: false,
         onPopInvokedWithResult: (didPop, _) {},
-        child: Column(
-            children: [
-              Expanded(
-                child: Stack(
-                  children: [
-                    // Black background visible only during iOS top overscroll
-                    Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      child: ColoredBox(
-                        color: AppColors.dark.background,
-                        child: const SizedBox(height: 300),
-                      ),
+        child: Stack(
+          children: [
+            // Black background visible only during iOS top overscroll
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: ColoredBox(
+                color: AppColors.dark.background,
+                child: const SizedBox(height: 300),
+              ),
+            ),
+            BBRefreshIndicator(
+              onRefresh: () async {
+                final bloc = context.read<WalletBloc>();
+                bloc.add(const WalletRefreshed());
+                await bloc.stream.firstWhere((state) => !state.isSyncing);
+              },
+              child: CustomScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: [
+                  const SliverToBoxAdapter(child: WalletHomeTopSection()),
+                  const SliverToBoxAdapter(child: HomeWarnings()),
+                  const SliverToBoxAdapter(child: AutoSwapFeeWarning()),
+                  SliverToBoxAdapter(
+                    child: WalletCards(
+                      onTap: (w) {
+                        context.pushNamed(
+                          WalletRoute.walletDetail.name,
+                          pathParameters: {'walletId': w.id},
+                        );
+                      },
                     ),
-                    RefreshIndicator(
-                  edgeOffset: 30,
-                  onRefresh: () async {
-                    final bloc = context.read<WalletBloc>();
-                    bloc.add(const WalletRefreshed());
-                    await bloc.stream.firstWhere((state) => !state.isSyncing);
-                  },
-                  child: SingleChildScrollView(
-                    physics: const AlwaysScrollableScrollPhysics(),
+                  ),
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
                     child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        const WalletHomeTopSection(),
-                        const HomeWarnings(),
-                        const AutoSwapFeeWarning(),
-                        WalletCards(
-                          onTap: (w) {
-                            context.pushNamed(
-                              WalletRoute.walletDetail.name,
-                              pathParameters: {'walletId': w.id},
-                            );
-                          },
+                        Spacer(),
+                        Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 13.0),
+                          child: WalletBottomButtons(),
                         ),
+                        Gap(16),
                       ],
                     ),
                   ),
-                  ),
-                  ],
-                ),
+                ],
               ),
-              const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 13.0),
-                child: WalletBottomButtons(),
-              ),
-              const Gap(16),
-            ],
-          ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/wallet/ui/widgets/wallet_detail_txs_list.dart
+++ b/lib/features/wallet/ui/widgets/wallet_detail_txs_list.dart
@@ -10,30 +10,18 @@ class WalletDetailTxsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Column(
-        mainAxisSize: .min,
-        children: [
-          Expanded(
-            child:
-                BlocSelector<
-                  TransactionsCubit,
-                  TransactionsState,
-                  ({Map<int, List<Transaction>>? txsByDay, Object? err})
-                >(
-                  selector: (state) => (
-                    txsByDay: state.filteredTransactionsByDay,
-                    err: state.err,
-                  ),
-                  builder: (context, selected) => TransactionsByDayList(
-                    transactionsByDay: selected.txsByDay,
-                    errorMessage: selected.err != null
-                        ? context.loc.transactionListLoadingFailed
-                        : null,
-                  ),
-                ),
-          ),
-        ],
+    return BlocSelector<
+      TransactionsCubit,
+      TransactionsState,
+      ({Map<int, List<Transaction>>? txsByDay, Object? err})
+    >(
+      selector: (state) =>
+          (txsByDay: state.filteredTransactionsByDay, err: state.err),
+      builder: (context, selected) => TransactionsByDayList(
+        transactionsByDay: selected.txsByDay,
+        errorMessage: selected.err != null
+            ? context.loc.transactionListLoadingFailed
+            : null,
       ),
     );
   }


### PR DESCRIPTION
- Adds `BBRefreshIndicator` so every pull-to-refresh in the app shows a
  spinner centered on the screen, never overlapping the AppBar / BULL
  logo.
- Restructures screens so the pull gesture is accepted across the full
  viewport, including the bottom action bar that previously sat outside
  the scroll view.

## Why

`wallet_home` and `exchange_home` share a parent `Scaffold` with
`extendBodyBehindAppBar: true`. The previous `edgeOffset: 30` placed
the indicator on top of the AppBar's logo. On other screens, the
bottom-pinned button area lived in a `Stack` overlay outside the
`RefreshIndicator`, so pulling from there silently did nothing.

## Approach

`BBRefreshIndicator` wraps `RefreshIndicator` and bakes in:
- `edgeOffset = MediaQuery.sizeOf(context).height / 2 - 60` to center
  the spinner.
- Forwards `indicatorKey` for screens that need
  `GlobalKey<RefreshIndicatorState>` (`service_status_page` calls
  `.show()` on first paint).

Per-screen layout patterns:
- Sliver layouts (`wallet_home`, `exchange_home`, `ark_wallet_detail`,
  `electrum_settings`): `CustomScrollView` +
  `SliverFillRemaining(hasScrollBody: false)` to host bottom buttons
  inside the scroll view.
- `wallet_detail`: `SingleChildScrollView` + `SizedBox(maxHeight)` +
  `Expanded(WalletDetailTxsList)` — needed because the inner
  `TransactionsByDayList` is a `ListView.builder` that must keep lazy
  build.
- `transactions_screen` and `service_status_page`: only the indicator
  wrapper is swapped — restructuring would require sliver-converting
  shared list widgets (out of scope).

## Test plan

- [x] **Wallet home (BULL tab)**
  - [x] Pull from anywhere — top, middle, over the bottom Send/Receive
        buttons. Indicator triggers from any zone.
  - [ ] Spinner is centered vertically on screen.
  - [x] BULL logo in the AppBar is not covered by the spinner.
  - [ ] iOS top-overscroll still shows the black background.
- [x] **Exchange home (Exchange tab)**
  - [ ] Pull from anywhere — top, middle, over the
        Deposit/Withdraw buttons.
  - [ ] Spinner centered, BULL logo not covered.
  - [ ] Deposit and Withdraw buttons still tap correctly (they used to
        be a `Positioned` overlay, now sit inside the scroll view).
  - [ ] Floating/pinned `SliverAppBar` still floats correctly.
- [x] **Wallet detail (tap a wallet from home)**
- [x] **Transactions (top-bar history icon)**
- [x] **Service status (Settings → Service status)**

