### PR TITLE
Fix: Redirect to onboarding if create wallet fails

### DIFF
--- a/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
+++ b/lib/features/onboarding/presentation/bloc/onboarding_bloc.dart
@@ -37,6 +37,7 @@ class OnboardingBloc extends Bloc<OnboardingEvent, OnboardingState> {
     emit(
       state.copyWith(
         onboardingStepStatus: OnboardingStepStatus.none,
+        step: OnboardingStep.splash,
         statusError: error.toString(),
       ),
     );


### PR DESCRIPTION
Fixes a bug where create wallet failure would lead to an infinite loader instead of re-routing to the onboarding screen to try create a wallet again.