### PR TITLE
fix(send): reject expired BOLT11 invoices

### DIFF
--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -277,6 +277,15 @@ class SendCubit extends Cubit<SendState> {
         final invoice = await _decodeInvoiceUsecase.execute(
           invoice: paymentRequest.invoice,
         );
+        if (invoice.isExpired) {
+          emit(
+            state.copyWith(
+              loadingBestWallet: false,
+              swapCreationException: ExpiredInvoiceException(),
+            ),
+          );
+          return;
+        }
         if (invoice.sats == 0) {
           emit(
             state.copyWith(

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -456,6 +456,10 @@ class AmountlessInvoiceException extends SwapCreationException {
   AmountlessInvoiceException(super.message);
 }
 
+class ExpiredInvoiceException extends SwapCreationException {
+  ExpiredInvoiceException() : super('Expired invoice');
+}
+
 class InsufficientBalanceException extends BullException {
   InsufficientBalanceException([
     super.message = 'Not enough balance to cover this payment',

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -245,6 +245,8 @@ class AddressErrorSection extends StatelessWidget {
       return BBText(
         swapError is AmountlessInvoiceException
             ? context.loc.sendErrorInvoiceMustContainAmount
+            : swapError is ExpiredInvoiceException
+            ? context.loc.sendErrorInvoiceExpired
             : swapError.message,
         style: context.font.bodyMedium,
         color: context.appColors.error,

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -7201,6 +7201,10 @@
   "@sendErrorInvoiceMustContainAmount": {
     "description": "Error when a Lightning invoice without an amount is used"
   },
+  "sendErrorInvoiceExpired": "This invoice is expired. Ask the recipient for a new invoice.",
+  "@sendErrorInvoiceExpired": {
+    "description": "Error when an expired Lightning invoice is used"
+  },
   "sendErrorInsufficientBalanceForPayment": "Not enough balance to cover this payment",
   "@sendErrorInsufficientBalanceForPayment": {
     "description": "Error when wallet balance is insufficient for payment"


### PR DESCRIPTION
## Summary
- reject expired BOLT11 invoices immediately after decoding
- show a specific expired invoice error in the send address step
- add the localized English error copy requested in issue #2161

Fixes #2161

## Verification
- Could not complete focused test/analyze in a clean upstream worktree because ignored generated Freezed/Drift/asset outputs are absent and local build_runner currently fails with Dart build-hooks support: `'dart compile' does not support build hooks, use 'dart build' instead`.
- The same code path was tested successfully in the existing feature worktree before extracting this narrow PR.