### PR TITLE
fix: display autoswap active status when enabled

### DIFF
--- a/lib/features/wallet/presentation/bloc/wallet_state.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_state.dart
@@ -81,8 +81,6 @@ sealed class WalletState with _$WalletState {
   }
 
   bool showAutoSwapActiveStatus() {
-    return autoSwapSettings != null &&
-        autoSwapSettings!.enabled &&
-        !autoSwapSettings!.showWarning;
+    return autoSwapSettings != null && autoSwapSettings!.enabled;
   }
 }


### PR DESCRIPTION
Fix: #2196

<img width="500" alt="Simulator Screenshot - iPhone 16e - 2026-06-01 at 17 42 50" src="https://github.com/user-attachments/assets/1594cc2b-d1e5-4cf0-9676-64b8fba3eb2f" />
