### PR TITLE
refactor(pull-to-refresh): standardize via BBPullableBody, fix small-screen reach

### DIFF
--- a/lib/core/widgets/bb_pullable_body.dart
+++ b/lib/core/widgets/bb_pullable_body.dart
@@ -1,0 +1,55 @@
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:flutter/material.dart';
+
+/// Standard pull-to-refresh body. Use this for any screen that supports
+/// pull-to-refresh — it enforces the three invariants that make the gesture
+/// reliable across the whole screen:
+///
+/// 1. Single scrollable (CustomScrollView) so notifications never fight with
+///    nested ListView/SingleChildScrollView.
+/// 2. `AlwaysScrollableScrollPhysics` so short content can still overscroll
+///    and trigger refresh.
+/// 3. `SliverFillRemaining(hasScrollBody: false)` appended so the scrollable
+///    fills the viewport — the pull gesture works from anywhere on screen,
+///    including any [bottomChild] that gets pinned to the bottom.
+///
+/// Pass screen content as [slivers]. If the screen has a footer (action
+/// buttons, etc.) supply it as [bottomChild]; it will be pushed to the
+/// bottom of the viewport when content is short, and follow the content
+/// when it overflows.
+class BBPullableBody extends StatelessWidget {
+  const BBPullableBody({
+    super.key,
+    this.indicatorKey,
+    required this.onRefresh,
+    required this.slivers,
+    this.bottomChild,
+  });
+
+  /// Forwarded to the inner [BBRefreshIndicator]. Use a
+  /// `GlobalKey<RefreshIndicatorState>` to call `.show()` programmatically.
+  final Key? indicatorKey;
+  final RefreshCallback onRefresh;
+  final List<Widget> slivers;
+  final Widget? bottomChild;
+
+  @override
+  Widget build(BuildContext context) {
+    return BBRefreshIndicator(
+      indicatorKey: indicatorKey,
+      onRefresh: onRefresh,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          ...slivers,
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: bottomChild == null
+                ? const SizedBox.shrink()
+                : Column(children: [const Spacer(), bottomChild!]),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/bb_refresh_indicator.dart
+++ b/lib/core/widgets/bb_refresh_indicator.dart
@@ -33,19 +33,17 @@ class BBRefreshIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Position the spinner around the upper third of the actual scroll
-    // area (not the full screen — MediaQuery would include the bottom
-    // nav and bias the indicator toward the bottom of the body).
-    // 60 = default RefreshIndicator displacement (40) + half indicator
-    // height (~20). The displacement is left at its native value to
-    // preserve drag feel.
-    return LayoutBuilder(
-      builder: (context, constraints) => RefreshIndicator(
-        key: indicatorKey,
-        edgeOffset: constraints.maxHeight * 0.4 - 60,
-        onRefresh: onRefresh,
-        child: child,
-      ),
+    // Center the spinner vertically on the screen. 60 = default
+    // RefreshIndicator displacement (40) + half indicator height (~20),
+    // so subtracting it lands the indicator's center on the midline.
+    // The displacement is left at its native value to preserve drag feel.
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    final offset = (screenHeight * 0.40 - 60).clamp(0.0, screenHeight);
+    return RefreshIndicator(
+      key: indicatorKey,
+      edgeOffset: offset,
+      onRefresh: onRefresh,
+      child: child,
     );
   }
 }

--- a/lib/core/widgets/lists/transactions_by_day_list.dart
+++ b/lib/core/widgets/lists/transactions_by_day_list.dart
@@ -14,109 +14,135 @@ class TransactionsByDayList extends StatelessWidget {
     required this.transactionsByDay,
     this.ongoingSwaps,
     this.errorMessage,
+    this.sliver = false,
   });
 
   final Map<int, List<Transaction>>? transactionsByDay;
   final List<Transaction>? ongoingSwaps;
   final String? errorMessage;
 
+  /// When true, returns Sliver* widgets so the list can live inside a
+  /// CustomScrollView and share the parent's scroll/refresh gesture.
+  final bool sliver;
+
+  Widget _wrapPlaceholder(Widget child) =>
+      sliver ? SliverToBoxAdapter(child: child) : child;
+
   @override
   Widget build(BuildContext context) {
     if (errorMessage != null) {
-      return Center(
-        child: Column(
-          children: [
-            const Gap(16),
-            BBText(
-              errorMessage!,
-              maxLines: 2,
-              textAlign: .center,
-              style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
-                color: context.appColors.error,
+      return _wrapPlaceholder(
+        Center(
+          child: Column(
+            children: [
+              const Gap(16),
+              BBText(
+                errorMessage!,
+                maxLines: 2,
+                textAlign: .center,
+                style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
+                  color: context.appColors.error,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       );
     } else if (transactionsByDay == null) {
-      return Center(
-        child: Column(
-          children: [
-            const Gap(16),
-            BBText(
-              'Loading transactions...',
-              maxLines: 2,
-              textAlign: .center,
-              style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
-                color: context.appColors.onSurface,
+      return _wrapPlaceholder(
+        Center(
+          child: Column(
+            children: [
+              const Gap(16),
+              BBText(
+                'Loading transactions...',
+                maxLines: 2,
+                textAlign: .center,
+                style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
+                  color: context.appColors.onSurface,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       );
     } else if (transactionsByDay!.isEmpty &&
         (ongoingSwaps == null || ongoingSwaps!.isEmpty)) {
-      return Center(
-        child: Column(
-          children: [
-            const Gap(16),
-            BBText(
-              'No transactions yet.',
-              maxLines: 2,
-              textAlign: .center,
-              style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
-                color: context.appColors.onSurface,
-              ),
-            ),
-          ],
-        ),
-      );
-    } else {
-      return ListView.builder(
-        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-        itemCount:
-            transactionsByDay!.entries.length +
-            (ongoingSwaps != null && ongoingSwaps!.isNotEmpty ? 1 : 0),
-        itemBuilder: (context, index) {
-          // Show ongoing swaps section at the top
-          if (ongoingSwaps != null && ongoingSwaps!.isNotEmpty && index == 0) {
-            return OngoingSwapsWidget(ongoingSwaps: ongoingSwaps!);
-          }
-
-          // Adjust index if we have ongoing swaps
-          final adjustedIndex = ongoingSwaps != null && ongoingSwaps!.isNotEmpty
-              ? index - 1
-              : index;
-          final entry = transactionsByDay!.entries.elementAt(adjustedIndex);
-          final date = DateTime.fromMillisecondsSinceEpoch(entry.key);
-          final txs = entry.value;
-          final now = DateTime.now();
-          final today = DateTime(now.year, now.month, now.day);
-          final yesterday = DateTime(now.year, now.month, now.day - 1);
-
-          return Column(
-            crossAxisAlignment: .start,
+      return _wrapPlaceholder(
+        Center(
+          child: Column(
             children: [
+              const Gap(16),
               BBText(
-                date.compareTo(today) > 0
-                    ? 'Pending'
-                    : date.isAtSameMomentAs(today)
-                    ? 'Today'
-                    : date.isAtSameMomentAs(yesterday)
-                    ? 'Yesterday'
-                    : date.year == DateTime.now().year
-                    ? DateFormat.MMMMd().format(date)
-                    : DateFormat.yMMMMd().format(date),
-                style: context.font.titleSmall?.copyWith(
+                'No transactions yet.',
+                maxLines: 2,
+                textAlign: .center,
+                style: AppFonts.textTheme.textTheme.bodyMedium?.copyWith(
                   color: context.appColors.onSurface,
                 ),
               ),
-              const Gap(16),
-              ...txs.map((tx) => TxListItem(tx: tx)),
-              const Gap(16),
             ],
-          );
-        },
+          ),
+        ),
+      );
+    } else {
+      final itemCount =
+          transactionsByDay!.entries.length +
+          (ongoingSwaps != null && ongoingSwaps!.isNotEmpty ? 1 : 0);
+      Widget itemBuilder(BuildContext context, int index) {
+        // Show ongoing swaps section at the top
+        if (ongoingSwaps != null && ongoingSwaps!.isNotEmpty && index == 0) {
+          return OngoingSwapsWidget(ongoingSwaps: ongoingSwaps!);
+        }
+
+        // Adjust index if we have ongoing swaps
+        final adjustedIndex = ongoingSwaps != null && ongoingSwaps!.isNotEmpty
+            ? index - 1
+            : index;
+        final entry = transactionsByDay!.entries.elementAt(adjustedIndex);
+        final date = DateTime.fromMillisecondsSinceEpoch(entry.key);
+        final txs = entry.value;
+        final now = DateTime.now();
+        final today = DateTime(now.year, now.month, now.day);
+        final yesterday = DateTime(now.year, now.month, now.day - 1);
+
+        return Column(
+          crossAxisAlignment: .start,
+          children: [
+            BBText(
+              date.compareTo(today) > 0
+                  ? 'Pending'
+                  : date.isAtSameMomentAs(today)
+                  ? 'Today'
+                  : date.isAtSameMomentAs(yesterday)
+                  ? 'Yesterday'
+                  : date.year == DateTime.now().year
+                  ? DateFormat.MMMMd().format(date)
+                  : DateFormat.yMMMMd().format(date),
+              style: context.font.titleSmall?.copyWith(
+                color: context.appColors.onSurface,
+              ),
+            ),
+            const Gap(16),
+            ...txs.map((tx) => TxListItem(tx: tx)),
+            const Gap(16),
+          ],
+        );
+      }
+
+      if (sliver) {
+        return SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          sliver: SliverList.builder(
+            itemCount: itemCount,
+            itemBuilder: itemBuilder,
+          ),
+        );
+      }
+      return ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        itemCount: itemCount,
+        itemBuilder: itemBuilder,
       );
     }
   }

--- a/lib/features/ark/ui/ark_wallet_detail_page.dart
+++ b/lib/features/ark/ui/ark_wallet_detail_page.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:bb_mobile/features/ark/router.dart';
@@ -39,52 +39,41 @@ class ArkWalletDetailPage extends StatelessWidget {
         ],
       ),
       body: SafeArea(
-        child: BBRefreshIndicator(
+        child: BBPullableBody(
           onRefresh: () async => await cubit.load(),
-          child: CustomScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            slivers: [
+          slivers: [
+            SliverToBoxAdapter(
+              child: ArkBalanceDetailWidget(arkBalance: state.arkBalance),
+            ),
+            if (state.isLoading)
               SliverToBoxAdapter(
-                child: ArkBalanceDetailWidget(arkBalance: state.arkBalance),
-              ),
-              if (state.isLoading)
-                SliverToBoxAdapter(
-                  child: LinearProgressIndicator(
-                    backgroundColor: context.appColors.surface,
-                    color: context.appColors.primary,
-                  ),
-                ),
-              const SliverToBoxAdapter(child: Gap(16.0)),
-              SliverToBoxAdapter(
-                child: TransactionHistoryWidget(
-                  transactions: state.transactions,
-                  isLoading: state.isLoading,
+                child: LinearProgressIndicator(
+                  backgroundColor: context.appColors.surface,
+                  color: context.appColors.primary,
                 ),
               ),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: Column(
-                  children: [
-                    const Spacer(),
-                    Padding(
-                      padding: const EdgeInsets.all(13.0),
-                      child: BBButton.big(
-                        label: context.loc.arkSettleTransactions,
-                        onPressed: () => SettleBottomSheet.show(context, cubit),
-                        bgColor: context.appColors.primary,
-                        textColor: context.appColors.onPrimary,
-                      ),
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.only(
-                        left: 13.0,
-                        right: 13.0,
-                        bottom: 40.0,
-                      ),
-                      child: ArkWalletBottomButtons(),
-                    ),
-                  ],
+            const SliverToBoxAdapter(child: Gap(16.0)),
+            SliverToBoxAdapter(
+              child: TransactionHistoryWidget(
+                transactions: state.transactions,
+                isLoading: state.isLoading,
+              ),
+            ),
+          ],
+          bottomChild: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(13.0),
+                child: BBButton.big(
+                  label: context.loc.arkSettleTransactions,
+                  onPressed: () => SettleBottomSheet.show(context, cubit),
+                  bgColor: context.appColors.primary,
+                  textColor: context.appColors.onPrimary,
                 ),
+              ),
+              const Padding(
+                padding: EdgeInsets.only(left: 13.0, right: 13.0, bottom: 40.0),
+                child: ArkWalletBottomButtons(),
               ),
             ],
           ),

--- a/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
+++ b/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
@@ -41,9 +41,9 @@ class ElectrumSettingsScreen extends StatelessWidget {
       body: SafeArea(
         child: BBPullableBody(
           onRefresh: () async {
-            context.read<ElectrumSettingsBloc>().add(
-              ElectrumSettingsLoaded(isLiquid: isLiquid),
-            );
+            final bloc = context.read<ElectrumSettingsBloc>();
+            bloc.add(ElectrumSettingsLoaded(isLiquid: isLiquid));
+            await bloc.stream.firstWhere((state) => !state.isLoadingData);
           },
           slivers: [
             SliverPadding(

--- a/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
+++ b/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/features/electrum_settings/frameworks/ui/widgets/draggable_server_list.dart';
@@ -39,65 +39,52 @@ class ElectrumSettingsScreen extends StatelessWidget {
         ),
       ),
       body: SafeArea(
-        child: BBRefreshIndicator(
+        child: BBPullableBody(
           onRefresh: () async {
             context.read<ElectrumSettingsBloc>().add(
               ElectrumSettingsLoaded(isLiquid: isLiquid),
             );
           },
-          child: CustomScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                sliver: SliverList(
-                  delegate: SliverChildListDelegate([
-                    const Gap(16),
-                    BBSegmentFull(
-                      items: {
-                        context.loc.electrumNetworkBitcoin,
-                        context.loc.electrumNetworkLiquid,
-                      },
-                      initialValue: isLiquid
-                          ? context.loc.electrumNetworkLiquid
-                          : context.loc.electrumNetworkBitcoin,
-                      onSelected: (value) {
-                        context.read<ElectrumSettingsBloc>().add(
-                          ElectrumSettingsLoaded(
-                            isLiquid:
-                                value == context.loc.electrumNetworkLiquid,
-                          ),
-                        );
-                      },
-                    ),
-                    const TorProxyErrorBanner(),
-                    const Gap(16),
-                    const DraggableServerList(),
-                  ]),
-                ),
-              ),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: Column(
-                  children: [
-                    const Spacer(),
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: TextButton(
-                        onPressed: () =>
-                            SetAdvancedOptionsBottomSheet.show(context),
-                        child: Text(
-                          context.loc.electrumAdvancedOptions,
-                          style: context.font.bodyMedium?.copyWith(
-                            color: context.appColors.primary,
-                          ),
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  const Gap(16),
+                  BBSegmentFull(
+                    items: {
+                      context.loc.electrumNetworkBitcoin,
+                      context.loc.electrumNetworkLiquid,
+                    },
+                    initialValue: isLiquid
+                        ? context.loc.electrumNetworkLiquid
+                        : context.loc.electrumNetworkBitcoin,
+                    onSelected: (value) {
+                      context.read<ElectrumSettingsBloc>().add(
+                        ElectrumSettingsLoaded(
+                          isLiquid: value == context.loc.electrumNetworkLiquid,
                         ),
-                      ),
-                    ),
-                  ],
+                      );
+                    },
+                  ),
+                  const TorProxyErrorBanner(),
+                  const Gap(16),
+                  const DraggableServerList(),
+                ]),
+              ),
+            ),
+          ],
+          bottomChild: Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextButton(
+              onPressed: () => SetAdvancedOptionsBottomSheet.show(context),
+              child: Text(
+                context.loc.electrumAdvancedOptions,
+                style: context.font.bodyMedium?.copyWith(
+                  color: context.appColors.primary,
                 ),
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/exchange/ui/screens/exchange_home_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_home_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar_bull_logo.dart';
 import 'package:bb_mobile/features/bitcoin_price/presentation/cubit/price_chart_cubit.dart';
@@ -43,193 +43,177 @@ class ExchangeHomeScreen extends StatelessWidget {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return BBRefreshIndicator(
+    return BBPullableBody(
       onRefresh: () async {
         await context.read<ExchangeCubit>().fetchUserSummary();
       },
-      child: CustomScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        slivers: [
-          SliverStack(
-            children: [
-              SliverList(
-                delegate: SliverChildListDelegate([
-                  const ExchangeHomeTopSection(),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: Column(
-                      children: [
-                        const Gap(12),
-                        if (!isFullyVerified) const ExchangeHomeKycCard(),
-                        const Gap(12),
-                        DcaListTile(hasDcaActive: hasDcaActive, dca: dca),
-                        const Gap(12),
-                        if (!notLoggedIn) const AnnouncementBanner(),
-                      ],
-                    ),
-                  ),
-                ]),
-              ),
-              BlocBuilder<PriceChartCubit, PriceChartState>(
-                builder: (context, priceChartState) {
-                  final showChart = priceChartState.showChart;
-
-                  return SliverAppBar(
-                    backgroundColor: Colors.transparent,
-                    floating: true,
-                    pinned: true,
-                    elevation: 0,
-                    centerTitle: true,
-                    title: showChart ? null : const TopBarBullLogo(),
-                    leading: Padding(
-                      padding: const EdgeInsets.only(left: 16.0),
-                      child: showChart
-                          ? IconButton(
-                              icon: Icon(
-                                Icons.arrow_back,
-                                color: context.appColors.onPrimary,
-                                size: 24,
-                              ),
-                              onPressed: () {
-                                context.read<PriceChartCubit>().hideChart();
-                              },
-                            )
-                          : SizedBox(
-                              width: 96,
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  IconButton(
-                                    padding: EdgeInsets.zero,
-                                    constraints: const BoxConstraints(),
-                                    visualDensity: VisualDensity.compact,
-                                    icon: Icon(
-                                      Icons.show_chart,
-                                      color: context.appColors.onPrimary,
-                                      size: 24,
-                                    ),
-                                    onPressed: () {
-                                      context
-                                          .read<PriceChartCubit>()
-                                          .showChart();
-                                    },
-                                  ),
-                                  IconButton(
-                                    padding: EdgeInsets.zero,
-                                    constraints: const BoxConstraints(),
-                                    visualDensity: VisualDensity.compact,
-                                    icon: Icon(
-                                      Icons.chat_bubble_outline,
-                                      color: context.appColors.onPrimary,
-                                      size: 24,
-                                    ),
-                                    onPressed: () {
-                                      final notLoggedIn = context
-                                          .read<ExchangeCubit>()
-                                          .state
-                                          .notLoggedIn;
-                                      if (notLoggedIn) {
-                                        context.pushNamed(
-                                          ExchangeRoute
-                                              .exchangeLoginForSupport
-                                              .name,
-                                        );
-                                      } else {
-                                        context.pushNamed(
-                                          ExchangeSupportChatRoute
-                                              .supportChat
-                                              .name,
-                                        );
-                                      }
-                                    },
-                                  ),
-                                ],
-                              ),
-                            ),
-                    ),
-                    leadingWidth: showChart ? 56 : 112,
-                    actionsIconTheme: IconThemeData(
-                      color: context.appColors.onPrimary,
-                      size: 24,
-                    ),
-                    actionsPadding: const EdgeInsets.only(right: 16),
-                    actions: showChart
-                        ? null
-                        : [
-                            IconButton(
-                              onPressed: () {
-                                context.pushNamed(
-                                  TransactionsRoute.transactions.name,
-                                );
-                              },
-                              visualDensity: VisualDensity.compact,
-                              color: context.appColors.onPrimary,
-                              iconSize: 32,
-                              icon: const Icon(Icons.history),
-                            ),
-                            const Gap(16),
-                            InkWell(
-                              onTap: () => context.pushNamed(
-                                SettingsRoute.settings.name,
-                              ),
-                              child: Image.asset(
-                                Assets.icons.settingsLine.path,
-                                width: 32,
-                                height: 32,
-                                color: context.appColors.onPrimary,
-                              ),
-                            ),
-                          ],
-                  );
-                },
-              ),
-            ],
-          ),
-          SliverFillRemaining(
-            hasScrollBody: false,
-            child: Column(
-              children: [
-                const Spacer(),
+      slivers: [
+        SliverStack(
+          children: [
+            SliverList(
+              delegate: SliverChildListDelegate([
+                const ExchangeHomeTopSection(),
                 Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Column(
                     children: [
-                      Expanded(
-                        child: BBButton.big(
-                          iconData: Icons.arrow_downward,
-                          label: context.loc.exchangeHomeDepositButton,
-                          iconFirst: true,
-                          onPressed: () => context.pushNamed(
-                            FundExchangeRoute.fundExchange.name,
-                          ),
-                          bgColor: context.appColors.secondaryFixed,
-                          textColor: context.appColors.onSecondaryFixed,
-                          outlined: true,
-                          borderColor: context.appColors.onSecondaryFixed,
-                        ),
-                      ),
-                      const Gap(4),
-                      Expanded(
-                        child: BBButton.big(
-                          iconData: Icons.arrow_upward,
-                          label: context.loc.exchangeHomeWithdrawButton,
-                          iconFirst: true,
-                          disabled: false,
-                          onPressed: () =>
-                              context.pushNamed(WithdrawRoute.withdraw.name),
-                          bgColor: context.appColors.secondaryFixed,
-                          textColor: context.appColors.onSecondaryFixed,
-                          outlined: true,
-                          borderColor: context.appColors.onSecondaryFixed,
-                        ),
-                      ),
+                      const Gap(12),
+                      if (!isFullyVerified) const ExchangeHomeKycCard(),
+                      const Gap(12),
+                      DcaListTile(hasDcaActive: hasDcaActive, dca: dca),
+                      const Gap(12),
+                      if (!notLoggedIn) const AnnouncementBanner(),
                     ],
                   ),
                 ),
-              ],
+              ]),
             ),
-          ),
-        ],
+            BlocBuilder<PriceChartCubit, PriceChartState>(
+              builder: (context, priceChartState) {
+                final showChart = priceChartState.showChart;
+
+                return SliverAppBar(
+                  backgroundColor: Colors.transparent,
+                  floating: true,
+                  pinned: true,
+                  elevation: 0,
+                  centerTitle: true,
+                  title: showChart ? null : const TopBarBullLogo(),
+                  leading: Padding(
+                    padding: const EdgeInsets.only(left: 16.0),
+                    child: showChart
+                        ? IconButton(
+                            icon: Icon(
+                              Icons.arrow_back,
+                              color: context.appColors.onPrimary,
+                              size: 24,
+                            ),
+                            onPressed: () {
+                              context.read<PriceChartCubit>().hideChart();
+                            },
+                          )
+                        : SizedBox(
+                            width: 96,
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  padding: EdgeInsets.zero,
+                                  constraints: const BoxConstraints(),
+                                  visualDensity: VisualDensity.compact,
+                                  icon: Icon(
+                                    Icons.show_chart,
+                                    color: context.appColors.onPrimary,
+                                    size: 24,
+                                  ),
+                                  onPressed: () {
+                                    context.read<PriceChartCubit>().showChart();
+                                  },
+                                ),
+                                IconButton(
+                                  padding: EdgeInsets.zero,
+                                  constraints: const BoxConstraints(),
+                                  visualDensity: VisualDensity.compact,
+                                  icon: Icon(
+                                    Icons.chat_bubble_outline,
+                                    color: context.appColors.onPrimary,
+                                    size: 24,
+                                  ),
+                                  onPressed: () {
+                                    final notLoggedIn = context
+                                        .read<ExchangeCubit>()
+                                        .state
+                                        .notLoggedIn;
+                                    if (notLoggedIn) {
+                                      context.pushNamed(
+                                        ExchangeRoute
+                                            .exchangeLoginForSupport
+                                            .name,
+                                      );
+                                    } else {
+                                      context.pushNamed(
+                                        ExchangeSupportChatRoute
+                                            .supportChat
+                                            .name,
+                                      );
+                                    }
+                                  },
+                                ),
+                              ],
+                            ),
+                          ),
+                  ),
+                  leadingWidth: showChart ? 56 : 112,
+                  actionsIconTheme: IconThemeData(
+                    color: context.appColors.onPrimary,
+                    size: 24,
+                  ),
+                  actionsPadding: const EdgeInsets.only(right: 16),
+                  actions: showChart
+                      ? null
+                      : [
+                          IconButton(
+                            onPressed: () {
+                              context.pushNamed(
+                                TransactionsRoute.transactions.name,
+                              );
+                            },
+                            visualDensity: VisualDensity.compact,
+                            color: context.appColors.onPrimary,
+                            iconSize: 32,
+                            icon: const Icon(Icons.history),
+                          ),
+                          const Gap(16),
+                          InkWell(
+                            onTap: () =>
+                                context.pushNamed(SettingsRoute.settings.name),
+                            child: Image.asset(
+                              Assets.icons.settingsLine.path,
+                              width: 32,
+                              height: 32,
+                              color: context.appColors.onPrimary,
+                            ),
+                          ),
+                        ],
+                );
+              },
+            ),
+          ],
+        ),
+      ],
+      bottomChild: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Expanded(
+              child: BBButton.big(
+                iconData: Icons.arrow_downward,
+                label: context.loc.exchangeHomeDepositButton,
+                iconFirst: true,
+                onPressed: () =>
+                    context.pushNamed(FundExchangeRoute.fundExchange.name),
+                bgColor: context.appColors.secondaryFixed,
+                textColor: context.appColors.onSecondaryFixed,
+                outlined: true,
+                borderColor: context.appColors.onSecondaryFixed,
+              ),
+            ),
+            const Gap(4),
+            Expanded(
+              child: BBButton.big(
+                iconData: Icons.arrow_upward,
+                label: context.loc.exchangeHomeWithdrawButton,
+                iconFirst: true,
+                disabled: false,
+                onPressed: () => context.pushNamed(WithdrawRoute.withdraw.name),
+                bgColor: context.appColors.secondaryFixed,
+                textColor: context.appColors.onSecondaryFixed,
+                outlined: true,
+                borderColor: context.appColors.onSecondaryFixed,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
+++ b/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
@@ -47,37 +47,56 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
         errorMessage: null,
       ),
     );
+    try {
+      await _fetchAndApplyData();
+    } finally {
+      emit(state.copyWith(isLoading: false));
+    }
+  }
 
+  /// Reload server data from local DB then probe each server's status, all
+  /// under a single `isLoading` flag so the top progress bar reflects the
+  /// full pull-to-refresh duration.
+  Future<void> refresh() async {
+    emit(state.copyWith(isLoading: true));
+    try {
+      await _fetchAndApplyData();
+      final defaultServer = state.defaultServer;
+      final customServer = state.customServer;
+      await Future.wait([
+        if (defaultServer != null) checkServerStatus(defaultServer),
+        if (customServer != null) checkServerStatus(customServer),
+      ]);
+    } finally {
+      emit(state.copyWith(isLoading: false));
+    }
+  }
+
+  Future<void> _fetchAndApplyData() async {
     try {
       final request = LoadMempoolServerDataRequest(isLiquid: state.isLiquid);
-
       final response = await _loadDataUsecase.execute(request);
-
       emit(
         state.copyWith(
           defaultServer: response.defaultServer,
           customServer: response.customServer,
           settings: response.settings,
-          isLoading: false,
         ),
       );
     } catch (e) {
-      emit(
-        state.copyWith(
-          isLoading: false,
-          errorMessage: e.toString(),
-        ),
-      );
+      emit(state.copyWith(errorMessage: e.toString()));
     }
   }
 
   Future<bool> setCustomServer(String url, {bool enableSsl = true}) async {
-    emit(state.copyWith(
-      isSavingServer: true,
-      setServerError: null,
-      validationErrorType: null,
-      errorMessage: null,
-    ));
+    emit(
+      state.copyWith(
+        isSavingServer: true,
+        setServerError: null,
+        validationErrorType: null,
+        errorMessage: null,
+      ),
+    );
 
     try {
       final request = SetCustomMempoolServerRequest(
@@ -103,18 +122,19 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
         return false;
       }
     } catch (e) {
-      emit(
-        state.copyWith(
-          isSavingServer: false,
-          errorMessage: e.toString(),
-        ),
-      );
+      emit(state.copyWith(isSavingServer: false, errorMessage: e.toString()));
       return false;
     }
   }
 
   Future<void> deleteCustomServer() async {
-    emit(state.copyWith(isDeletingServer: true, setServerError: null, errorMessage: null));
+    emit(
+      state.copyWith(
+        isDeletingServer: true,
+        setServerError: null,
+        errorMessage: null,
+      ),
+    );
 
     try {
       final request = DeleteCustomMempoolServerRequest(
@@ -125,17 +145,18 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
 
       emit(state.copyWith(customServer: null, isDeletingServer: false));
     } catch (e) {
-      emit(
-        state.copyWith(
-          isDeletingServer: false,
-          errorMessage: e.toString(),
-        ),
-      );
+      emit(state.copyWith(isDeletingServer: false, errorMessage: e.toString()));
     }
   }
 
   Future<void> updateUseForFeeEstimation(bool value) async {
-    emit(state.copyWith(isUpdatingSettings: true, setServerError: null, errorMessage: null));
+    emit(
+      state.copyWith(
+        isUpdatingSettings: true,
+        setServerError: null,
+        errorMessage: null,
+      ),
+    );
 
     try {
       final request = UpdateMempoolSettingsRequest(
@@ -157,10 +178,7 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
       );
     } catch (e) {
       emit(
-        state.copyWith(
-          isUpdatingSettings: false,
-          errorMessage: e.toString(),
-        ),
+        state.copyWith(isUpdatingSettings: false, errorMessage: e.toString()),
       );
     }
   }
@@ -190,8 +208,9 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
         enableSsl: server.enableSsl,
       );
 
-      final finalStatus =
-          isValid ? MempoolServerStatus.online : MempoolServerStatus.offline;
+      final finalStatus = isValid
+          ? MempoolServerStatus.online
+          : MempoolServerStatus.offline;
       final finalServer = server.copyWith(status: finalStatus);
 
       if (server.isCustom) {
@@ -210,10 +229,12 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
   }
 
   void clearError() {
-    emit(state.copyWith(
-      setServerError: null,
-      validationErrorType: null,
-      errorMessage: null,
-    ));
+    emit(
+      state.copyWith(
+        setServerError: null,
+        validationErrorType: null,
+        errorMessage: null,
+      ),
+    );
   }
 }

--- a/lib/features/mempool_settings/ui/mempool_settings_screen.dart
+++ b/lib/features/mempool_settings/ui/mempool_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/cards/info_card.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
@@ -49,47 +50,62 @@ class _MempoolSettingsScreenState extends State<MempoolSettingsScreen> {
         ),
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: BlocBuilder<MempoolSettingsCubit, MempoolSettingsState>(
-              builder: (context, state) {
-                return Column(
-                  children: [
-                    const SizedBox(height: 16),
-                    BBSegmentFull(
-                      items: {
-                        context.loc.electrumNetworkBitcoin,
-                        context.loc.electrumNetworkLiquid,
-                      },
-                      initialValue: state.isLiquid
-                          ? context.loc.electrumNetworkLiquid
-                          : context.loc.electrumNetworkBitcoin,
-                      onSelected: (value) {
-                        context.read<MempoolSettingsCubit>().loadData(
-                              isLiquid: value == context.loc.electrumNetworkLiquid,
-                            );
-                      },
-                    ),
-                    if (state.hasError) ...[
-                      const Gap(16),
-                      InfoCard(
-                        description: getMempoolSettingsErrorMessage(context, state),
-                        tagColor: context.appColors.error,
-                        bgColor: context.appColors.errorContainer,
-                        onTap: () {
-                          context.read<MempoolSettingsCubit>().clearError();
+        child: BBPullableBody(
+          onRefresh: () async {
+            final cubit = context.read<MempoolSettingsCubit>();
+            await cubit.loadData(isLiquid: cubit.state.isLiquid);
+            final defaultServer = cubit.state.defaultServer;
+            final customServer = cubit.state.customServer;
+            await Future.wait([
+              if (defaultServer != null) cubit.checkServerStatus(defaultServer),
+              if (customServer != null) cubit.checkServerStatus(customServer),
+            ]);
+          },
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: BlocBuilder<MempoolSettingsCubit, MempoolSettingsState>(
+                builder: (context, state) {
+                  return SliverList(
+                    delegate: SliverChildListDelegate([
+                      const SizedBox(height: 16),
+                      BBSegmentFull(
+                        items: {
+                          context.loc.electrumNetworkBitcoin,
+                          context.loc.electrumNetworkLiquid,
+                        },
+                        initialValue: state.isLiquid
+                            ? context.loc.electrumNetworkLiquid
+                            : context.loc.electrumNetworkBitcoin,
+                        onSelected: (value) {
+                          context.read<MempoolSettingsCubit>().loadData(
+                            isLiquid:
+                                value == context.loc.electrumNetworkLiquid,
+                          );
                         },
                       ),
-                    ],
-                    const SizedBox(height: 16),
-                    const MempoolServerList(),
-                  ],
-                );
-              },
+                      if (state.hasError) ...[
+                        const Gap(16),
+                        InfoCard(
+                          description: getMempoolSettingsErrorMessage(
+                            context,
+                            state,
+                          ),
+                          tagColor: context.appColors.error,
+                          bgColor: context.appColors.errorContainer,
+                          onTap: () {
+                            context.read<MempoolSettingsCubit>().clearError();
+                          },
+                        ),
+                      ],
+                      const SizedBox(height: 16),
+                      const MempoolServerList(),
+                    ]),
+                  );
+                },
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/features/mempool_settings/ui/mempool_settings_screen.dart
+++ b/lib/features/mempool_settings/ui/mempool_settings_screen.dart
@@ -51,16 +51,8 @@ class _MempoolSettingsScreenState extends State<MempoolSettingsScreen> {
       ),
       body: SafeArea(
         child: BBPullableBody(
-          onRefresh: () async {
-            final cubit = context.read<MempoolSettingsCubit>();
-            await cubit.loadData(isLiquid: cubit.state.isLiquid);
-            final defaultServer = cubit.state.defaultServer;
-            final customServer = cubit.state.customServer;
-            await Future.wait([
-              if (defaultServer != null) cubit.checkServerStatus(defaultServer),
-              if (customServer != null) cubit.checkServerStatus(customServer),
-            ]);
-          },
+          onRefresh: () async =>
+              await context.read<MempoolSettingsCubit>().refresh(),
           slivers: [
             SliverPadding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/features/status_check/service_status_page.dart
+++ b/lib/features/status_check/service_status_page.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/status/domain/entity/service_status.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/presentation/state.dart';
@@ -36,67 +36,56 @@ class _ServiceStatusPageState extends State<ServiceStatusPage> {
           final serviceStatus = state.serviceStatus;
           final cubit = context.read<ServiceStatusCubit>();
 
-          return BBRefreshIndicator(
+          return BBPullableBody(
             indicatorKey: _refreshIndicatorKey,
             onRefresh: () async => await cubit.checkStatus(),
-            child: SingleChildScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              child: Padding(
+            slivers: [
+              SliverPadding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
                   vertical: 24,
                 ),
-                child: Column(
-                  mainAxisSize: .min,
-                  crossAxisAlignment: .start,
-                  children: [
-                    Column(
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    _ServiceStatusItem(
+                      service: serviceStatus.internetConnection,
+                    ),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.bitcoinElectrum),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.liquidElectrum),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.boltz),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.payjoin),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.pricer),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.mempool),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.tor),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.recoverbull),
+                    const SizedBox(height: 12),
+                    _ServiceStatusItem(service: serviceStatus.ark),
+                    const SizedBox(height: 16),
+                    Row(
+                      mainAxisAlignment: .center,
                       children: [
-                        _ServiceStatusItem(
-                          service: serviceStatus.internetConnection,
-                        ),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(
-                          service: serviceStatus.bitcoinElectrum,
-                        ),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(
-                          service: serviceStatus.liquidElectrum,
-                        ),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.boltz),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.payjoin),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.pricer),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.mempool),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.tor),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.recoverbull),
-                        const SizedBox(height: 12),
-                        _ServiceStatusItem(service: serviceStatus.ark),
-                        const SizedBox(height: 16),
-                        Row(
-                          mainAxisAlignment: .center,
-                          children: [
-                            if (serviceStatus.lastChecked != null)
-                              BBText(
-                                context.loc.statusCheckLastChecked(
-                                  _formatDateTime(serviceStatus.lastChecked!),
-                                ),
-                                style: context.font.bodySmall,
-                                color: context.appColors.onSurfaceVariant,
-                              ),
-                          ],
-                        ),
+                        if (serviceStatus.lastChecked != null)
+                          BBText(
+                            context.loc.statusCheckLastChecked(
+                              _formatDateTime(serviceStatus.lastChecked!),
+                            ),
+                            style: context.font.bodySmall,
+                            color: context.appColors.onSurfaceVariant,
+                          ),
                       ],
                     ),
-                  ],
+                  ]),
                 ),
               ),
-            ),
+            ],
           );
         },
       ),

--- a/lib/features/transactions/ui/screens/transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/transactions_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transactions_cubit.dart';
@@ -43,33 +43,30 @@ class _Screen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final err = context.select((TransactionsCubit cubit) => cubit.state.err);
-    return Column(
-      crossAxisAlignment: .start,
-      children: [
-        const TxsFilterRow(),
-        const TxsSyncingIndicator(),
+    return BBPullableBody(
+      onRefresh: () async {
+        final bloc = context.read<WalletBloc>();
+        bloc.add(const WalletRefreshed());
+        await bloc.stream.firstWhere((state) => !state.isSyncing);
+        if (!context.mounted) return;
+        await context.read<TransactionsCubit>().loadTxs();
+      },
+      slivers: [
+        const SliverToBoxAdapter(child: TxsFilterRow()),
+        const SliverToBoxAdapter(child: TxsSyncingIndicator()),
         if (err != null)
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: BBText(
-              context.loc.transactionError(err.toString()),
-              style: context.font.bodyLarge,
-              color: context.appColors.error,
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: BBText(
+                context.loc.transactionError(err.toString()),
+                style: context.font.bodyLarge,
+                color: context.appColors.error,
+              ),
             ),
           ),
-        const Gap(16.0),
-        Expanded(
-          child: BBRefreshIndicator(
-            onRefresh: () async {
-              final bloc = context.read<WalletBloc>();
-              bloc.add(const WalletRefreshed());
-              await bloc.stream.firstWhere((state) => !state.isSyncing);
-              if (!context.mounted) return;
-              await context.read<TransactionsCubit>().loadTxs();
-            },
-            child: const TxList(),
-          ),
-        ),
+        const SliverToBoxAdapter(child: Gap(16.0)),
+        const TxList(sliver: true),
       ],
     );
   }

--- a/lib/features/transactions/ui/widgets/tx_list.dart
+++ b/lib/features/transactions/ui/widgets/tx_list.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class TxList extends StatelessWidget {
-  const TxList({super.key});
+  const TxList({super.key, this.sliver = false});
+
+  final bool sliver;
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +26,7 @@ class TxList extends StatelessWidget {
         transactionsByDay: const {},
         ongoingSwaps: ongoingSwaps,
         errorMessage: context.loc.transactionListLoadingFailed,
+        sliver: sliver,
       );
     }
 
@@ -40,6 +43,7 @@ class TxList extends StatelessWidget {
     return TransactionsByDayList(
       transactionsByDay: txsByDay,
       ongoingSwaps: showOngoingSwaps ? ongoingSwaps : [],
+      sliver: sliver,
     );
   }
 }

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -54,37 +54,29 @@ class WalletDetailScreen extends StatelessWidget {
           : BlocProvider<TransactionsCubit>(
               create: (_) =>
                   locator<TransactionsCubit>(param1: walletId)..loadTxs(),
-              child: BBRefreshIndicator(
+              child: BBPullableBody(
                 onRefresh: () async {
                   final bloc = context.read<WalletBloc>();
                   bloc.add(const WalletRefreshed());
                   await bloc.stream.firstWhere((state) => !state.isSyncing);
                 },
-                child: LayoutBuilder(
-                  builder: (context, constraints) => SingleChildScrollView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    child: SizedBox(
-                      height: constraints.maxHeight,
-                      child: Column(
-                        children: [
-                          WalletDetailBalanceCard(
-                            balanceSat: wallet.balanceSat.toInt(),
-                            isLiquid: wallet.isLiquid,
-                            signer: wallet.signer,
-                          ),
-                          const Gap(16),
-                          const Expanded(child: WalletDetailTxsList()),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 13.0,
-                              vertical: 40,
-                            ),
-                            child: WalletBottomButtons(wallet: wallet),
-                          ),
-                        ],
-                      ),
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: WalletDetailBalanceCard(
+                      balanceSat: wallet.balanceSat.toInt(),
+                      isLiquid: wallet.isLiquid,
+                      signer: wallet.signer,
                     ),
                   ),
+                  const SliverToBoxAdapter(child: Gap(16)),
+                  const WalletDetailTxsList(sliver: true),
+                ],
+                bottomChild: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 13.0,
+                    vertical: 40,
+                  ),
+                  child: WalletBottomButtons(wallet: wallet),
                 ),
               ),
             ),

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/themes/colors.dart';
-import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/auto_swap_fee_warning.dart';
@@ -54,42 +54,30 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                 child: const SizedBox(height: 300),
               ),
             ),
-            BBRefreshIndicator(
+            BBPullableBody(
               onRefresh: () async {
                 final bloc = context.read<WalletBloc>();
                 bloc.add(const WalletRefreshed());
                 await bloc.stream.firstWhere((state) => !state.isSyncing);
               },
-              child: CustomScrollView(
-                physics: const AlwaysScrollableScrollPhysics(),
-                slivers: [
-                  const SliverToBoxAdapter(child: WalletHomeTopSection()),
-                  const SliverToBoxAdapter(child: HomeWarnings()),
-                  const SliverToBoxAdapter(child: AutoSwapFeeWarning()),
-                  SliverToBoxAdapter(
-                    child: WalletCards(
-                      onTap: (w) {
-                        context.pushNamed(
-                          WalletRoute.walletDetail.name,
-                          pathParameters: {'walletId': w.id},
-                        );
-                      },
-                    ),
+              slivers: [
+                const SliverToBoxAdapter(child: WalletHomeTopSection()),
+                const SliverToBoxAdapter(child: HomeWarnings()),
+                const SliverToBoxAdapter(child: AutoSwapFeeWarning()),
+                SliverToBoxAdapter(
+                  child: WalletCards(
+                    onTap: (w) {
+                      context.pushNamed(
+                        WalletRoute.walletDetail.name,
+                        pathParameters: {'walletId': w.id},
+                      );
+                    },
                   ),
-                  const SliverFillRemaining(
-                    hasScrollBody: false,
-                    child: Column(
-                      children: [
-                        Spacer(),
-                        Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 13.0),
-                          child: WalletBottomButtons(),
-                        ),
-                        Gap(16),
-                      ],
-                    ),
-                  ),
-                ],
+                ),
+              ],
+              bottomChild: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 13.0),
+                child: Column(children: [WalletBottomButtons(), Gap(16)]),
               ),
             ),
           ],

--- a/lib/features/wallet/ui/widgets/wallet_detail_txs_list.dart
+++ b/lib/features/wallet/ui/widgets/wallet_detail_txs_list.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class WalletDetailTxsList extends StatelessWidget {
-  const WalletDetailTxsList({super.key});
+  const WalletDetailTxsList({super.key, this.sliver = false});
+
+  final bool sliver;
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +24,7 @@ class WalletDetailTxsList extends StatelessWidget {
         errorMessage: selected.err != null
             ? context.loc.transactionListLoadingFailed
             : null,
+        sliver: sliver,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Pull-to-refresh was inconsistent across the app and unreliable on small screens. The shared `BBRefreshIndicator` was correct in isolation, but each screen wired its own scroll widget, physics, and bottom-buttons layout, so the gesture only worked in part of the screen, and small phones required an awkwardly long pull. Some screens were missing pull-to-refresh entirely.

This PR introduces a single `BBPullableBody` widget that enforces the three invariants pull-to-refresh actually needs:

1. A single scrollable that fills the viewport (`CustomScrollView` + `SliverFillRemaining`).
2. `AlwaysScrollableScrollPhysics` so short content can still overscroll and trigger refresh.
3. No nested scrollables (lists inside the body opt into a `sliver: true` mode).

`BBPullableBody` accepts a list of `slivers` and an optional `bottomChild` that auto-pins to the bottom of the viewport via `SliverFillRemaining(hasScrollBody: false)`. Future screens get correct gesture coverage by default.

`BBRefreshIndicator` now centers the spinner around 40% of screen height (via `MediaQuery.sizeOf`) so it lands in a consistent, reachable spot on every device.

## Test plan

Pull from the **middle of the screen** (and verify spinner lands ~40% from top) on:

- [x] Wallet home — pull, verify wallets refresh; bottom action buttons stay pinned
- [x] Wallet detail — open any wallet, pull from over the tx list area (was the worst case before)
- [x] Transactions — empty filter result, populated list, with active filter; pull from filter row, middle, bottom
- [x] Service status — initial spinner appears on open; subsequent pull triggers re-check
- [x] Exchange home (logged in) — pull, verify user summary refresh; bottom buttons stay pinned
- [x] Electrum settings — pull, spinner persists until load completes (no more instant dismiss)
- [ ] ~~Ark wallet detail — pull, verify ark cubit reloads; bottom buttons stay pinned~~
- [x] Mempool settings — pull, verify both default and custom server status indicators flicker to "checking" then update (same effect as the small refresh icon next to each server)

Verify on a small and big device that the pull distance feels comfortable.
