### PR TITLE
feat(android): add installable beta tester channel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ ios/
 .fvm/
 
 # Local APKs/AABs built previously (host-side artifacts)
+BULL-*.apk
+BULL-*.aab
 app-*.apk
 app-*.aab
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       mode:
         type: choice
-        options: [release, debug]
+        options: [release, debug, beta]
         default: release
 
 jobs:
@@ -26,12 +26,31 @@ jobs:
           large-packages: true
           swap-storage: false
 
+      # Dedicated beta signing key, written before the build so the container
+      # image (Containerfile.app copies the repo) picks it up. If the secret is
+      # unset, the build falls back to the committed debug keystore.
+      - name: Configure beta signing key
+        if: ${{ inputs.mode == 'beta' && secrets.BETA_KEYSTORE_BASE64 != '' }}
+        env:
+          BETA_KEYSTORE_BASE64: ${{ secrets.BETA_KEYSTORE_BASE64 }}
+          BETA_KEY_ALIAS: ${{ secrets.BETA_KEY_ALIAS }}
+          BETA_KEY_PASSWORD: ${{ secrets.BETA_KEY_PASSWORD }}
+          BETA_STORE_PASSWORD: ${{ secrets.BETA_STORE_PASSWORD }}
+        run: |
+          echo "$BETA_KEYSTORE_BASE64" | base64 -d > android/app/beta-upload.keystore
+          cat > android/key-beta.properties <<EOF
+          storeFile=beta-upload.keystore
+          storePassword=$BETA_STORE_PASSWORD
+          keyAlias=$BETA_KEY_ALIAS
+          keyPassword=$BETA_KEY_PASSWORD
+          EOF
+
       - name: Build APK
         # makefile uses `podman` directly; ubuntu-24.04 ships podman 4.9.3 preinstalled.
-        run: make apk ${{ inputs.mode }}
+        run: make android ${{ inputs.mode }}
 
       - uses: actions/upload-artifact@v7
         with:
-          name: app-${{ inputs.mode }}
-          path: app-${{ inputs.mode }}.apk
+          name: BULL-${{ inputs.mode }}
+          path: BULL-${{ inputs.mode }}.apk
           retention-days: 30

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -27,16 +27,26 @@ jobs:
           swap-storage: false
 
       # Dedicated beta signing key, written before the build so the container
-      # image (Containerfile.app copies the repo) picks it up. If the secret is
-      # unset, the build falls back to the committed debug keystore.
+      # image (Containerfile.app copies the repo) picks it up. A beta that ships
+      # to testers must be signed with the real beta key; build.gradle leaves it
+      # unsigned (never the public debug keystore) when the key is absent, so we
+      # require all four secrets here and fail loud rather than produce an
+      # uninstallable/unsigned artifact. The secret presence check lives in the
+      # run body on purpose: the `secrets` context is not available in a step
+      # `if:` (only `inputs`/`env` etc. are), so gating on it there would not work.
       - name: Configure beta signing key
-        if: ${{ inputs.mode == 'beta' && secrets.BETA_KEYSTORE_BASE64 != '' }}
+        if: ${{ inputs.mode == 'beta' }}
         env:
           BETA_KEYSTORE_BASE64: ${{ secrets.BETA_KEYSTORE_BASE64 }}
           BETA_KEY_ALIAS: ${{ secrets.BETA_KEY_ALIAS }}
           BETA_KEY_PASSWORD: ${{ secrets.BETA_KEY_PASSWORD }}
           BETA_STORE_PASSWORD: ${{ secrets.BETA_STORE_PASSWORD }}
         run: |
+          if [ -z "$BETA_KEYSTORE_BASE64" ] || [ -z "$BETA_KEY_ALIAS" ] \
+            || [ -z "$BETA_KEY_PASSWORD" ] || [ -z "$BETA_STORE_PASSWORD" ]; then
+            echo "::error::Beta signing secrets (BETA_KEYSTORE_BASE64/BETA_KEY_ALIAS/BETA_KEY_PASSWORD/BETA_STORE_PASSWORD) are not all set; refusing to build an unsigned beta."
+            exit 1
+          fi
           echo "$BETA_KEYSTORE_BASE64" | base64 -d > android/app/beta-upload.keystore
           cat > android/key-beta.properties <<EOF
           storeFile=beta-upload.keystore

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,15 @@ app.*.map.json
 /android/app/release
 **/.cxx
 
+# Beta signing secrets written by CI — never commit. (The debug keystore at
+# android/app/debug.keystore is intentionally tracked and not ignored.)
+/android/key-beta.properties
+/android/app/beta-upload.keystore
+
+# APKs/AABs extracted to the repo root by `make android`
+/BULL-*.apk
+/BULL-*.aab
+
 # FVM Version Cache
 .fvm/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Bull Bitcoin Mobile: self-custodial Bitcoin + Liquid + Lightning wallet. Flutter
   - `make setup` — full first-time setup (clean + deps + build-runner + translations + hooks + ios pods on macOS)
   - `make unit-test` / `make integration-test` / `make test`
   - `make drift-migrations` — after changing Drift schema
-  - `make apk` / `make apk release` — reproducible build
+  - `make android` / `make android release` — reproducible build
+  - `make android beta` — beta tester channel APK (`.beta` applicationId, installs alongside production)
   - `make verify` — verify a built APK matches a published release
   - `make build-runner-watch` — codegen in watch mode during dev
 - **Analyze the whole project, never specific files.** `fvm flutter analyze` (no path arg). CI runs `--fatal-warnings --fatal-infos` ([analyze_and_test.yml](.github/workflows/analyze_and_test.yml)) — match it locally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ This applies equally to architectural suggestions, tooling, CI tricks, command f
 - Don't put business logic in BLoCs or `/lib/core`.
 - Don't reinvent a widget that already exists in `lib/core/widgets/`.
 - Don't hardcode user-facing strings — use `AppLocalizations`.
+- Don't hard-wrap prose mid-sentence in markdown, comments, PR descriptions, or commit bodies — write each sentence on one continuous line and let the editor soft-wrap. Manual line breaks belong only between paragraphs or list items.
 - Don't add `path:` deps to pubspec.
 - Don't amend or force-push without explicit ask.
 - Don't add `Co-Authored-By`.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,6 +18,15 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
+// Beta-channel signing. Optional dedicated key (android/key-beta.properties);
+// falls back to the committed debug keystore so CI and local beta builds are
+// always signed and installable without ever exposing the production release key.
+def betaKeystoreProperties = new Properties()
+def betaKeystorePropertiesFile = rootProject.file('key-beta.properties')
+if (betaKeystorePropertiesFile.exists()) {
+    betaKeystoreProperties.load(new FileInputStream(betaKeystorePropertiesFile))
+}
+
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode') ?: '1'
 def flutterVersionName = localProperties.getProperty('flutter.versionName') ?: '1.0'
 
@@ -56,6 +65,12 @@ android {
             storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
             storePassword keystoreProperties['storePassword']
         }
+        beta {
+            keyAlias betaKeystoreProperties.getProperty('keyAlias', 'androiddebugkey')
+            keyPassword betaKeystoreProperties.getProperty('keyPassword', 'android')
+            storeFile betaKeystoreProperties['storeFile'] ? file(betaKeystoreProperties['storeFile']) : file('debug.keystore')
+            storePassword betaKeystoreProperties.getProperty('storePassword', 'android')
+        }
     }
 
     buildTypes {
@@ -68,7 +83,39 @@ android {
         release {
             minifyEnabled false
             shrinkResources false
-            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
+            // No signingConfig here on purpose: signing is set per-flavor below.
+            // AGP resolves a build-type signingConfig ahead of a flavor's, so
+            // setting it here would stop the beta flavor from using its own key.
+        }
+    }
+
+    flavorDimensions = ['channel']
+    productFlavors {
+        // Official channel. Zero overrides: same applicationId, version and
+        // (release) signing key, so already-distributed releases keep updating
+        // in place (Android matches on applicationId + signing cert).
+        // Reproducibility: selecting a flavor makes Flutter bake
+        // FLUTTER_APP_FLAVOR into libapp.so, so the production binary changes
+        // once when flavors land. The build stays deterministic, so verifying a
+        // tag (rebuilt with the same flavor) still works.
+        production {
+            dimension 'channel'
+            // Set only when the release key is present (e.g. on the signing
+            // machine / release pipeline). Passing a literal null to a flavor's
+            // signingConfig is an ambiguous Groovy overload, so guard with if.
+            if (keystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.release
+            }
+        }
+        // Beta channel for direct (store-less) distribution to testers. The .beta
+        // applicationId suffix lets it install alongside the production app in its
+        // own sandbox/storage. Signed with its own key (CI provides it; debug
+        // keystore fallback locally) — never the production release key.
+        beta {
+            dimension 'channel'
+            applicationIdSuffix '.beta'
+            versionNameSuffix '-beta'
+            signingConfig signingConfigs.beta
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,9 +18,12 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
-// Beta-channel signing. Optional dedicated key (android/key-beta.properties);
-// falls back to the committed debug keystore so CI and local beta builds are
-// always signed and installable without ever exposing the production release key.
+// Beta-channel signing. Dedicated beta key only (android/key-beta.properties,
+// provided by CI from a secret). No fallback: a beta built without its key is
+// left unsigned rather than signed with the public debug keystore, so a
+// distributed beta can never be debug-signed and forged. CI requires the key and
+// fails loud if it is missing (see build-android.yml). Never touches the
+// production release key.
 def betaKeystoreProperties = new Properties()
 def betaKeystorePropertiesFile = rootProject.file('key-beta.properties')
 if (betaKeystorePropertiesFile.exists()) {
@@ -66,10 +69,10 @@ android {
             storePassword keystoreProperties['storePassword']
         }
         beta {
-            keyAlias betaKeystoreProperties.getProperty('keyAlias', 'androiddebugkey')
-            keyPassword betaKeystoreProperties.getProperty('keyPassword', 'android')
-            storeFile betaKeystoreProperties['storeFile'] ? file(betaKeystoreProperties['storeFile']) : file('debug.keystore')
-            storePassword betaKeystoreProperties.getProperty('storePassword', 'android')
+            keyAlias betaKeystoreProperties['keyAlias']
+            keyPassword betaKeystoreProperties['keyPassword']
+            storeFile betaKeystoreProperties['storeFile'] ? file(betaKeystoreProperties['storeFile']) : null
+            storePassword betaKeystoreProperties['storePassword']
         }
     }
 
@@ -109,13 +112,18 @@ android {
         }
         // Beta channel for direct (store-less) distribution to testers. The .beta
         // applicationId suffix lets it install alongside the production app in its
-        // own sandbox/storage. Signed with its own key (CI provides it; debug
-        // keystore fallback locally) — never the production release key.
+        // own sandbox/storage. Signed only with its own dedicated key (CI provides
+        // it from a secret) — never the production release key, and never the
+        // public debug keystore. As with production, the signingConfig is set only
+        // when the key is present; without it the beta build is left unsigned
+        // rather than debug-signed, so a distributed beta can't be forged.
         beta {
             dimension 'channel'
             applicationIdSuffix '.beta'
             versionNameSuffix '-beta'
-            signingConfig signingConfigs.beta
+            if (betaKeystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.beta
+            }
         }
     }
 

--- a/android/app/src/beta/AndroidManifest.xml
+++ b/android/app/src/beta/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <!-- Beta flavor source set. Overrides only the launcher label so the beta
+         build is distinct from the production app it installs next to; the icon
+         falls back to production. src/main is left untouched so the production
+         variant stays byte-reproducible. -->
+    <application
+        android:label="Bull Beta"
+        tools:replace="android:label"
+    />
+</manifest>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:bull_sdk/bull_sdk.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show appFlavor;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:payjoin_flutter/common.dart';
@@ -295,8 +296,18 @@ class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
                     localizationsDelegates:
                         AppLocalizations.localizationsDelegates,
                     supportedLocales: AppLocalizations.supportedLocales,
-                    builder: (_, child) {
-                      return AppStartupWidget(app: child!);
+                    builder: (context, child) {
+                      final app = AppStartupWidget(app: child!);
+                      // Mark beta-channel builds (`make android beta`) with a
+                      // corner banner. Release mode drops the Flutter debug
+                      // banner, so this is how testers tell beta from production.
+                      if (appFlavor != 'beta') return app;
+                      return Banner(
+                        message: 'BETA',
+                        location: BannerLocation.topEnd,
+                        color: Theme.of(context).colorScheme.error,
+                        child: app,
+                      );
                     },
                   );
                 },

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all setup clean deps deps-update build-runner translations hooks ios-pod-update drift-migrations devcontainer container-tools container-app apk verify test unit-test integration-test fvm-check
+.PHONY: all setup clean deps deps-update build-runner translations hooks ios-pod-update drift-migrations devcontainer container-tools container-app android release debug beta verify test unit-test integration-test fvm-check
 
 fvm-check:
 	@echo "🔍 Checking FVM"
@@ -91,30 +91,51 @@ container-app: container-tools
 
 MODE ?= debug
 FORMAT ?= apk
+FLAVOR ?= production
 
-# Allow "make apk release" or "make apk debug" syntax
+# Allow "make android release", "make android debug" or "make android beta".
+# release/debug build the production flavor; beta is the tester channel — the
+# beta flavor (.beta applicationId, its own signing) in release mode, for direct
+# store-less distribution.
 ifneq (,$(filter release,$(MAKECMDGOALS)))
   MODE := release
 endif
 ifneq (,$(filter debug,$(MAKECMDGOALS)))
   MODE := debug
 endif
-release debug:
+ifneq (,$(filter beta,$(MAKECMDGOALS)))
+  MODE := release
+  FLAVOR := beta
+endif
+release debug beta:
 	@:
 
-# Flutter writes APK and AAB to different paths
-ifeq ($(FORMAT),aab)
-  CONTAINER_OUTPUT := /app/build/app/outputs/bundle/$(MODE)/app-$(MODE).aab
-  HOST_OUTPUT := ./app-$(MODE).aab
-  FLUTTER_BUILD := fvm flutter build appbundle --$(MODE)
+# Gradle appbundle output dir is camelCase <flavor><BuildType> (e.g. productionRelease).
+MODE_CAP := $(if $(filter release,$(MODE)),Release,Debug)
+
+# Host artifact name reflects the build target: BULL-release / BULL-debug for the
+# production flavor, and BULL-<flavor> (e.g. BULL-beta) for channel flavors. The
+# in-container Flutter output keeps its app-<flavor>-<mode> names below; only the
+# extracted host file is branded.
+ifeq ($(FLAVOR),production)
+  HOST_NAME := $(MODE)
 else
-  CONTAINER_OUTPUT := /app/build/app/outputs/flutter-apk/app-$(MODE).apk
-  HOST_OUTPUT := ./app-$(MODE).apk
-  FLUTTER_BUILD := fvm flutter build apk --$(MODE)
+  HOST_NAME := $(FLAVOR)
 endif
 
-apk: container-app
-	@echo "🔨 Building $(FORMAT) ($(MODE)) via $(CONTAINER)"
+# Flutter writes APK and AAB to different, flavor-namespaced paths
+ifeq ($(FORMAT),aab)
+  CONTAINER_OUTPUT := /app/build/app/outputs/bundle/$(FLAVOR)$(MODE_CAP)/app-$(FLAVOR)-$(MODE).aab
+  HOST_OUTPUT := ./BULL-$(HOST_NAME).aab
+  FLUTTER_BUILD := fvm flutter build appbundle --$(MODE) --flavor $(FLAVOR)
+else
+  CONTAINER_OUTPUT := /app/build/app/outputs/flutter-apk/app-$(FLAVOR)-$(MODE).apk
+  HOST_OUTPUT := ./BULL-$(HOST_NAME).apk
+  FLUTTER_BUILD := fvm flutter build apk --$(MODE) --flavor $(FLAVOR)
+endif
+
+android: container-app
+	@echo "🔨 Building $(FORMAT) ($(FLAVOR) $(MODE)) via $(CONTAINER)"
 	@$(CONTAINER) rm -f bull-build > /dev/null 2>&1 || true
 	@$(CONTAINER) run --name bull-build \
 		--ulimit nofile=65536:65536 \

--- a/makefile
+++ b/makefile
@@ -117,8 +117,18 @@ MODE_CAP := $(if $(filter release,$(MODE)),Release,Debug)
 # production flavor, and BULL-<flavor> (e.g. BULL-beta) for channel flavors. The
 # in-container Flutter output keeps its app-<flavor>-<mode> names below; only the
 # extracted host file is branded.
+#
+# Channel flavors (beta) are signed only when their key is present, mirroring the
+# gradle signingConfig guard (android/key-beta.properties). With no key the build
+# is unsigned — Flutter still names it app-<flavor>-<mode>.apk, so flag it -unsigned
+# on the host so an uninstallable build is obvious. CI requires the key, so this
+# only triggers for keyless local beta builds. Production names are left unbranded:
+# release is intentionally unsigned in the reproducibility/verify flow and both CI
+# upload and verify_build.sh depend on the exact BULL-release name.
 ifeq ($(FLAVOR),production)
   HOST_NAME := $(MODE)
+else ifeq (,$(wildcard android/key-beta.properties))
+  HOST_NAME := $(FLAVOR)-unsigned
 else
   HOST_NAME := $(FLAVOR)
 endif

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -159,6 +159,10 @@ dev_dependencies:
   drift_dev: ^2.29.0
 
 flutter:
+  # Android product flavors live in android/app/build.gradle (production | beta).
+  # Without an explicit --flavor (e.g. `flutter run`, IDE launches, integration
+  # tests) Flutter builds this default, so existing workflows keep working.
+  default-flavor: production
   generate: true # Needed for code generation, for example for internationalization
   uses-material-design: true
 

--- a/reproducibility/README.md
+++ b/reproducibility/README.md
@@ -8,7 +8,7 @@ Three components work together:
 
 ### `../Containerfile.tools` and `../Containerfile.app` (root)
 
-Two-file build setup driven by `make apk release`:
+Two-file build setup driven by `make android release`:
 
 - `Containerfile.tools` installs all toolchains (Rust pinned via `RUST_VERSION`, Flutter via FVM, Android SDK, Gradle).
 - `Containerfile.app` copies the repo, runs `pub get` / `build_runner` / `gen-l10n`, and configures Gradle. It does NOT run `flutter build` — that happens via `podman run` against the resulting image so the multi-GB build output is never committed to a layer.
@@ -28,8 +28,8 @@ Orchestrates the full verification:
 
 1. Builds the verification tools image from `Dockerfile`
 2. Optionally downloads the official APK from the GitHub release, or uses a locally provided APK or split APK directory
-3. Builds the app from the current repo checkout via `make apk release` (which uses the root `Containerfile.tools` + `Containerfile.app`)
-4. Picks up the extracted APK from the repo root (`./app-release.apk`)
+3. Builds the app from the current repo checkout via `make android release` (which uses the root `Containerfile.tools` + `Containerfile.app`)
+4. Picks up the extracted APK from the repo root (`./BULL-release.apk`)
 5. Decodes both APKs with apktool (inside the tools container)
 6. Diffs the decoded output excluding `META-INF` (signatures are not part of reproducibility)
 7. Writes a `RESULTS.md` verdict to the workspace directory

--- a/reproducibility/test.sh
+++ b/reproducibility/test.sh
@@ -47,8 +47,8 @@ $CTR build -q -t "$VERIFY_TOOLS_IMAGE" "$SCRIPT_DIR" > /dev/null
 echo ""
 echo -e "${YELLOW}=== Build 1 ===${NC}"
 cd "$REPO_ROOT"
-CONTAINER="$CTR" make apk "$MODE"
-cp "$REPO_ROOT/app-${MODE}.apk" "$WORK_DIR/build1.apk"
+CONTAINER="$CTR" make android "$MODE"
+cp "$REPO_ROOT/BULL-${MODE}.apk" "$WORK_DIR/build1.apk"
 
 echo "Saved: $WORK_DIR/build1.apk"
 sha256sum "$WORK_DIR/build1.apk"
@@ -59,8 +59,8 @@ echo -e "${YELLOW}=== Build 2 (no cache) ===${NC}"
 # Drop the image so the second build re-runs every step from a clean slate
 $CTR rmi bull-app > /dev/null 2>&1 || true
 
-CONTAINER="$CTR" make apk "$MODE"
-cp "$REPO_ROOT/app-${MODE}.apk" "$WORK_DIR/build2.apk"
+CONTAINER="$CTR" make android "$MODE"
+cp "$REPO_ROOT/BULL-${MODE}.apk" "$WORK_DIR/build2.apk"
 
 echo "Saved: $WORK_DIR/build2.apk"
 sha256sum "$WORK_DIR/build2.apk"

--- a/reproducibility/verify_build.sh
+++ b/reproducibility/verify_build.sh
@@ -304,13 +304,13 @@ buildFormat="apk"
 [[ "$verificationMode" == "device" ]] && buildFormat="aab"
 
 cd "$REPO_ROOT"
-GRADLE_HEAP="$gradle_heap" FORMAT="$buildFormat" CONTAINER="$CONTAINER_CMD" make apk release
+GRADLE_HEAP="$gradle_heap" FORMAT="$buildFormat" CONTAINER="$CONTAINER_CMD" make android release
 cd - > /dev/null
 
 if [[ "$verificationMode" == "github" ]]; then
-    cp "$REPO_ROOT/app-release.apk" "$workDir/built.apk"
+    cp "$REPO_ROOT/BULL-release.apk" "$workDir/built.apk"
 else
-    cp "$REPO_ROOT/app-release.aab" "$workDir/built.aab"
+    cp "$REPO_ROOT/BULL-release.aab" "$workDir/built.aab"
 fi
 
 echo "Build complete"


### PR DESCRIPTION
Adds a **`beta`** Android product flavor: a release-mode build that installs
**alongside** the production app, for handing release candidates directly to
testers (no store). Replaces the practice of shipping **debug** APKs as candidates.

## Why

We were giving testers **debug** builds, which are too big and not
representative of what ships. Neither existing build fits a tester channel:

- **debug** — Dart runs in **JIT** (full VM + uncompiled kernel snapshots, no
  tree-shaking, VM service exposed), so the APK is ~2–3× a release build, slower,
  and not something you want in testers' hands for a wallet.
- **release** — shares the production `applicationId` and needs the **production
  signing key**, so it would *overwrite* a tester's real app and force the prod
  key into the build pipeline.

`beta` gives the small, optimized, AOT-compiled output of a release build, but as
a **separate, independently-signed app**.

## beta vs release vs debug

| | debug (old candidate) | release (official) | **beta (this PR)** |
|---|---|---|---|
| Dart compilation | JIT | AOT (optimized) | **AOT (optimized)** |
| APK size | ~2–3× larger | small | **small (≈ release)** |
| applicationId | `…mobile.debug` | `…mobile` | **`…mobile.beta`** |
| Installs next to production? | yes | **no — replaces it** | **yes** |
| Signing key | public debug key | production release key | **own dedicated beta key, no fallback** |
| In-app marker | DEBUG banner | none | **BETA banner** + "Bull Beta" label |
| Fit for a tester channel? | no | no | **yes** |

## How it works

- **`beta` flavor** (`android/app/build.gradle`): `.beta` applicationId suffix,
  `-beta` versionName, "Bull Beta" launcher label (`src/beta/`), and an in-app
  **BETA** corner banner (`appFlavor == 'beta'`) since release mode drops the
  Flutter DEBUG banner. The `.beta` id means its own sandbox/storage — a tester's
  real wallet is never touched.
- **Per-flavor signing**, isolated by design:
  - **release** → the production key (applied on the signing machine; unsigned
    elsewhere, e.g. in the reproducibility/verify flow).
  - **beta** → its **own dedicated key only**, provided by CI from secrets.
    There is **no debug-keystore fallback**: a beta built without its key is left
    **unsigned** (never signed with the public debug key), so a distributed beta
    can't be forged with the repo's public key.
  - **debug** → the committed public debug keystore.
  - The `release` build type sets no signingConfig on purpose — AGP resolves a
    build-type signingConfig ahead of a flavor's, so signing is set per-flavor.
- **Official build untouched**: the `production` flavor adds no applicationId or
  version overrides and keeps the release signing key, so reproducible-build
  verification and in-place updates of already-distributed releases are unaffected.
- ⚠️ **Reproducibility note**: selecting any flavor makes Flutter bake
  `FLUTTER_APP_FLAVOR` into `libapp.so`, so the production binary changes **once**
  at this commit. The build stays deterministic, so `make verify` (rebuilds the
  matching tag with the same flavor) still works — it's a one-time hash change,
  not a verification break.

## Usage

```bash
make android beta          # -> ./BULL-beta.apk  (release mode, .beta id)
```

With no local `android/key-beta.properties`, the beta build is unsigned and is
extracted as `./BULL-beta-unsigned.apk` to make that obvious. `make android
release|debug` are unchanged (the `apk` target was renamed to `android` and host
artifacts branded `BULL-<target>`).

In CI: **Actions → Build Android APK → mode `beta`** signs with the beta key from
repo secrets (`BETA_KEYSTORE_BASE64` / `BETA_KEY_ALIAS` / `BETA_KEY_PASSWORD` /
`BETA_STORE_PASSWORD`). If any are missing the build **fails loud** rather than
producing an unsigned/forgeable artifact. It uploads `BULL-beta.apk`; no release
publishing, no token — distribution is manual: attach to a GitHub **pre-release**
and testers auto-update via Obtainium.
