### PR TITLE
fix(reproducibility): unbreak APK build (git hardlink shim + makefile reuse)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,15 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Workaround for CVE-2024-32020 hardlink check failing on overlayfs:
+# git >= 2.45.1 verifies inode equality after hardlinking during local clone;
+# overlayfs returns different inodes so the check aborts. Pub does many local
+# clones from its bare cache, so we force --no-hardlinks for `git clone`.
+# Upstream fix tracked in git PR #1796 (not merged).
+RUN mv /usr/bin/git /usr/bin/git.real && \
+    printf '#!/bin/sh\nif [ "$1" = "clone" ]; then shift; exec /usr/bin/git.real clone --no-hardlinks "$@"; fi\nexec /usr/bin/git.real "$@"\n' > /usr/bin/git && \
+    chmod +x /usr/bin/git
+
 # Create user
 RUN adduser --disabled-password --gecos '' $USER
 RUN adduser $USER sudo

--- a/Dockerfile.apk
+++ b/Dockerfile.apk
@@ -15,9 +15,9 @@ WORKDIR /app
 RUN fvm install
 
 # Setup the project
-RUN fvm flutter pub get
-RUN fvm dart run build_runner build --delete-conflicting-outputs
-RUN fvm flutter gen-l10n
+RUN make deps
+RUN make build-runner
+RUN make translations
 
 
 # Configure Gradle for containerized builds

--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ build-runner-watch:
 
 translations:
 	@echo "🌐 Generating translations files"
-	@fvm flutter pub get
+	@fvm flutter gen-l10n
 
 hooks:
 	@CURRENT_HOOKS_PATH=$$(git config --local core.hooksPath); \


### PR DESCRIPTION
## Summary
- Work around CVE-2024-32020 hardlink check: git ≥ 2.45.1 verifies inode equality after hardlinking during local clone, but overlayfs returns different inodes, so `git clone` aborts with `fatal: hardlink different from source`. `pub get` does many local clones from its bare cache (one per `git:` dependency in `pubspec.yaml`), hitting this on every build. Upstream fix is tracked in [git PR #1796](https://github.com/git/git/pull/1796) but not yet merged. We shim `/usr/bin/git` so `clone` always passes `--no-hardlinks`. Semantic no-op, only disables a clone-time perf optimization.
- Replace inline `fvm flutter pub get`, `dart run build_runner`, `flutter gen-l10n` calls in `Dockerfile.apk` with `make deps`, `make build-runner`, `make translations` so the container path matches local setup and stays in sync.
- Fix `translations` makefile target which was running `fvm flutter pub get` instead of `fvm flutter gen-l10n`.
