### PR TITLE
fix(settings): use goNamed for support chat to avoid navigator key collision

### DIFF
--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -205,11 +205,11 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
                         final notLoggedIn =
                             context.read<ExchangeCubit>().state.notLoggedIn;
                         if (notLoggedIn) {
-                          context.pushNamed(
+                          context.goNamed(
                             ExchangeRoute.exchangeLoginForSupport.name,
                           );
                         } else {
-                          context.pushNamed(
+                          context.goNamed(
                             ExchangeSupportChatRoute.supportChat.name,
                           );
                         }


### PR DESCRIPTION
Pushing a shell-wrapped route (supportChat, exchangeLoginForSupport) from
the top-level settings route caused duplicate page keys on the root navigator and crashed with `!keyReservation.contains(key)`. Switch back to goNamed from settings; pushNamed from wallet home (already inside the shell) is unaffected.