### PR TITLE
fix(broadcast_signed_tx): show broadcast failures and pin action buttons

### DIFF
--- a/lib/features/broadcast_signed_tx/errors.dart
+++ b/lib/features/broadcast_signed_tx/errors.dart
@@ -9,6 +9,10 @@ class InvalidTxError extends BroadcastSignedTxError {
     : super('Input is not a transaction using PSBT or HEX format');
 }
 
+class BroadcastFailedError extends BroadcastSignedTxError {
+  BroadcastFailedError() : super('Failed to broadcast the transaction');
+}
+
 class PushTxNoNdefRecordsError extends BroadcastSignedTxError {
   PushTxNoNdefRecordsError() : super('PushTx: No NDEF records found');
 }

--- a/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
+++ b/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
@@ -160,7 +160,9 @@ class BroadcastSignedTxCubit extends Cubit<BroadcastSignedTxState> {
         state.transaction == null) {
       return;
     }
-    emit(state.copyWith(isBroadcasting: true));
+    // Clear any error from a previous failed attempt so the stale message
+    // doesn't linger under the spinner while the retry is in flight.
+    emit(state.copyWith(isBroadcasting: true, error: null));
     try {
       await _broadcastBitcoinTransactionUsecase.execute(
         state.transaction!.data,

--- a/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
+++ b/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:bb_mobile/core/bbqr/bbqr.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/errors.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/presentation/broadcast_signed_tx_state.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/type.dart';
@@ -166,8 +167,18 @@ class BroadcastSignedTxCubit extends Cubit<BroadcastSignedTxState> {
         isPsbt: state.transaction!.format == TxFormat.psbt,
       );
       emit(state.copyWith(isBroadcasted: true, isBroadcasting: false));
-    } catch (e) {
-      emit(state.copyWith(error: UnexpectedError(e), isBroadcasting: false));
+    } catch (e, st) {
+      // Keep the raw infra detail (Electrum server / node rejection) in the
+      // logs instead of leaking it to the UI; the screen shows a generic
+      // localized message. A rejected broadcast is an expected user-facing
+      // condition (already confirmed, fee too low, server down), so this is a
+      // warning, not a Sentry-reported severe.
+      log.warning(
+        'Failed to broadcast signed transaction',
+        error: e,
+        trace: st,
+      );
+      emit(state.copyWith(error: BroadcastFailedError(), isBroadcasting: false));
     }
   }
 }

--- a/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
+++ b/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
@@ -34,6 +34,17 @@ class BroadcastSignedTxPage extends StatelessWidget {
           onBack: () => context.pop(),
         ),
       ),
+      // Actions are pinned to the bottom of the screen (not inline in the
+      // scroll content) so they don't jump when the error appears/disappears.
+      bottomNavigationBar:
+          BlocBuilder<BroadcastSignedTxCubit, BroadcastSignedTxState>(
+            builder: (context, state) {
+              final showActions =
+                  state.transaction != null && !state.isBroadcasted;
+              if (!showActions) return const SizedBox.shrink();
+              return const SafeArea(child: _BroadcastActions());
+            },
+          ),
       body: BlocBuilder<BroadcastSignedTxCubit, BroadcastSignedTxState>(
         builder: (context, state) {
           final cubit = context.read<BroadcastSignedTxCubit>();
@@ -98,6 +109,12 @@ class BroadcastSignedTxPage extends StatelessWidget {
                       bitcoinTx: state.transaction!.tx,
                     ),
                   ),
+                  // Broadcast failure is shown here in the scroll content so
+                  // the pinned action buttons stay put when it toggles.
+                  if (state.error != null) ...[
+                    const Gap(16),
+                    const _BroadcastError(),
+                  ],
                 ],
 
                 if (state.isBroadcasted == true) ...[
@@ -139,6 +156,7 @@ class _BroadcastActions extends StatelessWidget {
     final isBroadcasting = context.select(
       (BroadcastSignedTxCubit c) => c.state.isBroadcasting,
     );
+
     return Row(
       children: [
         if (pushTxUri != null)
@@ -171,6 +189,34 @@ class _BroadcastActions extends StatelessWidget {
   }
 }
 
+/// Error block shown in the review screen when a broadcast attempt fails.
+/// Shows a generic localized message only — the underlying server/node reason
+/// is logged via `log.severe` (and Sentry), not leaked to the UI.
+class _BroadcastError extends StatelessWidget {
+  const _BroadcastError();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.error_outline, color: context.appColors.error, size: 20),
+          const Gap(8),
+          Expanded(
+            child: BBText(
+              context.loc.broadcastSignedTxBroadcastError,
+              style: context.font.bodyMedium,
+              color: context.appColors.error,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _TransactionReviewSection extends StatefulWidget {
   const _TransactionReviewSection({required this.bitcoinTx});
 
@@ -195,6 +241,8 @@ class _TransactionReviewSectionState extends State<_TransactionReviewSection> {
 
   @override
   Widget build(BuildContext context) {
-    return const TransactionReviewView(bottomActions: _BroadcastActions());
+    // Actions are rendered in the page's bottomNavigationBar (pinned), not
+    // here, so they don't shift with the scroll content.
+    return const TransactionReviewView();
   }
 }

--- a/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
+++ b/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
@@ -191,7 +191,8 @@ class _BroadcastActions extends StatelessWidget {
 
 /// Error block shown in the review screen when a broadcast attempt fails.
 /// Shows a generic localized message only — the underlying server/node reason
-/// is logged via `log.severe` (and Sentry), not leaked to the UI.
+/// is logged via `log.warning` (file + console, no Sentry), not leaked to the
+/// UI.
 class _BroadcastError extends StatelessWidget {
   const _BroadcastError();
 

--- a/lib/features/broadcast_signed_tx/ui/transaction_review_view.dart
+++ b/lib/features/broadcast_signed_tx/ui/transaction_review_view.dart
@@ -31,7 +31,6 @@ import 'package:gap/gap.dart';
 /// - [fiatAmount] — fiat equivalent shown next to the send amount
 /// - [feePriorityWidget] — fee priority selector (e.g. fastest/medium/slow)
 /// - [topWidget] — custom widget shown above the transaction details
-/// - [bottomActions] — action buttons (confirm, broadcast, etc.)
 class TransactionReviewView extends StatelessWidget {
   const TransactionReviewView({
     super.key,
@@ -41,7 +40,6 @@ class TransactionReviewView extends StatelessWidget {
     this.fiatAmount,
     this.feePriorityWidget,
     this.topWidget,
-    this.bottomActions,
   });
 
   /// Optional title displayed at the top.
@@ -64,10 +62,6 @@ class TransactionReviewView extends StatelessWidget {
   /// Optional widget shown above the transaction details (e.g. top area icon).
   final Widget? topWidget;
 
-  /// Widget slot for action buttons (confirm, broadcast, etc.)
-  /// placed at the bottom of the screen.
-  final Widget? bottomActions;
-
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<TransactionReviewCubit, TransactionReviewState>(
@@ -83,7 +77,6 @@ class TransactionReviewView extends StatelessWidget {
             fiatAmount: fiatAmount,
             feePriorityWidget: feePriorityWidget,
             topWidget: topWidget,
-            bottomActions: bottomActions,
           ),
           TransactionReviewErrorState(:final error) => _ErrorView(error: error),
         };
@@ -171,7 +164,6 @@ class _LoadedView extends StatelessWidget {
     this.fiatAmount,
     this.feePriorityWidget,
     this.topWidget,
-    this.bottomActions,
   });
 
   final ReviewableTransaction transaction;
@@ -181,7 +173,6 @@ class _LoadedView extends StatelessWidget {
   final String? fiatAmount;
   final Widget? feePriorityWidget;
   final Widget? topWidget;
-  final Widget? bottomActions;
 
   @override
   Widget build(BuildContext context) {
@@ -198,7 +189,6 @@ class _LoadedView extends StatelessWidget {
             fiatAmount: fiatAmount,
             feePriorityWidget: feePriorityWidget,
           ),
-          if (bottomActions != null) ...[const Gap(24), bottomActions!],
         ],
       ),
     );

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -11251,6 +11251,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "البث...",
+  "broadcastSignedTxBroadcastError": "فشل بث المعاملة",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -6775,6 +6775,7 @@
     "description": "Button to broadcast signed transaction"
   },
   "broadcastSignedTxBroadcasting": "প্ৰচাৰ হৈ আছে...",
+  "broadcastSignedTxBroadcastError": "লেনদেন সম্প্ৰচাৰ কৰিবলৈ విఫల হ’ল",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -1,4 +1,5 @@
 {
+  "broadcastSignedTxBroadcastError": "Неуспешно излъчване на транзакцията",
   "translationWarningTitle": "Преводи, генерирани от ИИ",
   "@translationWarningTitle": {
     "description": "Title for the AI translation warning bottom sheet"

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -11688,6 +11688,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "ব্রডকাস্টিং..।",
+  "broadcastSignedTxBroadcastError": "লেনদেন সম্প্রচার করতে ব্যর্থ হয়েছে",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -11697,6 +11697,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "Vysílání...",
+  "broadcastSignedTxBroadcastError": "Nepodařilo se odvysílat transakci",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -3946,6 +3946,7 @@
   "swapProgressPendingMessage": "Die Übertragung läuft. Bitcoin-Transaktionen können eine Weile zur Bestätigung benötigen. Sie können zum Startbildschirm zurückkehren und warten.",
   "walletDetailsNetworkLabel": "Netzwerk",
   "broadcastSignedTxBroadcasting": "Wird übertragen…",
+  "broadcastSignedTxBroadcastError": "Übertragung der Transaktion fehlgeschlagen",
   "recoverbullSelectRecoverWallet": "Wallet wiederherstellen",
   "receivePayjoinActivated": "Payjoin aktiviert",
   "importMnemonicContinue": "Fortfahren",

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -9927,6 +9927,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "Broadcasting...",
+  "broadcastSignedTxBroadcastError": "Αποτυχία μετάδοσης της συναλλαγής",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -9899,6 +9899,10 @@
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },
+  "broadcastSignedTxBroadcastError": "Failed to broadcast the transaction",
+  "@broadcastSignedTxBroadcastError": {
+    "description": "Headline shown when broadcasting a signed transaction fails"
+  },
   "broadcastSignedTxPageTitle": "Broadcast signed transaction",
   "@broadcastSignedTxPageTitle": {
     "description": "Page title for broadcast signed transaction screen"

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -3146,6 +3146,7 @@
   "broadcastSignedTxTo": "A",
   "broadcastSignedTxBroadcast": "Transmitir",
   "broadcastSignedTxBroadcasting": "Transmitiendo...",
+  "broadcastSignedTxBroadcastError": "Error al difundir la transacción",
   "broadcastSignedTxPageTitle": "Transmitir transacción firmada",
   "broadcastSignedTxPasteHint": "Pegar un PSBT o HEX de transacción",
   "broadcastSignedTxCameraButton": "Cámara",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -11209,6 +11209,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "پخش ...",
+  "broadcastSignedTxBroadcastError": "ارسال تراکنش ناموفق بود",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -3093,6 +3093,7 @@
   "broadcastSignedTxTo": "Vastaanottaja",
   "broadcastSignedTxBroadcast": "Lähetä",
   "broadcastSignedTxBroadcasting": "Lähetetään...",
+  "broadcastSignedTxBroadcastError": "Tapahtuman lähetys epäonnistui",
   "broadcastSignedTxPageTitle": "Lähetä allekirjoitettu transaktio",
   "broadcastSignedTxPasteHint": "Liitä PSBT tai transaktion HEX",
   "broadcastSignedTxCameraButton": "Kamera",

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -3143,6 +3143,7 @@
   "broadcastSignedTxTo": "À",
   "broadcastSignedTxBroadcast": "Diffuser",
   "broadcastSignedTxBroadcasting": "Diffusion en cours...",
+  "broadcastSignedTxBroadcastError": "Échec de la diffusion de la transaction",
   "broadcastSignedTxPageTitle": "Diffuser une transaction signée",
   "broadcastSignedTxPasteHint": "Coller un PSBT ou un HEX de transaction",
   "broadcastSignedTxCameraButton": "Caméra",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -11996,6 +11996,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "प्रसारण..।",
+  "broadcastSignedTxBroadcastError": "लेन-देन प्रसारित करने में विफल",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -8970,6 +8970,7 @@
     "description": "Button to broadcast signed transaction"
   },
   "broadcastSignedTxBroadcasting": "Broadcast ho raha hai...",
+  "broadcastSignedTxBroadcastError": "Len-den prasarit karne mein viphal raha",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -1,4 +1,5 @@
 {
+  "broadcastSignedTxBroadcastError": "Չհաջողվեց հեռարձակել գործարքը",
   "exchangeFileUploadUploadCount": "Upload {count} {count, plural, =1{File} other{Files}}",
   "appInitErrorTitle": "Հավելվածը չհաջողվեց գործարկել",
   "@appInitErrorTitle": {

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -3999,6 +3999,7 @@
   "swapProgressPendingMessage": "Il trasferimento è in corso. Le transazioni Bitcoin possono richiedere un po' di tempo per confermare. Puoi tornare a casa e aspettare.",
   "walletDetailsNetworkLabel": "Rete di rete",
   "broadcastSignedTxBroadcasting": "Trasmissione...",
+  "broadcastSignedTxBroadcastError": "Trasmissione della transazione non riuscita",
   "recoverbullSelectRecoverWallet": "Recuperare Wallet",
   "receivePayjoinActivated": "Payjoin attivato",
   "importMnemonicContinue": "Continua",

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -1,4 +1,5 @@
 {
+  "broadcastSignedTxBroadcastError": "ტრანზაქციის გავრცელება ვერ მოხერხდა",
   "transactionNoteAddTitle": "შენიშვნის დამატება",
   "@transactionNoteAddTitle": {
     "description": "Title for add note dialog"

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12004,6 +12004,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "방송...",
+  "broadcastSignedTxBroadcastError": "거래 전송에 실패했습니다",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -3972,6 +3972,7 @@
   "swapProgressPendingMessage": "A transferência está em andamento. As transações Bitcoin podem demorar um pouco para confirmar. Podes voltar para casa e esperar.",
   "walletDetailsNetworkLabel": "Rede",
   "broadcastSignedTxBroadcasting": "Transmissão...",
+  "broadcastSignedTxBroadcastError": "Falha ao transmitir a transação",
   "recoverbullSelectRecoverWallet": "Recuperar Carteira",
   "receivePayjoinActivated": "Payjoin ativado",
   "importMnemonicContinue": "Continue",

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -10176,6 +10176,7 @@
     "description": "Bold label for Google/Apple cloud recommendation"
   },
   "broadcastSignedTxBroadcasting": "Transmissão...",
+  "broadcastSignedTxBroadcastError": "Falha ao transmitir a transação",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -3997,6 +3997,7 @@
   "swapProgressPendingMessage": "Перенос продолжается. Биткойн-транзакции могут занять некоторое время, чтобы подтвердить. Вы можете вернуться домой и подождать.",
   "walletDetailsNetworkLabel": "Сеть",
   "broadcastSignedTxBroadcasting": "Вещание...",
+  "broadcastSignedTxBroadcastError": "Не удалось транслировать транзакцию",
   "recoverbullSelectRecoverWallet": "Recover Wallet",
   "receivePayjoinActivated": "Payjoin активирован",
   "importMnemonicContinue": "Продолжить",

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -1,4 +1,5 @@
 {
+  "broadcastSignedTxBroadcastError": "Imeshindwa kutangaza muamala",
   "languageSettingsLabel": "| Lugha |",
   "@languageSettingsLabel": {
     "description": "The label for the button to access the language settings"

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -11996,6 +11996,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "ออกอากาศ ...",
+  "broadcastSignedTxBroadcastError": "ไม่สามารถบรอดแคสต์ธุรกรรมได้",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -11895,6 +11895,7 @@
     "description": "Label for the network field in wallet details"
   },
   "broadcastSignedTxBroadcasting": "Yayınlama...",
+  "broadcastSignedTxBroadcastError": "İşlem yayınlanamadı",
   "@broadcastSignedTxBroadcasting": {
     "description": "Loading message while broadcasting"
   },

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4026,6 +4026,7 @@
   "dcaPaymentMethodLabel": "Спосіб оплати",
   "swapProgressPendingMessage": "Передача здійснюється в процесі. Біткойн-транзакції можуть зайняти під час підтвердження. Ви можете повернутися додому і чекати.",
   "broadcastSignedTxBroadcasting": "Трансляція...",
+  "broadcastSignedTxBroadcastError": "Не вдалося транслювати транзакцію",
   "recoverbullSelectRecoverWallet": "Відновлення гаманця",
   "importMnemonicContinue": "Продовжити",
   "psbtFlowMoveLaser": "Перемістити червоному лазеру вгору і вниз по QR-коду",

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -1,4 +1,5 @@
 {
+  "broadcastSignedTxBroadcastError": "Không thể phát đi giao dịch",
   "exchangeFileUploadUploadCount": "Upload {count} {count, plural, =1{File} other{Files}}",
   "appInitErrorTitle": "Ứng dụng không thể khởi động",
   "@appInitErrorTitle": {

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -3997,6 +3997,7 @@
   "swapProgressPendingMessage": "移交工作正在进行之中。 交易可在确认时进行。 你可以回家,等待.",
   "walletDetailsNetworkLabel": "网络",
   "broadcastSignedTxBroadcasting": "广播.",
+  "broadcastSignedTxBroadcastError": "广播交易失败",
   "recoverbullSelectRecoverWallet": "恢复钱包",
   "receivePayjoinActivated": "Payjoin",
   "importMnemonicContinue": "继续",


### PR DESCRIPTION
Broadcast failures were caught in the cubit but never rendered: the error
UI only existed in the paste/scan branch (transaction == null), so a rejected broadcast (already confirmed, fee too low, no servers reachable)
silently re-enabled the button with no feedback — which users read as "the
broadcast button doesn't work".

- Render a localized error in the review screen via a new typed BroadcastFailedError; the raw Electrum/node detail goes to log.warning (file + console, no Sentry) instead of leaking to the UI.
- Add broadcastSignedTxBroadcastError and translate it across all locales.
- Pin the action buttons to the bottom (bottomNavigationBar + SafeArea) and move the error into the scroll content, so the buttons no longer jump when the error appears/disappears.