### PR TITLE
refactor(logs): tighten Sentry pipeline + remove critical

### DIFF
--- a/lib/core/background_tasks/handler.dart
+++ b/lib/core/background_tasks/handler.dart
@@ -21,6 +21,16 @@ Future<bool> tasksHandler(String task) async {
   final startTime = DateTime.now();
 
   await Bull.initLogs();
+  // Note: `Report.init` is intentionally NOT called here. The BG isolate
+  // has its own Dart-side Sentry hub but the native plugin (Sentry
+  // Android / iOS) is a process-level singleton. Calling
+  // `SentryFlutter.init` again from the BG isolate would re-init the
+  // native SDK and stomp the main isolate's crash-handler config when
+  // both isolates are alive (foreground app + BG task firing). The
+  // trade-off: BG-task failures are captured to the on-disk TSV log
+  // only; they don't reach Sentry. If/when we need BG observability,
+  // switch to envelope-forwarding (write events to a queue here, ship
+  // them next time the main isolate boots).
   await LibLwk.init();
 
   try {

--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -75,8 +75,15 @@ class SqliteDatabase extends _$SqliteDatabase {
   SqliteDatabase([QueryExecutor? executor])
     : super(executor ?? _openConnection());
 
+  /// Current drift schema version. Bump in lockstep with adding a new
+  /// `Schema<N-1>To<N>.migrate` step in [migration]. `Report.init`
+  /// asserts that an entry for this number exists in the
+  /// schema → app-version map so a future bump can't silently
+  /// misclassify upgrade events.
+  static const int currentSchemaVersion = 12;
+
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => currentSchemaVersion;
 
   static QueryExecutor _openConnection() {
     return driftDatabase(
@@ -135,9 +142,10 @@ class SqliteDatabase extends _$SqliteDatabase {
   }
 
   /// Wraps a per-version drift migration step so a failure is surfaced to
-  /// Sentry via the always-on migration channel before the rethrow aborts
-  /// init. Drift migrations run lazily on first query, so wrapping the step
-  /// fn (not the constructor) is what actually catches failures.
+  /// Sentry (consent-gated, tagged `category=migration`) before the
+  /// rethrow aborts init. Drift migrations run lazily on first query,
+  /// so wrapping the step fn (not the constructor) is what actually
+  /// catches failures.
   static Future<void> Function(Migrator, Schema) _reportingMigration<Schema>(
     String name,
     Future<void> Function(Migrator, Schema) fn,

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -7,7 +7,15 @@ import 'package:flutter/foundation.dart';
 import 'package:logging_colorful/logging_colorful.dart' as dep;
 export 'package:logging_colorful/logging_colorful.dart';
 
-Logger log = Logger.init();
+// The top-level holder is eagerly seeded with a placeholder anchored at
+// `Directory.current` so that any log line emitted before `Bull.initLogs`
+// runs (e.g. from a thrown exception during early `WidgetsFlutterBinding`
+// init) doesn't hit a `LateInitializationError`. `Bull.initLogs` then
+// calls [Logger.replace] which cancels this placeholder's
+// `dep.Logger.root.onRecord` subscription before attaching a new one —
+// preventing the duplicate-listener leak that occurred when both
+// instances stayed subscribed to the same broadcast stream.
+Logger log = Logger.replace(directory: Directory.current);
 
 class Logger {
   final Directory dir;
@@ -16,17 +24,25 @@ class Logger {
   static const _logFilename = 'bull_logs.tsv';
   static const _maxLogSizeKb = 100;
 
+  /// Tracks the currently-active Logger so [replace] can cancel its
+  /// `dep.Logger.root.onRecord` subscription before installing the
+  /// next one. Per-isolate (Dart isolates do not share static state),
+  /// so background-task isolates that call `Bull.initLogs` get their
+  /// own single-listener lifecycle.
+  static Logger? _current;
+
   IOSink? _sink;
   Future<void> _opChain = Future.value();
   bool _isLogging = false;
   bool _handlingLoggerFailure = false;
+  StreamSubscription<dep.LogRecord>? _subscription;
 
   File get logsFile => File('${dir.path}/$_logFilename');
 
   Logger._(this.dir, this.logger) {
     dep.Logger.root.level = dep.Level.ALL;
 
-    dep.Logger.root.onRecord.listen((record) {
+    _subscription = dep.Logger.root.onRecord.listen((record) {
       _isLogging = true;
       try {
         final content = _recordToContent(record);
@@ -49,16 +65,23 @@ class Logger {
     });
   }
 
-  Logger.init({String name = 'Logger', Directory? directory})
-    : this._(
-        directory ?? Directory.current,
-        // iOS emulator doesn't support colors –> https://github.com/flutter/flutter/issues/20663
-        // We don't want colors in release mode either
-        dep.LoggerColorful(
-          name,
-          disabledColors: Platform.isIOS || kReleaseMode,
-        ),
-      );
+  /// Builds a new Logger anchored at [directory] and retires the prior
+  /// instance (if any) by cancelling its `dep.Logger.root.onRecord`
+  /// subscription. Idempotent: safe to call when no prior instance
+  /// exists. Callers must reassign the top-level [log] holder to the
+  /// returned instance — `Bull.initLogs` is the canonical caller.
+  static Logger replace({String name = 'Logger', required Directory directory}) {
+    _current?._subscription?.cancel();
+    _current?._subscription = null;
+    final next = Logger._(
+      directory,
+      // iOS emulator doesn't support colors –> https://github.com/flutter/flutter/issues/20663
+      // We don't want colors in release mode either
+      dep.LoggerColorful(name, disabledColors: Platform.isIOS || kReleaseMode),
+    );
+    _current = next;
+    return next;
+  }
 
   // ---------------------------------------------------------------------------
   // Public API
@@ -87,11 +110,6 @@ class Logger {
       _reportLoggerFailure('Failed to read logs', e);
       rethrow;
     }
-  }
-
-  Future<int> getSizeInKb() async {
-    final stat = await logsFile.stat();
-    return stat.size ~/ 1000;
   }
 
   Future<void> prune() => _enqueue(() async {
@@ -228,12 +246,20 @@ class Logger {
   /// Optional [category] attaches a `category=<name>` Sentry tag for
   /// crash-cache filtering (e.g. [ReportCategory.migration] for
   /// storage-migration faults); when omitted the tag is `none`.
-  void shout({
+  ///
+  /// Returns a `Future<void>` that completes once the underlying
+  /// `Report.shout` has finished its Sentry capture. Awaiting it lets
+  /// callers serialize before persisting state that depends on the
+  /// capture having reached the wire — notably the install/upgrade
+  /// milestone, where `Report.commitVersion` advances the persisted
+  /// version marker only after the Sentry event is in flight, so a
+  /// crash between the two retries the event on the next launch.
+  Future<void> shout({
     required String message,
     Object? error,
     StackTrace? trace,
     ReportCategory? category,
-  }) {
+  }) async {
     if (_isLogging) {
       _emitDirect(
         level: 'SHOUT',
@@ -251,7 +277,7 @@ class Logger {
     }
 
     try {
-      Report.shout(
+      await Report.shout(
         message: message,
         exception: error,
         stackTrace: trace,
@@ -274,6 +300,11 @@ class Logger {
   // listener is already firing (reentrancy) or when the logger itself is in
   // a failure path — both cases where re-entering the dependency logger
   // would risk a "Cannot fire new event" crash.
+  //
+  // Sanitize per column before joining: `_sanitize` replaces tabs and
+  // newlines with spaces, so applying it to the already-joined string
+  // would collapse the column-separator tabs and produce a row with a
+  // different shape than the normal listener path.
   void _emitDirect({
     required String level,
     required String message,
@@ -281,7 +312,13 @@ class Logger {
     String trace = '',
   }) {
     final time = DateTime.now().toIso8601String();
-    final line = _sanitize([time, level, message, error, trace].join('\t'));
+    final line = [
+      time,
+      level,
+      message,
+      error,
+      trace,
+    ].map(_sanitize).join('\t');
     _queueWrite(line, flush: true);
     if (kDebugMode) debugPrint('[REENTRANT] $line');
   }
@@ -345,11 +382,5 @@ class Logger {
     final colors = RegExp(r'\x1B\[[0-9;]*[a-zA-Z]'); // ascii colors
     final tabNewLine = RegExp(r'[\t\n\r]');
     return input.replaceAll(tabNewLine, ' ').replaceAll(colors, '');
-  }
-
-  static String redactAddressOrTxId(String? value) {
-    if (value == null || value.isEmpty) return value ?? '';
-    if (value.length <= 6) return value;
-    return '${value.substring(0, 3)}...${value.substring(value.length - 3)}';
   }
 }

--- a/lib/core/utils/report.dart
+++ b/lib/core/utils/report.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -59,6 +60,18 @@ class Report {
   /// from/to tags and so `SentryFlutter.init` can read consent. Safe
   /// to call before Sentry is initialized — no capture here.
   static Future<void> init({bool? wizardConsent}) async {
+    // Debug-only guard: a schema bump that forgets to add an entry to
+    // `_schemaToVersion` would silently emit `'schema-N'` as the from-
+    // version tag for every upgrade event. Catching it here means a
+    // forgotten map entry surfaces on the first dev launch after the
+    // bump rather than weeks later in Sentry filters.
+    assert(
+      _schemaToVersion.containsKey(SqliteDatabase.currentSchemaVersion),
+      'Add an entry for schema ${SqliteDatabase.currentSchemaVersion} to '
+      'Report._schemaToVersion when bumping '
+      'SqliteDatabase.currentSchemaVersion',
+    );
+
     final info = await PackageInfo.fromPlatform();
     final to = '${info.version}+${info.buildNumber}';
 
@@ -120,7 +133,6 @@ class Report {
       options.enableUserInteractionBreadcrumbs = false;
       options.enableUserInteractionTracing = false;
       options.enableWindowMetricBreadcrumbs = false;
-      options.enableAppLifecycleBreadcrumbs = false;
       options.enableBrightnessChangeBreadcrumbs = false;
       options.enableTextScaleChangeBreadcrumbs = false;
 
@@ -134,21 +146,40 @@ class Report {
       // ── Misc reporting
       options.reportSilentFlutterErrors = true;
 
-      // ── Consent-gated
+      // ── Defaults pinned for intent. Match SDK defaults today; pinned
+      //    so a future SDK upgrade that flips them doesn't drift our
+      //    privacy posture without a code review.
+      options.attachStacktrace = true;
+      options.maxBreadcrumbs = 100;
+
+      // ── Consent-gated. These flags are init-only — once the SDK is
+      //    constructed the booleans cannot be hot-toggled. Mid-session
+      //    opt-out is enforced dynamically via `beforeSend` and
+      //    `beforeSendTransaction` below; these flags only stop *new*
+      //    transactions / sessions / breadcrumbs from being generated
+      //    when consent is OFF at boot.
       final consent = Report.consent;
       options.sendClientReports = consent;
       options.enableAutoSessionTracking = consent;
       options.enableAutoPerformanceTracing = consent;
       options.enableAutoNativeBreadcrumbs = consent;
+      options.enableAppLifecycleBreadcrumbs = consent;
       options.tracesSampleRate = consent ? 0.2 : 0.0; // 0.2 instead of 1.0
       options.anrEnabled = consent;
 
       // ── Final scrub. No consent → no event, no exceptions (even
-      //    install/upgrade milestones tagged `category=critical`).
+      //    install/upgrade milestones tagged `category=migration`).
       //    Passing events are anonymized so we never leak txids,
       //    addresses, or seed-derived strings.
+      //
+      //    Re-reads `Report.consent` on every event (rather than using
+      //    a closure-captured boolean) so the runtime opt-out path —
+      //    `SettingsRepository.setErrorReportingEnabled(false)` →
+      //    `Report.updateConsent(false)` — takes effect for the
+      //    remainder of the session, not just for the next cold
+      //    start.
       options.beforeSend = (event, hint) {
-        if (!consent) return null;
+        if (!Report.consent) return null;
 
         event.exceptions?.forEach((e) => e.value = null);
         // Keep only the install UUID we set ourselves; drop anything else
@@ -183,6 +214,16 @@ class Report {
         }).toList();
 
         return event;
+      };
+
+      // Transactions ride a separate pipeline from `beforeSend` (events).
+      // With no callback set, traces generated when consent was ON at
+      // boot would keep flowing after a runtime opt-out until the next
+      // cold start. Re-reading `Report.consent` here closes that gap
+      // symmetrically with `beforeSend`.
+      options.beforeSendTransaction = (transaction, hint) {
+        if (!Report.consent) return null;
+        return transaction;
       };
     });
 
@@ -225,28 +266,42 @@ class Report {
   }
 
   /// Maps a drift schema number to the first released app version that
-  /// shipped with that schema. Append a new case here whenever
-  /// `SqliteDatabase.schemaVersion` is bumped.
-  static String _versionFromSchema(int schema) => switch (schema) {
-    1 => 'v5.0.0..v5.2.0',
-    2 => 'v5.3.0',
-    3 => 'v5.3.1',
-    4 => 'v5.4.0..v5.4.3',
-    5 => 'v5.4.4',
-    6 => 'v6.0.0',
-    7 => 'v6.1.0..v6.2.3',
-    8 => 'v6.3.0..v6.3.2',
-    9 => 'v6.3.3..v6.3.8',
-    10 => 'v6.4.0..v6.4.3',
-    11 => 'v6.5.0..v6.5.4',
-    12 => 'v6.6.0+',
-    _ => 'schema-$schema',
+  /// shipped with that schema. Append a new entry here whenever
+  /// [SqliteDatabase.currentSchemaVersion] is bumped — the assert in
+  /// [init] enforces coverage for the current schema in debug builds.
+  static const Map<int, String> _schemaToVersion = {
+    1: 'v5.0.0..v5.2.0',
+    2: 'v5.3.0',
+    3: 'v5.3.1',
+    4: 'v5.4.0..v5.4.3',
+    5: 'v5.4.4',
+    6: 'v6.0.0',
+    7: 'v6.1.0..v6.2.3',
+    8: 'v6.3.0..v6.3.2',
+    9: 'v6.3.3..v6.3.8',
+    10: 'v6.4.0..v6.4.3',
+    11: 'v6.5.0..v6.5.4',
+    12: 'v6.6.0+',
   };
+
+  static String _versionFromSchema(int schema) =>
+      _schemaToVersion[schema] ?? 'schema-$schema';
 
   /// Consent-gated error capture. Dropped by `beforeSend` when the user
   /// has opted out of the error-report program. Tagged `category=error`
   /// by default; an explicit [category] (e.g. [ReportCategory.migration])
   /// overrides it for crash-cache filtering. Routed from `log.severe`.
+  ///
+  /// The capture is detached from the calling stack via
+  /// `Future.microtask` on purpose: `log.severe` is reachable from the
+  /// `runZonedGuarded` error handler in `main.dart`. A synchronous
+  /// `Sentry.captureException` that itself throws would re-enter that
+  /// zone handler → re-enter `log.severe` → recurse. The microtask hop
+  /// breaks the chain. Side-effect: the `Future<void>` returned here
+  /// completes after scheduling, NOT after capture — callers awaiting
+  /// it cannot synchronize with capture completion. That is acceptable
+  /// for the error path; the milestone path (`Report.shout`) needs
+  /// real serialization and awaits captures directly.
   static Future<void> error({
     required Object exception,
     required StackTrace stackTrace,
@@ -254,16 +309,26 @@ class Report {
     ReportCategory category = ReportCategory.error,
   }) async {
     if (!Sentry.isEnabled) return;
-    Future.microtask(
-      () => Sentry.captureException(
-        exception,
-        stackTrace: stackTrace,
-        withScope: (s) {
-          if (message != null) _applyContexts(s, message);
-          _applyTags(s, categoryTag: category.name);
-        },
-      ),
-    );
+    // The microtask hop alone doesn't break the recursion loop — a throw
+    // inside the body still surfaces to `runZonedGuarded`'s error
+    // handler in `main.dart`, which would call `log.severe` →
+    // `Report.error` → another microtask → throw → … . The try/catch
+    // here is what actually breaks the loop: capture failures are
+    // logged via `debugPrint` only and never re-enter the zone handler.
+    Future.microtask(() async {
+      try {
+        await Sentry.captureException(
+          exception,
+          stackTrace: stackTrace,
+          withScope: (s) {
+            if (message != null) _applyContexts(s, message);
+            _applyTags(s, categoryTag: category.name);
+          },
+        );
+      } catch (e) {
+        if (kDebugMode) debugPrint('[Sentry capture failed] $e');
+      }
+    });
   }
 
   /// Non-error high-priority log — milestones (install/upgrade,
@@ -275,6 +340,14 @@ class Report {
   /// [exception] and [stackTrace] are both set, captured as an
   /// exception; otherwise captured as an info-level message. Routed
   /// from `log.shout`.
+  ///
+  /// Awaits the underlying `Sentry.capture*` directly (no microtask
+  /// hop) so callers can synchronize subsequent persistence with the
+  /// capture having reached the wire — see `main.dart`, where
+  /// `Report.commitVersion` advances the persisted version marker only
+  /// after the milestone capture completes. Unlike [error], this path
+  /// is not reached from a zone error handler, so re-entrancy isn't a
+  /// concern.
   static Future<void> shout({
     required String message,
     Object? exception,
@@ -283,24 +356,22 @@ class Report {
   }) async {
     if (!Sentry.isEnabled) return;
     final categoryTag = category?.name ?? 'none';
-    Future.microtask(() async {
-      if (exception != null && stackTrace != null) {
-        await Sentry.captureException(
-          exception,
-          stackTrace: stackTrace,
-          withScope: (s) {
-            _applyContexts(s, message);
-            _applyTags(s, categoryTag: categoryTag);
-          },
-        );
-      } else {
-        await Sentry.captureMessage(
-          message,
-          level: SentryLevel.info,
-          withScope: (s) => _applyTags(s, categoryTag: categoryTag),
-        );
-      }
-    });
+    if (exception != null && stackTrace != null) {
+      await Sentry.captureException(
+        exception,
+        stackTrace: stackTrace,
+        withScope: (s) {
+          _applyContexts(s, message);
+          _applyTags(s, categoryTag: categoryTag);
+        },
+      );
+    } else {
+      await Sentry.captureMessage(
+        message,
+        level: SentryLevel.info,
+        withScope: (s) => _applyTags(s, categoryTag: categoryTag),
+      );
+    }
   }
 
   static void _applyTags(Scope scope, {required String categoryTag}) {

--- a/lib/features/settings/ui/screens/app_settings/app_settings_screen.dart
+++ b/lib/features/settings/ui/screens/app_settings/app_settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/app_language_picker.dart';
 import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
-import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/settings/ui/widgets/dev_mode_switch.dart';
@@ -87,22 +86,6 @@ class AppSettingsScreen extends StatelessWidget {
                   icon: Icons.bug_report,
                   title: context.loc.settingsErrorReportingTitle,
                   trailing: const ErrorReportingSwitch(),
-                ),
-                SettingsEntryItem(
-                  icon: Icons.sync_problem,
-                  title: context.loc.errorReportingCriticalTitle,
-                  trailing: Switch(
-                    value: true,
-                    // Read-only — tapping surfaces the snackbar.
-                    onChanged: (_) => SnackBarUtils.showSnackBar(
-                      context,
-                      context.loc.errorReportingCriticalSnackbar,
-                    ),
-                  ),
-                  onTap: () => SnackBarUtils.showSnackBar(
-                    context,
-                    context.loc.errorReportingCriticalSnackbar,
-                  ),
                 ),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,10 +79,13 @@ class Bull {
     Report.consent = (await settings.fetch()).isErrorReportingEnabled;
     await initWorkmanager();
     // Emits the install/upgrade transition event (no-op on a normal
-    // launch) and advances the persisted version marker.
+    // launch) and advances the persisted version marker. The shout is
+    // awaited so a crash between scheduling and capture cannot lose
+    // the milestone — the persisted marker only advances once Sentry
+    // has the event.
     final type = Report.migrationType;
     if (type != null) {
-      log.shout(message: type.name, category: ReportCategory.migration);
+      await log.shout(message: type.name, category: ReportCategory.migration);
       await Report.commitVersion();
     }
   }
@@ -102,7 +105,7 @@ class Bull {
 
   static Future<void> initLogs() async {
     final logDirectory = await getApplicationDocumentsDirectory();
-    log = Logger.init(directory: logDirectory);
+    log = Logger.replace(directory: logDirectory);
     await log.ensureLogsExist();
   }
 

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12539,17 +12539,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "السجلات الحرجة",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "مفعّل دائمًا — يتيح لنا التأكد من انتقال محفظتك بأمان بين إصدارات التطبيق.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "لا يمكن تعطيل السجلات الحرجة. فهي تُبلّغ عن حالات فشل الترقية والترحيل وأخطاء بدء تشغيل التطبيق حتى نتمكن من إصلاح المشكلات التي قد تؤثر على الآخرين.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "استخدم نسختك الاحتياطية",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -110,17 +110,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "জটিল লগসমূহ",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "সদায় সক্ৰিয় — এই ফিচাৰে এপৰ সংস্কৰণসমূহৰ মাজত আপোনাৰ ৱালেটৰ সুৰক্ষিত স্থানান্তৰ নিশ্চিত কৰে।",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "জটিল লগসমূহ নিষ্ক্ৰিয় কৰিব নোৱাৰি। ই বিফল আপগ্ৰেড, মাইগ্ৰেশ্বন, আৰু এপ আৰম্ভণিৰ ত্ৰুটিসমূহ ৰিপৰ্ট কৰে যাতে আমি আনক প্ৰভাৱিত কৰিব পৰা সমস্যাসমূহ সমাধান কৰিব পাৰোঁ।",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "আপোনাৰ বেকআপ ব্যৱহাৰ কৰক",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -9546,17 +9546,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Критични логове",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Винаги активно — ни позволява да видим дали портфейлът ви мигрира безопасно между версиите на приложението.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Критичните логове не могат да бъдат изключени. Те докладват за неуспешни надстройки, миграции и грешки при стартиране на приложението, за да можем да отстраним проблеми, които биха могли да засегнат други потребители.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Използвайте резервното си копие",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12253,17 +12253,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "গুরুতর লগ",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "সবসময় সক্রিয় — অ্যাপের সংস্করণগুলির মধ্যে আপনার ওয়ালেট নিরাপদে মাইগ্রেট হচ্ছে কিনা তা আমাদের দেখতে দেয়।",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "গুরুতর লগ নিষ্ক্রিয় করা যাবে না। তারা ব্যর্থ আপগ্রেড, মাইগ্রেশন এবং অ্যাপ শুরুর ত্রুটিগুলি রিপোর্ট করে যাতে আমরা অন্যদের প্রভাবিত করতে পারে এমন সমস্যাগুলি ঠিক করতে পারি।",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "আপনার ব্যাকআপ ব্যবহার করুন",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Kritické protokoly",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Vždy zapnuto — umožňuje nám vidět, zda se vaše peněženka bezpečně migruje mezi verzemi aplikace.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Kritické protokoly nelze vypnout. Hlásí neúspěšné upgrady, migrace a chyby při spouštění aplikace, abychom mohli opravit problémy, které by se mohly týkat ostatních.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Použijte svou zálohu",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -4425,17 +4425,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Kritische Protokolle",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Immer aktiv — ermöglicht uns zu sehen, ob deine Wallet sicher zwischen App-Versionen migriert",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Kritische Protokolle können nicht deaktiviert werden. Sie melden fehlgeschlagene Upgrades, Migrationen und Fehler beim App-Start, damit wir Probleme beheben können, die andere betreffen könnten.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Nutze dein Backup",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Κρίσιμα αρχεία καταγραφής",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Πάντα ενεργό — μας επιτρέπει να βλέπουμε αν το πορτοφόλι σας μεταφέρεται με ασφάλεια μεταξύ εκδόσεων της εφαρμογής.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Τα κρίσιμα αρχεία καταγραφής δεν μπορούν να απενεργοποιηθούν. Αναφέρουν αποτυχημένες αναβαθμίσεις, μετεγκαταστάσεις και σφάλματα εκκίνησης της εφαρμογής, ώστε να μπορούμε να διορθώνουμε προβλήματα που ενδέχεται να επηρεάσουν άλλους.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Χρησιμοποιήστε το αντίγραφο ασφαλείας σας",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -12946,14 +12946,6 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch shown in the wizard and settings"
   },
-  "errorReportingCriticalTitle": "Critical logs",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only critical logs switch shown in the wizard and settings"
-  },
-  "errorReportingCriticalSnackbar": "Critical logs can't be disabled. They report failed upgrades, migrations, and app startup errors so we can fix problems that may affect others.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled critical logs switch"
-  },
   "appInitErrorHasBackupTitle": "Use your backup",
   "@appInitErrorHasBackupTitle": {
     "description": "Reassurance headline shown on the init-error screen when the user already has a backup"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -4542,17 +4542,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Registros críticos",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Siempre activo — nos permite saber si tu monedero migra de forma segura entre versiones de la aplicación.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Los registros críticos no se pueden desactivar. Informan sobre actualizaciones, migraciones y errores de inicio fallidos para que podamos solucionar problemas que puedan afectar a otros usuarios.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Usa tu copia de seguridad",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "گزارش‌های حیاتی",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "همیشه روشن — به ما اجازه می‌دهد ببینیم آیا کیف پول شما به‌طور ایمن بین نسخه‌های برنامه منتقل می‌شود.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "گزارش‌های حیاتی را نمی‌توان غیرفعال کرد. آن‌ها ارتقاها، مهاجرت‌ها و خطاهای راه‌اندازی برنامه ناموفق را گزارش می‌دهند تا بتوانیم مشکلاتی را که ممکن است بر دیگران تأثیر بگذارد برطرف کنیم.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "از نسخه پشتیبان خود استفاده کنید",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4528,17 +4528,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Kriittiset lokit",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Aina päällä — näemme, siirtyykö lompakkosi turvallisesti sovellusversioiden välillä.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Kriittisiä lokeja ei voi poistaa käytöstä. Ne raportoivat epäonnistuneista päivityksistä, siirroista ja sovelluksen käynnistysvirheistä, jotta voimme korjata ongelmia, jotka saattavat vaikuttaa muihin.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Käytä varmuuskopiotasi",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -4525,17 +4525,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Journaux critiques",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Toujours actif — nous permet de vérifier que votre portefeuille migre en toute sécurité entre les versions de l'application.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Les journaux critiques ne peuvent pas être désactivés. Ils signalent les échecs de mises à jour, de migrations et les erreurs de démarrage de l'application afin que nous puissions corriger les problèmes susceptibles d'affecter d'autres utilisateurs.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Utilisez votre sauvegarde",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "गंभीर लॉग",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "हमेशा चालू — हमें यह देखने देता है कि आपका वॉलेट ऐप संस्करणों के बीच सुरक्षित रूप से माइग्रेट होता है या नहीं।",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "गंभीर लॉग को बंद नहीं किया जा सकता। ये असफल अपग्रेड, माइग्रेशन और ऐप स्टार्टअप त्रुटियों की रिपोर्ट करते हैं ताकि हम उन समस्याओं को ठीक कर सकें जो दूसरों को प्रभावित कर सकती हैं।",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "अपने बैकअप का उपयोग करें",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -111,17 +111,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Կարևոր գրառումներ",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Միշտ միացված — թույլ է տալիս տեսնել՝ ձեր դրամապանակը ապահով է տեղափոխվում հավելվածի տարբերակների միջև։",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Կարևոր գրառումները չեն կարող անջատվել։ Դրանք զեկուցում են ձախողված թարմացումների, միգրացիաների և հավելվածի գործարկման սխալների մասին, որպեսզի մենք կարողանանք լուծել խնդիրները, որոնք կարող են ազդել ուրիշների վրա։",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Օգտագործեք ձեր պահուստը",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -4536,17 +4536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Log critici",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Sempre attivo — ci permette di verificare che il tuo portafoglio migri in sicurezza tra le versioni dell'app.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "I log critici non possono essere disattivati. Segnalano aggiornamenti, migrazioni ed errori di avvio dell'app non riusciti, così possiamo risolvere i problemi che potrebbero riguardare altri.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Usa il tuo backup",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -323,17 +323,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "კრიტიკული ჟურნალები",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "ყოველთვის ჩართული — საშუალებას გვაძლევს ვნახოთ, თქვენი საფულე უსაფრთხოდ გადადის აპის ვერსიებს შორის თუ არა.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "კრიტიკული ჟურნალების გამორთვა შეუძლებელია. ისინი აფიქსირებენ წარუმატებელ განახლებებს, მიგრაციებსა და აპლიკაციის გაშვების შეცდომებს, რათა შევძლოთ იმ პრობლემების გადაჭრა, რომლებმაც შესაძლოა სხვებზე იმოქმედოს.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "გამოიყენეთ თქვენი სარეზერვო ასლი",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "중요 로그",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "항상 켜짐 — 앱 버전 간에 지갑이 안전하게 마이그레이션되는지 확인할 수 있게 해줍니다.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "중요 로그는 비활성화할 수 없습니다. 실패한 업그레이드, 마이그레이션, 앱 시작 오류를 보고하여 다른 사용자에게 영향을 줄 수 있는 문제를 해결할 수 있도록 합니다.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "백업을 사용하세요",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -4591,17 +4591,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Registos críticos",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Sempre ativo — permite-nos ver se a sua carteira migra em segurança entre versões da aplicação.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Os registos críticos não podem ser desativados. Comunicam atualizações, migrações e erros de arranque da aplicação falhados para que possamos corrigir problemas que possam afetar outros utilizadores.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Use a sua cópia de segurança",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -12532,17 +12532,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Logs críticos",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Sempre ativo — permite que vejamos se sua carteira migra com segurança entre versões do aplicativo.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Os logs críticos não podem ser desativados. Eles relatam atualizações, migrações e erros de inicialização do aplicativo que falharam para que possamos corrigir problemas que possam afetar outros.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Use seu backup",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -4545,17 +4545,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Критические журналы",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Всегда включено — позволяет нам видеть, безопасно ли мигрирует ваш кошелёк между версиями приложения.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Критические журналы нельзя отключить. Они сообщают о неудачных обновлениях, миграциях и ошибках запуска приложения, чтобы мы могли устранить проблемы, которые могут затронуть других.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Используйте резервную копию",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -131,17 +131,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Rekodi muhimu",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Inaendelea kuwashwa — inatuwezesha kuona kama pochi yako inahama kwa usalama kati ya matoleo ya programu.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Rekodi muhimu haziwezi kuzimwa. Zinaripoti maboresho, uhamiaji na hitilafu za kuanzisha programu zilizoshindwa ili tuweze kurekebisha matatizo yanayoweza kuwaathiri wengine.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Tumia nakala rudufu yako",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "บันทึกสำคัญ",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "เปิดอยู่เสมอ — ช่วยให้เราเห็นว่ากระเป๋าเงินของคุณย้ายข้อมูลระหว่างเวอร์ชันแอปอย่างปลอดภัยหรือไม่",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "ไม่สามารถปิดบันทึกสำคัญได้ บันทึกเหล่านี้รายงานการอัปเกรด การย้ายข้อมูล และข้อผิดพลาดในการเริ่มต้นแอปที่ล้มเหลว เพื่อให้เราสามารถแก้ไขปัญหาที่อาจส่งผลกระทบต่อผู้อื่นได้",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "ใช้ข้อมูลสำรองของคุณ",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12536,17 +12536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Kritik günlükler",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Her zaman açık — cüzdanınızın uygulama sürümleri arasında güvenle taşınıp taşınmadığını görmemizi sağlar.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Kritik günlükler devre dışı bırakılamaz. Başarısız yükseltmeleri, geçişleri ve uygulama başlatma hatalarını bildirirler; böylece başkalarını etkileyebilecek sorunları giderebiliriz.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Yedeğinizi kullanın",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4533,17 +4533,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Критичні журнали",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Завжди ввімкнено — дозволяє нам бачити, чи ваш гаманець безпечно переходить між версіями застосунку.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Критичні журнали не можна вимкнути. Вони повідомляють про невдалі оновлення, міграції та помилки запуску застосунку, щоб ми могли виправити проблеми, які можуть вплинути на інших.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Використайте резервну копію",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -111,17 +111,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "Nhật ký quan trọng",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "Luôn bật — giúp chúng tôi biết ví của bạn có di chuyển an toàn giữa các phiên bản ứng dụng hay không.",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "Không thể tắt nhật ký quan trọng. Chúng báo cáo các bản nâng cấp, di chuyển và lỗi khởi động ứng dụng không thành công để chúng tôi có thể khắc phục các sự cố có thể ảnh hưởng đến những người khác.",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "Sử dụng bản sao lưu của bạn",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -4536,17 +4536,9 @@
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
   },
-  "errorReportingCriticalTitle": "关键日志",
-  "@errorReportingCriticalTitle": {
-    "description": "Title of the read-only migration logs switch shown in the wizard and settings"
-  },
   "errorReportingMigrationSubtitle": "始终开启 — 让我们能看到您的钱包在应用版本之间是否安全迁移。",
   "@errorReportingMigrationSubtitle": {
     "description": "Subtitle explaining why the migration logs switch cannot be disabled"
-  },
-  "errorReportingCriticalSnackbar": "关键日志无法禁用。它们会报告失败的升级、迁移和应用启动错误，以便我们可以修复可能影响他人的问题。",
-  "@errorReportingCriticalSnackbar": {
-    "description": "Snackbar shown when the user taps the disabled migration logs switch"
   },
   "appInitErrorHasBackupTitle": "使用您的备份",
   "@appInitErrorHasBackupTitle": {


### PR DESCRIPTION
## Summary

- Sentry consent now applies mid-session (events **and** transactions), instead of only at the next cold start.
- Single `dep.Logger.root.onRecord` subscription per isolate — kills a duplicate-listener leak the top-level `Logger` was creating.
- Migration milestone (`log.shout`) awaits the Sentry capture before persisting the version marker, so a crash between scheduling and capture doesn't lose the event.
- Removed the read-only "Critical logs" settings toggle and its translations: it promised an always-on channel that no longer exists in the new design.
- Smaller dead-code / hardening cleanup folded in.

## Why

Audit of `lib/core/utils/report.dart` and `lib/core/utils/logger.dart` surfaced a few concrete bugs:

1. **Closure-captured consent**: `beforeSend` read `consent` from a local captured at `SentryFlutter.init` time. If the user toggled error reporting **off** in settings, events kept flowing for the rest of the session because `beforeSend` still saw the old value.
2. **Duplicate listener**: `Logger log = Logger.init();` ran at import time and `Bull.initLogs` called `Logger.init` again. Both instances' listeners stayed subscribed to the global broadcast stream — every record was processed twice and the first instance's writes silently failed against `Directory.current`.
3. **Migration milestone race**: `log.shout(...)` returned `void` and scheduled the Sentry capture as a `Future.microtask`. `Report.commitVersion()` then advanced the persisted version marker before the capture had a chance to land. A crash between the two lost the milestone forever (next launch saw `fromVersion == toVersion` and re-emitted nothing).
4. **`Report.error` recursion guard was incomplete**: the `Future.microtask` hop didn't actually break the recursion loop with `runZonedGuarded`'s error handler — a throw inside the body still surfaced and re-entered `log.severe`.
5. **Dead "Critical logs" UI**: a read-only `Switch(value: true)` whose snackbar told users the channel was always-on and couldn't be disabled. With the new design every category — including `migration` — is consent-gated through `beforeSend`, so the UI was lying.

## Changes

### Sentry / Report

- `beforeSend` and a new `beforeSendTransaction` re-read `Report.consent` dynamically. Runtime opt-out now takes effect on every event and every transaction.
- `Report.shout` drops the `Future.microtask` wrapper and awaits `Sentry.capture*` directly so callers (the migration milestone in `main.dart`) can serialize subsequent persistence on capture completion.
- `Report.error` keeps the microtask (zone-handler re-entrancy isolation) but now has try/catch around the capture so a failure can't recurse into `log.severe`.
- `attachStacktrace = true`, `maxBreadcrumbs = 100`, `enableAppLifecycleBreadcrumbs = consent` pinned explicitly so SDK-default drift doesn't quietly change our privacy posture.
- Schema → app-version map turned into a const map with a debug-only `assert` tied to `SqliteDatabase.currentSchemaVersion`. A schema bump that forgets to add a map entry now fails fast in dev rather than silently emitting `'schema-N'` to Sentry forever.

### Logger

- New `Logger.replace({required directory, name})` static cancels the prior `dep.Logger.root.onRecord` subscription before installing the next. `Bull.initLogs` is the canonical caller; the BG-task isolate path is idempotent.
- `log.shout` returns `Future<void>` and awaits `Report.shout`.
- `_emitDirect` sanitizes per column before joining with `\t`, so the reentrancy / failure-path TSV row has the same 5-column shape as the normal listener path.
- Removed unused `Logger.redactAddressOrTxId` and `Logger.getSizeInKb`.

### UI / translations

- Removed the "Critical logs" `SettingsEntryItem` from `app_settings_screen.dart`.
- Stripped `errorReportingCriticalTitle` / `errorReportingCriticalSnackbar` and their `@key` description blocks from all 26 ARB files.

## Test plan

- [ ] Fresh install → wizard → consent **on** → reach home → confirm a single set of console log lines per event (no duplicates) and a single TSV row per event in `${appdocs}/bull_logs.tsv`.
- [ ] Trigger a known `log.severe` path (Tor unreachable, mempool fetch failure). Confirm the event reaches Sentry.
- [ ] Settings → toggle error reporting **off**. Trigger another `log.severe`. Confirm the event is **not** captured this session.
- [ ] Toggle **back on**. Trigger a `log.severe`. Confirm capture resumes.
- [ ] Cold-restart with consent **off**. Confirm session-tracking and perf transactions stop being generated, resume after restart with consent on.
- [ ] Force the migration milestone path: clear `_lastVersionKey`, install a higher app version. Confirm a single `migration` install/upgrade event lands in Sentry **before** the persisted marker advances (i.e. no duplicate on next launch).
- [ ] Stage a fake schema bump locally (set `SqliteDatabase.currentSchemaVersion = 99` without adding to `_schemaToVersion`). Confirm the debug assert fires.
- [ ] App settings screen renders without the Critical-logs row.
