### PR TITLE
fix: tag pre-v6.6.0 upgrades correctly via drift schema callback

### DIFF
--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_net
 import 'package:bb_mobile/core/storage/migrations/migrations.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.steps.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/report.dart';
 import 'package:bb_mobile/core/storage/tables/auto_swap.dart';
 import 'package:bb_mobile/core/storage/tables/bip85_derivations_table.dart';
 import 'package:bb_mobile/core/storage/tables/electrum_servers_table.dart';
@@ -119,6 +120,17 @@ class SqliteDatabase extends _$SqliteDatabase {
         from10To11: _reportingMigration('from10To11', Schema10To11.migrate),
         from11To12: _reportingMigration('from11To12', Schema11To12.migrate),
       ),
+      // Backfills `Report.fromVersion` for installs that predate the
+      // `_lastVersionKey` SharedPreferences marker (added in v6.6.0).
+      // Drift sets `versionBefore` to the on-disk schema before any
+      // step runs, so this fires once on the first launch after a
+      // pre-v6.6.0 → v6.6.0+ upgrade and is a no-op otherwise.
+      beforeOpen: (details) async {
+        if (details.versionBefore != null &&
+            details.versionBefore != details.versionNow) {
+          Report.recordSchemaUpgrade(from: details.versionBefore!);
+        }
+      },
     );
   }
 

--- a/lib/core/utils/report.dart
+++ b/lib/core/utils/report.dart
@@ -101,6 +101,36 @@ class Report {
     await prefs.setString(_lastVersionKey, to);
   }
 
+  /// Fallback for installs that predate the `_lastVersionKey` marker
+  /// (added in v6.6.0). Wired into drift's `MigrationStrategy.beforeOpen`
+  /// — drift only fires the upgrade path when the on-disk schema
+  /// differs from the current one, so a schema upgrade is observable
+  /// even when prefs is empty. Without this, pre-v6.6.0 upgrades are
+  /// misclassified as installs in Sentry. Idempotent: a populated
+  /// `fromVersion` from prefs takes precedence.
+  static void recordSchemaUpgrade({required int from}) {
+    fromVersion ??= _versionFromSchema(from);
+  }
+
+  /// Maps a drift schema number to the first released app version that
+  /// shipped with that schema. Append a new case here whenever
+  /// `SqliteDatabase.schemaVersion` is bumped.
+  static String _versionFromSchema(int schema) => switch (schema) {
+    1 => 'v5.0.0..v5.2.0',
+    2 => 'v5.3.0',
+    3 => 'v5.3.1',
+    4 => 'v5.4.0..v5.4.3',
+    5 => 'v5.4.4',
+    6 => 'v6.0.0',
+    7 => 'v6.1.0..v6.2.3',
+    8 => 'v6.3.0..v6.3.2',
+    9 => 'v6.3.3..v6.3.8',
+    10 => 'v6.4.0..v6.4.3',
+    11 => 'v6.5.0..v6.5.4',
+    12 => 'v6.6.0+',
+    _ => 'schema-$schema',
+  };
+
   /// Consent-gated error capture. Dropped by `beforeSend` when the user
   /// has opted out of the error-report program. Tagged `category=error`.
   /// Routed from `log.severe`.


### PR DESCRIPTION
Pre-v6.6.0 upgrades were tagged `migration_type=install` because the `last_seen_app_version` SharedPreferences marker only exists from v6.6.0 onward (commit 718e49ee5).

Wires drift's `MigrationStrategy.beforeOpen` into a new `Report.recordSchemaUpgrade(from:)` that backfills `fromVersion` from the on-disk schema number when prefs is empty. One-shot: `commitVersion`  rites the precise version on first launch and the fallback never fires again for that user.

## Test plan

- Android emulator: rolled DB back to schema 11, cleared prefs marker, ran patched build → `SHOUT upgrade` fired (would have been `install` without patch); drift migrated 11→12 cleanly; prefs committed to current version.
- [ ] Verify `from_version=v6.x` tag appears in Sentry on a release build
