### PR TITLE
Fixes in storage warning and backup warning UX

### DIFF
--- a/lib/core/widgets/backup_success_screen.dart
+++ b/lib/core/widgets/backup_success_screen.dart
@@ -1,0 +1,76 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
+import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
+import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
+import 'package:gif/gif.dart';
+import 'package:go_router/go_router.dart';
+
+class BackupSuccessScreen extends StatelessWidget {
+  const BackupSuccessScreen({
+    super.key,
+    required this.title,
+    required this.message,
+    required this.buttonLabel,
+  });
+
+  final String title;
+  final String message;
+  final String buttonLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: .spaceBetween,
+          children: <Widget>[
+            const Spacer(),
+            Column(
+              children: [
+                SizedBox(
+                  height: 200,
+                  width: 200,
+                  child: Gif(
+                    image: AssetImage(Assets.animations.successTick.path),
+                    autostart: Autostart.once,
+                    height: 200,
+                    width: 200,
+                  ),
+                ),
+                const Gap(8),
+                BBText(title, style: context.font.headlineLarge),
+                const Gap(8),
+                BBText(
+                  message,
+                  style: context.font.bodyMedium,
+                  textAlign: .center,
+                ),
+              ],
+            ),
+            const Spacer(flex: 2),
+            Padding(
+              padding: EdgeInsets.only(
+                bottom: MediaQuery.of(context).size.height * 0.05,
+              ),
+              child: BBButton.big(
+                label: buttonLabel,
+                bgColor: context.appColors.secondary,
+                textColor: context.appColors.onSecondary,
+                onPressed: () {
+                  context.read<WalletBloc>().add(const WalletRefreshed());
+                  context.goNamed(WalletRoute.walletHome.name);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/backup_success_screen.dart
+++ b/lib/core/widgets/backup_success_screen.dart
@@ -63,7 +63,7 @@ class BackupSuccessScreen extends StatelessWidget {
                 bgColor: context.appColors.secondary,
                 textColor: context.appColors.onSecondary,
                 onPressed: () {
-                  context.read<WalletBloc>().add(const WalletRefreshed());
+                  context.read<WalletBloc>().add(const VerifyBackupStatus());
                   context.goNamed(WalletRoute.walletHome.name);
                 },
               ),

--- a/lib/core/widgets/snackbar_utils.dart
+++ b/lib/core/widgets/snackbar_utils.dart
@@ -36,7 +36,7 @@ class SnackBarUtils {
         backgroundColor: context.appColors.onSurface.withAlpha(204),
         behavior: .floating,
         elevation: 4,
-        margin: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
+        margin: const EdgeInsets.fromLTRB(40, 16, 40, 96),
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),

--- a/lib/features/recoverbull/ui/pages/test_completed_page.dart
+++ b/lib/features/recoverbull/ui/pages/test_completed_page.dart
@@ -1,68 +1,16 @@
-import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/buttons/button.dart';
-import 'package:bb_mobile/core/widgets/text/text.dart';
-import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
-import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
+import 'package:bb_mobile/core/widgets/backup_success_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
-import 'package:gif/gif.dart';
-import 'package:go_router/go_router.dart';
 
 class TestCompletedPage extends StatelessWidget {
   const TestCompletedPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: .spaceBetween,
-          children: <Widget>[
-            const Spacer(),
-            Column(
-              children: [
-                SizedBox(
-                  height: 200,
-                  width: 200,
-                  child: Gif(
-                    image: AssetImage(Assets.animations.successTick.path),
-                    autostart: Autostart.once,
-                    height: 200,
-                    width: 200,
-                  ),
-                ),
-                const Gap(8),
-                BBText(
-                  context.loc.recoverbullTestCompletedTitle,
-                  style: context.font.headlineLarge,
-                ),
-                const Gap(8),
-                BBText(
-                  context.loc.recoverbullTestSuccessDescription,
-                  style: context.font.bodyMedium,
-                  textAlign: .center,
-                ),
-              ],
-            ),
-            const Spacer(flex: 2),
-            Padding(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).size.height * 0.05,
-              ),
-              child: BBButton.big(
-                label: context.loc.recoverbullGotIt,
-                bgColor: context.appColors.secondary,
-                textColor: context.appColors.onSecondary,
-                onPressed: () {
-                  context.goNamed(WalletRoute.walletHome.name);
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
+    return BackupSuccessScreen(
+      title: context.loc.recoverbullTestCompletedTitle,
+      message: context.loc.recoverbullTestSuccessDescription,
+      buttonLabel: context.loc.recoverbullGotIt,
     );
   }
 }

--- a/lib/features/test_wallet_backup/ui/screens/backup_test_success.dart
+++ b/lib/features/test_wallet_backup/ui/screens/backup_test_success.dart
@@ -1,66 +1,16 @@
-import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/buttons/button.dart';
-import 'package:bb_mobile/core/widgets/text/text.dart';
-import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
-import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
+import 'package:bb_mobile/core/widgets/backup_success_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
-import 'package:gif/gif.dart';
-import 'package:go_router/go_router.dart';
 
 class BackupTestSuccessScreen extends StatelessWidget {
   const BackupTestSuccessScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: .spaceBetween,
-          children: <Widget>[
-            const Spacer(),
-            Column(
-              children: [
-                SizedBox(
-                  height: 200,
-                  width: 200,
-                  child: Gif(
-                    image: AssetImage(Assets.animations.successTick.path),
-                    autostart: Autostart.once,
-                    height: 200,
-                    width: 200,
-                  ),
-                ),
-                const Gap(8),
-                BBText(
-                  context.loc.testBackupSuccessTitle,
-                  style: context.font.headlineLarge,
-                ),
-                const Gap(8),
-                BBText(
-                  context.loc.testBackupSuccessMessage,
-                  style: context.font.bodyMedium,
-                  textAlign: .center,
-                ),
-              ],
-            ),
-            const Spacer(flex: 2),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 24),
-              child: BBButton.big(
-                label: context.loc.testBackupSuccessButton,
-                bgColor: context.appColors.secondary,
-                textColor: context.appColors.onSecondary,
-                onPressed: () {
-                  context.goNamed(WalletRoute.walletHome.name);
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
+    return BackupSuccessScreen(
+      title: context.loc.testBackupSuccessTitle,
+      message: context.loc.testBackupSuccessMessage,
+      buttonLabel: context.loc.testBackupSuccessButton,
     );
   }
 }

--- a/lib/features/wallet/presentation/bloc/wallet_bloc.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_bloc.dart
@@ -17,6 +17,7 @@ import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
 import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -56,7 +57,9 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     required GetArkWalletUsecase getArkWalletUsecase,
     required CheckArkWalletSetupUsecase checkArkWalletSetupUsecase,
     required SeedStoreTypeDatasource seedStoreTypeDatasource,
+    required CheckBackupNeededUsecase checkBackupNeededUsecase,
   }) : _getWalletsUsecase = getWalletsUsecase,
+       _checkBackupNeededUsecase = checkBackupNeededUsecase,
        _checkWalletSyncingUsecase = checkWalletSyncingUsecase,
        _watchStartedWalletSyncsUsecase = watchStartedWalletSyncsUsecase,
        _watchFinishedWalletSyncsUsecase = watchFinishedWalletSyncsUsecase,
@@ -92,6 +95,7 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     on<DisableAutoSwap>(_onDisableAutoSwap);
     on<DismissBackupWarning>(_onDismissBackupWarning);
     on<DismissLegacyStorageWarning>(_onDismissLegacyStorageWarning);
+    on<VerifyBackupStatus>(_onVerifyBackupStatus);
   }
 
   final GetWalletsUsecase _getWalletsUsecase;
@@ -113,6 +117,7 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
   final GetArkWalletUsecase _getArkWalletUsecase;
   final CheckArkWalletSetupUsecase _checkArkWalletSetupUsecase;
   final SeedStoreTypeDatasource _seedStoreTypeDatasource;
+  final CheckBackupNeededUsecase _checkBackupNeededUsecase;
 
   StreamSubscription? _startedSyncsSubscription;
   StreamSubscription? _finishedSyncsSubscription;
@@ -634,5 +639,15 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     Emitter<WalletState> emit,
   ) {
     emit(state.copyWith(legacyStorageWarningDismissed: true));
+  }
+
+  Future<void> _onVerifyBackupStatus(
+    VerifyBackupStatus event,
+    Emitter<WalletState> emit,
+  ) async {
+    final dbBackupNeeded = await _checkBackupNeededUsecase.execute();
+    if (dbBackupNeeded == state.hasNoBackup()) return;
+    final wallets = await _getWalletsUsecase.execute();
+    emit(state.copyWith(wallets: wallets));
   }
 }

--- a/lib/features/wallet/presentation/bloc/wallet_event.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_event.dart
@@ -71,3 +71,7 @@ class DismissBackupWarning extends WalletEvent {
 class DismissLegacyStorageWarning extends WalletEvent {
   const DismissLegacyStorageWarning();
 }
+
+class VerifyBackupStatus extends WalletEvent {
+  const VerifyBackupStatus();
+}

--- a/lib/features/wallet/presentation/bloc/wallet_state.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_state.dart
@@ -59,8 +59,7 @@ sealed class WalletState with _$WalletState {
   }
 
   bool showBackupWarning() {
-    // Suppressed when on legacy storage — the legacy overlay handles both cases.
-    return hasNoBackup() && !backupWarningDismissed && !isOnLegacyStorage;
+    return hasNoBackup() && totalBalance() > 0 && !backupWarningDismissed;
   }
 
   bool showLegacyStorageWarning() {

--- a/lib/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart
+++ b/lib/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart
@@ -55,7 +55,7 @@ class _LegacyStorageAreYouSureScreenState
         label: loc.legacyStorageContinueWithoutBackupButton,
         onPressed: widget.onConfirmContinue,
         disabled: !_accepted,
-        bgColor: context.appColors.surface,
+        bgColor: context.appColors.background,
         textColor: context.appColors.primary,
         borderColor: context.appColors.primary,
         outlined: true,

--- a/lib/features/wallet/ui/screens/legacy_storage_warning_screen.dart
+++ b/lib/features/wallet/ui/screens/legacy_storage_warning_screen.dart
@@ -37,6 +37,7 @@ class LegacyStorageWarningScreen extends StatelessWidget {
       title: hasNoBackup
           ? loc.legacyStorageNoBackupPageTitle
           : loc.legacyStorageHasBackupPageTitle,
+      dotCount: hasNoBackup ? 2 : 1,
       dotIndex: 0,
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -54,7 +55,9 @@ class LegacyStorageWarningScreen extends StatelessWidget {
           const Gap(10),
           LegacyStorageImportantCallout(
             title: loc.legacyStorageImportantTitle,
-            body: loc.legacyStorageImportantBody,
+            body: hasNoBackup
+                ? loc.legacyStorageImportantBody
+                : loc.legacyStorageHasBackupImportantBody,
           ),
           const Gap(10),
           BBText(
@@ -68,16 +71,20 @@ class LegacyStorageWarningScreen extends StatelessWidget {
           ),
         ],
       ),
-      primaryButton: BBButton.big(
-        label: loc.legacyStorageBackupNowButton,
-        onPressed: onBackupNow,
-        bgColor: context.appColors.primary,
-        textColor: context.appColors.onPrimary,
-      ),
+      primaryButton: hasNoBackup
+          ? BBButton.big(
+              label: loc.legacyStorageBackupNowButton,
+              onPressed: onBackupNow,
+              bgColor: context.appColors.primary,
+              textColor: context.appColors.onPrimary,
+            )
+          : null,
       secondaryButton: BBButton.big(
-        label: loc.legacyStorageRiskAckButton,
+        label: hasNoBackup
+            ? loc.legacyStorageRiskAckButton
+            : loc.legacyStorageRiskAckButtonHasBackup,
         onPressed: onAcknowledgeRisk,
-        bgColor: context.appColors.surface,
+        bgColor: context.appColors.background,
         textColor: context.appColors.primary,
         borderColor: context.appColors.primary,
         outlined: true,

--- a/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
@@ -1,11 +1,9 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
-import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
@@ -25,8 +23,7 @@ class BackupWarningOverlay extends StatelessWidget {
         return Stack(
           children: [
             child,
-            if (state.showBackupWarning())
-              const _BackupWarningBlocker(),
+            if (state.showBackupWarning()) const _BackupWarningBlocker(),
           ],
         );
       },
@@ -42,28 +39,14 @@ class _BackupWarningBlocker extends StatefulWidget {
 }
 
 class _BackupWarningBlockerState extends State<_BackupWarningBlocker> {
-  bool? _backupNeeded;
-
   @override
   void initState() {
     super.initState();
-    _verify();
-  }
-
-  Future<void> _verify() async {
-    final needed = await locator<CheckBackupNeededUsecase>().execute();
-    if (!mounted) return;
-    if (!needed) {
-      // Bloc cache was stale — sync it so the warning's gate matches reality.
-      context.read<WalletBloc>().add(const WalletRefreshed());
-    }
-    setState(() => _backupNeeded = needed);
+    context.read<WalletBloc>().add(const VerifyBackupStatus());
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_backupNeeded != true) return const SizedBox.shrink();
-
     return Positioned.fill(
       child: Material(
         color: context.appColors.surface.withAlpha(100),

--- a/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart
@@ -11,7 +11,7 @@ class LegacyStorageScreenScaffold extends StatelessWidget {
     required this.badgeLabel,
     required this.title,
     required this.body,
-    required this.primaryButton,
+    this.primaryButton,
     required this.secondaryButton,
     required this.dotIndex,
     this.belowButtons,
@@ -21,7 +21,7 @@ class LegacyStorageScreenScaffold extends StatelessWidget {
   final String badgeLabel;
   final String title;
   final Widget body;
-  final Widget primaryButton;
+  final Widget? primaryButton;
   final Widget secondaryButton;
   final Widget? belowButtons;
   final int dotIndex;
@@ -30,7 +30,7 @@ class LegacyStorageScreenScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: context.appColors.surface,
+      color: context.appColors.background,
       child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
@@ -64,8 +64,7 @@ class LegacyStorageScreenScaffold extends StatelessWidget {
               const Gap(10),
               Expanded(child: SingleChildScrollView(child: body)),
               const Gap(10),
-              primaryButton,
-              const Gap(8),
+              if (primaryButton != null) ...[primaryButton!, const Gap(8)],
               secondaryButton,
               if (belowButtons != null) ...[
                 const Gap(10),

--- a/lib/features/wallet/ui/widgets/legacy_storage_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage_warning_overlay.dart
@@ -1,9 +1,7 @@
-import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart';
 import 'package:bb_mobile/features/wallet/ui/screens/legacy_storage_warning_screen.dart';
-import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -46,24 +44,15 @@ class _LegacyStorageWarningBlocker extends StatefulWidget {
 class _LegacyStorageWarningBlockerState
     extends State<_LegacyStorageWarningBlocker> {
   bool _showAreYouSure = false;
-  bool? _dbHasNoBackup;
 
   @override
   void initState() {
     super.initState();
-    _refreshFromDb();
+    context.read<WalletBloc>().add(const VerifyBackupStatus());
   }
 
-  Future<void> _refreshFromDb() async {
-    final needed = await locator<CheckBackupNeededUsecase>().execute();
-    if (!mounted) return;
-    setState(() => _dbHasNoBackup = needed);
-  }
-
-  Future<void> _backupNow() async {
-    await context.pushNamed(BackupSettingsSubroute.backupOptions.name);
-    if (!mounted) return;
-    await _refreshFromDb();
+  void _backupNow() {
+    context.pushNamed(BackupSettingsSubroute.backupOptions.name);
   }
 
   void _dismiss() {
@@ -71,14 +60,12 @@ class _LegacyStorageWarningBlockerState
   }
 
   void _acknowledgeRisk() {
-    if (_effectiveHasNoBackup) {
+    if (widget.hasNoBackup) {
       setState(() => _showAreYouSure = true);
     } else {
       _dismiss();
     }
   }
-
-  bool get _effectiveHasNoBackup => _dbHasNoBackup ?? widget.hasNoBackup;
 
   @override
   Widget build(BuildContext context) {
@@ -89,7 +76,7 @@ class _LegacyStorageWarningBlockerState
               onConfirmContinue: _dismiss,
             )
           : LegacyStorageWarningScreen(
-              hasNoBackup: _effectiveHasNoBackup,
+              hasNoBackup: widget.hasNoBackup,
               onBackupNow: _backupNow,
               onAcknowledgeRisk: _acknowledgeRisk,
             ),

--- a/lib/features/wallet/ui/widgets/legacy_storage_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage_warning_overlay.dart
@@ -1,7 +1,9 @@
+import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart';
 import 'package:bb_mobile/features/wallet/ui/screens/legacy_storage_warning_screen.dart';
+import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -44,9 +46,24 @@ class _LegacyStorageWarningBlocker extends StatefulWidget {
 class _LegacyStorageWarningBlockerState
     extends State<_LegacyStorageWarningBlocker> {
   bool _showAreYouSure = false;
+  bool? _dbHasNoBackup;
 
-  void _backupNow() {
-    context.pushNamed(BackupSettingsSubroute.backupOptions.name);
+  @override
+  void initState() {
+    super.initState();
+    _refreshFromDb();
+  }
+
+  Future<void> _refreshFromDb() async {
+    final needed = await locator<CheckBackupNeededUsecase>().execute();
+    if (!mounted) return;
+    setState(() => _dbHasNoBackup = needed);
+  }
+
+  Future<void> _backupNow() async {
+    await context.pushNamed(BackupSettingsSubroute.backupOptions.name);
+    if (!mounted) return;
+    await _refreshFromDb();
   }
 
   void _dismiss() {
@@ -54,12 +71,14 @@ class _LegacyStorageWarningBlockerState
   }
 
   void _acknowledgeRisk() {
-    if (widget.hasNoBackup) {
+    if (_effectiveHasNoBackup) {
       setState(() => _showAreYouSure = true);
     } else {
       _dismiss();
     }
   }
+
+  bool get _effectiveHasNoBackup => _dbHasNoBackup ?? widget.hasNoBackup;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +89,7 @@ class _LegacyStorageWarningBlockerState
               onConfirmContinue: _dismiss,
             )
           : LegacyStorageWarningScreen(
-              hasNoBackup: widget.hasNoBackup,
+              hasNoBackup: _effectiveHasNoBackup,
               onBackupNow: _backupNow,
               onAcknowledgeRisk: _acknowledgeRisk,
             ),

--- a/lib/features/wallet/wallet_locator.dart
+++ b/lib/features/wallet/wallet_locator.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/save_auto_swap_settings_use
 import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
 import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -59,6 +60,7 @@ class WalletLocator {
         autoSwapExecutionUsecase: locator<AutoSwapExecutionUsecase>(),
         deleteWalletUsecase: locator<DeleteWalletUsecase>(),
         seedStoreTypeDatasource: locator<SeedStoreTypeDatasource>(),
+        checkBackupNeededUsecase: locator<CheckBackupNeededUsecase>(),
       ),
     );
   }

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12617,7 +12617,7 @@
   "legacyStorageStepBackupWallet": "احفظ نسخة احتياطية لمحفظتك",
   "legacyStorageStepExportLabels": "صدّر تسمياتك (إن وُجدت)",
   "legacyStorageStepEnsureSwapsCompleted": "تأكد من اكتمال جميع عمليات التبادل",
-  "legacyStorageStepUninstall": "أزل التطبيق بالكامل من جهازك",
+  "legacyStorageStepUninstall": "قم بإلغاء تثبيت التطبيق من جهازك",
   "legacyStorageStepReinstall": "نزّل أحدث إصدار وأعد التثبيت",
   "legacyStorageStepRestoreBackup": "استعِد نسختك الاحتياطية",
   "legacyStorageImportantTitle": "هام",

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12608,5 +12608,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "إجراء مطلوب",
+  "legacyStorageBadgeConfirm": "تأكيد",
+  "legacyStorageNoBackupPageTitle": "احفظ نسخة احتياطية وأعد تثبيت محفظتك",
+  "legacyStorageHasBackupPageTitle": "أعد تثبيت محفظتك",
+  "legacyStorageIntroDescription": "محفظتك تعمل على برنامج سيتم إيقافه قريبًا. لا يمكن تحديثه دون إلغاء تثبيت التطبيق وإعادة تثبيته.",
+  "legacyStorageStepBackupWallet": "احفظ نسخة احتياطية لمحفظتك",
+  "legacyStorageStepExportLabels": "صدّر تسمياتك (إن وُجدت)",
+  "legacyStorageStepEnsureSwapsCompleted": "تأكد من اكتمال جميع عمليات التبادل",
+  "legacyStorageStepUninstall": "أزل التطبيق بالكامل من جهازك",
+  "legacyStorageStepReinstall": "نزّل أحدث إصدار وأعد التثبيت",
+  "legacyStorageStepRestoreBackup": "استعِد نسختك الاحتياطية",
+  "legacyStorageImportantTitle": "هام",
+  "legacyStorageImportantBody": "لا تتخطَّ هذه العملية إلا إذا كنت لا تستطيع فعلًا عمل نسخة احتياطية في هذه اللحظة.",
+  "legacyStorageContinueFooterNoBackup": "يمكنك متابعة استخدام التطبيق دون عمل نسخة احتياطية، لكننا ننصح بشدة بعدم القيام بذلك.",
+  "legacyStorageContinueFooterHasBackup": "يمكنك متابعة استخدام التطبيق، لكننا ننصح بشدة بعدم القيام بذلك.",
+  "legacyStorageBackupNowButton": "احفظ نسخة احتياطية الآن",
+  "legacyStorageRiskAckButton": "لا، أتفهم المخاطر",
+  "legacyStorageAreYouSureTitle": "هل أنت متأكد؟",
+  "legacyStorageAreYouSureParagraphOne": "البرنامج المستخدم لتخزين مفاتيح بيتكوين الخاصة بمحفظتك يتم إيقافه. ننصح بشدة أن تعمل نسخة احتياطية الآن لتجنب أي تعطل في المستقبل.",
+  "legacyStorageAreYouSureParagraphTwo": "خيار النسخة الاحتياطية المشفّرة لا يستغرق سوى دقيقة، ولا يتطلب أدوات خاصة. أما النسخة الاحتياطية المادية، فكل ما تحتاجه قلم وورقة.",
+  "legacyStorageContinueWithoutBackupButton": "متابعة دون نسخة احتياطية",
+  "legacyStorageAcceptRisksCheckbox": "أوافق على مخاطر عدم عمل نسخة احتياطية",
+  "legacyStorageHasBackupImportantBody": "يرجى عدم تخطي هذه العملية إلا إذا كنت بحاجة ماسة إلى استخدام المحفظة بشكل عاجل أو في انتظار اكتمال عملية مبادلة.",
+  "legacyStorageRiskAckButtonHasBackup": "أفهم المخاطر"
 }

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -179,5 +179,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "কাৰ্য প্ৰয়োজনীয়",
+  "legacyStorageBadgeConfirm": "নিশ্চিত কৰক",
+  "legacyStorageNoBackupPageTitle": "আপোনাৰ ৱালেটৰ বেকআপ লওক আৰু পুনৰ ইনষ্টল কৰক",
+  "legacyStorageHasBackupPageTitle": "আপোনাৰ ৱালেট পুনৰ ইনষ্টল কৰক",
+  "legacyStorageIntroDescription": "আপোনাৰ ৱালেট এনে চফ্টৱেৰত চলি আছে যিটো অলপতে অপ্ৰচলিত হ'ব। এপটো আনইনষ্টল কৰি পুনৰ ইনষ্টল নকৰাকৈ ই আপডেট কৰিব নোৱাৰি।",
+  "legacyStorageStepBackupWallet": "আপোনাৰ ৱালেটৰ বেকআপ লওক",
+  "legacyStorageStepExportLabels": "আপোনাৰ লেবেলবোৰ এক্সপৰ্ট কৰক (যদি থাকে)",
+  "legacyStorageStepEnsureSwapsCompleted": "সকলো স্বেপ সম্পূৰ্ণ হৈছে নে নিশ্চিত কৰক",
+  "legacyStorageStepUninstall": "আপোনাৰ ডিভাইচৰপৰা এপটো সম্পূৰ্ণৰূপে আনইনষ্টল কৰক",
+  "legacyStorageStepReinstall": "আটাইতকৈ নতুন সংস্কৰণ ডাউনলোড কৰি পুনৰ ইনষ্টল কৰক",
+  "legacyStorageStepRestoreBackup": "আপোনাৰ বেকআপ পুনৰুদ্ধাৰ কৰক",
+  "legacyStorageImportantTitle": "গুৰুত্বপূৰ্ণ",
+  "legacyStorageImportantBody": "এই মুহূৰ্তত যদি আপুনি একেবাৰে বেকআপ ল'ব পৰা নাই, তেতিয়াহে এই প্ৰক্ৰিয়া এৰি যাব।",
+  "legacyStorageContinueFooterNoBackup": "আপুনি বেকআপ নকৰাকৈ এপটো ব্যৱহাৰ চলাই থাকিব পাৰে, কিন্তু আমি ইয়াক দৃঢ়ভাৱে নিৰুৎসাহিত কৰোঁ।",
+  "legacyStorageContinueFooterHasBackup": "আপুনি এপটো ব্যৱহাৰ চলাই থাকিব পাৰে, কিন্তু আমি ইয়াক দৃঢ়ভাৱে নিৰুৎসাহিত কৰোঁ।",
+  "legacyStorageBackupNowButton": "এতিয়াই বেকআপ লওক",
+  "legacyStorageRiskAckButton": "নহয়, মই বিপদ বুজি পাইছোঁ",
+  "legacyStorageAreYouSureTitle": "আপুনি নিশ্চিতনে?",
+  "legacyStorageAreYouSureParagraphOne": "আপোনাৰ ৱালেটৰ বিটক'ইন প্ৰাইভেট কীবোৰ ৰাখিবলৈ ব্যৱহাৰ কৰা চফ্টৱেৰটো অপ্ৰচলিত হৈ গৈছে। ভৱিষ্যতৰ যিকোনো ব্যাঘাত পৰিহাৰ কৰিবলৈ আমি দৃঢ়ভাৱে এতিয়াই বেকআপ লোৱাৰ পৰামৰ্শ দিওঁ।",
+  "legacyStorageAreYouSureParagraphTwo": "এনক্ৰিপ্টেড ভল্ট বেকআপ বিকল্পত মাত্ৰ এক মিনিটমান লাগে, কোনো বিশেষ সঁজুলিৰ প্ৰয়োজন নহয়। ফিজিকেল বেকআপ ব্যৱহাৰ কৰিলে আপোনাক কেৱল কলম আৰু কাগজ লাগিব।",
+  "legacyStorageContinueWithoutBackupButton": "বেকআপ নকৰাকৈ আগবাঢ়ক",
+  "legacyStorageAcceptRisksCheckbox": "মই বেকআপ নকৰাৰ বিপদ গ্ৰহণ কৰোঁ",
+  "legacyStorageHasBackupImportantBody": "এই প্ৰক্ৰিয়া এৰি নাযাব যদিহে আপুনি ৱালেট জৰুৰীভাৱে ব্যৱহাৰ কৰাটো অত্যাৱশ্যক নহয় বা এটা স্বেপ সম্পূৰ্ণ হোৱালৈ অপেক্ষা কৰি আছে।",
+  "legacyStorageRiskAckButtonHasBackup": "মই বিপদটো বুজি পাইছোঁ"
 }

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -188,7 +188,7 @@
   "legacyStorageStepBackupWallet": "আপোনাৰ ৱালেটৰ বেকআপ লওক",
   "legacyStorageStepExportLabels": "আপোনাৰ লেবেলবোৰ এক্সপৰ্ট কৰক (যদি থাকে)",
   "legacyStorageStepEnsureSwapsCompleted": "সকলো স্বেপ সম্পূৰ্ণ হৈছে নে নিশ্চিত কৰক",
-  "legacyStorageStepUninstall": "আপোনাৰ ডিভাইচৰপৰা এপটো সম্পূৰ্ণৰূপে আনইনষ্টল কৰক",
+  "legacyStorageStepUninstall": "আপোনাৰ ডিভাইচৰ পৰা এপটো আনইনষ্টল কৰক",
   "legacyStorageStepReinstall": "আটাইতকৈ নতুন সংস্কৰণ ডাউনলোড কৰি পুনৰ ইনষ্টল কৰক",
   "legacyStorageStepRestoreBackup": "আপোনাৰ বেকআপ পুনৰুদ্ধাৰ কৰক",
   "legacyStorageImportantTitle": "গুৰুত্বপূৰ্ণ",

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -9615,5 +9615,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ИЗИСКВА СЕ ДЕЙСТВИЕ",
+  "legacyStorageBadgeConfirm": "ПОТВЪРДИ",
+  "legacyStorageNoBackupPageTitle": "НАПРАВЕТЕ РЕЗЕРВНО КОПИЕ И ПРЕИНСТАЛИРАЙТЕ ПОРТФЕЙЛА",
+  "legacyStorageHasBackupPageTitle": "ПРЕИНСТАЛИРАЙТЕ ПОРТФЕЙЛА",
+  "legacyStorageIntroDescription": "Портфейлът ви работи със софтуер, който скоро ще бъде изведен от употреба. Той не може да бъде обновен, без да деинсталирате и преинсталирате приложението.",
+  "legacyStorageStepBackupWallet": "Направете резервно копие на портфейла",
+  "legacyStorageStepExportLabels": "Експортирайте етикетите си (ако имате такива)",
+  "legacyStorageStepEnsureSwapsCompleted": "Уверете се, че всички размени са завършени",
+  "legacyStorageStepUninstall": "Деинсталирайте приложението напълно от устройството си",
+  "legacyStorageStepReinstall": "Изтеглете най-новата версия и инсталирайте отново",
+  "legacyStorageStepRestoreBackup": "Възстановете резервното копие",
+  "legacyStorageImportantTitle": "Важно",
+  "legacyStorageImportantBody": "Не пропускайте този процес, освен ако наистина не можете да направите резервно копие в момента.",
+  "legacyStorageContinueFooterNoBackup": "Можете да продължите да използвате приложението без резервно копие, но категорично не препоръчваме това.",
+  "legacyStorageContinueFooterHasBackup": "Можете да продължите да използвате приложението, но категорично не препоръчваме това.",
+  "legacyStorageBackupNowButton": "Резервно копие сега",
+  "legacyStorageRiskAckButton": "Не, разбирам риска",
+  "legacyStorageAreYouSureTitle": "СИГУРНИ ЛИ СТЕ?",
+  "legacyStorageAreYouSureParagraphOne": "Софтуерът, използван за съхранение на частните Bitcoin ключове на портфейла, се извежда от употреба. Силно ви препоръчваме да направите резервно копие сега, за да избегнете прекъсвания в бъдеще.",
+  "legacyStorageAreYouSureParagraphTwo": "Опцията за криптирано резервно копие отнема около 1 минута и не изисква специални инструменти. За физическо резервно копие ви трябват само химикалка и хартия.",
+  "legacyStorageContinueWithoutBackupButton": "Продължи без резервно копие",
+  "legacyStorageAcceptRisksCheckbox": "Приемам рисковете от това да не направя резервно копие",
+  "legacyStorageHasBackupImportantBody": "Моля, не пропускайте този процес, освен ако наистина не се налага спешно да използвате портфейла или не чакате суап да приключи.",
+  "legacyStorageRiskAckButtonHasBackup": "Разбирам риска"
 }

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -9624,7 +9624,7 @@
   "legacyStorageStepBackupWallet": "Направете резервно копие на портфейла",
   "legacyStorageStepExportLabels": "Експортирайте етикетите си (ако имате такива)",
   "legacyStorageStepEnsureSwapsCompleted": "Уверете се, че всички размени са завършени",
-  "legacyStorageStepUninstall": "Деинсталирайте приложението напълно от устройството си",
+  "legacyStorageStepUninstall": "Деинсталирайте приложението от устройството си",
   "legacyStorageStepReinstall": "Изтеглете най-новата версия и инсталирайте отново",
   "legacyStorageStepRestoreBackup": "Възстановете резервното копие",
   "legacyStorageImportantTitle": "Важно",

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12331,7 +12331,7 @@
   "legacyStorageStepBackupWallet": "আপনার ওয়ালেট ব্যাকআপ করুন",
   "legacyStorageStepExportLabels": "আপনার লেবেলগুলো এক্সপোর্ট করুন (যদি থাকে)",
   "legacyStorageStepEnsureSwapsCompleted": "নিশ্চিত করুন সব সোয়াপ সম্পন্ন হয়েছে",
-  "legacyStorageStepUninstall": "ডিভাইস থেকে অ্যাপটি সম্পূর্ণ আনইনস্টল করুন",
+  "legacyStorageStepUninstall": "আপনার ডিভাইস থেকে অ্যাপটি আনইনস্টল করুন",
   "legacyStorageStepReinstall": "সর্বশেষ সংস্করণ ডাউনলোড করে পুনরায় ইনস্টল করুন",
   "legacyStorageStepRestoreBackup": "আপনার ব্যাকআপ পুনরুদ্ধার করুন",
   "legacyStorageImportantTitle": "গুরুত্বপূর্ণ",

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12322,5 +12322,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "পদক্ষেপ প্রয়োজন",
+  "legacyStorageBadgeConfirm": "নিশ্চিত করুন",
+  "legacyStorageNoBackupPageTitle": "আপনার ওয়ালেট ব্যাকআপ ও পুনরায় ইনস্টল করুন",
+  "legacyStorageHasBackupPageTitle": "আপনার ওয়ালেট পুনরায় ইনস্টল করুন",
+  "legacyStorageIntroDescription": "আপনার ওয়ালেট এমন সফটওয়্যারে চলছে যেটি শীঘ্রই অপ্রচলিত হবে। অ্যাপটি আনইনস্টল ও পুনরায় ইনস্টল না করে এটি আপডেট করা যাবে না।",
+  "legacyStorageStepBackupWallet": "আপনার ওয়ালেট ব্যাকআপ করুন",
+  "legacyStorageStepExportLabels": "আপনার লেবেলগুলো এক্সপোর্ট করুন (যদি থাকে)",
+  "legacyStorageStepEnsureSwapsCompleted": "নিশ্চিত করুন সব সোয়াপ সম্পন্ন হয়েছে",
+  "legacyStorageStepUninstall": "ডিভাইস থেকে অ্যাপটি সম্পূর্ণ আনইনস্টল করুন",
+  "legacyStorageStepReinstall": "সর্বশেষ সংস্করণ ডাউনলোড করে পুনরায় ইনস্টল করুন",
+  "legacyStorageStepRestoreBackup": "আপনার ব্যাকআপ পুনরুদ্ধার করুন",
+  "legacyStorageImportantTitle": "গুরুত্বপূর্ণ",
+  "legacyStorageImportantBody": "এই মুহূর্তে একেবারেই ব্যাকআপ নেওয়া সম্ভব না হলে ছাড়া এই প্রক্রিয়া এড়িয়ে যাবেন না।",
+  "legacyStorageContinueFooterNoBackup": "ব্যাকআপ না করেও আপনি অ্যাপটি ব্যবহার চালিয়ে যেতে পারেন, তবে আমরা দৃঢ়ভাবে এর বিরুদ্ধে পরামর্শ দিই।",
+  "legacyStorageContinueFooterHasBackup": "আপনি অ্যাপটি ব্যবহার চালিয়ে যেতে পারেন, তবে আমরা দৃঢ়ভাবে এর বিরুদ্ধে পরামর্শ দিই।",
+  "legacyStorageBackupNowButton": "এখনই ব্যাকআপ",
+  "legacyStorageRiskAckButton": "না, আমি ঝুঁকি বুঝি",
+  "legacyStorageAreYouSureTitle": "আপনি কি নিশ্চিত?",
+  "legacyStorageAreYouSureParagraphOne": "আপনার ওয়ালেটের বিটকয়েন প্রাইভেট কী সংরক্ষণে ব্যবহৃত সফটওয়্যারটি অপ্রচলিত হয়ে যাচ্ছে। ভবিষ্যতে কোনো বাধা এড়াতে আমরা দৃঢ়ভাবে এখনই ব্যাকআপ নেওয়ার পরামর্শ দিই।",
+  "legacyStorageAreYouSureParagraphTwo": "এনক্রিপ্টেড ভল্ট ব্যাকআপের অপশনটি প্রায় ১ মিনিট সময় নেয়, কোনো বিশেষ সরঞ্জাম লাগে না। ফিজিক্যাল ব্যাকআপের জন্য কেবল কলম ও কাগজ যথেষ্ট।",
+  "legacyStorageContinueWithoutBackupButton": "ব্যাকআপ ছাড়াই চালিয়ে যান",
+  "legacyStorageAcceptRisksCheckbox": "ব্যাকআপ না করার ঝুঁকি আমি গ্রহণ করছি",
+  "legacyStorageHasBackupImportantBody": "এই প্রক্রিয়াটি এড়িয়ে যাবেন না যদি না আপনার জরুরিভাবে ওয়ালেট ব্যবহার করার একান্ত প্রয়োজন হয় অথবা একটি স্বপ সম্পন্ন হওয়ার জন্য অপেক্ষা করছেন।",
+  "legacyStorageRiskAckButtonHasBackup": "আমি ঝুঁকি বুঝতে পারছি"
 }

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "Zazálohujte si peněženku",
   "legacyStorageStepExportLabels": "Exportujte své štítky (pokud je máte)",
   "legacyStorageStepEnsureSwapsCompleted": "Ujistěte se, že všechny swapy jsou dokončené",
-  "legacyStorageStepUninstall": "Zcela odinstalujte aplikaci z vašeho zařízení",
+  "legacyStorageStepUninstall": "Odinstalujte aplikaci ze svého zařízení",
   "legacyStorageStepReinstall": "Stáhněte nejnovější verzi a znovu nainstalujte",
   "legacyStorageStepRestoreBackup": "Obnovte zálohu",
   "legacyStorageImportantTitle": "Důležité",

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "VYŽADUJE AKCI",
+  "legacyStorageBadgeConfirm": "POTVRDIT",
+  "legacyStorageNoBackupPageTitle": "ZÁLOHUJTE A PŘEINSTALUJTE PENĚŽENKU",
+  "legacyStorageHasBackupPageTitle": "PŘEINSTALUJTE PENĚŽENKU",
+  "legacyStorageIntroDescription": "Vaše peněženka běží na softwaru, který bude brzy ukončen. Nelze jej aktualizovat bez odinstalování a opětovné instalace aplikace.",
+  "legacyStorageStepBackupWallet": "Zazálohujte si peněženku",
+  "legacyStorageStepExportLabels": "Exportujte své štítky (pokud je máte)",
+  "legacyStorageStepEnsureSwapsCompleted": "Ujistěte se, že všechny swapy jsou dokončené",
+  "legacyStorageStepUninstall": "Zcela odinstalujte aplikaci z vašeho zařízení",
+  "legacyStorageStepReinstall": "Stáhněte nejnovější verzi a znovu nainstalujte",
+  "legacyStorageStepRestoreBackup": "Obnovte zálohu",
+  "legacyStorageImportantTitle": "Důležité",
+  "legacyStorageImportantBody": "Tento postup nepřeskakujte, ledaže opravdu nemůžete teď zálohu udělat.",
+  "legacyStorageContinueFooterNoBackup": "Můžete pokračovat v používání aplikace bez zálohy, ale rozhodně to nedoporučujeme.",
+  "legacyStorageContinueFooterHasBackup": "Můžete pokračovat v používání aplikace, ale rozhodně to nedoporučujeme.",
+  "legacyStorageBackupNowButton": "Zálohovat nyní",
+  "legacyStorageRiskAckButton": "Ne, riziko chápu",
+  "legacyStorageAreYouSureTitle": "JSTE SI JISTÍ?",
+  "legacyStorageAreYouSureParagraphOne": "Software používaný k uložení Bitcoin privátních klíčů peněženky se ukončuje. Důrazně doporučujeme zálohu vytvořit teď, aby v budoucnu nedošlo k žádným potížím.",
+  "legacyStorageAreYouSureParagraphTwo": "Šifrovaná záloha (Encrypted Vault) trvá asi 1 minutu a nepotřebujete žádné speciální nástroje. Pro fyzickou zálohu vám stačí pero a papír.",
+  "legacyStorageContinueWithoutBackupButton": "Pokračovat bez zálohy",
+  "legacyStorageAcceptRisksCheckbox": "Přijímám rizika spojená s tím, že nemám zálohu",
+  "legacyStorageHasBackupImportantBody": "Tento proces nepřeskakujte, pokud nezbytně nepotřebujete peněženku použít naléhavě nebo nečekáte na dokončení swapu.",
+  "legacyStorageRiskAckButtonHasBackup": "Rozumím riziku"
 }

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -4503,7 +4503,7 @@
   "legacyStorageStepBackupWallet": "Sichere deine Wallet",
   "legacyStorageStepExportLabels": "Exportiere deine Labels (falls vorhanden)",
   "legacyStorageStepEnsureSwapsCompleted": "Stelle sicher, dass alle Swaps abgeschlossen sind",
-  "legacyStorageStepUninstall": "Deinstalliere die App vollständig von deinem Gerät",
+  "legacyStorageStepUninstall": "Deinstallieren Sie die App von Ihrem Gerät",
   "legacyStorageStepReinstall": "Lade die neueste Version herunter und installiere sie neu",
   "legacyStorageStepRestoreBackup": "Stelle deine Sicherung wieder her",
   "legacyStorageImportantTitle": "Wichtig",

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -4494,5 +4494,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "AKTION ERFORDERLICH",
+  "legacyStorageBadgeConfirm": "BESTÄTIGEN",
+  "legacyStorageNoBackupPageTitle": "WALLET SICHERN UND NEU INSTALLIEREN",
+  "legacyStorageHasBackupPageTitle": "WALLET NEU INSTALLIEREN",
+  "legacyStorageIntroDescription": "Deine Wallet läuft auf einer Software, die bald nicht mehr unterstützt wird. Sie kann nicht aktualisiert werden, ohne die App zu deinstallieren und neu zu installieren.",
+  "legacyStorageStepBackupWallet": "Sichere deine Wallet",
+  "legacyStorageStepExportLabels": "Exportiere deine Labels (falls vorhanden)",
+  "legacyStorageStepEnsureSwapsCompleted": "Stelle sicher, dass alle Swaps abgeschlossen sind",
+  "legacyStorageStepUninstall": "Deinstalliere die App vollständig von deinem Gerät",
+  "legacyStorageStepReinstall": "Lade die neueste Version herunter und installiere sie neu",
+  "legacyStorageStepRestoreBackup": "Stelle deine Sicherung wieder her",
+  "legacyStorageImportantTitle": "Wichtig",
+  "legacyStorageImportantBody": "Überspringe diesen Vorgang nur, wenn du jetzt absolut keine Sicherung erstellen kannst.",
+  "legacyStorageContinueFooterNoBackup": "Du kannst die App auch ohne Sicherung weiter nutzen, wir raten aber dringend davon ab.",
+  "legacyStorageContinueFooterHasBackup": "Du kannst die App weiter nutzen, wir raten aber dringend davon ab.",
+  "legacyStorageBackupNowButton": "Jetzt sichern",
+  "legacyStorageRiskAckButton": "Nein, ich verstehe das Risiko",
+  "legacyStorageAreYouSureTitle": "BIST DU SICHER?",
+  "legacyStorageAreYouSureParagraphOne": "Die Software, die die privaten Bitcoin-Schlüssel deiner Wallet speichert, wird nicht mehr unterstützt. Wir empfehlen dir dringend, jetzt eine Sicherung zu erstellen, um spätere Störungen zu vermeiden.",
+  "legacyStorageAreYouSureParagraphTwo": "Die verschlüsselte Vault-Sicherung dauert nur etwa 1 Minute und benötigt keine besonderen Werkzeuge. Für eine physische Sicherung brauchst du nur Stift und Papier.",
+  "legacyStorageContinueWithoutBackupButton": "Ohne Sicherung fortfahren",
+  "legacyStorageAcceptRisksCheckbox": "Ich akzeptiere die Risiken, keine Sicherung zu haben",
+  "legacyStorageHasBackupImportantBody": "Bitte überspringen Sie diesen Vorgang nur, wenn Sie die Wallet unbedingt dringend verwenden müssen oder auf den Abschluss eines Swaps warten.",
+  "legacyStorageRiskAckButtonHasBackup": "Ich verstehe das Risiko"
 }

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ΑΠΑΙΤΕΙΤΑΙ ΕΝΕΡΓΕΙΑ",
+  "legacyStorageBadgeConfirm": "ΕΠΙΒΕΒΑΙΩΣΗ",
+  "legacyStorageNoBackupPageTitle": "ΔΗΜΙΟΥΡΓΗΣΕ ΑΝΤΙΓΡΑΦΟ ΑΣΦΑΛΕΙΑΣ ΚΑΙ ΕΠΑΝΕΓΚΑΤΑΣΤΗΣΕ ΤΟ ΠΟΡΤΟΦΟΛΙ",
+  "legacyStorageHasBackupPageTitle": "ΕΠΑΝΕΓΚΑΤΑΣΤΗΣΕ ΤΟ ΠΟΡΤΟΦΟΛΙ",
+  "legacyStorageIntroDescription": "Το πορτοφόλι σου τρέχει σε λογισμικό που σύντομα θα παύσει να υποστηρίζεται. Δεν μπορεί να ενημερωθεί χωρίς να απεγκαταστήσεις και να επανεγκαταστήσεις την εφαρμογή.",
+  "legacyStorageStepBackupWallet": "Δημιούργησε αντίγραφο ασφαλείας του πορτοφολιού",
+  "legacyStorageStepExportLabels": "Εξάγαγε τις ετικέτες σου (αν έχεις)",
+  "legacyStorageStepEnsureSwapsCompleted": "Βεβαιώσου ότι όλα τα swaps έχουν ολοκληρωθεί",
+  "legacyStorageStepUninstall": "Απεγκατάστησε εντελώς την εφαρμογή από τη συσκευή σου",
+  "legacyStorageStepReinstall": "Κατέβασε την πιο πρόσφατη έκδοση και εγκατάστησέ την ξανά",
+  "legacyStorageStepRestoreBackup": "Επανάφερε το αντίγραφο ασφαλείας",
+  "legacyStorageImportantTitle": "Σημαντικό",
+  "legacyStorageImportantBody": "Μην παραλείψεις αυτή τη διαδικασία εκτός αν πραγματικά δεν μπορείς να κάνεις αντίγραφο ασφαλείας τώρα.",
+  "legacyStorageContinueFooterNoBackup": "Μπορείς να συνεχίσεις να χρησιμοποιείς την εφαρμογή χωρίς αντίγραφο ασφαλείας, αλλά το αποτρέπουμε έντονα.",
+  "legacyStorageContinueFooterHasBackup": "Μπορείς να συνεχίσεις να χρησιμοποιείς την εφαρμογή, αλλά το αποτρέπουμε έντονα.",
+  "legacyStorageBackupNowButton": "Δημιούργησε αντίγραφο τώρα",
+  "legacyStorageRiskAckButton": "Όχι, καταλαβαίνω τον κίνδυνο",
+  "legacyStorageAreYouSureTitle": "ΕΙΣΑΙ ΣΙΓΟΥΡΟΣ;",
+  "legacyStorageAreYouSureParagraphOne": "Το λογισμικό που χρησιμοποιείται για την αποθήκευση των ιδιωτικών κλειδιών Bitcoin του πορτοφολιού σου παύει να υποστηρίζεται. Σου συνιστούμε ανεπιφύλακτα να κάνεις αντίγραφο ασφαλείας τώρα για να αποφύγεις τυχόν διακοπές στο μέλλον.",
+  "legacyStorageAreYouSureParagraphTwo": "Η επιλογή Encrypted Vault διαρκεί περίπου 1 λεπτό και δεν απαιτεί ειδικά εργαλεία. Για το φυσικό αντίγραφο, χρειάζεσαι μόνο στυλό και χαρτί.",
+  "legacyStorageContinueWithoutBackupButton": "Συνέχιση χωρίς αντίγραφο",
+  "legacyStorageAcceptRisksCheckbox": "Αποδέχομαι τον κίνδυνο να μην έχω αντίγραφο ασφαλείας",
+  "legacyStorageHasBackupImportantBody": "Παρακαλώ μην παραλείψετε αυτή τη διαδικασία εκτός εάν είναι απολύτως απαραίτητο να χρησιμοποιήσετε επειγόντως το πορτοφόλι ή περιμένετε να ολοκληρωθεί ένα swap.",
+  "legacyStorageRiskAckButtonHasBackup": "Κατανοώ τον κίνδυνο"
 }

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "Δημιούργησε αντίγραφο ασφαλείας του πορτοφολιού",
   "legacyStorageStepExportLabels": "Εξάγαγε τις ετικέτες σου (αν έχεις)",
   "legacyStorageStepEnsureSwapsCompleted": "Βεβαιώσου ότι όλα τα swaps έχουν ολοκληρωθεί",
-  "legacyStorageStepUninstall": "Απεγκατάστησε εντελώς την εφαρμογή από τη συσκευή σου",
+  "legacyStorageStepUninstall": "Απεγκαταστήστε την εφαρμογή από τη συσκευή σας",
   "legacyStorageStepReinstall": "Κατέβασε την πιο πρόσφατη έκδοση και εγκατάστησέ την ξανά",
   "legacyStorageStepRestoreBackup": "Επανάφερε το αντίγραφο ασφαλείας",
   "legacyStorageImportantTitle": "Σημαντικό",

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -12986,8 +12986,12 @@
   "@wizardPageIndicator": {
     "description": "Eyebrow label above each wizard page title indicating progress",
     "placeholders": {
-      "current": {"type": "int"},
-      "total": {"type": "int"}
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
     }
   },
   "wizardNextButton": "Next",
@@ -13043,19 +13047,43 @@
     "description": "Intro paragraph on the wizard journey/tips page"
   },
   "wizardJourneyTip1": "Add a security PIN to unlock your wallet",
-  "@wizardJourneyTip1": {"description": "Tip 1 on the wizard journey page"},
+  "@wizardJourneyTip1": {
+    "description": "Tip 1 on the wizard journey page"
+  },
   "wizardJourneyTip2": "Try the encrypted vault backup",
-  "@wizardJourneyTip2": {"description": "Tip 2 on the wizard journey page"},
+  "@wizardJourneyTip2": {
+    "description": "Tip 2 on the wizard journey page"
+  },
   "wizardJourneyTip3": "Connect to your own Bitcoin node",
-  "@wizardJourneyTip3": {"description": "Tip 3 on the wizard journey page"},
+  "@wizardJourneyTip3": {
+    "description": "Tip 3 on the wizard journey page"
+  },
   "wizardJourneyTip4": "Connect to your own Mempool explorer",
-  "@wizardJourneyTip4": {"description": "Tip 4 on the wizard journey page"},
+  "@wizardJourneyTip4": {
+    "description": "Tip 4 on the wizard journey page"
+  },
   "wizardJourneyTip5": "Transfer between Bitcoin and Liquid with no KYC",
-  "@wizardJourneyTip5": {"description": "Tip 5 on the wizard journey page"},
+  "@wizardJourneyTip5": {
+    "description": "Tip 5 on the wizard journey page"
+  },
   "wizardJourneyTip6": "Customize your autoswap settings",
-  "@wizardJourneyTip6": {"description": "Tip 6 on the wizard journey page"},
+  "@wizardJourneyTip6": {
+    "description": "Tip 6 on the wizard journey page"
+  },
   "wizardJourneyTip7": "Switch between Bitcoin (BTC) and Satoshis (sats)",
-  "@wizardJourneyTip7": {"description": "Tip 7 on the wizard journey page"},
+  "@wizardJourneyTip7": {
+    "description": "Tip 7 on the wizard journey page"
+  },
   "wizardJourneyTip8": "Create air-gapped transactions for your hardware wallet",
-  "@wizardJourneyTip8": {"description": "Tip 8 on the wizard journey page"}
+  "@wizardJourneyTip8": {
+    "description": "Tip 8 on the wizard journey page"
+  },
+  "legacyStorageHasBackupImportantBody": "Please do not skip this process unless you absolutely need to use the wallet urgently or waiting for a swap to complete.",
+  "@legacyStorageHasBackupImportantBody": {
+    "description": "Important callout body shown only on the reinstall variant of the legacy storage warning (when the user already has a verified backup)."
+  },
+  "legacyStorageRiskAckButtonHasBackup": "I understand the risk",
+  "@legacyStorageRiskAckButtonHasBackup": {
+    "description": "Risk-acknowledge button label on the reinstall variant of the legacy storage warning (no leading \"No,\" because there is no Backup Now alternative on this page)."
+  }
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -12858,7 +12858,7 @@
   "@legacyStorageStepEnsureSwapsCompleted": {
     "description": "Step in the legacy storage warning checklist instructing the user to wait for in-flight swaps"
   },
-  "legacyStorageStepUninstall": "Fully uninstall the app from your device",
+  "legacyStorageStepUninstall": "Uninstall the app from your device",
   "@legacyStorageStepUninstall": {
     "description": "Uninstall step in the legacy storage warning checklist"
   },

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -4611,5 +4611,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ACCIÓN REQUERIDA",
+  "legacyStorageBadgeConfirm": "CONFIRMAR",
+  "legacyStorageNoBackupPageTitle": "RESPALDA Y REINSTALA TU MONEDERO",
+  "legacyStorageHasBackupPageTitle": "REINSTALA TU MONEDERO",
+  "legacyStorageIntroDescription": "Tu monedero está corriendo sobre un software que pronto dejará de mantenerse. No se puede actualizar sin desinstalar y reinstalar la app.",
+  "legacyStorageStepBackupWallet": "Respalda tu monedero",
+  "legacyStorageStepExportLabels": "Exporta tus etiquetas (si tienes)",
+  "legacyStorageStepEnsureSwapsCompleted": "Asegúrate de que todos los swaps estén completados",
+  "legacyStorageStepUninstall": "Desinstala la app por completo de tu dispositivo",
+  "legacyStorageStepReinstall": "Descarga la última versión e instálala de nuevo",
+  "legacyStorageStepRestoreBackup": "Restaura tu respaldo",
+  "legacyStorageImportantTitle": "Importante",
+  "legacyStorageImportantBody": "No te saltes este proceso a menos que de verdad no puedas hacer un respaldo en este momento.",
+  "legacyStorageContinueFooterNoBackup": "Puedes seguir usando la app sin hacer un respaldo, pero te recomendamos firmemente no hacerlo.",
+  "legacyStorageContinueFooterHasBackup": "Puedes seguir usando la app, pero te recomendamos firmemente no hacerlo.",
+  "legacyStorageBackupNowButton": "Respaldar ahora",
+  "legacyStorageRiskAckButton": "No, entiendo el riesgo",
+  "legacyStorageAreYouSureTitle": "¿ESTÁS SEGURO?",
+  "legacyStorageAreYouSureParagraphOne": "El software que guarda las claves privadas de Bitcoin de tu monedero ya no se mantendrá. Te recomendamos firmemente hacer un respaldo ahora mismo para evitar problemas en el futuro.",
+  "legacyStorageAreYouSureParagraphTwo": "La opción de respaldo cifrado (Encrypted Vault) toma alrededor de 1 minuto y no necesita herramientas especiales. Para el respaldo físico solo necesitas lápiz y papel.",
+  "legacyStorageContinueWithoutBackupButton": "Continuar sin respaldo",
+  "legacyStorageAcceptRisksCheckbox": "Acepto los riesgos de no hacer un respaldo",
+  "legacyStorageHasBackupImportantBody": "Por favor, no omita este proceso a menos que necesite usar la billetera urgentemente o esté esperando a que se complete un intercambio.",
+  "legacyStorageRiskAckButtonHasBackup": "Entiendo el riesgo"
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -4620,7 +4620,7 @@
   "legacyStorageStepBackupWallet": "Respalda tu monedero",
   "legacyStorageStepExportLabels": "Exporta tus etiquetas (si tienes)",
   "legacyStorageStepEnsureSwapsCompleted": "Asegúrate de que todos los swaps estén completados",
-  "legacyStorageStepUninstall": "Desinstala la app por completo de tu dispositivo",
+  "legacyStorageStepUninstall": "Desinstala la aplicación de tu dispositivo",
   "legacyStorageStepReinstall": "Descarga la última versión e instálala de nuevo",
   "legacyStorageStepRestoreBackup": "Restaura tu respaldo",
   "legacyStorageImportantTitle": "Importante",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "از کیف پول خود نسخه پشتیبان بگیرید",
   "legacyStorageStepExportLabels": "برچسب‌های خود را خروجی بگیرید (اگر دارید)",
   "legacyStorageStepEnsureSwapsCompleted": "مطمئن شوید همه swap ها تکمیل شده‌اند",
-  "legacyStorageStepUninstall": "برنامه را کاملاً از دستگاه خود حذف کنید",
+  "legacyStorageStepUninstall": "برنامه را از دستگاه خود حذف کنید",
   "legacyStorageStepReinstall": "آخرین نسخه را دانلود کرده و دوباره نصب کنید",
   "legacyStorageStepRestoreBackup": "نسخه پشتیبان خود را بازیابی کنید",
   "legacyStorageImportantTitle": "مهم",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "اقدام لازم است",
+  "legacyStorageBadgeConfirm": "تأیید",
+  "legacyStorageNoBackupPageTitle": "از کیف پول خود نسخه پشتیبان بگیرید و دوباره نصب کنید",
+  "legacyStorageHasBackupPageTitle": "کیف پول خود را دوباره نصب کنید",
+  "legacyStorageIntroDescription": "کیف پول شما روی نرم‌افزاری اجرا می‌شود که به‌زودی منسوخ می‌شود. بدون حذف و نصب مجدد برنامه نمی‌توان آن را به‌روزرسانی کرد.",
+  "legacyStorageStepBackupWallet": "از کیف پول خود نسخه پشتیبان بگیرید",
+  "legacyStorageStepExportLabels": "برچسب‌های خود را خروجی بگیرید (اگر دارید)",
+  "legacyStorageStepEnsureSwapsCompleted": "مطمئن شوید همه swap ها تکمیل شده‌اند",
+  "legacyStorageStepUninstall": "برنامه را کاملاً از دستگاه خود حذف کنید",
+  "legacyStorageStepReinstall": "آخرین نسخه را دانلود کرده و دوباره نصب کنید",
+  "legacyStorageStepRestoreBackup": "نسخه پشتیبان خود را بازیابی کنید",
+  "legacyStorageImportantTitle": "مهم",
+  "legacyStorageImportantBody": "این مراحل را رد نکنید مگر آنکه واقعاً در این لحظه نتوانید پشتیبان بگیرید.",
+  "legacyStorageContinueFooterNoBackup": "می‌توانید بدون گرفتن پشتیبان از برنامه استفاده کنید، اما ما اکیداً توصیه می‌کنیم این کار را نکنید.",
+  "legacyStorageContinueFooterHasBackup": "می‌توانید از برنامه استفاده کنید، اما ما اکیداً توصیه می‌کنیم این کار را نکنید.",
+  "legacyStorageBackupNowButton": "همین حالا پشتیبان بگیر",
+  "legacyStorageRiskAckButton": "نه، خطر را می‌فهمم",
+  "legacyStorageAreYouSureTitle": "مطمئن هستید؟",
+  "legacyStorageAreYouSureParagraphOne": "نرم‌افزاری که کلیدهای خصوصی بیت‌کوین کیف پول شما را ذخیره می‌کند در حال منسوخ شدن است. اکیداً توصیه می‌کنیم همین حالا یک پشتیبان بگیرید تا در آینده دچار اختلال نشوید.",
+  "legacyStorageAreYouSureParagraphTwo": "گزینه Encrypted Vault حدود ۱ دقیقه طول می‌کشد و به ابزار خاصی نیاز ندارد. برای پشتیبان فیزیکی، فقط به قلم و کاغذ نیاز دارید.",
+  "legacyStorageContinueWithoutBackupButton": "ادامه بدون پشتیبان",
+  "legacyStorageAcceptRisksCheckbox": "ریسک‌های نگرفتن پشتیبان را می‌پذیرم",
+  "legacyStorageHasBackupImportantBody": "لطفاً این فرآیند را رد نکنید مگر اینکه واقعاً نیاز فوری به استفاده از کیف پول داشته باشید یا منتظر تکمیل یک سواپ هستید.",
+  "legacyStorageRiskAckButtonHasBackup": "خطر را درک می‌کنم"
 }

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4606,7 +4606,7 @@
   "legacyStorageStepBackupWallet": "Varmuuskopioi lompakkosi",
   "legacyStorageStepExportLabels": "Vie tunnisteesi (jos sinulla on)",
   "legacyStorageStepEnsureSwapsCompleted": "Varmista, että kaikki swapit ovat valmistuneet",
-  "legacyStorageStepUninstall": "Poista sovellus kokonaan laitteeltasi",
+  "legacyStorageStepUninstall": "Poista sovellus laitteeltasi",
   "legacyStorageStepReinstall": "Lataa uusin versio ja asenna se uudelleen",
   "legacyStorageStepRestoreBackup": "Palauta varmuuskopiosi",
   "legacyStorageImportantTitle": "Tärkeää",

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4597,5 +4597,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "TOIMENPIDE VAADITAAN",
+  "legacyStorageBadgeConfirm": "VAHVISTA",
+  "legacyStorageNoBackupPageTitle": "VARMUUSKOPIOI JA ASENNA LOMPAKKO UUDELLEEN",
+  "legacyStorageHasBackupPageTitle": "ASENNA LOMPAKKO UUDELLEEN",
+  "legacyStorageIntroDescription": "Lompakkosi käyttää ohjelmistoa, jonka tuki on pian päättymässä. Sitä ei voi päivittää poistamatta ja asentamatta sovellusta uudelleen.",
+  "legacyStorageStepBackupWallet": "Varmuuskopioi lompakkosi",
+  "legacyStorageStepExportLabels": "Vie tunnisteesi (jos sinulla on)",
+  "legacyStorageStepEnsureSwapsCompleted": "Varmista, että kaikki swapit ovat valmistuneet",
+  "legacyStorageStepUninstall": "Poista sovellus kokonaan laitteeltasi",
+  "legacyStorageStepReinstall": "Lataa uusin versio ja asenna se uudelleen",
+  "legacyStorageStepRestoreBackup": "Palauta varmuuskopiosi",
+  "legacyStorageImportantTitle": "Tärkeää",
+  "legacyStorageImportantBody": "Älä ohita tätä prosessia, ellet todella pysty tekemään varmuuskopiota juuri nyt.",
+  "legacyStorageContinueFooterNoBackup": "Voit jatkaa sovelluksen käyttöä ilman varmuuskopiota, mutta suosittelemme vahvasti ettet tee niin.",
+  "legacyStorageContinueFooterHasBackup": "Voit jatkaa sovelluksen käyttöä, mutta suosittelemme vahvasti ettet tee niin.",
+  "legacyStorageBackupNowButton": "Varmuuskopioi nyt",
+  "legacyStorageRiskAckButton": "Ei, ymmärrän riskin",
+  "legacyStorageAreYouSureTitle": "OLETKO VARMA?",
+  "legacyStorageAreYouSureParagraphOne": "Lompakkosi Bitcoin-yksityisavainten tallentamiseen käytetyn ohjelmiston tuki on päättymässä. Suosittelemme vahvasti varmuuskopion ottamista heti, jotta vältät keskeytykset tulevaisuudessa.",
+  "legacyStorageAreYouSureParagraphTwo": "Salattu Vault -varmuuskopiointi vie noin minuutin eikä vaadi erityisiä työkaluja. Fyysiseen varmuuskopioon tarvitset vain kynän ja paperia.",
+  "legacyStorageContinueWithoutBackupButton": "Jatka ilman varmuuskopiota",
+  "legacyStorageAcceptRisksCheckbox": "Hyväksyn riskit siitä, etten tee varmuuskopiota",
+  "legacyStorageHasBackupImportantBody": "Älä ohita tätä prosessia, ellet ehdottomasti tarvitse lompakkoa kiireellisesti tai odota swapin valmistumista.",
+  "legacyStorageRiskAckButtonHasBackup": "Ymmärrän riskin"
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -4594,5 +4594,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ACTION REQUISE",
+  "legacyStorageBadgeConfirm": "CONFIRMER",
+  "legacyStorageNoBackupPageTitle": "SAUVEGARDEZ ET RÉINSTALLEZ VOTRE PORTEFEUILLE",
+  "legacyStorageHasBackupPageTitle": "RÉINSTALLEZ VOTRE PORTEFEUILLE",
+  "legacyStorageIntroDescription": "Votre portefeuille fonctionne avec un logiciel qui sera bientôt obsolète. Il ne peut pas être mis à jour sans désinstaller et réinstaller l'application.",
+  "legacyStorageStepBackupWallet": "Sauvegardez votre portefeuille",
+  "legacyStorageStepExportLabels": "Exportez vos étiquettes (si vous en avez)",
+  "legacyStorageStepEnsureSwapsCompleted": "Assurez-vous que tous les swaps sont terminés",
+  "legacyStorageStepUninstall": "Désinstallez complètement l'application de votre appareil",
+  "legacyStorageStepReinstall": "Téléchargez la dernière version et réinstallez",
+  "legacyStorageStepRestoreBackup": "Restaurez votre sauvegarde",
+  "legacyStorageImportantTitle": "Important",
+  "legacyStorageImportantBody": "Ne sautez pas cette procédure à moins que vous ne puissiez vraiment pas faire de sauvegarde en ce moment.",
+  "legacyStorageContinueFooterNoBackup": "Vous pouvez continuer à utiliser l'application sans sauvegarde, mais nous vous le déconseillons fortement.",
+  "legacyStorageContinueFooterHasBackup": "Vous pouvez continuer à utiliser l'application, mais nous vous le déconseillons fortement.",
+  "legacyStorageBackupNowButton": "Sauvegarder maintenant",
+  "legacyStorageRiskAckButton": "Non, je comprends le risque",
+  "legacyStorageAreYouSureTitle": "ÊTES-VOUS SÛR ?",
+  "legacyStorageAreYouSureParagraphOne": "Le logiciel utilisé pour stocker les clés privées Bitcoin de votre portefeuille est en fin de vie. Nous vous recommandons fortement de faire une sauvegarde maintenant pour éviter toute interruption à l'avenir.",
+  "legacyStorageAreYouSureParagraphTwo": "L'option Encrypted Vault prend environ 1 minute et ne nécessite aucun outil spécial. Pour la sauvegarde physique, il vous suffit d'un stylo et de papier.",
+  "legacyStorageContinueWithoutBackupButton": "Continuer sans sauvegarde",
+  "legacyStorageAcceptRisksCheckbox": "J'accepte les risques de ne pas faire de sauvegarde",
+  "legacyStorageHasBackupImportantBody": "Veuillez ne pas ignorer ce processus, sauf si vous devez absolument utiliser le portefeuille en urgence ou si vous attendez qu'un swap se termine.",
+  "legacyStorageRiskAckButtonHasBackup": "Je comprends le risque"
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -4603,7 +4603,7 @@
   "legacyStorageStepBackupWallet": "Sauvegardez votre portefeuille",
   "legacyStorageStepExportLabels": "Exportez vos étiquettes (si vous en avez)",
   "legacyStorageStepEnsureSwapsCompleted": "Assurez-vous que tous les swaps sont terminés",
-  "legacyStorageStepUninstall": "Désinstallez complètement l'application de votre appareil",
+  "legacyStorageStepUninstall": "Désinstallez l'application de votre appareil",
   "legacyStorageStepReinstall": "Téléchargez la dernière version et réinstallez",
   "legacyStorageStepRestoreBackup": "Restaurez votre sauvegarde",
   "legacyStorageImportantTitle": "Important",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "अपना वॉलेट बैकअप लें",
   "legacyStorageStepExportLabels": "अपने लेबल एक्सपोर्ट करें (अगर हों)",
   "legacyStorageStepEnsureSwapsCompleted": "सुनिश्चित करें कि सभी स्वैप पूरे हो चुके हैं",
-  "legacyStorageStepUninstall": "ऐप को अपने डिवाइस से पूरी तरह अनइंस्टॉल करें",
+  "legacyStorageStepUninstall": "अपने डिवाइस से ऐप को अनइंस्टॉल करें",
   "legacyStorageStepReinstall": "नवीनतम संस्करण डाउनलोड करें और फिर से इंस्टॉल करें",
   "legacyStorageStepRestoreBackup": "अपना बैकअप पुनर्स्थापित करें",
   "legacyStorageImportantTitle": "महत्वपूर्ण",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "कार्रवाई आवश्यक",
+  "legacyStorageBadgeConfirm": "पुष्टि करें",
+  "legacyStorageNoBackupPageTitle": "अपना वॉलेट बैकअप लें और फिर से इंस्टॉल करें",
+  "legacyStorageHasBackupPageTitle": "अपना वॉलेट फिर से इंस्टॉल करें",
+  "legacyStorageIntroDescription": "आपका वॉलेट ऐसे सॉफ़्टवेयर पर चल रहा है जिसे जल्द बंद किया जा रहा है। इसे ऐप अनइंस्टॉल किए बिना और दोबारा इंस्टॉल किए बिना अपडेट नहीं किया जा सकता।",
+  "legacyStorageStepBackupWallet": "अपना वॉलेट बैकअप लें",
+  "legacyStorageStepExportLabels": "अपने लेबल एक्सपोर्ट करें (अगर हों)",
+  "legacyStorageStepEnsureSwapsCompleted": "सुनिश्चित करें कि सभी स्वैप पूरे हो चुके हैं",
+  "legacyStorageStepUninstall": "ऐप को अपने डिवाइस से पूरी तरह अनइंस्टॉल करें",
+  "legacyStorageStepReinstall": "नवीनतम संस्करण डाउनलोड करें और फिर से इंस्टॉल करें",
+  "legacyStorageStepRestoreBackup": "अपना बैकअप पुनर्स्थापित करें",
+  "legacyStorageImportantTitle": "महत्वपूर्ण",
+  "legacyStorageImportantBody": "इस प्रक्रिया को तभी छोड़ें जब आप सचमुच इस वक़्त बैकअप नहीं ले सकते।",
+  "legacyStorageContinueFooterNoBackup": "आप बैकअप लिए बिना भी ऐप का इस्तेमाल जारी रख सकते हैं, लेकिन हम इसकी पुरज़ोर सलाह नहीं देते।",
+  "legacyStorageContinueFooterHasBackup": "आप ऐप का इस्तेमाल जारी रख सकते हैं, लेकिन हम इसकी पुरज़ोर सलाह नहीं देते।",
+  "legacyStorageBackupNowButton": "अभी बैकअप लें",
+  "legacyStorageRiskAckButton": "नहीं, मैं जोखिम समझता हूँ",
+  "legacyStorageAreYouSureTitle": "क्या आप निश्चित हैं?",
+  "legacyStorageAreYouSureParagraphOne": "आपके वॉलेट की Bitcoin प्राइवेट कीज़ संग्रहित करने वाला सॉफ़्टवेयर बंद हो रहा है। भविष्य में किसी रुकावट से बचने के लिए हम पुरज़ोर सलाह देते हैं कि आप अभी बैकअप लें।",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault बैकअप विकल्प में लगभग 1 मिनट लगता है, कोई विशेष उपकरण नहीं चाहिए। फ़िज़िकल बैकअप के लिए सिर्फ़ कलम और कागज़ चाहिए।",
+  "legacyStorageContinueWithoutBackupButton": "बैकअप के बिना जारी रखें",
+  "legacyStorageAcceptRisksCheckbox": "मैं बैकअप न लेने के जोखिम स्वीकार करता हूँ",
+  "legacyStorageHasBackupImportantBody": "कृपया इस प्रक्रिया को न छोड़ें जब तक कि आपको तत्काल वॉलेट का उपयोग करने की नितांत आवश्यकता न हो या आप किसी स्वैप के पूरा होने की प्रतीक्षा कर रहे हों।",
+  "legacyStorageRiskAckButtonHasBackup": "मैं जोखिम समझता हूँ"
 }

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -189,7 +189,7 @@
   "legacyStorageStepBackupWallet": "Պահուստավորեք ձեր դրամապանակը",
   "legacyStorageStepExportLabels": "Արտահանեք ձեր պիտակները (եթե կան)",
   "legacyStorageStepEnsureSwapsCompleted": "Համոզվեք, որ բոլոր փոխանակումներն ավարտված են",
-  "legacyStorageStepUninstall": "Հեռացրեք հավելվածը ձեր սարքից ամբողջությամբ",
+  "legacyStorageStepUninstall": "Ապատեղադրեք հավելվածը ձեր սարքից",
   "legacyStorageStepReinstall": "Ներբեռնեք ամենավերջին տարբերակը և նորից տեղադրեք",
   "legacyStorageStepRestoreBackup": "Վերականգնեք ձեր պահուստը",
   "legacyStorageImportantTitle": "Կարևոր",

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -180,5 +180,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ՊԱՀԱՆՋՎՈՒՄ Է ԳՈՐԾՈՂՈՒԹՅՈՒՆ",
+  "legacyStorageBadgeConfirm": "ՀԱՍՏԱՏԵԼ",
+  "legacyStorageNoBackupPageTitle": "ՊԱՀՈՒՍՏԱՎՈՐԵՔ ԵՎ ՎԵՐԱԿԱՆԳՆԵՔ ՁԵՐ ԴՐԱՄԱՊԱՆԱԿԸ",
+  "legacyStorageHasBackupPageTitle": "ՎԵՐԱԿԱՆԳՆԵՔ ՁԵՐ ԴՐԱՄԱՊԱՆԱԿԸ",
+  "legacyStorageIntroDescription": "Ձեր դրամապանակն աշխատում է ծրագրաշարով, որը շուտով կդադարեցվի։ Այն չի կարող թարմացվել առանց հավելվածը հեռացնելու և նորից տեղադրելու։",
+  "legacyStorageStepBackupWallet": "Պահուստավորեք ձեր դրամապանակը",
+  "legacyStorageStepExportLabels": "Արտահանեք ձեր պիտակները (եթե կան)",
+  "legacyStorageStepEnsureSwapsCompleted": "Համոզվեք, որ բոլոր փոխանակումներն ավարտված են",
+  "legacyStorageStepUninstall": "Հեռացրեք հավելվածը ձեր սարքից ամբողջությամբ",
+  "legacyStorageStepReinstall": "Ներբեռնեք ամենավերջին տարբերակը և նորից տեղադրեք",
+  "legacyStorageStepRestoreBackup": "Վերականգնեք ձեր պահուստը",
+  "legacyStorageImportantTitle": "Կարևոր",
+  "legacyStorageImportantBody": "Մի բաց թողեք այս գործընթացը, քանի դեռ իսկապես չեք կարող այս պահին պահուստավորում անել։",
+  "legacyStorageContinueFooterNoBackup": "Կարող եք շարունակել օգտվել հավելվածից առանց պահուստավորման, բայց մենք խստորեն խորհուրդ ենք տալիս չանել այդպես։",
+  "legacyStorageContinueFooterHasBackup": "Կարող եք շարունակել օգտվել հավելվածից, բայց մենք խստորեն խորհուրդ ենք տալիս չանել այդպես։",
+  "legacyStorageBackupNowButton": "Պահուստավորել հիմա",
+  "legacyStorageRiskAckButton": "Ոչ, ես հասկանում եմ ռիսկը",
+  "legacyStorageAreYouSureTitle": "ՎՍՏԱ՞Հ ԵՔ",
+  "legacyStorageAreYouSureParagraphOne": "Ձեր դրամապանակի Bitcoin մասնավոր բանալիների պահպանման համար օգտագործվող ծրագրաշարը դադարեցվում է։ Խստորեն խորհուրդ ենք տալիս հենց հիմա պահուստավորում անել՝ ապագայում խանգարումներից խուսափելու համար։",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault պահուստավորման տարբերակը տևում է մոտ 1 րոպե և չի պահանջում հատուկ գործիքներ։ Ֆիզիկական պահուստավորման համար ձեզ անհրաժեշտ է միայն գրիչ և թուղթ։",
+  "legacyStorageContinueWithoutBackupButton": "Շարունակել առանց պահուստավորման",
+  "legacyStorageAcceptRisksCheckbox": "Ընդունում եմ պահուստավորում չանելու ռիսկերը",
+  "legacyStorageHasBackupImportantBody": "Խնդրում ենք բաց չթողնել այս գործընթացը, եթե ձեզ հրատապ չի անհրաժեշտ օգտագործել դրամապանակը կամ սպասում եք սվոփի ավարտին։",
+  "legacyStorageRiskAckButtonHasBackup": "Ես հասկանում եմ ռիսկը"
 }

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -4614,7 +4614,7 @@
   "legacyStorageStepBackupWallet": "Esegui il backup del portafoglio",
   "legacyStorageStepExportLabels": "Esporta le tue etichette (se ne hai)",
   "legacyStorageStepEnsureSwapsCompleted": "Assicurati che tutti gli swap siano completati",
-  "legacyStorageStepUninstall": "Disinstalla completamente l'app dal tuo dispositivo",
+  "legacyStorageStepUninstall": "Disinstalla l'app dal tuo dispositivo",
   "legacyStorageStepReinstall": "Scarica la versione più recente e reinstalla",
   "legacyStorageStepRestoreBackup": "Ripristina il tuo backup",
   "legacyStorageImportantTitle": "Importante",

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -4605,5 +4605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "AZIONE RICHIESTA",
+  "legacyStorageBadgeConfirm": "CONFERMA",
+  "legacyStorageNoBackupPageTitle": "ESEGUI BACKUP E REINSTALLA IL PORTAFOGLIO",
+  "legacyStorageHasBackupPageTitle": "REINSTALLA IL PORTAFOGLIO",
+  "legacyStorageIntroDescription": "Il tuo portafoglio funziona su un software che presto verrà dismesso. Non può essere aggiornato senza disinstallare e reinstallare l'app.",
+  "legacyStorageStepBackupWallet": "Esegui il backup del portafoglio",
+  "legacyStorageStepExportLabels": "Esporta le tue etichette (se ne hai)",
+  "legacyStorageStepEnsureSwapsCompleted": "Assicurati che tutti gli swap siano completati",
+  "legacyStorageStepUninstall": "Disinstalla completamente l'app dal tuo dispositivo",
+  "legacyStorageStepReinstall": "Scarica la versione più recente e reinstalla",
+  "legacyStorageStepRestoreBackup": "Ripristina il tuo backup",
+  "legacyStorageImportantTitle": "Importante",
+  "legacyStorageImportantBody": "Non saltare questa procedura a meno che proprio non sia possibile fare un backup in questo momento.",
+  "legacyStorageContinueFooterNoBackup": "Puoi continuare a usare l'app senza fare un backup, ma sconsigliamo vivamente di farlo.",
+  "legacyStorageContinueFooterHasBackup": "Puoi continuare a usare l'app, ma sconsigliamo vivamente di farlo.",
+  "legacyStorageBackupNowButton": "Esegui backup ora",
+  "legacyStorageRiskAckButton": "No, capisco il rischio",
+  "legacyStorageAreYouSureTitle": "SEI SICURO?",
+  "legacyStorageAreYouSureParagraphOne": "Il software che custodisce le chiavi private Bitcoin del tuo portafoglio sta per essere dismesso. Ti consigliamo vivamente di fare un backup adesso per evitare interruzioni in futuro.",
+  "legacyStorageAreYouSureParagraphTwo": "L'opzione Encrypted Vault impiega circa 1 minuto e non richiede strumenti speciali. Per il backup fisico ti basta carta e penna.",
+  "legacyStorageContinueWithoutBackupButton": "Continua senza backup",
+  "legacyStorageAcceptRisksCheckbox": "Accetto i rischi di non fare un backup",
+  "legacyStorageHasBackupImportantBody": "Si prega di non saltare questo processo a meno che non sia assolutamente necessario utilizzare il portafoglio con urgenza o si stia aspettando il completamento di uno swap.",
+  "legacyStorageRiskAckButtonHasBackup": "Capisco il rischio"
 }

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -392,5 +392,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ქმედება საჭიროა",
+  "legacyStorageBadgeConfirm": "დადასტურება",
+  "legacyStorageNoBackupPageTitle": "შექმენით სარეზერვო ასლი და დააინსტალირეთ თავიდან საფულე",
+  "legacyStorageHasBackupPageTitle": "თავიდან დააინსტალირეთ საფულე",
+  "legacyStorageIntroDescription": "თქვენი საფულე მუშაობს პროგრამაზე, რომელიც მალე აღარ იქნება მხარდაჭერილი. მისი განახლება შეუძლებელია აპლიკაციის წაშლისა და თავიდან ინსტალაციის გარეშე.",
+  "legacyStorageStepBackupWallet": "შექმენით საფულის სარეზერვო ასლი",
+  "legacyStorageStepExportLabels": "ექსპორტი გაუკეთეთ თქვენს ლეიბლებს (თუ გაქვთ)",
+  "legacyStorageStepEnsureSwapsCompleted": "დარწმუნდით, რომ ყველა swap დასრულებულია",
+  "legacyStorageStepUninstall": "სრულად წაშალეთ აპლიკაცია თქვენი მოწყობილობიდან",
+  "legacyStorageStepReinstall": "ჩამოტვირთეთ უახლესი ვერსია და თავიდან დააინსტალირეთ",
+  "legacyStorageStepRestoreBackup": "აღადგინეთ თქვენი სარეზერვო ასლი",
+  "legacyStorageImportantTitle": "მნიშვნელოვანი",
+  "legacyStorageImportantBody": "ნუ გამოტოვებთ ამ პროცესს, თუ ნამდვილად არ შეგიძლიათ ამ მომენტში სარეზერვო ასლის შექმნა.",
+  "legacyStorageContinueFooterNoBackup": "შეგიძლიათ გააგრძელოთ აპის გამოყენება სარეზერვო ასლის გარეშეც, მაგრამ მტკიცედ გირჩევთ, რომ ასე არ მოიქცეთ.",
+  "legacyStorageContinueFooterHasBackup": "შეგიძლიათ გააგრძელოთ აპის გამოყენება, მაგრამ მტკიცედ გირჩევთ, რომ ასე არ მოიქცეთ.",
+  "legacyStorageBackupNowButton": "სარეზერვო ასლი ახლავე",
+  "legacyStorageRiskAckButton": "არა, ვაცნობიერებ რისკს",
+  "legacyStorageAreYouSureTitle": "დარწმუნებული ხართ?",
+  "legacyStorageAreYouSureParagraphOne": "თქვენი საფულის Bitcoin-ის პირადი გასაღებების შესანახად გამოყენებული პროგრამა მხარდაჭერას წყვეტს. მკაცრად გირჩევთ ახლავე შექმნათ სარეზერვო ასლი, რათა მომავალში პრობლემები არ შეგექმნათ.",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault სარეზერვო ასლის ოფცია იღებს დაახლოებით 1 წუთს და სპეციალური ხელსაწყოები არ ჭირდება. ფიზიკური სარეზერვო ასლისთვის სულ რაც გჭირდებათ კალამი და ქაღალდია.",
+  "legacyStorageContinueWithoutBackupButton": "გაგრძელება სარეზერვო ასლის გარეშე",
+  "legacyStorageAcceptRisksCheckbox": "ვაღიარებ რისკებს, რომ სარეზერვო ასლი არ მაქვს",
+  "legacyStorageHasBackupImportantBody": "გთხოვთ, არ გამოტოვოთ ეს პროცესი, თუ არ გჭირდებათ საფულის გადაუდებელი გამოყენება ან არ ელოდებით სვოპის დასრულებას.",
+  "legacyStorageRiskAckButtonHasBackup": "მესმის რისკი"
 }

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -401,7 +401,7 @@
   "legacyStorageStepBackupWallet": "შექმენით საფულის სარეზერვო ასლი",
   "legacyStorageStepExportLabels": "ექსპორტი გაუკეთეთ თქვენს ლეიბლებს (თუ გაქვთ)",
   "legacyStorageStepEnsureSwapsCompleted": "დარწმუნდით, რომ ყველა swap დასრულებულია",
-  "legacyStorageStepUninstall": "სრულად წაშალეთ აპლიკაცია თქვენი მოწყობილობიდან",
+  "legacyStorageStepUninstall": "წაშალეთ აპლიკაცია თქვენი მოწყობილობიდან",
   "legacyStorageStepReinstall": "ჩამოტვირთეთ უახლესი ვერსია და თავიდან დააინსტალირეთ",
   "legacyStorageStepRestoreBackup": "აღადგინეთ თქვენი სარეზერვო ასლი",
   "legacyStorageImportantTitle": "მნიშვნელოვანი",

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "조치 필요",
+  "legacyStorageBadgeConfirm": "확인",
+  "legacyStorageNoBackupPageTitle": "지갑을 백업하고 다시 설치하세요",
+  "legacyStorageHasBackupPageTitle": "지갑을 다시 설치하세요",
+  "legacyStorageIntroDescription": "지갑이 곧 지원이 종료될 소프트웨어에서 동작 중입니다. 앱을 삭제하고 다시 설치하지 않으면 업데이트할 수 없습니다.",
+  "legacyStorageStepBackupWallet": "지갑을 백업하세요",
+  "legacyStorageStepExportLabels": "라벨이 있다면 내보내세요",
+  "legacyStorageStepEnsureSwapsCompleted": "모든 스왑이 완료되었는지 확인하세요",
+  "legacyStorageStepUninstall": "앱을 기기에서 완전히 삭제하세요",
+  "legacyStorageStepReinstall": "최신 버전을 다운로드해 다시 설치하세요",
+  "legacyStorageStepRestoreBackup": "백업을 복원하세요",
+  "legacyStorageImportantTitle": "중요",
+  "legacyStorageImportantBody": "지금 정말로 백업을 할 수 없는 경우가 아니라면 이 절차를 건너뛰지 마세요.",
+  "legacyStorageContinueFooterNoBackup": "백업 없이 앱을 계속 사용할 수도 있지만, 그렇게 하지 않을 것을 강력히 권장합니다.",
+  "legacyStorageContinueFooterHasBackup": "앱을 계속 사용할 수도 있지만, 그렇게 하지 않을 것을 강력히 권장합니다.",
+  "legacyStorageBackupNowButton": "지금 백업",
+  "legacyStorageRiskAckButton": "아니요, 위험을 이해합니다",
+  "legacyStorageAreYouSureTitle": "정말 진행하시겠습니까?",
+  "legacyStorageAreYouSureParagraphOne": "지갑의 비트코인 개인키를 보관하는 소프트웨어가 지원 종료됩니다. 향후 문제를 방지하기 위해 지금 즉시 백업할 것을 강력히 권장합니다.",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault 백업 옵션은 약 1분 정도 소요되며 별도의 도구가 필요 없습니다. 물리 백업을 사용하는 경우 펜과 종이만 있으면 됩니다.",
+  "legacyStorageContinueWithoutBackupButton": "백업 없이 계속",
+  "legacyStorageAcceptRisksCheckbox": "백업을 하지 않는 위험을 감수합니다",
+  "legacyStorageHasBackupImportantBody": "지갑을 긴급하게 사용해야 하거나 스왑이 완료되기를 기다리는 경우가 아니라면 이 과정을 건너뛰지 마세요.",
+  "legacyStorageRiskAckButtonHasBackup": "위험을 이해합니다"
 }

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "지갑을 백업하세요",
   "legacyStorageStepExportLabels": "라벨이 있다면 내보내세요",
   "legacyStorageStepEnsureSwapsCompleted": "모든 스왑이 완료되었는지 확인하세요",
-  "legacyStorageStepUninstall": "앱을 기기에서 완전히 삭제하세요",
+  "legacyStorageStepUninstall": "기기에서 앱을 삭제하세요",
   "legacyStorageStepReinstall": "최신 버전을 다운로드해 다시 설치하세요",
   "legacyStorageStepRestoreBackup": "백업을 복원하세요",
   "legacyStorageImportantTitle": "중요",

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -4669,7 +4669,7 @@
   "legacyStorageStepBackupWallet": "Faça backup da sua carteira",
   "legacyStorageStepExportLabels": "Exporte as suas etiquetas (se as tiver)",
   "legacyStorageStepEnsureSwapsCompleted": "Certifique-se de que todos os swaps estão concluídos",
-  "legacyStorageStepUninstall": "Desinstale completamente a aplicação do seu dispositivo",
+  "legacyStorageStepUninstall": "Desinstale a aplicação do seu dispositivo",
   "legacyStorageStepReinstall": "Descarregue a versão mais recente e reinstale",
   "legacyStorageStepRestoreBackup": "Restaure o seu backup",
   "legacyStorageImportantTitle": "Importante",

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -4660,5 +4660,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "AÇÃO NECESSÁRIA",
+  "legacyStorageBadgeConfirm": "CONFIRMAR",
+  "legacyStorageNoBackupPageTitle": "FAÇA BACKUP E REINSTALE A SUA CARTEIRA",
+  "legacyStorageHasBackupPageTitle": "REINSTALE A SUA CARTEIRA",
+  "legacyStorageIntroDescription": "A sua carteira está a correr num software que vai deixar de ser suportado em breve. Não pode ser atualizado sem desinstalar e reinstalar a aplicação.",
+  "legacyStorageStepBackupWallet": "Faça backup da sua carteira",
+  "legacyStorageStepExportLabels": "Exporte as suas etiquetas (se as tiver)",
+  "legacyStorageStepEnsureSwapsCompleted": "Certifique-se de que todos os swaps estão concluídos",
+  "legacyStorageStepUninstall": "Desinstale completamente a aplicação do seu dispositivo",
+  "legacyStorageStepReinstall": "Descarregue a versão mais recente e reinstale",
+  "legacyStorageStepRestoreBackup": "Restaure o seu backup",
+  "legacyStorageImportantTitle": "Importante",
+  "legacyStorageImportantBody": "Não salte este processo a menos que mesmo não consiga fazer um backup neste momento.",
+  "legacyStorageContinueFooterNoBackup": "Pode continuar a usar a aplicação sem fazer backup, mas desaconselhamos vivamente.",
+  "legacyStorageContinueFooterHasBackup": "Pode continuar a usar a aplicação, mas desaconselhamos vivamente.",
+  "legacyStorageBackupNowButton": "Fazer backup agora",
+  "legacyStorageRiskAckButton": "Não, percebo o risco",
+  "legacyStorageAreYouSureTitle": "TEM A CERTEZA?",
+  "legacyStorageAreYouSureParagraphOne": "O software usado para guardar as chaves privadas Bitcoin da sua carteira está a ser descontinuado. Recomendamos vivamente que faça já um backup para evitar quaisquer problemas no futuro.",
+  "legacyStorageAreYouSureParagraphTwo": "A opção Encrypted Vault demora cerca de 1 minuto e não precisa de ferramentas especiais. Para o backup físico só precisa de uma caneta e papel.",
+  "legacyStorageContinueWithoutBackupButton": "Continuar sem backup",
+  "legacyStorageAcceptRisksCheckbox": "Aceito os riscos de não fazer um backup",
+  "legacyStorageHasBackupImportantBody": "Por favor, não ignore este processo, a menos que precise mesmo de usar a carteira urgentemente ou esteja à espera que uma troca seja concluída.",
+  "legacyStorageRiskAckButtonHasBackup": "Compreendo o risco"
 }

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -12601,5 +12601,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "AÇÃO NECESSÁRIA",
+  "legacyStorageBadgeConfirm": "CONFIRMAR",
+  "legacyStorageNoBackupPageTitle": "FAÇA BACKUP E REINSTALE SUA CARTEIRA",
+  "legacyStorageHasBackupPageTitle": "REINSTALE SUA CARTEIRA",
+  "legacyStorageIntroDescription": "Sua carteira está rodando em um software que em breve será descontinuado. Ele não pode ser atualizado sem desinstalar e reinstalar o aplicativo.",
+  "legacyStorageStepBackupWallet": "Faça backup da sua carteira",
+  "legacyStorageStepExportLabels": "Exporte seus rótulos (se tiver)",
+  "legacyStorageStepEnsureSwapsCompleted": "Certifique-se de que todos os swaps foram concluídos",
+  "legacyStorageStepUninstall": "Desinstale completamente o aplicativo do seu dispositivo",
+  "legacyStorageStepReinstall": "Baixe a versão mais recente e reinstale",
+  "legacyStorageStepRestoreBackup": "Restaure seu backup",
+  "legacyStorageImportantTitle": "Importante",
+  "legacyStorageImportantBody": "Não pule este processo a menos que realmente não consiga fazer um backup neste momento.",
+  "legacyStorageContinueFooterNoBackup": "Você pode continuar usando o aplicativo sem fazer backup, mas desaconselhamos fortemente.",
+  "legacyStorageContinueFooterHasBackup": "Você pode continuar usando o aplicativo, mas desaconselhamos fortemente.",
+  "legacyStorageBackupNowButton": "Fazer backup agora",
+  "legacyStorageRiskAckButton": "Não, entendo o risco",
+  "legacyStorageAreYouSureTitle": "TEM CERTEZA?",
+  "legacyStorageAreYouSureParagraphOne": "O software usado para guardar as chaves privadas Bitcoin da sua carteira está sendo descontinuado. Recomendamos fortemente que você faça um backup agora para evitar problemas no futuro.",
+  "legacyStorageAreYouSureParagraphTwo": "A opção Encrypted Vault leva cerca de 1 minuto e não precisa de ferramentas especiais. Para o backup físico, basta caneta e papel.",
+  "legacyStorageContinueWithoutBackupButton": "Continuar sem backup",
+  "legacyStorageAcceptRisksCheckbox": "Aceito os riscos de não fazer backup",
+  "legacyStorageHasBackupImportantBody": "Por favor, não pule este processo, a menos que você precise usar a carteira urgentemente ou esteja esperando uma troca ser concluída.",
+  "legacyStorageRiskAckButtonHasBackup": "Eu entendo o risco"
 }

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -12610,7 +12610,7 @@
   "legacyStorageStepBackupWallet": "Faça backup da sua carteira",
   "legacyStorageStepExportLabels": "Exporte seus rótulos (se tiver)",
   "legacyStorageStepEnsureSwapsCompleted": "Certifique-se de que todos os swaps foram concluídos",
-  "legacyStorageStepUninstall": "Desinstale completamente o aplicativo do seu dispositivo",
+  "legacyStorageStepUninstall": "Desinstale o aplicativo do seu dispositivo",
   "legacyStorageStepReinstall": "Baixe a versão mais recente e reinstale",
   "legacyStorageStepRestoreBackup": "Restaure seu backup",
   "legacyStorageImportantTitle": "Importante",

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -4623,7 +4623,7 @@
   "legacyStorageStepBackupWallet": "Сделайте резервную копию кошелька",
   "legacyStorageStepExportLabels": "Экспортируйте свои метки (если они есть)",
   "legacyStorageStepEnsureSwapsCompleted": "Убедитесь, что все обмены (swap) завершены",
-  "legacyStorageStepUninstall": "Полностью удалите приложение с устройства",
+  "legacyStorageStepUninstall": "Удалите приложение с вашего устройства",
   "legacyStorageStepReinstall": "Скачайте последнюю версию и установите её заново",
   "legacyStorageStepRestoreBackup": "Восстановите резервную копию",
   "legacyStorageImportantTitle": "Важно",

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -4614,5 +4614,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ТРЕБУЕТСЯ ДЕЙСТВИЕ",
+  "legacyStorageBadgeConfirm": "ПОДТВЕРДИТЬ",
+  "legacyStorageNoBackupPageTitle": "СДЕЛАЙТЕ РЕЗЕРВНУЮ КОПИЮ И ПЕРЕУСТАНОВИТЕ КОШЕЛЁК",
+  "legacyStorageHasBackupPageTitle": "ПЕРЕУСТАНОВИТЕ КОШЕЛЁК",
+  "legacyStorageIntroDescription": "Ваш кошелёк работает на программном обеспечении, поддержка которого скоро прекратится. Его нельзя обновить, не удалив и не установив приложение заново.",
+  "legacyStorageStepBackupWallet": "Сделайте резервную копию кошелька",
+  "legacyStorageStepExportLabels": "Экспортируйте свои метки (если они есть)",
+  "legacyStorageStepEnsureSwapsCompleted": "Убедитесь, что все обмены (swap) завершены",
+  "legacyStorageStepUninstall": "Полностью удалите приложение с устройства",
+  "legacyStorageStepReinstall": "Скачайте последнюю версию и установите её заново",
+  "legacyStorageStepRestoreBackup": "Восстановите резервную копию",
+  "legacyStorageImportantTitle": "Важно",
+  "legacyStorageImportantBody": "Не пропускайте этот процесс, если у вас действительно нет возможности сделать резервную копию прямо сейчас.",
+  "legacyStorageContinueFooterNoBackup": "Вы можете продолжить пользоваться приложением без резервной копии, но мы настоятельно не рекомендуем этого.",
+  "legacyStorageContinueFooterHasBackup": "Вы можете продолжить пользоваться приложением, но мы настоятельно не рекомендуем этого.",
+  "legacyStorageBackupNowButton": "Сделать копию сейчас",
+  "legacyStorageRiskAckButton": "Нет, я понимаю риск",
+  "legacyStorageAreYouSureTitle": "ВЫ УВЕРЕНЫ?",
+  "legacyStorageAreYouSureParagraphOne": "Программное обеспечение, в котором хранятся приватные ключи Bitcoin вашего кошелька, прекращает поддержку. Мы настоятельно рекомендуем сделать резервную копию прямо сейчас, чтобы избежать сбоев в будущем.",
+  "legacyStorageAreYouSureParagraphTwo": "Резервная копия Encrypted Vault занимает около 1 минуты и не требует особых инструментов. Для физической копии достаточно ручки и листа бумаги.",
+  "legacyStorageContinueWithoutBackupButton": "Продолжить без копии",
+  "legacyStorageAcceptRisksCheckbox": "Я принимаю риски отказа от резервной копии",
+  "legacyStorageHasBackupImportantBody": "Пожалуйста, не пропускайте этот процесс, если только вам не нужно срочно использовать кошелёк или вы не ждёте завершения свопа.",
+  "legacyStorageRiskAckButtonHasBackup": "Я понимаю риск"
 }

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -200,5 +200,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "HATUA INAHITAJIKA",
+  "legacyStorageBadgeConfirm": "THIBITISHA",
+  "legacyStorageNoBackupPageTitle": "HIFADHI NAKALA NA SAKINISHA UPYA WALLET YAKO",
+  "legacyStorageHasBackupPageTitle": "SAKINISHA UPYA WALLET YAKO",
+  "legacyStorageIntroDescription": "Wallet yako inatumia programu ambayo itaachwa hivi karibuni. Haiwezi kusasishwa bila kuondoa programu na kuiweka tena.",
+  "legacyStorageStepBackupWallet": "Hifadhi nakala ya wallet yako",
+  "legacyStorageStepExportLabels": "Hamisha lebo zako (kama unazo)",
+  "legacyStorageStepEnsureSwapsCompleted": "Hakikisha swaps zote zimekamilika",
+  "legacyStorageStepUninstall": "Ondoa programu kabisa kutoka kwenye kifaa chako",
+  "legacyStorageStepReinstall": "Pakua toleo jipya zaidi na uweke tena",
+  "legacyStorageStepRestoreBackup": "Rejesha nakala yako",
+  "legacyStorageImportantTitle": "Muhimu",
+  "legacyStorageImportantBody": "Usiruke utaratibu huu isipokuwa kweli huwezi kuhifadhi nakala kwa sasa.",
+  "legacyStorageContinueFooterNoBackup": "Unaweza kuendelea kutumia programu bila kuhifadhi nakala, lakini tunashauri sana usifanye hivyo.",
+  "legacyStorageContinueFooterHasBackup": "Unaweza kuendelea kutumia programu, lakini tunashauri sana usifanye hivyo.",
+  "legacyStorageBackupNowButton": "Hifadhi sasa",
+  "legacyStorageRiskAckButton": "Hapana, naelewa hatari",
+  "legacyStorageAreYouSureTitle": "UNA UHAKIKA?",
+  "legacyStorageAreYouSureParagraphOne": "Programu inayohifadhi funguo binafsi za Bitcoin za wallet yako inaachwa. Tunashauri sana uhifadhi nakala sasa hivi ili kuepuka usumbufu wowote baadaye.",
+  "legacyStorageAreYouSureParagraphTwo": "Chaguo la Encrypted Vault linachukua takriban dakika 1 na halihitaji vifaa maalum. Kwa nakala ya kimwili unahitaji kalamu na karatasi tu.",
+  "legacyStorageContinueWithoutBackupButton": "Endelea bila nakala",
+  "legacyStorageAcceptRisksCheckbox": "Ninakubali hatari za kutohifadhi nakala",
+  "legacyStorageHasBackupImportantBody": "Tafadhali usiruke mchakato huu isipokuwa lazima utumie pochi kwa haraka au unasubiri swap ikamilike.",
+  "legacyStorageRiskAckButtonHasBackup": "Ninaelewa hatari"
 }

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -209,7 +209,7 @@
   "legacyStorageStepBackupWallet": "Hifadhi nakala ya wallet yako",
   "legacyStorageStepExportLabels": "Hamisha lebo zako (kama unazo)",
   "legacyStorageStepEnsureSwapsCompleted": "Hakikisha swaps zote zimekamilika",
-  "legacyStorageStepUninstall": "Ondoa programu kabisa kutoka kwenye kifaa chako",
+  "legacyStorageStepUninstall": "Ondoa programu kwenye kifaa chako",
   "legacyStorageStepReinstall": "Pakua toleo jipya zaidi na uweke tena",
   "legacyStorageStepRestoreBackup": "Rejesha nakala yako",
   "legacyStorageImportantTitle": "Muhimu",

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ต้องดำเนินการ",
+  "legacyStorageBadgeConfirm": "ยืนยัน",
+  "legacyStorageNoBackupPageTitle": "สำรองข้อมูลและติดตั้งกระเป๋าใหม่",
+  "legacyStorageHasBackupPageTitle": "ติดตั้งกระเป๋าใหม่",
+  "legacyStorageIntroDescription": "กระเป๋าของคุณกำลังใช้ซอฟต์แวร์ที่กำลังจะถูกยกเลิกในไม่ช้า ไม่สามารถอัปเดตได้หากไม่ถอนการติดตั้งและติดตั้งแอปใหม่",
+  "legacyStorageStepBackupWallet": "สำรองข้อมูลกระเป๋าของคุณ",
+  "legacyStorageStepExportLabels": "ส่งออกป้ายของคุณ (ถ้ามี)",
+  "legacyStorageStepEnsureSwapsCompleted": "ตรวจสอบว่า swap ทั้งหมดเสร็จสมบูรณ์แล้ว",
+  "legacyStorageStepUninstall": "ถอนการติดตั้งแอปออกจากอุปกรณ์ของคุณทั้งหมด",
+  "legacyStorageStepReinstall": "ดาวน์โหลดเวอร์ชันล่าสุดและติดตั้งใหม่",
+  "legacyStorageStepRestoreBackup": "กู้คืนข้อมูลสำรองของคุณ",
+  "legacyStorageImportantTitle": "สำคัญ",
+  "legacyStorageImportantBody": "อย่าข้ามขั้นตอนนี้เว้นแต่ว่าคุณจะไม่สามารถสำรองข้อมูลได้จริง ๆ ในตอนนี้",
+  "legacyStorageContinueFooterNoBackup": "คุณสามารถใช้แอปต่อได้โดยไม่สำรองข้อมูล แต่เราแนะนำอย่างยิ่งว่าไม่ควรทำเช่นนั้น",
+  "legacyStorageContinueFooterHasBackup": "คุณสามารถใช้แอปต่อได้ แต่เราแนะนำอย่างยิ่งว่าไม่ควรทำเช่นนั้น",
+  "legacyStorageBackupNowButton": "สำรองข้อมูลตอนนี้",
+  "legacyStorageRiskAckButton": "ไม่ ฉันเข้าใจความเสี่ยง",
+  "legacyStorageAreYouSureTitle": "คุณแน่ใจหรือ?",
+  "legacyStorageAreYouSureParagraphOne": "ซอฟต์แวร์ที่ใช้เก็บคีย์ส่วนตัว Bitcoin ของกระเป๋าคุณกำลังถูกยกเลิก เราแนะนำอย่างยิ่งให้คุณสำรองข้อมูลตอนนี้เลยเพื่อหลีกเลี่ยงปัญหาในอนาคต",
+  "legacyStorageAreYouSureParagraphTwo": "ตัวเลือก Encrypted Vault ใช้เวลาประมาณ 1 นาที ไม่ต้องใช้เครื่องมือพิเศษ สำหรับการสำรองข้อมูลแบบกระดาษ คุณต้องใช้เพียงปากกาและกระดาษ",
+  "legacyStorageContinueWithoutBackupButton": "ดำเนินการต่อโดยไม่สำรองข้อมูล",
+  "legacyStorageAcceptRisksCheckbox": "ฉันยอมรับความเสี่ยงของการไม่สำรองข้อมูล",
+  "legacyStorageHasBackupImportantBody": "โปรดอย่าข้ามขั้นตอนนี้ เว้นแต่คุณจำเป็นต้องใช้กระเป๋าเงินอย่างเร่งด่วน หรือกำลังรอให้สวอปเสร็จสมบูรณ์",
+  "legacyStorageRiskAckButtonHasBackup": "ฉันเข้าใจความเสี่ยง"
 }

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "สำรองข้อมูลกระเป๋าของคุณ",
   "legacyStorageStepExportLabels": "ส่งออกป้ายของคุณ (ถ้ามี)",
   "legacyStorageStepEnsureSwapsCompleted": "ตรวจสอบว่า swap ทั้งหมดเสร็จสมบูรณ์แล้ว",
-  "legacyStorageStepUninstall": "ถอนการติดตั้งแอปออกจากอุปกรณ์ของคุณทั้งหมด",
+  "legacyStorageStepUninstall": "ถอนการติดตั้งแอปจากอุปกรณ์ของคุณ",
   "legacyStorageStepReinstall": "ดาวน์โหลดเวอร์ชันล่าสุดและติดตั้งใหม่",
   "legacyStorageStepRestoreBackup": "กู้คืนข้อมูลสำรองของคุณ",
   "legacyStorageImportantTitle": "สำคัญ",

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12605,5 +12605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "İŞLEM GEREKLİ",
+  "legacyStorageBadgeConfirm": "ONAYLA",
+  "legacyStorageNoBackupPageTitle": "CÜZDANINIZIN YEDEĞİNİ ALIN VE YENİDEN YÜKLEYİN",
+  "legacyStorageHasBackupPageTitle": "CÜZDANINIZI YENİDEN YÜKLEYİN",
+  "legacyStorageIntroDescription": "Cüzdanınız kısa süre içinde kullanımdan kalkacak bir yazılım üzerinde çalışıyor. Uygulama kaldırılıp yeniden yüklenmeden güncellenemez.",
+  "legacyStorageStepBackupWallet": "Cüzdanınızın yedeğini alın",
+  "legacyStorageStepExportLabels": "Etiketlerinizi dışa aktarın (varsa)",
+  "legacyStorageStepEnsureSwapsCompleted": "Tüm swap işlemlerinin tamamlandığından emin olun",
+  "legacyStorageStepUninstall": "Uygulamayı cihazınızdan tamamen kaldırın",
+  "legacyStorageStepReinstall": "En güncel sürümü indirip yeniden yükleyin",
+  "legacyStorageStepRestoreBackup": "Yedeğinizi geri yükleyin",
+  "legacyStorageImportantTitle": "Önemli",
+  "legacyStorageImportantBody": "Şu an gerçekten yedek alamayacaksanız bu işlemi atlamayın.",
+  "legacyStorageContinueFooterNoBackup": "Yedek almadan da uygulamayı kullanmaya devam edebilirsiniz, ancak bunu kesinlikle önermiyoruz.",
+  "legacyStorageContinueFooterHasBackup": "Uygulamayı kullanmaya devam edebilirsiniz, ancak bunu kesinlikle önermiyoruz.",
+  "legacyStorageBackupNowButton": "Şimdi yedekle",
+  "legacyStorageRiskAckButton": "Hayır, riski anlıyorum",
+  "legacyStorageAreYouSureTitle": "EMİN MİSİNİZ?",
+  "legacyStorageAreYouSureParagraphOne": "Cüzdanınızın Bitcoin özel anahtarlarını saklamak için kullanılan yazılım kullanımdan kalkıyor. İleride yaşanabilecek aksaklıkları önlemek için hemen yedek almanızı kesinlikle öneririz.",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault yedekleme seçeneği yaklaşık 1 dakika sürer ve özel araç gerektirmez. Fiziksel yedek için ihtiyacınız olan tek şey kalem ve kağıttır.",
+  "legacyStorageContinueWithoutBackupButton": "Yedek almadan devam et",
+  "legacyStorageAcceptRisksCheckbox": "Yedek almamanın risklerini kabul ediyorum",
+  "legacyStorageHasBackupImportantBody": "Cüzdanı acilen kullanmanız mutlak gerekmedikçe veya bir takasın tamamlanmasını beklemiyorsanız, lütfen bu işlemi atlamayın.",
+  "legacyStorageRiskAckButtonHasBackup": "Riski anlıyorum"
 }

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12614,7 +12614,7 @@
   "legacyStorageStepBackupWallet": "Cüzdanınızın yedeğini alın",
   "legacyStorageStepExportLabels": "Etiketlerinizi dışa aktarın (varsa)",
   "legacyStorageStepEnsureSwapsCompleted": "Tüm swap işlemlerinin tamamlandığından emin olun",
-  "legacyStorageStepUninstall": "Uygulamayı cihazınızdan tamamen kaldırın",
+  "legacyStorageStepUninstall": "Uygulamayı cihazınızdan kaldırın",
   "legacyStorageStepReinstall": "En güncel sürümü indirip yeniden yükleyin",
   "legacyStorageStepRestoreBackup": "Yedeğinizi geri yükleyin",
   "legacyStorageImportantTitle": "Önemli",

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4611,7 +4611,7 @@
   "legacyStorageStepBackupWallet": "Створіть резервну копію гаманця",
   "legacyStorageStepExportLabels": "Експортуйте свої мітки (якщо є)",
   "legacyStorageStepEnsureSwapsCompleted": "Переконайтеся, що всі swap-операції завершено",
-  "legacyStorageStepUninstall": "Повністю видаліть застосунок зі свого пристрою",
+  "legacyStorageStepUninstall": "Видаліть програму зі свого пристрою",
   "legacyStorageStepReinstall": "Завантажте найновішу версію та встановіть знову",
   "legacyStorageStepRestoreBackup": "Відновіть резервну копію",
   "legacyStorageImportantTitle": "Важливо",

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4602,5 +4602,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "ПОТРІБНА ДІЯ",
+  "legacyStorageBadgeConfirm": "ПІДТВЕРДИТИ",
+  "legacyStorageNoBackupPageTitle": "СТВОРІТЬ РЕЗЕРВНУ КОПІЮ ТА ПЕРЕВСТАНОВІТЬ ГАМАНЕЦЬ",
+  "legacyStorageHasBackupPageTitle": "ПЕРЕВСТАНОВІТЬ ГАМАНЕЦЬ",
+  "legacyStorageIntroDescription": "Ваш гаманець працює на програмному забезпеченні, підтримку якого незабаром буде припинено. Його неможливо оновити без видалення та повторного встановлення застосунку.",
+  "legacyStorageStepBackupWallet": "Створіть резервну копію гаманця",
+  "legacyStorageStepExportLabels": "Експортуйте свої мітки (якщо є)",
+  "legacyStorageStepEnsureSwapsCompleted": "Переконайтеся, що всі swap-операції завершено",
+  "legacyStorageStepUninstall": "Повністю видаліть застосунок зі свого пристрою",
+  "legacyStorageStepReinstall": "Завантажте найновішу версію та встановіть знову",
+  "legacyStorageStepRestoreBackup": "Відновіть резервну копію",
+  "legacyStorageImportantTitle": "Важливо",
+  "legacyStorageImportantBody": "Не пропускайте цей процес, якщо ви справді не можете створити резервну копію прямо зараз.",
+  "legacyStorageContinueFooterNoBackup": "Ви можете продовжувати користуватися застосунком без резервної копії, але ми наполегливо радимо так не робити.",
+  "legacyStorageContinueFooterHasBackup": "Ви можете продовжувати користуватися застосунком, але ми наполегливо радимо так не робити.",
+  "legacyStorageBackupNowButton": "Створити копію зараз",
+  "legacyStorageRiskAckButton": "Ні, я розумію ризик",
+  "legacyStorageAreYouSureTitle": "ВИ ВПЕВНЕНІ?",
+  "legacyStorageAreYouSureParagraphOne": "Програмне забезпечення, яке зберігає приватні ключі Bitcoin вашого гаманця, припиняє підтримку. Ми наполегливо радимо створити резервну копію прямо зараз, щоб уникнути збоїв у майбутньому.",
+  "legacyStorageAreYouSureParagraphTwo": "Резервне копіювання Encrypted Vault займає близько 1 хвилини та не потребує спеціальних інструментів. Для фізичної резервної копії вам знадобляться лише ручка та папір.",
+  "legacyStorageContinueWithoutBackupButton": "Продовжити без копії",
+  "legacyStorageAcceptRisksCheckbox": "Я приймаю ризики відсутності резервної копії",
+  "legacyStorageHasBackupImportantBody": "Будь ласка, не пропускайте цей процес, якщо тільки вам не потрібно терміново скористатися гаманцем або ви не очікуєте на завершення свопу.",
+  "legacyStorageRiskAckButtonHasBackup": "Я розумію ризик"
 }

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -180,5 +180,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "CẦN HÀNH ĐỘNG",
+  "legacyStorageBadgeConfirm": "XÁC NHẬN",
+  "legacyStorageNoBackupPageTitle": "SAO LƯU VÀ CÀI ĐẶT LẠI VÍ CỦA BẠN",
+  "legacyStorageHasBackupPageTitle": "CÀI ĐẶT LẠI VÍ CỦA BẠN",
+  "legacyStorageIntroDescription": "Ví của bạn đang chạy trên phần mềm sẽ sớm ngừng hỗ trợ. Phần mềm này không thể cập nhật nếu không gỡ và cài lại ứng dụng.",
+  "legacyStorageStepBackupWallet": "Sao lưu ví của bạn",
+  "legacyStorageStepExportLabels": "Xuất nhãn của bạn (nếu có)",
+  "legacyStorageStepEnsureSwapsCompleted": "Đảm bảo tất cả swap đã hoàn tất",
+  "legacyStorageStepUninstall": "Gỡ hoàn toàn ứng dụng khỏi thiết bị",
+  "legacyStorageStepReinstall": "Tải phiên bản mới nhất và cài đặt lại",
+  "legacyStorageStepRestoreBackup": "Khôi phục bản sao lưu của bạn",
+  "legacyStorageImportantTitle": "Quan trọng",
+  "legacyStorageImportantBody": "Đừng bỏ qua quy trình này trừ khi bạn thực sự không thể sao lưu vào lúc này.",
+  "legacyStorageContinueFooterNoBackup": "Bạn vẫn có thể tiếp tục sử dụng ứng dụng mà không sao lưu, nhưng chúng tôi đặc biệt khuyên bạn không nên làm vậy.",
+  "legacyStorageContinueFooterHasBackup": "Bạn vẫn có thể tiếp tục sử dụng ứng dụng, nhưng chúng tôi đặc biệt khuyên bạn không nên làm vậy.",
+  "legacyStorageBackupNowButton": "Sao lưu ngay",
+  "legacyStorageRiskAckButton": "Không, tôi hiểu rủi ro",
+  "legacyStorageAreYouSureTitle": "BẠN CÓ CHẮC KHÔNG?",
+  "legacyStorageAreYouSureParagraphOne": "Phần mềm lưu trữ khoá riêng Bitcoin của ví của bạn đang bị ngừng hỗ trợ. Chúng tôi đặc biệt khuyến nghị bạn sao lưu ngay bây giờ để tránh gián đoạn về sau.",
+  "legacyStorageAreYouSureParagraphTwo": "Tuỳ chọn Encrypted Vault chỉ mất khoảng 1 phút và không cần công cụ đặc biệt. Với bản sao lưu vật lý, bạn chỉ cần bút và giấy.",
+  "legacyStorageContinueWithoutBackupButton": "Tiếp tục không sao lưu",
+  "legacyStorageAcceptRisksCheckbox": "Tôi chấp nhận rủi ro khi không sao lưu",
+  "legacyStorageHasBackupImportantBody": "Vui lòng không bỏ qua quy trình này trừ khi bạn thực sự cần sử dụng ví khẩn cấp hoặc đang chờ một giao dịch hoán đổi hoàn tất.",
+  "legacyStorageRiskAckButtonHasBackup": "Tôi hiểu rủi ro"
 }

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -189,7 +189,7 @@
   "legacyStorageStepBackupWallet": "Sao lưu ví của bạn",
   "legacyStorageStepExportLabels": "Xuất nhãn của bạn (nếu có)",
   "legacyStorageStepEnsureSwapsCompleted": "Đảm bảo tất cả swap đã hoàn tất",
-  "legacyStorageStepUninstall": "Gỡ hoàn toàn ứng dụng khỏi thiết bị",
+  "legacyStorageStepUninstall": "Gỡ cài đặt ứng dụng khỏi thiết bị của bạn",
   "legacyStorageStepReinstall": "Tải phiên bản mới nhất và cài đặt lại",
   "legacyStorageStepRestoreBackup": "Khôi phục bản sao lưu của bạn",
   "legacyStorageImportantTitle": "Quan trọng",

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -4605,5 +4605,29 @@
         "type": "int"
       }
     }
-  }
+  },
+  "legacyStorageBadgeActionRequired": "需要操作",
+  "legacyStorageBadgeConfirm": "确认",
+  "legacyStorageNoBackupPageTitle": "备份并重新安装您的钱包",
+  "legacyStorageHasBackupPageTitle": "重新安装您的钱包",
+  "legacyStorageIntroDescription": "您的钱包正在使用即将停止支持的软件。除非卸载并重新安装应用,否则无法更新。",
+  "legacyStorageStepBackupWallet": "备份您的钱包",
+  "legacyStorageStepExportLabels": "导出您的标签(如果有)",
+  "legacyStorageStepEnsureSwapsCompleted": "确认所有 swap 已完成",
+  "legacyStorageStepUninstall": "从设备上完全卸载应用",
+  "legacyStorageStepReinstall": "下载最新版本并重新安装",
+  "legacyStorageStepRestoreBackup": "恢复您的备份",
+  "legacyStorageImportantTitle": "重要",
+  "legacyStorageImportantBody": "除非此刻您实在无法备份,否则请勿跳过此流程。",
+  "legacyStorageContinueFooterNoBackup": "您可以在不备份的情况下继续使用应用,但我们强烈不建议这样做。",
+  "legacyStorageContinueFooterHasBackup": "您可以继续使用应用,但我们强烈不建议这样做。",
+  "legacyStorageBackupNowButton": "立即备份",
+  "legacyStorageRiskAckButton": "否,我了解风险",
+  "legacyStorageAreYouSureTitle": "您确定吗?",
+  "legacyStorageAreYouSureParagraphOne": "用于保管钱包 Bitcoin 私钥的软件即将停止支持。强烈建议您立即备份,以避免日后出现任何中断。",
+  "legacyStorageAreYouSureParagraphTwo": "Encrypted Vault 备份大约需要 1 分钟,无需任何特殊工具。物理备份只需一支笔和一张纸。",
+  "legacyStorageContinueWithoutBackupButton": "不备份继续",
+  "legacyStorageAcceptRisksCheckbox": "我接受不进行备份的风险",
+  "legacyStorageHasBackupImportantBody": "除非您必须紧急使用钱包或正在等待一笔兑换完成，否则请不要跳过此流程。",
+  "legacyStorageRiskAckButtonHasBackup": "我了解风险"
 }

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -4614,7 +4614,7 @@
   "legacyStorageStepBackupWallet": "备份您的钱包",
   "legacyStorageStepExportLabels": "导出您的标签(如果有)",
   "legacyStorageStepEnsureSwapsCompleted": "确认所有 swap 已完成",
-  "legacyStorageStepUninstall": "从设备上完全卸载应用",
+  "legacyStorageStepUninstall": "从您的设备中卸载该应用",
   "legacyStorageStepReinstall": "下载最新版本并重新安装",
   "legacyStorageStepRestoreBackup": "恢复您的备份",
   "legacyStorageImportantTitle": "重要",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.9.102+177
+version: 6.9.106+177
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
 - Dark mode background on the storage warning screens now matches the wizard.
 - Backup warning bottom sheet only shown if balance is above 0
 - After completing a backup, the warning lands directly on the "Reinstall" title instead of flashing "Backup and Reinstall"
   for a few seconds.
- "Vault created successfully" snackbar no longer covers the "Test Recovery" button.
- Merged two near-identical "backup test complete" screens into one.
