### PR TITLE
fix: stop satoshifier from re-initializing flutter_rust_bridge

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1676,8 +1676,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: b2978285d6e45d62f57d545d0f87d3ee474784c8
-      resolved-ref: b2978285d6e45d62f57d545d0f87d3ee474784c8
+      ref: "535eeea782ffb610a69dbee2eac4739c6a45c99e"
+      resolved-ref: "535eeea782ffb610a69dbee2eac4739c6a45c99e"
       url: "https://github.com/SatoshiPortal/dart-satoshifier"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,7 +109,7 @@ dependencies:
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/dart-satoshifier
-      ref: b2978285d6e45d62f57d545d0f87d3ee474784c8
+      ref: 535eeea782ffb610a69dbee2eac4739c6a45c99e
   flutter_nfc_kit: ^3.6.1
   ledger_bitcoin:
     git:


### PR DESCRIPTION
## Summary
- Bump `satoshifier` git ref `b2978285` → `535eeea` so `LibSatoshifier.init()` no longer calls `BullSdk.init()` a second time after `main.dart` already booted it.
- Fixes `FATAL: Failed to initialize native libraries: Bad state: Should not initialize flutter_rust_bridge twice` thrown at `flutter_rust_bridge-2.12.0/lib/src/main_components/entrypoint.dart:44`.

## Related
- Satoshifier change: SatoshiPortal/dart-satoshifier@535eeea (`refactor: drop LibSatoshifier.init, host owns bull_sdk init`)
- Bull-sdk submodule bump: SatoshiPortal/bull_sdk@3c2ae00
