### PR TITLE
refactor(devcontainer): mount ssh socket under $HOME so it's visible in podman VM

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "${localWorkspaceFolderBasename}",
   "build": {
-    "dockerfile": "../Containerfile.tools",
+    "dockerfile": "../Containerfile.app",
     "args": {
       "USERNAME": "${localEnv:USER}",
     },
@@ -21,7 +21,7 @@
   ],
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
-    "source=/tmp/ssh-agent.sock,target=/ssh-agent,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.ssh-agent-devcontainer.sock,target=/ssh-agent,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
   ],
   "containerEnv": {

--- a/.devcontainer/init-ssh-agent.sh
+++ b/.devcontainer/init-ssh-agent.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
-# Normalize SSH agent socket path for devcontainer mount
+# Normalize SSH agent socket path for devcontainer mount.
+# Place under $HOME so the file is visible inside the podman-machine VM on macOS
+# (the VM bind-mounts /Users from the host but not /tmp).
+SOCKET="${HOME}/.ssh-agent-devcontainer.sock"
 case "$(uname)" in
   Linux)
-    # Symlink real SSH agent socket
-    ln -sf "$SSH_AUTH_SOCK" /tmp/ssh-agent.sock
+    ln -sf "$SSH_AUTH_SOCK" "$SOCKET"
     ;;
   Darwin)
-    # Create dummy so the mount doesn't fail (SSH agent not supported on macOS Podman)
-    rm -f /tmp/ssh-agent.sock
-    touch /tmp/ssh-agent.sock
+    # SSH agent not supported on macOS podman; create dummy so mount doesn't fail
+    rm -f "$SOCKET"
+    touch "$SOCKET"
     ;;
 esac


### PR DESCRIPTION
The ssh-agent socket source was hard-coded to /tmp/ssh-agent.sock. On the podman machine VM, /tmp is its own tmpfs (only /Users and /var/folders are virtiofs-mounted from the host), so the bind mount failed with "statfs /tmp/ssh-agent.sock: no such file or directory". Move the path to $HOME/.ssh-agent-devcontainer.sock so it lives under /Users and is visible inside the VM on macOS. Linux is unaffected (native podman + real /tmp).