### PR TITLE
dedup no_screenshot kotlin source dirs for K2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,21 @@ subprojects {
     }
 }
 
+// Workaround: no_screenshot 1.1.0 lists `src/main/kotlin` twice, which the K2
+// frontend (Kotlin 2.2.10) rejects as "Conflicting declarations". Dedup its
+// Kotlin source dirs by canonical path.
+// TODO: consider moving to a more maintained screenshot-prevention plugin.
+subprojects {
+    afterEvaluate { project ->
+        if (project.name == 'no_screenshot') {
+            def kotlinExt = project.extensions.findByName('kotlin')
+            kotlinExt?.sourceSets?.configureEach { ss ->
+                ss.kotlin.setSrcDirs(ss.kotlin.srcDirs.collect { it.canonicalFile }.unique())
+            }
+        }
+    }
+}
+
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
on a fresh setup/build ran into this error:

```
e: file:///home/human/.pub-cache/hosted/pub.dev/no_screenshot-1.1.0/android/src/main/kotlin/com/flutterplaza/no_screenshot/NoScree
  nshotPlugin.kt:39:11 Conflicting declarations:
  val SCREENSHOT_ON_CONST: String
  e: .../NoScreenshotPlugin.kt:42:11 Conflicting declarations:
  val PREF_NAME: String
  ...
  e: .../NoScreenshotPlugin.kt:72:38 Overload resolution ambiguity between candidates:
  val PREF_NAME: String
  val PREF_NAME: String
  e: .../NoScreenshotPlugin.kt:97:65 Overload resolution ambiguity between candidates:
  val SCREENSHOT_METHOD_CHANNEL: String
  val SCREENSHOT_METHOD_CHANNEL: String
  ...

  FAILURE: Build failed with an exception.

  * What went wrong:
  Execution failed for task ':no_screenshot:compileDebugKotlin'.
  > A failure occurred while executing
  org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
     > Compilation error. See log for more details

  BUILD FAILED in 41s
  Error: Gradle task assembleDebug failed with exit code 1
```

the full log repeats this for every top level constant

we probably need to consider eventually mvoing to a more maintained screenshot-prevention plugin