### PR TITLE
build tools container before devcontainer builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "remoteUser": "${localEnv:USER}",
     "updateRemoteUserUID": true,
     "shutdownAction": "stopContainer",
-    "initializeCommand": ".devcontainer/init-ssh-agent.sh",
+    "initializeCommand": ".devcontainer/init-ssh-agent.sh && make container-tools",
     "runArgs": [
         "--name",
         "${localWorkspaceFolderBasename}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,31 @@
 {
-    "name": "${localWorkspaceFolderBasename}",
-    "build": {
-        "dockerfile": "../Containerfile.app",
-        "args": {
-            "USERNAME": "${localEnv:USER}"
-        }
+  "name": "${localWorkspaceFolderBasename}",
+  "build": {
+    "dockerfile": "../Containerfile.tools",
+    "args": {
+      "USERNAME": "${localEnv:USER}",
     },
-    "remoteUser": "${localEnv:USER}",
-    "updateRemoteUserUID": true,
-    "shutdownAction": "stopContainer",
-    "initializeCommand": ".devcontainer/init-ssh-agent.sh && make container-tools",
-    "runArgs": [
-        "--name",
-        "${localWorkspaceFolderBasename}",
-        "--hostname",
-        "bull",
-        "--memory=8g",
-        "--security-opt",
-        "label=disable"
-    ],
-    "mounts": [
-        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
-        "source=/tmp/ssh-agent.sock,target=/ssh-agent,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached"
-    ],
-    "containerEnv": {
-        "SSH_AUTH_SOCK": "/ssh-agent"
-    },
-    "postStartCommand": "sudo chown -R --no-dereference ${localEnv:USER}:${localEnv:USER} /home/${localEnv:USER}/.ssh || true; chmod 700 /home/${localEnv:USER}/.ssh; find /home/${localEnv:USER}/.ssh -maxdepth 1 -type f -exec chmod 600 {} + 2>/dev/null || true"
+  },
+  "remoteUser": "${localEnv:USER}",
+  "updateRemoteUserUID": true,
+  "shutdownAction": "stopContainer",
+  "initializeCommand": ".devcontainer/init-ssh-agent.sh",
+  "runArgs": [
+    "--name",
+    "${localWorkspaceFolderBasename}",
+    "--hostname",
+    "bull",
+    "--memory=8g",
+    "--security-opt",
+    "label=disable",
+  ],
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
+    "source=/tmp/ssh-agent.sock,target=/ssh-agent,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
+  ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/ssh-agent",
+  },
+  "postStartCommand": "sudo chown -R --no-dereference ${localEnv:USER}:${localEnv:USER} /home/${localEnv:USER}/.ssh || true; chmod 700 /home/${localEnv:USER}/.ssh; find /home/${localEnv:USER}/.ssh -maxdepth 1 -type f -exec chmod 600 {} + 2>/dev/null || true",
 }

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ deps:
 
 build-runner:
 	@echo "🏗️ Build runner for json_serializable and flutter_gen"
-	@fvm dart run build_runner build --delete-conflicting-outputs --force-jit
+	@fvm dart run build_runner build --force-jit
 
 build-runner-watch:
 	@echo "🏗️ Build runner for json_serializable and flutter_gen (watch mode)"


### PR DESCRIPTION
A small 2 line change

Added `make container-tools` to `initializeCommand` in `devcontainer.json` otherwise you manually have to run this command before DC is setup else the CLI or VSCode extension fails. This now works with VSCode and the CLI. Zed still fails probably because they don't follow the spec completely

Also removed `--delete-conflicting-outputs` from `make build-runner` because it's been removed in [v2.7.0](https://pub.dev/packages/build_runner/changelog#270)