### PR TITLE
fix: transfer flow should allow receive exact amount option for liquid. better errors in form validation. escalation backup warning content as a bulleted list.

### DIFF
--- a/lib/core/errors/send_errors.dart
+++ b/lib/core/errors/send_errors.dart
@@ -4,6 +4,10 @@ class SwapCreationException extends BullException {
   SwapCreationException(super.message);
 }
 
+class InsufficientFundsSwapException extends SwapCreationException {
+  InsufficientFundsSwapException() : super('Insufficient Funds');
+}
+
 class InsufficientBalanceException extends BullException {
   InsufficientBalanceException(super.message);
 }

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -317,7 +317,12 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
     TransferAmountChanged event,
     Emitter<TransferState> emit,
   ) async {
-    emit(state.copyWith(amount: event.amount));
+    emit(
+      state.copyWith(
+        amount: event.amount,
+        swapCreationException: null,
+      ),
+    );
   }
 
   Future<void> _onSwapCreated(
@@ -339,6 +344,13 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
       final inputAmountSat = state.bitcoinUnit == BitcoinUnit.sats
           ? int.parse(event.amount)
           : ConvertAmount.btcToSats(double.parse(event.amount));
+
+      // Insufficient balance is surfaced as an inline form error on the
+      // amount field (see SwapAmountInput); stop here so no swap is created.
+      final balanceSat = state.fromWallet?.balanceSat.toInt() ?? 0;
+      if (inputAmountSat > balanceSat) {
+        return;
+      }
 
       int paymentAmountSat = inputAmountSat;
       if (state.receiveExactAmount && !state.isSameChainTransfer) {
@@ -643,13 +655,11 @@ class TransferBloc extends Bloc<TransferEvent, TransferState> {
         ),
       );
     } catch (e) {
-      final errorMessage = _isInsufficientFundsException(e)
-          ? 'Insufficient Balance To Cover Fees And Amount'
-          : e.toString();
+      final swapCreationException = _isInsufficientFundsException(e)
+          ? InsufficientFundsSwapException()
+          : SwapCreationException(e.toString());
       emit(
-        state.copyWith(
-          swapCreationException: SwapCreationException(errorMessage),
-        ),
+        state.copyWith(swapCreationException: swapCreationException),
       );
     } finally {
       emit(state.copyWith(isCreatingSwap: false, continueClicked: false));

--- a/lib/features/swap/presentation/transfer_state.dart
+++ b/lib/features/swap/presentation/transfer_state.dart
@@ -89,7 +89,6 @@ sealed class TransferState with _$TransferState {
   }
 
   int get inputAmountSat {
-    if (amount.isEmpty) return 0;
     if (bitcoinUnit == BitcoinUnit.sats) {
       return int.tryParse(amount) ?? 0;
     } else {
@@ -130,6 +129,10 @@ sealed class TransferState with _$TransferState {
 
   bool get shouldShowAdvancedOptions {
     return fromWallet?.isLiquid == false;
+  }
+
+  bool get shouldShowReceiveExactAmount {
+    return fromWallet != null && !isSameChainTransfer;
   }
 
   int get selectedUtxoTotalSat {
@@ -180,6 +183,16 @@ sealed class TransferState with _$TransferState {
     } else {
       return FormatAmount.btc(ConvertAmount.satsToBtc(selectedUtxoTotalSat));
     }
+  }
+
+  bool get isInsufficientBalance {
+    if (fromWallet == null) return false;
+    if (inputAmountSat <= 0) return false;
+    return inputAmountSat > fromWallet!.balanceSat.toInt();
+  }
+
+  bool get hasAmountError {
+    return amountValidationError != null || isInsufficientBalance;
   }
 
   String? get amountValidationError {

--- a/lib/features/swap/ui/pages/swap_in_progress_page.dart
+++ b/lib/features/swap/ui/pages/swap_in_progress_page.dart
@@ -128,9 +128,14 @@ class SwapInProgressPage extends StatelessWidget {
                 if (swap?.status != SwapStatus.completed) ...[
                   if (swap?.status != SwapStatus.completed) ...[
                     InfoCard(
-                      description:
-                          '${context.loc.swapDoNotUninstallWarning}\n\n'
-                          '${context.loc.transactionSwapOpenWithin24h}',
+                      description: context.loc.swapDoNotUninstallWarning,
+                      tagColor: context.appColors.tertiary,
+                      bgColor: context.appColors.warningContainer,
+                      boldDescription: true,
+                    ),
+                    const Gap(12),
+                    InfoCard(
+                      description: context.loc.transactionSwapOpenWithin24h,
                       tagColor: context.appColors.tertiary,
                       bgColor: context.appColors.warningContainer,
                       boldDescription: true,

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -218,8 +218,12 @@ class SwapPageState extends State<SwapPage> {
                         if (swapCreationError == null) {
                           return const SizedBox.shrink();
                         }
+                        final message =
+                            swapCreationError is InsufficientFundsSwapException
+                            ? context.loc.swapInsufficientFunds
+                            : swapCreationError.message;
                         return Text(
-                          swapCreationError.message,
+                          message,
                           style: context.font.labelLarge?.copyWith(
                             color: context.appColors.error,
                           ),
@@ -228,9 +232,7 @@ class SwapPageState extends State<SwapPage> {
                       },
                     ),
                     BlocSelector<TransferBloc, TransferState, bool>(
-                      selector: (state) =>
-                          state.shouldShowAdvancedOptions &&
-                          !state.isSameChainTransfer,
+                      selector: (state) => state.shouldShowReceiveExactAmount,
                       builder: (context, showReceiveExactAmount) {
                         if (!showReceiveExactAmount) {
                           return const SizedBox.shrink();
@@ -311,13 +313,14 @@ class SwapPageState extends State<SwapPage> {
                       selector: (state) =>
                           state.isStarting ||
                           state.isCreatingSwap ||
-                          state.continueClicked,
-                      builder: (context, isLoading) {
+                          state.continueClicked ||
+                          state.hasAmountError,
+                      builder: (context, disabled) {
                         return BBButton.big(
                           label: context.loc.swapContinueButton,
                           bgColor: context.appColors.secondary,
                           textColor: context.appColors.onSecondary,
-                          disabled: isLoading,
+                          disabled: disabled,
                           onPressed: () {
                             if (!_formKey.currentState!.validate()) {
                               return;

--- a/lib/features/swap/ui/widgets/swap_amount_input.dart
+++ b/lib/features/swap/ui/widgets/swap_amount_input.dart
@@ -34,6 +34,9 @@ class SwapAmountInput extends StatelessWidget {
     final amountValidationError = context.select(
       (TransferBloc bloc) => bloc.state.amountValidationError,
     );
+    final isInsufficientBalance = context.select(
+      (TransferBloc bloc) => bloc.state.isInsufficientBalance,
+    );
 
     return Column(
       crossAxisAlignment: .start,
@@ -103,10 +106,10 @@ class SwapAmountInput extends StatelessWidget {
             ),
           ),
         ),
-        if (amountValidationError != null) ...[
+        if (amountValidationError != null || isInsufficientBalance) ...[
           const Gap(8),
           Text(
-            amountValidationError,
+            amountValidationError ?? context.loc.swapInsufficientFunds,
             style: context.font.labelLarge?.copyWith(
               color: context.appColors.error,
             ),

--- a/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
@@ -53,53 +53,106 @@ class _BackupWarningBlockerState extends State<_BackupWarningBlocker> {
         child: Align(
           alignment: Alignment.bottomCenter,
           child: SafeArea(
-            child: Container(
-              padding: const EdgeInsets.all(24),
-              decoration: BoxDecoration(
-                color: context.appColors.surface,
-                borderRadius: const BorderRadius.vertical(
-                  top: Radius.circular(16),
-                ),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.85,
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  BBText(
-                    context.loc.backupWarningTitle,
-                    style: context.font.headlineMedium,
-                    color: context.appColors.onSurface,
+              child: Container(
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: context.appColors.surface,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(16),
                   ),
-                  const Gap(16),
-                  BBText(
-                    context.loc.backupWarningDescription,
-                    style: context.font.bodyMedium,
-                    color: context.appColors.onSurface,
-                  ),
-                  const Gap(24),
-                  BBButton.big(
-                    label: context.loc.backupWarningBackupNow,
-                    onPressed: () {
-                      context.pushNamed(
-                        BackupSettingsSubroute.backupOptions.name,
-                      );
-                    },
-                    bgColor: context.appColors.onSurface,
-                    textColor: context.appColors.surface,
-                  ),
-                  const Gap(12),
-                  BBButton.big(
-                    label: context.loc.backupWarningBackupLater,
-                    onPressed: () {
-                      context
-                          .read<WalletBloc>()
-                          .add(const DismissBackupWarning());
-                    },
-                    bgColor: context.appColors.surface,
-                    textColor: context.appColors.onSurface,
-                    outlined: true,
-                  ),
-                ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Flexible(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            BBText(
+                              context.loc.backupWarningTitle,
+                              style: context.font.headlineMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                              color: context.appColors.onSurface,
+                            ),
+                            const Gap(16),
+                            BBText(
+                              context.loc.backupWarningDescription,
+                              style: context.font.bodyMedium,
+                              color: context.appColors.onSurface,
+                            ),
+                            const Gap(8),
+                            for (final reason in [
+                              context.loc.backupWarningLoseReasonLostPhone,
+                              context.loc.backupWarningLoseReasonDeletedApp,
+                              context.loc.backupWarningLoseReasonCriticalIssue,
+                              context.loc.backupWarningLoseReasonKeystore,
+                              context.loc.backupWarningLoseReasonCloudRestore,
+                            ])
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 6),
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    BBText(
+                                      '•  ',
+                                      style: context.font.bodyMedium,
+                                      color: context.appColors.onSurface,
+                                    ),
+                                    Expanded(
+                                      child: BBText(
+                                        reason,
+                                        style: context.font.bodyMedium,
+                                        color: context.appColors.onSurface,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            const Gap(8),
+                            BBText(
+                              context.loc.backupWarningNoRecovery,
+                              style: context.font.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                              color: context.appColors.onSurface,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const Gap(24),
+                    BBButton.big(
+                      label: context.loc.backupWarningBackupNow,
+                      onPressed: () {
+                        context.pushNamed(
+                          BackupSettingsSubroute.backupOptions.name,
+                        );
+                      },
+                      bgColor: context.appColors.onSurface,
+                      textColor: context.appColors.surface,
+                    ),
+                    const Gap(12),
+                    BBButton.big(
+                      label: context.loc.backupWarningBackupLater,
+                      onPressed: () {
+                        context
+                            .read<WalletBloc>()
+                            .add(const DismissBackupWarning());
+                      },
+                      bgColor: context.appColors.surface,
+                      textColor: context.appColors.onSurface,
+                      outlined: true,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "بدون نسخة احتياطية، ستفقد إمكانية الوصول إلى عملات البيتكوين الخاصة بك في الحالات التالية:",
+  "backupWarningLoseReasonLostPhone": "فقدان هاتفك",
+  "backupWarningLoseReasonDeletedApp": "حذف التطبيق",
+  "backupWarningLoseReasonCriticalIssue": "حدوث مشكلة خطيرة في التطبيق أو الجهاز",
+  "backupWarningLoseReasonKeystore": "يقوم جهازك بإبطال مخزن المفاتيح (keystore) عند تغيير طريقة قفل الشاشة أو مصادقة الجهاز",
+  "backupWarningLoseReasonCloudRestore": "استعادة جهازك من نسخة احتياطية على السحابة",
+  "backupWarningNoRecovery": "لا توجد طريقة لاستعادة محفظتك بدون نسخة احتياطية.",
   "ledgerHelpTitle": "Ledger Troubleshooting",
   "@ledgerHelpTitle": {
     "description": "Title for Ledger troubleshooting help modal"
@@ -500,6 +507,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "المبلغ المستلم",
+  "swapInsufficientFunds": "أموال غير كافية",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "বেকআপ অবিহনে, তলত উল্লেখ কৰা ক্ষেত্ৰত আপুনি আপোনাৰ bitcoin-লৈ প্ৰৱেশ হেৰুৱাব:",
+  "backupWarningLoseReasonLostPhone": "আপুনি আপোনাৰ ফোন হেৰুৱালে",
+  "backupWarningLoseReasonDeletedApp": "আপুনি এপটো মচিলে",
+  "backupWarningLoseReasonCriticalIssue": "কোনো গুৰুতৰ এপ্প বা ডিভাইচ সম্পৰ্কীয় সমস্যা হ'লে",
+  "backupWarningLoseReasonKeystore": "আপুনি লকস্ক্ৰীন বা ডিভাইচ অথেণ্টিকেশ্বন সলালে আপোনাৰ ডিভাইচে কীষ্টোৰ (keystore) অবৈধ কৰি দিয়ে",
+  "backupWarningLoseReasonCloudRestore": "ক্লাউড বেকআপৰ পৰা আপোনাৰ ডিভাইচ ৰিষ্টোৰ কৰা",
+  "backupWarningNoRecovery": "বেকআপ অবিহনে আপোনাৰ wallet পুনৰুদ্ধাৰ কৰাৰ কোনো উপায় নাই।",
   "appInitErrorTitle": "এপটো আৰম্ভ হোৱাত ব্যৰ্থ হ'ল",
   "@appInitErrorTitle": {
     "description": "Title shown on the fatal init error screen in main.dart"
@@ -1929,6 +1936,7 @@
     "description": "Label for amount input section"
   },
   "swapReceiveExactAmountLabel": "নিৰ্দিষ্ট পৰিমাণ গ্ৰহণ কৰক",
+  "swapInsufficientFunds": "অপৰ্যাপ্ত পুঁজি",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },
@@ -9603,10 +9611,6 @@
   "backupWarningTitle": "এতিয়াই আপোনাৰ WALLET বেকআপ কৰক",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "বেকআপ অবিহনে, আপোনাৰ ফোন হেৰুৱালে, এপটো মচিলে, বা গুৰুতৰ এপ্প বা ডিভাইচ সম্পৰ্কীয় সমস্যাত পৰিলে আপুনি আপোনাৰ bitcoin-লৈ প্ৰৱেশ হেৰুৱাব। বেকআপ অবিহনে আপোনাৰ wallet পুনৰুদ্ধাৰ কৰাৰ কোনো উপায় নাই।",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "হয়",
   "@backupWarningBackupNow": {

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Без резервно копие ще загубите достъп до своите биткоини, ако:",
+  "backupWarningLoseReasonLostPhone": "Загубите телефона си",
+  "backupWarningLoseReasonDeletedApp": "Изтриете приложението",
+  "backupWarningLoseReasonCriticalIssue": "Възникне критичен проблем с приложението или устройството",
+  "backupWarningLoseReasonKeystore": "Устройството анулира keystore при смяна на заключения екран или удостоверяването на устройството",
+  "backupWarningLoseReasonCloudRestore": "Възстановяване на устройството от резервно копие в облака",
+  "backupWarningNoRecovery": "Без резервно копие няма начин да възстановите портфейла си.",
   "broadcastSignedTxBroadcastError": "Неуспешно излъчване на транзакцията",
   "translationWarningTitle": "Преводи, генерирани от ИИ",
   "@translationWarningTitle": {
@@ -683,6 +690,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Получете точната сума",
+  "swapInsufficientFunds": "Недостатъчни средства",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "ব্যাকআপ ছাড়া, নিচের ক্ষেত্রে আপনি আপনার বিটকয়েনে প্রবেশাধিকার হারাবেন:",
+  "backupWarningLoseReasonLostPhone": "আপনি আপনার ফোন হারালে",
+  "backupWarningLoseReasonDeletedApp": "আপনি অ্যাপ মুছলে",
+  "backupWarningLoseReasonCriticalIssue": "কোনো গুরুতর অ্যাপ্লিকেশন বা ডিভাইস সম্পর্কিত সমস্যা হলে",
+  "backupWarningLoseReasonKeystore": "আপনি লকস্ক্রিন বা ডিভাইস অথেন্টিকেশন পরিবর্তন করলে আপনার ডিভাইস কীস্টোর (keystore) বাতিল করে দেয়",
+  "backupWarningLoseReasonCloudRestore": "ক্লাউড ব্যাকআপ থেকে আপনার ডিভাইস রিস্টোর করা",
+  "backupWarningNoRecovery": "ব্যাকআপ ছাড়া আপনার ওয়ালেট পুনরুদ্ধার করার কোনো উপায় নেই।",
   "@@locale": "bn",
   "settingsTelegramLabel": "Telegram",
   "@settingsTelegramLabel": {
@@ -532,6 +539,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "নির্দিষ্ট পরিমাণ গ্রহণ করুন",
+  "swapInsufficientFunds": "অপর্যাপ্ত তহবিল",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },
@@ -12797,10 +12805,6 @@
   "backupWarningTitle": "এখনই আপনার ওয়ালেট ব্যাকআপ করুন",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "ব্যাকআপ ছাড়া, আপনার ফোন হারালে, অ্যাপ মুছলে বা কোনো গুরুতর অ্যাপ্লিকেশন বা ডিভাইস সম্পর্কিত সমস্যায় আপনি আপনার বিটকয়েনে প্রবেশাধিকার হারাবেন। ব্যাকআপ ছাড়া আপনার ওয়ালেট পুনরুদ্ধার করার কোনো উপায় নেই।",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "হ্যাঁ",
   "@backupWarningBackupNow": {

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Bez zálohy ztratíte přístup ke svým bitcoinům, pokud:",
+  "backupWarningLoseReasonLostPhone": "Ztratíte telefon",
+  "backupWarningLoseReasonDeletedApp": "Smažete aplikaci",
+  "backupWarningLoseReasonCriticalIssue": "Dojde ke kritickému problému s aplikací nebo zařízením",
+  "backupWarningLoseReasonKeystore": "Zařízení zneplatní keystore při změně zámku obrazovky nebo ověřování zařízení",
+  "backupWarningLoseReasonCloudRestore": "Obnovení zařízení ze zálohy v cloudu",
+  "backupWarningNoRecovery": "Bez zálohy nelze peněženku obnovit.",
   "durationSeconds": "{seconds} vteřin(y)",
   "@durationSeconds": {
     "description": "Duration format for seconds",
@@ -811,6 +818,7 @@
     "description": "Message shown while broadcasting transaction to network"
   },
   "swapReceiveExactAmountLabel": "Získejte přesné množství",
+  "swapInsufficientFunds": "Nedostatek prostředků",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Ohne Backup verlierst du den Zugriff auf deine bitcoin, wenn:",
+  "backupWarningLoseReasonLostPhone": "du dein Handy verlierst",
+  "backupWarningLoseReasonDeletedApp": "du die App löschst",
+  "backupWarningLoseReasonCriticalIssue": "ein kritisches App- oder Geräteproblem auftritt",
+  "backupWarningLoseReasonKeystore": "dein Gerät den Keystore ungültig macht, wenn du die Sperrbildschirm- oder Geräteauthentifizierung änderst",
+  "backupWarningLoseReasonCloudRestore": "du dein Gerät aus einem Cloud-Backup wiederherstellst",
+  "backupWarningNoRecovery": "Ohne Backup gibt es keine Möglichkeit, dein Wallet wiederherzustellen.",
   "translationWarningTitle": "KI-generierte Übersetzungen",
   "translationWarningDescription": "Die meisten Übersetzungen in dieser App wurden mit KI erstellt und können Ungenauigkeiten enthalten. Wenn Sie Fehler bemerken oder bei der Verbesserung der Übersetzungen helfen möchten, können Sie eine Korrektur in unserem GitHub-Repository einreichen.",
   "translationWarningContributeButton": "Übersetzungen verbessern",
@@ -191,6 +198,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Genauen Betrag erhalten",
+  "swapInsufficientFunds": "Unzureichendes Guthaben",
   "arkContinueButton": "Weiter",
   "ledgerImportButton": "Import starten",
   "dcaActivate": "Wiederkehrenden Kauf aktivieren",

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Χωρίς αντίγραφο ασφαλείας, θα χάσετε την πρόσβαση στα bitcoin σας εάν:",
+  "backupWarningLoseReasonLostPhone": "Χάσετε το τηλέφωνό σας",
+  "backupWarningLoseReasonDeletedApp": "Διαγράψετε την εφαρμογή",
+  "backupWarningLoseReasonCriticalIssue": "Προκύψει κρίσιμο πρόβλημα στην εφαρμογή ή τη συσκευή",
+  "backupWarningLoseReasonKeystore": "Η συσκευή σας ακυρώνει το keystore όταν αλλάζετε την οθόνη κλειδώματος ή τον έλεγχο ταυτότητας της συσκευής",
+  "backupWarningLoseReasonCloudRestore": "Επαναφορά της συσκευής σας από αντίγραφο ασφαλείας στο cloud",
+  "backupWarningNoRecovery": "Δεν υπάρχει τρόπος να ανακτήσετε το πορτοφόλι σας χωρίς αντίγραφο ασφαλείας.",
   "bitboxErrorMultipleDevicesFound": "Πολλαπλές συσκευές BitBox βρέθηκαν. Παρακαλούμε βεβαιωθείτε ότι μόνο μία συσκευή είναι συνδεδεμένη.",
   "@bitboxErrorMultipleDevicesFound": {
     "description": "Error when multiple BitBox devices are connected"
@@ -442,6 +449,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Λήψη ακριβούς ποσότητας",
+  "swapInsufficientFunds": "Ανεπαρκή κεφάλαια",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -5014,6 +5014,10 @@
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },
+  "swapInsufficientFunds": "Insufficient Funds",
+  "@swapInsufficientFunds": {
+    "description": "Error shown when the amount exceeds the wallet balance during a swap"
+  },
   "swapSubtractFeesLabel": "Subtract fees from amount",
   "@swapSubtractFeesLabel": {
     "description": "Label when receive exact amount toggle is off"
@@ -12916,9 +12920,33 @@
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
   },
-  "backupWarningDescription": "Without a backup, you will lose access to your bitcoin if you lose your phone, delete the app, or encounter a critical application or device related issue. There is no way to recover your wallet without a backup.",
+  "backupWarningDescription": "Without a backup, you will lose access to your bitcoin if:",
   "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
+    "description": "Lead-in line above the list of ways the wallet can be lost"
+  },
+  "backupWarningLoseReasonLostPhone": "You lose your phone",
+  "@backupWarningLoseReasonLostPhone": {
+    "description": "Backup warning bullet: lost phone"
+  },
+  "backupWarningLoseReasonDeletedApp": "You delete the app",
+  "@backupWarningLoseReasonDeletedApp": {
+    "description": "Backup warning bullet: deleted app"
+  },
+  "backupWarningLoseReasonCriticalIssue": "A critical app or device issue occurs",
+  "@backupWarningLoseReasonCriticalIssue": {
+    "description": "Backup warning bullet: critical app or device issue"
+  },
+  "backupWarningLoseReasonKeystore": "Your device invalidates the keystore when changing the lockscreen/device authentication",
+  "@backupWarningLoseReasonKeystore": {
+    "description": "Backup warning bullet: keystore invalidation on lockscreen/auth change"
+  },
+  "backupWarningLoseReasonCloudRestore": "Restoring your device from a cloud backup",
+  "@backupWarningLoseReasonCloudRestore": {
+    "description": "Backup warning bullet: restoring device from a cloud backup"
+  },
+  "backupWarningNoRecovery": "There is no way to recover your wallet without a backup.",
+  "@backupWarningNoRecovery": {
+    "description": "Bold closing line of the backup warning"
   },
   "backupWarningBackupNow": "YES",
   "@backupWarningBackupNow": {

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Sin una copia de seguridad, perderás el acceso a tus bitcoin si:",
+  "backupWarningLoseReasonLostPhone": "Pierdes tu teléfono",
+  "backupWarningLoseReasonDeletedApp": "Eliminas la aplicación",
+  "backupWarningLoseReasonCriticalIssue": "Ocurre un problema crítico relacionado con la aplicación o el dispositivo",
+  "backupWarningLoseReasonKeystore": "Tu dispositivo invalida el keystore al cambiar la autenticación del dispositivo o de la pantalla de bloqueo",
+  "backupWarningLoseReasonCloudRestore": "Restaurar tu dispositivo desde una copia de seguridad en la nube",
+  "backupWarningNoRecovery": "No hay forma de recuperar tu billetera sin una copia de seguridad.",
   "@@locale": "es",
   "translationWarningTitle": "Traducciones generadas por IA",
   "translationWarningDescription": "La mayoría de las traducciones en esta aplicación fueron generadas usando IA y pueden contener inexactitudes. Si notas algún error o deseas ayudar a mejorar las traducciones, puedes enviar una corrección en nuestro repositorio de GitHub.",
@@ -1369,6 +1376,7 @@
   "swapToLabel": "A",
   "swapAmountLabel": "Cantidad",
   "swapReceiveExactAmountLabel": "Recibir cantidad exacta",
+  "swapInsufficientFunds": "Fondos insuficientes",
   "swapSubtractFeesLabel": "Restar comisiones de la cantidad",
   "swapExternalAddressHint": "Ingrese la dirección de la billetera externa",
   "swapValidationEnterAmount": "Por favor ingrese una cantidad",
@@ -4438,10 +4446,6 @@
   "backupWarningTitle": "RESPALDA TU BILLETERA AHORA",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Sin una copia de seguridad, perderás el acceso a tus bitcoin si pierdes tu teléfono, eliminas la aplicación o encuentras un problema crítico relacionado con la aplicación o el dispositivo. No hay forma de recuperar tu billetera sin una copia de seguridad.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "SÍ",
   "@backupWarningBackupNow": {

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "بدون نسخه پشتیبان، در صورت وقوع موارد زیر دسترسی خود به بیت‌کوین‌هایتان را از دست می‌دهید:",
+  "backupWarningLoseReasonLostPhone": "گوشی‌تان را گم کنید",
+  "backupWarningLoseReasonDeletedApp": "برنامه را حذف کنید",
+  "backupWarningLoseReasonCriticalIssue": "مشکل جدی در برنامه یا دستگاه رخ دهد",
+  "backupWarningLoseReasonKeystore": "دستگاه شما هنگام تغییر قفل صفحه یا روش احراز هویت دستگاه، کی‌استور (keystore) را باطل می‌کند",
+  "backupWarningLoseReasonCloudRestore": "بازیابی دستگاه شما از یک نسخه پشتیبان ابری",
+  "backupWarningNoRecovery": "بدون نسخه پشتیبان هیچ راهی برای بازیابی کیف پول شما وجود ندارد.",
   "settingsTelegramLabel": "تلگرام",
   "@settingsTelegramLabel": {
     "description": "Label for the Telegram link in settings"
@@ -1727,6 +1734,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "دریافت مقدار دقیق",
+  "swapInsufficientFunds": "وجوه ناکافی",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Ilman varmuuskopiota menetät pääsyn bitcoineihisi, jos:",
+  "backupWarningLoseReasonLostPhone": "kadotat puhelimesi",
+  "backupWarningLoseReasonDeletedApp": "poistat sovelluksen",
+  "backupWarningLoseReasonCriticalIssue": "kohtaat kriittisen sovellus- tai laitteistoon liittyvän ongelman",
+  "backupWarningLoseReasonKeystore": "laitteesi mitätöi keystoren, kun vaihdat lukitusnäytön tai laitteen tunnistautumistavan",
+  "backupWarningLoseReasonCloudRestore": "palautat laitteen pilvivarmuuskopiosta",
+  "backupWarningNoRecovery": "Lompakkoasi ei voi palauttaa ilman varmuuskopiota.",
   "@@locale": "fi",
   "translationWarningTitle": "Tekoälyn luomat käännökset",
   "translationWarningDescription": "Suurin osa tämän sovelluksen käännöksistä on luotu tekoälyllä ja ne voivat sisältää epätarkkuuksia. Jos huomaat virheitä tai haluat auttaa parantamaan käännöksiä, voit lähettää korjauksen GitHub-tietovarastoomme.",
@@ -1328,6 +1335,7 @@
   "swapToLabel": "Kohteeseen",
   "swapAmountLabel": "Määrä",
   "swapReceiveExactAmountLabel": "Vastaanota tarkka määrä",
+  "swapInsufficientFunds": "Riittämättömät varat",
   "swapSubtractFeesLabel": "Vähennä kulut määrästä",
   "swapExternalAddressHint": "Syötä ulkoinen lompakon osoite",
   "swapValidationEnterAmount": "Syötä määrä",
@@ -4424,10 +4432,6 @@
   "backupWarningTitle": "VARMUUSKOPIOI LOMPAKKOSI NYT",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Ilman varmuuskopiota menetät pääsyn bitcoineihisi, jos kadotat puhelimesi, poistat sovelluksen tai kohtaat kriittisen sovellus- tai laitteistoon liittyvän ongelman. Lompakkoasi ei voi palauttaa ilman varmuuskopiota.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "KYLLÄ",
   "@backupWarningBackupNow": {

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Sans sauvegarde, vous perdrez l'accès à vos bitcoins si :",
+  "backupWarningLoseReasonLostPhone": "Vous perdez votre téléphone",
+  "backupWarningLoseReasonDeletedApp": "Vous supprimez l'application",
+  "backupWarningLoseReasonCriticalIssue": "Un problème critique lié à l'application ou à l'appareil survient",
+  "backupWarningLoseReasonKeystore": "Votre appareil invalide le keystore lorsque vous modifiez l'authentification de l'écran de verrouillage ou de l'appareil",
+  "backupWarningLoseReasonCloudRestore": "Restaurer votre appareil à partir d'une sauvegarde dans le cloud",
+  "backupWarningNoRecovery": "Il n'existe aucun moyen de récupérer votre portefeuille sans sauvegarde.",
   "@@locale": "fr",
   "translationWarningTitle": "Traductions générées par IA",
   "translationWarningDescription": "La plupart des traductions de cette application ont été générées par IA et peuvent contenir des inexactitudes. Si vous remarquez des erreurs ou souhaitez aider à améliorer les traductions, vous pouvez soumettre une correction sur notre dépôt GitHub.",
@@ -1366,6 +1373,7 @@
   "swapToLabel": "Vers",
   "swapAmountLabel": "Montant",
   "swapReceiveExactAmountLabel": "Recevoir le montant exact",
+  "swapInsufficientFunds": "Fonds insuffisants",
   "swapSubtractFeesLabel": "Soustraire les frais du montant",
   "swapExternalAddressHint": "Entrez l'adresse du portefeuille externe",
   "swapValidationEnterAmount": "Veuillez entrer un montant",
@@ -4421,10 +4429,6 @@
   "backupWarningTitle": "SAUVEGARDEZ VOTRE PORTEFEUILLE MAINTENANT",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Sans sauvegarde, vous perdrez l'accès à vos bitcoins si vous perdez votre téléphone, supprimez l'application, ou si vous rencontrez un problème critique lié à l'application ou à l'appareil. Il n'existe aucun moyen de récupérer votre portefeuille sans sauvegarde.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "OUI",
   "@backupWarningBackupNow": {

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "बैकअप के बिना, आप अपने Bitcoin तक पहुंच खो देंगे यदि:",
+  "backupWarningLoseReasonLostPhone": "आप अपना फ़ोन खो देते हैं",
+  "backupWarningLoseReasonDeletedApp": "आप ऐप हटा देते हैं",
+  "backupWarningLoseReasonCriticalIssue": "कोई गंभीर ऐप अथवा डिवाइस संबंधित समस्या आती है",
+  "backupWarningLoseReasonKeystore": "जब आप लॉकस्क्रीन या डिवाइस ऑथेंटिकेशन बदलते हैं, तो आपका डिवाइस कीस्टोर (keystore) को अमान्य कर देता है",
+  "backupWarningLoseReasonCloudRestore": "अपने डिवाइस को क्लाउड बैकअप से रिस्टोर करना",
+  "backupWarningNoRecovery": "बैकअप के बिना आपके वॉलेट को पुनर्प्राप्त करने का कोई तरीका नहीं है।",
   "@@locale": "hi",
   "bitboxErrorMultipleDevicesFound": "एकाधिक बिटबॉक्स उपकरण पाए गए। कृपया सुनिश्चित करें कि केवल एक डिवाइस जुड़ा हुआ है।।",
   "@bitboxErrorMultipleDevicesFound": {
@@ -524,6 +531,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "सटीक राशि प्राप्त करें",
+  "swapInsufficientFunds": "अपर्याप्त धनराशि",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },
@@ -12795,10 +12803,6 @@
   "backupWarningTitle": "अभी अपना वॉलेट बैकअप करें",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "बैकअप के बिना, यदि आप अपना फ़ोन खो देते हैं, ऐप हटा देते हैं, या किसी गंभीर ऐप अथवा डिवाइस संबंधित समस्या का सामना करते हैं, तो आप अपने Bitcoin तक पहुंच खो देंगे। बैकअप के बिना आपके वॉलेट को पुनर्प्राप्त करने का कोई तरीका नहीं है।",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "हाँ",
   "@backupWarningBackupNow": {

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Backup ke bina, aap apne bitcoin access kho denge agar:",
+  "backupWarningLoseReasonLostPhone": "Aap apna phone kho dete hain",
+  "backupWarningLoseReasonDeletedApp": "Aap app delete karte hain",
+  "backupWarningLoseReasonCriticalIssue": "Koi critical app ya device issue aata hai",
+  "backupWarningLoseReasonKeystore": "Jab aap lockscreen ya device authentication change karte hain, tab aapka device keystore ko invalid kar deta hai",
+  "backupWarningLoseReasonCloudRestore": "Apne device ko cloud backup se restore karna",
+  "backupWarningNoRecovery": "Backup ke bina wallet recover karne ka koi tarika nahi hai.",
   "@@locale": "hi_Latn",
   "translationWarningTitle": "AI-Generated Anuvad",
   "@translationWarningTitle": {
@@ -11815,10 +11822,6 @@
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
   },
-  "backupWarningDescription": "Backup ke bina, agar aap apna phone kho dete hain, app delete karte hain, ya koi critical application ya device issue aata hai toh aap apne bitcoin access kho denge. Backup ke bina wallet recover karne ka koi tarika nahi hai.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
-  },
   "backupWarningBackupNow": "HAAN",
   "@backupWarningBackupNow": {
     "description": "Button to navigate to backup options"
@@ -12703,6 +12706,7 @@
     "description": "Label for amount input section"
   },
   "swapReceiveExactAmountLabel": "Exact amount receive karein",
+  "swapInsufficientFunds": "Funds kaafi nahi hain",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -1,4 +1,12 @@
 {
+  "backupWarningDescription": "Առանց պահուստային պատճենի՝ դուք կկորցնեք ձեր bitcoin-ի հասանելիությունը, եթե՝",
+  "backupWarningLoseReasonLostPhone": "Կորցնեք ձեր հեռախոսը",
+  "backupWarningLoseReasonDeletedApp": "Ջնջեք հավելվածը",
+  "backupWarningLoseReasonCriticalIssue": "Տեղի ունենա հավելվածի կամ սարքի կրիտիկական խնդիր",
+  "backupWarningLoseReasonKeystore": "Ձեր սարքը չեղարկի բանալիների պահոցը (keystore)՝ էկրանի կողպման/սարքի նույնականացման փոփոխման ժամանակ",
+  "backupWarningLoseReasonCloudRestore": "Ձեր սարքը վերականգնեք ամպային պահուստից",
+  "backupWarningNoRecovery": "Առանց պահուստային պատճենի ձեր դրամապանակը վերականգնելու որևէ միջոց չկա։",
+  "swapInsufficientFunds": "Անբավարար միջոցներ",
   "broadcastSignedTxBroadcastError": "Չհաջողվեց հեռարձակել գործարքը",
   "exchangeFileUploadUploadCount": "Upload {count} {count, plural, =1{File} other{Files}}",
   "appInitErrorTitle": "Հավելվածը չհաջողվեց գործարկել",

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Senza un backup, perderai l'accesso ai tuoi bitcoin se:",
+  "backupWarningLoseReasonLostPhone": "Perdi il telefono",
+  "backupWarningLoseReasonDeletedApp": "Elimini l'app",
+  "backupWarningLoseReasonCriticalIssue": "Si verifica un problema critico legato all'applicazione o al dispositivo",
+  "backupWarningLoseReasonKeystore": "Il dispositivo invalida il keystore quando modifichi l'autenticazione della schermata di blocco o del dispositivo",
+  "backupWarningLoseReasonCloudRestore": "Ripristinare il dispositivo da un backup sul cloud",
+  "backupWarningNoRecovery": "Non c'è modo di recuperare il portafoglio senza un backup.",
   "translationWarningTitle": "Traduzioni generate dall'IA",
   "translationWarningDescription": "La maggior parte delle traduzioni in questa app sono state generate utilizzando l'IA e potrebbero contenere imprecisioni. Se noti errori o desideri aiutare a migliorare le traduzioni, puoi inviare una correzione sul nostro repository GitHub.",
   "translationWarningContributeButton": "Aiuta a migliorare le traduzioni",
@@ -192,6 +199,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Ricevi la quantità esatta",
+  "swapInsufficientFunds": "Fondi insufficienti",
   "arkContinueButton": "Continua",
   "ledgerImportButton": "Inizio Importazione",
   "dcaActivate": "Attivare l'acquisto ricorrente",
@@ -4432,10 +4440,6 @@
   "backupWarningTitle": "ESEGUI IL BACKUP DEL TUO PORTAFOGLIO ORA",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Senza un backup, perderai l'accesso ai tuoi bitcoin se perdi il telefono, elimini l'app o incontri un problema critico legato all'applicazione o al dispositivo. Non c'è modo di recuperare il portafoglio senza un backup.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "SÌ",
   "@backupWarningBackupNow": {

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -1,4 +1,12 @@
 {
+  "backupWarningDescription": "სარეზერვო ასლის გარეშე თქვენ დაკარგავთ წვდომას თქვენს bitcoin-ზე, თუ:",
+  "backupWarningLoseReasonLostPhone": "დაკარგავთ თქვენს ტელეფონს",
+  "backupWarningLoseReasonDeletedApp": "წაშლით აპლიკაციას",
+  "backupWarningLoseReasonCriticalIssue": "მოხდება აპლიკაციის ან მოწყობილობის კრიტიკული ხარვეზი",
+  "backupWarningLoseReasonKeystore": "თქვენი მოწყობილობა გააუქმებს გასაღებების საცავს (keystore) ეკრანის დაბლოკვის/მოწყობილობის ავთენტიფიკაციის შეცვლისას",
+  "backupWarningLoseReasonCloudRestore": "აღადგენთ თქვენს მოწყობილობას ღრუბლოვანი სარეზერვო ასლიდან",
+  "backupWarningNoRecovery": "სარეზერვო ასლის გარეშე საფულის აღდგენა შეუძლებელია.",
+  "swapInsufficientFunds": "არასაკმარისი სახსრები",
   "broadcastSignedTxBroadcastError": "ტრანზაქციის გავრცელება ვერ მოხერხდა",
   "transactionNoteAddTitle": "შენიშვნის დამატება",
   "@transactionNoteAddTitle": {

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "백업이 없으면 다음과 같은 경우 비트코인에 접근할 수 없습니다:",
+  "backupWarningLoseReasonLostPhone": "휴대폰을 분실한 경우",
+  "backupWarningLoseReasonDeletedApp": "앱을 삭제한 경우",
+  "backupWarningLoseReasonCriticalIssue": "앱이나 기기에 심각한 문제가 발생한 경우",
+  "backupWarningLoseReasonKeystore": "잠금화면/기기 인증 방식을 변경하면 기기가 키스토어를 무효화합니다",
+  "backupWarningLoseReasonCloudRestore": "클라우드 백업으로 기기를 복원하는 경우",
+  "backupWarningNoRecovery": "백업이 없으면 지갑을 복구할 방법이 없습니다.",
   "bitboxErrorMultipleDevicesFound": "발견되는 다수 BitBox 장치. 한 기기만 연결됩니다.",
   "@bitboxErrorMultipleDevicesFound": {
     "description": "Error when multiple BitBox devices are connected"
@@ -524,6 +531,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "정확한 금액",
+  "swapInsufficientFunds": "잔액 부족",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Sem um backup, você perderá o acesso ao seu bitcoin se:",
+  "backupWarningLoseReasonLostPhone": "Perder o telefone",
+  "backupWarningLoseReasonDeletedApp": "Excluir o aplicativo",
+  "backupWarningLoseReasonCriticalIssue": "Ocorrer um problema crítico relacionado ao aplicativo ou ao dispositivo",
+  "backupWarningLoseReasonKeystore": "O seu dispositivo invalida o keystore ao alterar a autenticação do ecrã de bloqueio ou do dispositivo",
+  "backupWarningLoseReasonCloudRestore": "Restaurar o seu dispositivo a partir de uma cópia de segurança na nuvem",
+  "backupWarningNoRecovery": "Não há como recuperar sua carteira sem um backup.",
   "translationWarningTitle": "Traduções geradas por IA",
   "translationWarningDescription": "A maioria das traduções neste aplicativo foram geradas usando IA e podem conter imprecisões. Se notar erros ou quiser ajudar a melhorar as traduções, pode submeter uma correção no nosso repositório GitHub.",
   "translationWarningContributeButton": "Ajudar a melhorar traduções",
@@ -190,6 +197,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Receber quantidade exata",
+  "swapInsufficientFunds": "Fundos insuficientes",
   "arkContinueButton": "Continue",
   "ledgerImportButton": "Importação de início",
   "dcaActivate": "Ativar a recuperação",
@@ -4487,10 +4495,6 @@
   "backupWarningTitle": "FAÇA BACKUP DA SUA CARTEIRA AGORA",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Sem um backup, você perderá o acesso ao seu bitcoin se perder o telefone, excluir o aplicativo ou encontrar um problema crítico relacionado ao aplicativo ou ao dispositivo. Não há como recuperar sua carteira sem um backup.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "SIM",
   "@backupWarningBackupNow": {

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Sem um backup, você perderá o acesso ao seu bitcoin se:",
+  "backupWarningLoseReasonLostPhone": "Perder o celular",
+  "backupWarningLoseReasonDeletedApp": "Excluir o aplicativo",
+  "backupWarningLoseReasonCriticalIssue": "Ocorrer um problema crítico no aplicativo ou no dispositivo",
+  "backupWarningLoseReasonKeystore": "Seu dispositivo invalida o keystore ao alterar a autenticação da tela de bloqueio ou do dispositivo",
+  "backupWarningLoseReasonCloudRestore": "Restaurar seu dispositivo a partir de um backup na nuvem",
+  "backupWarningNoRecovery": "Não há como recuperar sua carteira sem um backup.",
   "torSettingsPortHint": "9050",
   "@torSettingsPortHint": {
     "description": "Hint text for port input showing default value"
@@ -548,6 +555,7 @@
     "description": "Continue button text used in ark send flow"
   },
   "swapReceiveExactAmountLabel": "Receber quantidade exata",
+  "swapInsufficientFunds": "Fundos insuficientes",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Без резервной копии вы потеряете доступ к своим биткоинам, если:",
+  "backupWarningLoseReasonLostPhone": "Потеряете телефон",
+  "backupWarningLoseReasonDeletedApp": "Удалите приложение",
+  "backupWarningLoseReasonCriticalIssue": "Столкнётесь с критической проблемой приложения или устройства",
+  "backupWarningLoseReasonKeystore": "Устройство аннулирует keystore при смене блокировки экрана или способа аутентификации устройства",
+  "backupWarningLoseReasonCloudRestore": "Восстановление устройства из облачной резервной копии",
+  "backupWarningNoRecovery": "Без резервной копии восстановить кошелёк невозможно.",
   "translationWarningTitle": "Переводы, созданные ИИ",
   "translationWarningDescription": "Большинство переводов в этом приложении были созданы с помощью ИИ и могут содержать неточности. Если вы заметили ошибки или хотите помочь улучшить переводы, вы можете отправить исправление в наш репозиторий на GitHub.",
   "translationWarningContributeButton": "Помочь улучшить переводы",
@@ -191,6 +198,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Получить точную сумму",
+  "swapInsufficientFunds": "Недостаточно средств",
   "arkContinueButton": "Продолжить",
   "ledgerImportButton": "Начало",
   "dcaActivate": "Активировать покупку",
@@ -4441,10 +4449,6 @@
   "backupWarningTitle": "СДЕЛАЙТЕ РЕЗЕРВНУЮ КОПИЮ КОШЕЛЬКА СЕЙЧАС",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Без резервной копии вы потеряете доступ к своим биткоинам, если потеряете телефон, удалите приложение или столкнётесь с критической проблемой приложения или устройства. Без резервной копии восстановить кошелёк невозможно.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "ДА",
   "@backupWarningBackupNow": {

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -1,4 +1,12 @@
 {
+  "backupWarningDescription": "Bila nakala rudufu, utapoteza ufikiaji wa bitcoin yako iwapo:",
+  "backupWarningLoseReasonLostPhone": "Utapoteza simu yako",
+  "backupWarningLoseReasonDeletedApp": "Utafuta programu",
+  "backupWarningLoseReasonCriticalIssue": "Tatizo kubwa la programu au kifaa litatokea",
+  "backupWarningLoseReasonKeystore": "Kifaa chako kitabatilisha hifadhi ya funguo (keystore) unapobadilisha njia ya kufungua skrini/uthibitishaji wa kifaa",
+  "backupWarningLoseReasonCloudRestore": "Utarejesha kifaa chako kutoka kwenye nakala rudufu ya wingu",
+  "backupWarningNoRecovery": "Hakuna njia ya kurejesha pochi yako bila nakala rudufu.",
+  "swapInsufficientFunds": "Fedha hazitoshi",
   "broadcastSignedTxBroadcastError": "Imeshindwa kutangaza muamala",
   "languageSettingsLabel": "| Lugha |",
   "@languageSettingsLabel": {

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "หากไม่มีข้อมูลสำรอง คุณจะไม่สามารถเข้าถึงบิตคอยน์ของคุณได้ในกรณีต่อไปนี้:",
+  "backupWarningLoseReasonLostPhone": "คุณทำโทรศัพท์หาย",
+  "backupWarningLoseReasonDeletedApp": "คุณลบแอป",
+  "backupWarningLoseReasonCriticalIssue": "เกิดปัญหาร้ายแรงกับแอปหรืออุปกรณ์",
+  "backupWarningLoseReasonKeystore": "อุปกรณ์ของคุณจะยกเลิกคีย์สโตร์เมื่อเปลี่ยนรหัสล็อกหน้าจอ/วิธียืนยันตัวตนของอุปกรณ์",
+  "backupWarningLoseReasonCloudRestore": "การกู้คืนอุปกรณ์ของคุณจากการสำรองข้อมูลบนคลาวด์",
+  "backupWarningNoRecovery": "หากไม่มีข้อมูลสำรอง จะไม่มีทางกู้คืนกระเป๋าเงินของคุณได้",
   "bitboxErrorMultipleDevicesFound": "อุปกรณ์หลายหน้าจอ กรุณาตรวจสอบอุปกรณ์เดียว.",
   "@bitboxErrorMultipleDevicesFound": {
     "description": "Error when multiple BitBox devices are connected"
@@ -524,6 +531,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "รับจํานวนเงิน",
+  "swapInsufficientFunds": "เงินทุนไม่เพียงพอ",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Yedek olmadan, şu durumlarda bitcoin'lerinize erişimi kaybedersiniz:",
+  "backupWarningLoseReasonLostPhone": "Telefonunuzu kaybederseniz",
+  "backupWarningLoseReasonDeletedApp": "Uygulamayı silerseniz",
+  "backupWarningLoseReasonCriticalIssue": "Kritik bir uygulama veya cihaz sorunu oluşursa",
+  "backupWarningLoseReasonKeystore": "Kilit ekranını veya cihaz kimlik doğrulamasını değiştirdiğinizde cihazınız keystore'u geçersiz kılar",
+  "backupWarningLoseReasonCloudRestore": "Cihazınızı bir bulut yedeğinden geri yüklerseniz",
+  "backupWarningNoRecovery": "Yedek olmadan cüzdanınızı kurtarmanın hiçbir yolu yoktur.",
   "bitboxErrorMultipleDevicesFound": "Birçok BitBox cihazı bulundu. Lütfen sadece bir cihazın bağlantılı olmasını sağlayın.",
   "@bitboxErrorMultipleDevicesFound": {
     "description": "Error when multiple BitBox devices are connected"
@@ -524,6 +531,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "Tam miktar alın",
+  "swapInsufficientFunds": "Yetersiz bakiye",
   "@swapReceiveExactAmountLabel": {
     "description": "Label when receive exact amount toggle is on"
   },

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "Без резервної копії ви втратите доступ до своїх біткоїнів, якщо:",
+  "backupWarningLoseReasonLostPhone": "Втратите телефон",
+  "backupWarningLoseReasonDeletedApp": "Видалите застосунок",
+  "backupWarningLoseReasonCriticalIssue": "Зіткнетеся з критичною проблемою застосунку чи пристрою",
+  "backupWarningLoseReasonKeystore": "Пристрій анулює keystore під час зміни блокування екрана або способу автентифікації пристрою",
+  "backupWarningLoseReasonCloudRestore": "Відновлення пристрою з резервної копії у хмарі",
+  "backupWarningNoRecovery": "Відновити гаманець без резервної копії неможливо.",
   "translationWarningTitle": "Переклади, створені ШІ",
   "translationWarningDescription": "Більшість перекладів у цьому додатку були створені за допомогою ШІ і можуть містити неточності. Якщо ви помітили помилки або хочете допомогти покращити переклади, ви можете надіслати виправлення в наш репозиторій на GitHub.",
   "translationWarningContributeButton": "Допомогти покращити переклади",
@@ -1274,6 +1281,7 @@
   "importQrDeviceJadeStep7": "Щоб змінити тип адреси",
   "sendBroadcastingTransaction": "Трансляція угоди.",
   "swapReceiveExactAmountLabel": "Отримати точний розмір",
+  "swapInsufficientFunds": "Недостатньо коштів",
   "arkContinueButton": "Продовжити",
   "ledgerImportButton": "Імпорт",
   "dcaActivate": "Активувати продаж",
@@ -4429,10 +4437,6 @@
   "backupWarningTitle": "СТВОРІТЬ РЕЗЕРВНУ КОПІЮ ГАМАНЦЯ ЗАРАЗ",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "Без резервної копії ви втратите доступ до своїх біткоїнів, якщо втратите телефон, видалите застосунок або зіткнетеся з критичною проблемою застосунку чи пристрою. Відновити гаманець без резервної копії неможливо.",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "ТАК",
   "@backupWarningBackupNow": {

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -1,4 +1,12 @@
 {
+  "backupWarningDescription": "Nếu không có bản sao lưu, bạn sẽ mất quyền truy cập vào bitcoin của mình nếu:",
+  "backupWarningLoseReasonLostPhone": "Bạn làm mất điện thoại",
+  "backupWarningLoseReasonDeletedApp": "Bạn xóa ứng dụng",
+  "backupWarningLoseReasonCriticalIssue": "Xảy ra sự cố nghiêm trọng với ứng dụng hoặc thiết bị",
+  "backupWarningLoseReasonKeystore": "Thiết bị của bạn sẽ vô hiệu hóa keystore khi thay đổi khóa màn hình/phương thức xác thực thiết bị",
+  "backupWarningLoseReasonCloudRestore": "Khôi phục thiết bị của bạn từ bản sao lưu trên đám mây",
+  "backupWarningNoRecovery": "Không có cách nào khôi phục ví của bạn nếu không có bản sao lưu.",
+  "swapInsufficientFunds": "Không đủ tiền",
   "broadcastSignedTxBroadcastError": "Không thể phát đi giao dịch",
   "exchangeFileUploadUploadCount": "Upload {count} {count, plural, =1{File} other{Files}}",
   "appInitErrorTitle": "Ứng dụng không thể khởi động",

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -1,4 +1,11 @@
 {
+  "backupWarningDescription": "如果没有备份，在以下情况下您将无法访问您的比特币：",
+  "backupWarningLoseReasonLostPhone": "您丢失手机",
+  "backupWarningLoseReasonDeletedApp": "您删除应用程序",
+  "backupWarningLoseReasonCriticalIssue": "应用程序或设备出现严重问题",
+  "backupWarningLoseReasonKeystore": "更改锁屏密码/设备验证方式时，您的设备会使密钥库（Keystore）失效",
+  "backupWarningLoseReasonCloudRestore": "通过云端备份恢复您的设备",
+  "backupWarningNoRecovery": "没有备份，就无法恢复您的钱包。",
   "translationWarningTitle": "AI生成的翻译",
   "translationWarningDescription": "此应用中的大多数翻译是使用AI生成的，可能存在不准确之处。如果您发现任何错误或想帮助改进翻译，可以在我们的GitHub仓库中提交修复。",
   "translationWarningContributeButton": "帮助改进翻译",
@@ -192,6 +199,7 @@
     }
   },
   "swapReceiveExactAmountLabel": "收到确切数额",
+  "swapInsufficientFunds": "资金不足",
   "arkContinueButton": "继续",
   "ledgerImportButton": "开始导入",
   "dcaActivate": "主动同意",
@@ -4432,10 +4440,6 @@
   "backupWarningTitle": "立即备份您的钱包",
   "@backupWarningTitle": {
     "description": "Title for the backup warning bottom sheet"
-  },
-  "backupWarningDescription": "如果没有备份，一旦您丢失手机、删除应用程序或遇到与应用程序或设备相关的严重问题，您将无法访问您的比特币。没有备份，就无法恢复您的钱包。",
-  "@backupWarningDescription": {
-    "description": "Description explaining why backup is important"
   },
   "backupWarningBackupNow": "是",
   "@backupWarningBackupNow": {


### PR DESCRIPTION
Fixes:
Transfer Flow:

- [x] Show the `Recieve Exact Amount` option when the from wallet is liquid 
- [x] Insufficient balance should be a form validation error
- [x] Continue should not be clickable if form is not validated
- [x] Split the single large warning into two small warnings after transfer is confirmed

Backup Content:
- [x] Display content as a bulleted list for easier reading

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-05 at 17 19 07" src="https://github.com/user-attachments/assets/0add7954-9f58-45d8-9da8-52ef9bc1895f" />
