### PR TITLE
fix: log caught exceptions at proper level with typed error/stackTrace

### DIFF
--- a/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
+++ b/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
@@ -72,7 +72,7 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
 
       return rate;
     } catch (e) {
-      log.warning(e.toString());
+      log.warning('Pricer error', error: e);
       return 0.0;
     }
   }

--- a/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
+++ b/lib/core/exchange/data/datasources/exchange_notification_datasource.dart
@@ -109,6 +109,7 @@ class ExchangeNotificationDatasource {
         log.warning(
           'WebSocket endpoint not available - server may not support WebSocket on this endpoint. '
           'Disabling auto-reconnect.',
+          error: e,
         );
         _isManuallyDisconnected = true; // Prevent auto-reconnect
       }

--- a/lib/core/ledger/data/datasources/ledger_device_datasource.dart
+++ b/lib/core/ledger/data/datasources/ledger_device_datasource.dart
@@ -299,7 +299,7 @@ class LedgerDeviceDatasource {
       try {
         await _cachedConnection!.disconnect();
       } catch (e) {
-        log.info('Error disconnecting Ledger device', error: e);
+        log.warning('Error disconnecting Ledger device', error: e);
       }
       _cachedConnection = null;
     }

--- a/lib/core/mempool/application/usecases/set_custom_mempool_server_usecase.dart
+++ b/lib/core/mempool/application/usecases/set_custom_mempool_server_usecase.dart
@@ -122,7 +122,7 @@ class SetCustomMempoolServerUsecase {
 
       return SetCustomMempoolServerResult.success();
     } catch (e) {
-      log.warning('Failed to save mempool server: $e');
+      log.warning('Failed to save mempool server', error: e);
       return SetCustomMempoolServerResult.failure(
         SetCustomMempoolServerError.saveFailed,
       );

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -281,7 +281,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
             );
           } catch (e) {
             log.warning(
-              'Error broadcasting original transaction with server ${serverToUse.url}: $e',
+              'Error broadcasting original transaction with server ${serverToUse.url}',
+              error: e,
             );
             if (i == servers.length - 1) {
               rethrow; // If it's the last server, rethrow the error

--- a/lib/core/seed/data/repository/seed_repository.dart
+++ b/lib/core/seed/data/repository/seed_repository.dart
@@ -21,8 +21,8 @@ class SeedRepository {
       await _source.store(fingerprint: model.masterFingerprint, seed: model);
       return model.toEntity() as MnemonicSeed;
     } catch (e, stackTrace) {
-      log.info(
-        'Failed to create seed from mnemonic: $e',
+      log.severe(
+        message: 'Failed to create seed from mnemonic',
         error: e,
         trace: stackTrace,
       );
@@ -36,8 +36,8 @@ class SeedRepository {
       await _source.store(fingerprint: model.masterFingerprint, seed: model);
       return model.toEntity();
     } catch (e, stackTrace) {
-      log.info(
-        'Failed to create seed from bytes: $e',
+      log.severe(
+        message: 'Failed to create seed from bytes',
         error: e,
         trace: stackTrace,
       );
@@ -52,8 +52,8 @@ class SeedRepository {
       final entity = await compute(_toEntityInIsolate, model);
       return entity;
     } catch (e, stackTrace) {
-      log.info(
-        'Failed to get seed with fingerprint $fingerprint: $e',
+      log.severe(
+        message: 'Failed to get seed with fingerprint',
         error: e,
         trace: stackTrace,
       );
@@ -68,8 +68,8 @@ class SeedRepository {
     try {
       return await _source.exists(fingerprint);
     } catch (e, stackTrace) {
-      log.info(
-        'Failed to check if seed exists with fingerprint $fingerprint: $e',
+      log.severe(
+        message: 'Failed to check if seed exists with fingerprint',
         error: e,
         trace: stackTrace,
       );
@@ -103,8 +103,8 @@ class SeedRepository {
       // (toEntity() triggers expensive fingerprint computation)
       return await compute(convertToMnemonicSeedsInIsolate, models);
     } catch (e, stackTrace) {
-      log.info(
-        'Failed to get all mnemonic seeds: $e',
+      log.severe(
+        message: 'Failed to get all mnemonic seeds',
         error: e,
         trace: stackTrace,
       );

--- a/lib/core/wallet/data/datasources/lwk_facade.dart
+++ b/lib/core/wallet/data/datasources/lwk_facade.dart
@@ -31,8 +31,7 @@ class LwkFacade {
       log.fine('Found LwkDb');
       await dbFile.delete(recursive: true);
     } catch (e) {
-      log.fine('Failed to delete LwkDb');
-      log.fine(e.toString());
+      log.warning('Failed to delete LwkDb', error: e);
       rethrow;
     }
   }

--- a/lib/core/wallet/domain/usecases/check_liquid_wallet_status_usecase.dart
+++ b/lib/core/wallet/domain/usecases/check_liquid_wallet_status_usecase.dart
@@ -110,7 +110,7 @@ class TheDirtyLiquidUsecase {
         await file.delete();
       }
     } catch (e) {
-      log.warning('Failed to cleanup database file: $dbPath - $e');
+      log.warning('Failed to cleanup database file: $dbPath', error: e);
     }
   }
 

--- a/lib/core/wallet/domain/usecases/check_wallet_status_usecase.dart
+++ b/lib/core/wallet/domain/usecases/check_wallet_status_usecase.dart
@@ -122,7 +122,10 @@ class TheDirtyUsecase {
           wallet.applyUpdate(update: scanUpdate);
           break; // Exit the loop if sync is successful
         } catch (e) {
-          log.warning('Failed to sync with ${electrumServers[i].url}: $e');
+          log.warning(
+            'Failed to sync with ${electrumServers[i].url}',
+            error: e,
+          );
           if (i == electrumServers.length - 1) {
             throw Exception('All Electrum servers failed to sync.');
           }

--- a/lib/features/exchange/presentation/exchange_cubit.dart
+++ b/lib/features/exchange/presentation/exchange_cubit.dart
@@ -53,7 +53,7 @@ class ExchangeCubit extends Cubit<ExchangeState> {
     try {
       await _exchangeNotificationService.connect();
     } catch (e) {
-      log.warning('WebSocket connection failed: $e');
+      log.warning('WebSocket connection failed', error: e);
     }
   }
 

--- a/lib/features/import_watch_only_wallet/presentation/cubit/import_watch_only_cubit.dart
+++ b/lib/features/import_watch_only_wallet/presentation/cubit/import_watch_only_cubit.dart
@@ -65,7 +65,7 @@ class ImportWatchOnlyCubit extends Cubit<ImportWatchOnlyState> {
         final entity = await WatchOnlyWalletEntity.parse(value);
         emit(state.copyWith(watchOnlyWallet: entity));
       } catch (e) {
-        log.info(e.toString());
+        log.warning(e.toString());
         emit(state.copyWith(error: 'Invalid watch only format'));
       }
     }

--- a/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
+++ b/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
@@ -32,12 +32,12 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
 
   final CompletePhysicalBackupVerificationUsecase
   _completePhysicalBackupVerificationUsecase;
-  Future<void> _handleError(String error, Emitter<OnboardingState> emit) async {
+  Future<void> _handleError(Object error, Emitter<OnboardingState> emit) async {
     log.severe(error: error, trace: StackTrace.current);
     emit(
       state.copyWith(
         onboardingStepStatus: OnboardingStepStatus.none,
-        statusError: error,
+        statusError: error.toString(),
       ),
     );
   }
@@ -56,7 +56,7 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
       await _createDefaultWalletsUsecase.execute();
       emit(state.copyWith(onboardingStepStatus: OnboardingStepStatus.success));
     } catch (e) {
-      await _handleError(e.toString(), emit);
+      await _handleError(e, emit);
     }
   }
 
@@ -77,7 +77,7 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
       await _completePhysicalBackupVerificationUsecase.execute();
       emit(state.copyWith(onboardingStepStatus: OnboardingStepStatus.success));
     } catch (e) {
-      await _handleError(e.toString(), emit);
+      await _handleError(e, emit);
     }
   }
 }


### PR DESCRIPTION
Several catch blocks logged failures at info/fine, so events never reached Sentry. Others stringified the exception into the message, breaking Sentry's grouping by type and stack frames.

- seed_repository: 5 failure paths upgraded info → severe so seed creation/load failures land in Sentry.
- onboarding_bloc._handleError: takes Object instead of String so the original exception (and its type) flows to log.severe → Sentry.
- import_watch_only, ledger, lwk_facade: caught failures lifted out of info/fine into warning.
- bullbitcoin_api, exchange_cubit, exchange_notification, mempool_server, payjoin, check_wallet_status, check_liquid_wallet_status: replaced `'msg: $e'` interpolation with the `error: e` named argument so the typed exception reaches the logger instead of its toString().