### PR TITLE
fix(backup): persistent warning sheet +  status screen gradient

### DIFF
--- a/lib/core/recoverbull/domain/usecases/update_latest_encrypted_backup_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/update_latest_encrypted_backup_usecase.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/recoverbull/domain/entity/decrypted_vault.dart';
-import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bip32_keys/bip32_keys.dart';
@@ -11,10 +11,13 @@ import 'package:convert/convert.dart';
 /// If the key server is down
 class UpdateLatestEncryptedVaultTestUsecase {
   final WalletRepository _walletRepository;
+  final SettingsRepository _settingsRepository;
 
   UpdateLatestEncryptedVaultTestUsecase({
     required WalletRepository walletRepository,
-  }) : _walletRepository = walletRepository;
+    required SettingsRepository settingsRepository,
+  }) : _walletRepository = walletRepository,
+       _settingsRepository = settingsRepository;
 
   Future<void> execute({required DecryptedVault decryptedVault}) async {
     try {
@@ -27,9 +30,10 @@ class UpdateLatestEncryptedVaultTestUsecase {
       final decodedRoot = Bip32Keys.fromSeed(Uint8List.fromList(mnemonic.seed));
       final decodedFingerprint = hex.encode(decodedRoot.fingerprint);
 
+      final settings = await _settingsRepository.fetch();
       final availableWallets = await _walletRepository.getWallets(
         onlyDefaults: true,
-        environment: Environment.mainnet,
+        environment: settings.environment,
       );
 
       for (final wallet in availableWallets) {

--- a/lib/core/recoverbull/recoverbull_locator.dart
+++ b/lib/core/recoverbull/recoverbull_locator.dart
@@ -171,6 +171,7 @@ class RecoverbullLocator {
     locator.registerFactory<UpdateLatestEncryptedVaultTestUsecase>(
       () => UpdateLatestEncryptedVaultTestUsecase(
         walletRepository: locator<WalletRepository>(),
+        settingsRepository: locator<SettingsRepository>(),
       ),
     );
     locator.registerFactory<FetchRecoverbullUrlUsecase>(

--- a/lib/core/wallet/domain/usecases/check_backup_needed_usecase.dart
+++ b/lib/core/wallet/domain/usecases/check_backup_needed_usecase.dart
@@ -1,0 +1,29 @@
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+
+/// Reads from the wallet repo directly so callers can verify backup state
+/// against the DB rather than a potentially-stale bloc cache.
+class CheckBackupNeededUsecase {
+  final WalletRepository _walletRepository;
+  final SettingsRepository _settingsRepository;
+
+  CheckBackupNeededUsecase({
+    required WalletRepository walletRepository,
+    required SettingsRepository settingsRepository,
+  }) : _walletRepository = walletRepository,
+       _settingsRepository = settingsRepository;
+
+  Future<bool> execute() async {
+    final settings = await _settingsRepository.fetch();
+    final defaultWallets = await _walletRepository.getWallets(
+      onlyDefaults: true,
+      environment: settings.environment,
+    );
+
+    return defaultWallets.isNotEmpty &&
+        defaultWallets.any(
+          (wallet) =>
+              !wallet.isEncryptedVaultTested && !wallet.isPhysicalBackupTested,
+        );
+  }
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -19,6 +19,7 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_utxo_repository_i
 import 'package:bb_mobile/core/wallet/domain/ports/electrum_server_port.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_wallet_status_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_status_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
@@ -160,6 +161,12 @@ class WalletLocator {
     locator.registerFactory<CheckWalletSyncingUsecase>(
       () => CheckWalletSyncingUsecase(
         walletRepository: locator<WalletRepository>(),
+      ),
+    );
+    locator.registerFactory<CheckBackupNeededUsecase>(
+      () => CheckBackupNeededUsecase(
+        walletRepository: locator<WalletRepository>(),
+        settingsRepository: locator<SettingsRepository>(),
       ),
     );
 

--- a/lib/core/widgets/loading/progress_screen.dart
+++ b/lib/core/widgets/loading/progress_screen.dart
@@ -9,13 +9,11 @@ class ProgressScreen extends StatelessWidget {
   final String? title;
   final String? description;
   final bool isLoading;
-  final List<Widget> extras;
   const ProgressScreen({
     required this.isLoading,
     super.key,
     this.title,
     this.description,
-    this.extras = const [],
   });
 
   @override
@@ -33,9 +31,7 @@ class ProgressScreen extends StatelessWidget {
                 height: 200,
                 image: AssetImage(Assets.animations.cubesLoading.path),
               ),
-            )
-          else
-            const SizedBox.shrink(),
+            ),
           if (title != null) ...[
             const Gap(16),
             BBText(
@@ -55,7 +51,6 @@ class ProgressScreen extends StatelessWidget {
               maxLines: 3,
             ),
           ],
-          if (extras.isNotEmpty) ...[const Gap(16), ...extras],
         ],
       ),
     );

--- a/lib/core/widgets/loading/status_screen.dart
+++ b/lib/core/widgets/loading/status_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
 /// A screen that handles three states: loading, success, and error
-
 class StatusScreen extends StatelessWidget {
   final String? title;
   final String? description;
@@ -32,17 +31,17 @@ class StatusScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textColor = hasError ? context.appColors.error : null;
-
     return Scaffold(
       backgroundColor: context.appColors.surface,
       body: StackedPage(
         bottomChild: (!isLoading && onTap != null)
             ? BBButton.big(
-                label: hasError
-                    ? (buttonText ?? context.loc.statusScreenTryAgain)
-                    : (buttonText ?? context.loc.statusScreenContinue),
-                onPressed: onTap ?? () {},
+                label:
+                    buttonText ??
+                    (hasError
+                        ? context.loc.statusScreenTryAgain
+                        : context.loc.statusScreenContinue),
+                onPressed: onTap!,
                 textColor: context.appColors.onSecondary,
                 bgColor: context.appColors.secondary,
               )
@@ -52,19 +51,18 @@ class StatusScreen extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 30),
               child: Column(
-                mainAxisAlignment: .start,
                 children: [
                   if (hasError)
                     Icon(
                       Icons.error_outline_rounded,
                       size: 80,
-                      color: textColor,
-                    )
-                  else
-                    const SizedBox.shrink(),
+                      color: context.appColors.error,
+                    ),
                   ProgressScreen(
-                    title: !hasError ? title : "Oops! Something went wrong",
-                    description: !hasError ? description : errorMessage,
+                    title: hasError
+                        ? context.loc.oopsSomethingWentWrong
+                        : title,
+                    description: hasError ? errorMessage : description,
                     isLoading: isLoading && !hasError,
                   ),
                   if (extras.isNotEmpty && !hasError) ...[

--- a/lib/core/widgets/template/screen_template.dart
+++ b/lib/core/widgets/template/screen_template.dart
@@ -14,29 +14,33 @@ class StackedPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      fit: StackFit.expand,
       children: [
         child,
-        Container(
-          width: double.infinity,
-          padding: const EdgeInsets.only(
-            bottom: 32,
-            top: 8,
-            left: 16,
-            right: 16,
-          ),
-          alignment: Alignment.bottomCenter,
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [
-                context.appColors.onSecondary.withValues(alpha: 0.0),
-                context.appColors.onSecondary,
-              ],
-              stops: const [0.0, 0.3],
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: Container(
+            padding: const EdgeInsets.only(
+              bottom: 32,
+              top: 8,
+              left: 16,
+              right: 16,
             ),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  context.appColors.onSecondary.withValues(alpha: 0.0),
+                  context.appColors.onSecondary,
+                ],
+                stops: const [0.0, 0.3],
+              ),
+            ),
+            child: bottomChild,
           ),
-          child: bottomChild,
         ),
       ],
     );

--- a/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
@@ -1,9 +1,11 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
+import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
@@ -32,11 +34,36 @@ class BackupWarningOverlay extends StatelessWidget {
   }
 }
 
-class _BackupWarningBlocker extends StatelessWidget {
+class _BackupWarningBlocker extends StatefulWidget {
   const _BackupWarningBlocker();
 
   @override
+  State<_BackupWarningBlocker> createState() => _BackupWarningBlockerState();
+}
+
+class _BackupWarningBlockerState extends State<_BackupWarningBlocker> {
+  bool? _backupNeeded;
+
+  @override
+  void initState() {
+    super.initState();
+    _verify();
+  }
+
+  Future<void> _verify() async {
+    final needed = await locator<CheckBackupNeededUsecase>().execute();
+    if (!mounted) return;
+    if (!needed) {
+      // Bloc cache was stale — sync it so the warning's gate matches reality.
+      context.read<WalletBloc>().add(const WalletRefreshed());
+    }
+    setState(() => _backupNeeded = needed);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (_backupNeeded != true) return const SizedBox.shrink();
+
     return Positioned.fill(
       child: Material(
         color: context.appColors.surface.withAlpha(100),


### PR DESCRIPTION
Two backup-flow bugs surfaced while testing the encrypted vault flow:

- **Backup warning persisted after vault test** — the home sheet kept showing after a successful encrypted vault backup because `WalletBloc.state.wallets` was never re-read from the DB; `hasNoBackup()` kept returning true against stale cache. Added `CheckBackupNeededUsecase` that reads default-wallet metadata directly from the repo, made `_BackupWarningBlocker` stateful, and gated the sheet on the verification result. The blocker also dispatches `WalletRefreshed` to heal the bloc cache when the check finds the user actually does have a tested backup.
- **Status screen gradient** — `StackedPage`'s bottom container expanded to fill the whole `Stack`, so the fade-to-background gradient covered the title/description above the button (e.g. `VaultCreatedPage`). Anchored the gradient strip with `Positioned(bottom: 0)` and added `StackFit.expand` so the Stack still fills the body. Took the opportunity to drop the dead `ProgressScreen.extras` param, redundant `SizedBox.shrink()` else branches, and replace a hardcoded `"Oops! Something went wrong"` with the existing loc key.
- **Testnet env fix** — `UpdateLatestEncryptedVaultTestUsecase` hardcoded `Environment.mainnet`, so testnet users could never have their backup flagged as tested. Now reads the active environment from `SettingsRepository`.

## Test plan

- [x] Create a fresh wallet → `VaultCreatedPage` renders with title + description fully visible (no gradient over the text).
- [x] Complete encrypted vault backup → tap "Test Recovery" → enter password → reach `TestCompletedPage` → tap "Got it" → home renders **without** the backup warning sheet.


