### PR TITLE
fix(payjoin): correct malformed receive BIP21 URI

### DIFF
--- a/lib/features/receive/presentation/bloc/receive_state.dart
+++ b/lib/features/receive/presentation/bloc/receive_state.dart
@@ -111,7 +111,7 @@ abstract class ReceiveState with _$ReceiveState {
           scheme: 'bitcoin',
           path: bitcoinAddress!.address,
           queryParameters: {
-            if (confirmedAmountBtc > 0) 'amount': confirmedAmountBtc.toString(),
+            if (confirmedAmountBtc > 0) 'amount': formatBtcAmount(confirmedAmountBtc),
             if (note.isNotEmpty) 'message': note,
           },
         );
@@ -128,7 +128,7 @@ abstract class ReceiveState with _$ReceiveState {
           scheme: 'liquidnetwork',
           path: liquidAddress!.address,
           queryParameters: {
-            if (confirmedAmountBtc > 0) 'amount': confirmedAmountBtc.toString(),
+            if (confirmedAmountBtc > 0) 'amount': formatBtcAmount(confirmedAmountBtc),
             if (note.isNotEmpty) 'message': note,
             'assetid':
                 wallet != null && wallet!.network == Network.liquidMainnet
@@ -163,11 +163,24 @@ abstract class ReceiveState with _$ReceiveState {
     final base = pjUri.substring(0, q); // bitcoin:<address>
     final pdkQuery = pjUri.substring(q + 1); // [pjos=0&]pj=...
     final extras = <String>[
-      if (amountBtc > 0) 'amount=$amountBtc',
+      if (amountBtc > 0) 'amount=${formatBtcAmount(amountBtc)}',
       if (note.isNotEmpty) 'message=${Uri.encodeQueryComponent(note)}',
       if (!pdkQuery.contains('pjos=')) 'pjos=0',
     ];
     return extras.isEmpty ? pjUri : '$base?${extras.join('&')}&$pdkQuery';
+  }
+
+  /// Formats a BTC amount as a plain decimal for a BIP21 `amount` parameter.
+  ///
+  /// `double.toString()` switches to scientific notation below 1e-6 (e.g.
+  /// `1e-8` for 1 sat), which is not a valid BIP21 amount. Format with 8
+  /// decimals (sat precision) and trim trailing zeros.
+  static String formatBtcAmount(double amountBtc) {
+    var s = amountBtc.toStringAsFixed(8);
+    if (s.contains('.')) {
+      s = s.replaceAll(RegExp(r'0+$'), '').replaceAll(RegExp(r'\.$'), '');
+    }
+    return s;
   }
 
   String get addressOrInvoiceOnly {

--- a/lib/features/receive/presentation/bloc/receive_state.dart
+++ b/lib/features/receive/presentation/bloc/receive_state.dart
@@ -99,7 +99,15 @@ abstract class ReceiveState with _$ReceiveState {
           return bitcoinAddress!.address;
         }
 
-        Uri bip21Uri = Uri(
+        if (canPayjoin) {
+          return buildPayjoinPaymentRequest(
+            pjUri: payjoin!.pjUri,
+            amountBtc: confirmedAmountBtc,
+            note: note,
+          );
+        }
+
+        final bip21Uri = Uri(
           scheme: 'bitcoin',
           path: bitcoinAddress!.address,
           queryParameters: {
@@ -107,19 +115,6 @@ abstract class ReceiveState with _$ReceiveState {
             if (note.isNotEmpty) 'message': note,
           },
         );
-
-        // Add payjoin parameters if available
-        if (canPayjoin) {
-          final pjUri = Uri.parse(payjoin!.pjUri);
-          final queryParameters = {
-            if (bip21Uri.queryParameters.isNotEmpty)
-              ...bip21Uri.queryParameters,
-            if (pjUri.queryParameters['pjos'] != null)
-              'pjos': pjUri.queryParameters['pjos'],
-            'pj': pjUri.queryParameters['pj'],
-          };
-          bip21Uri = bip21Uri.replace(queryParameters: queryParameters);
-        }
         return bip21Uri.toString();
       case ReceiveType.lightning:
         return lightningInvoiceNormalized;
@@ -145,6 +140,34 @@ abstract class ReceiveState with _$ReceiveState {
       case _:
         return '';
     }
+  }
+
+  /// Builds the BIP21 payment request for a payjoin receive.
+  ///
+  /// [pjUri] is the complete, valid BIP21 URI produced by the payjoin PDK. We
+  /// append amount/message verbatim instead of re-encoding it through
+  /// dart:core [Uri], which percent-encodes the `://` of the pj endpoint and
+  /// would drop `pjos`. Keeping the pj byte-identical preserves the payjoin
+  /// endpoint and keeps it as the last parameter (BIP-77 SHOULD).
+  ///
+  /// `pjos=0` is advertised when the PDK omits it: our receiver never
+  /// substitutes outputs (it calls `commitOutputs` without substitution), so
+  /// disabling output substitution matches actual behavior.
+  static String buildPayjoinPaymentRequest({
+    required String pjUri,
+    required double amountBtc,
+    required String note,
+  }) {
+    final q = pjUri.indexOf('?');
+    if (q < 0) return pjUri;
+    final base = pjUri.substring(0, q); // bitcoin:<address>
+    final pdkQuery = pjUri.substring(q + 1); // [pjos=0&]pj=...
+    final extras = <String>[
+      if (amountBtc > 0) 'amount=$amountBtc',
+      if (note.isNotEmpty) 'message=${Uri.encodeQueryComponent(note)}',
+      if (!pdkQuery.contains('pjos=')) 'pjos=0',
+    ];
+    return extras.isEmpty ? pjUri : '$base?${extras.join('&')}&$pdkQuery';
   }
 
   String get addressOrInvoiceOnly {

--- a/test/features/receive/receive_payjoin_uri_test.dart
+++ b/test/features/receive/receive_payjoin_uri_test.dart
@@ -75,6 +75,47 @@ void main() {
     });
   });
 
+  group('formatBtcAmount', () {
+    test('never uses scientific notation for small amounts', () {
+      // 1 sat and 10 sats would render as 1e-8 / 1e-7 via double.toString().
+      expect(ReceiveState.formatBtcAmount(0.00000001), equals('0.00000001'));
+      expect(ReceiveState.formatBtcAmount(0.0000001), equals('0.0000001'));
+      expect(ReceiveState.formatBtcAmount(0.000001), equals('0.000001'));
+    });
+
+    test('trims trailing zeros', () {
+      expect(ReceiveState.formatBtcAmount(0.001), equals('0.001'));
+      expect(ReceiveState.formatBtcAmount(1.0), equals('1'));
+      expect(ReceiveState.formatBtcAmount(0.00666666), equals('0.00666666'));
+    });
+  });
+
+  group('regression: the previous dart:core Uri reconstruction', () {
+    // Reproduces the old implementation to document precisely why it was
+    // replaced: round-tripping the PDK pjUri through dart:core Uri
+    // percent-encoded the :// and dropped pjos.
+    test('over-encoded :// and dropped pjos', () {
+      final pjUri = Uri.parse(pdkPjUri);
+      var bip21Uri = Uri(
+        scheme: 'bitcoin',
+        path: 'tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p',
+        queryParameters: {'amount': '0.001'},
+      );
+      bip21Uri = bip21Uri.replace(
+        queryParameters: {
+          ...bip21Uri.queryParameters,
+          if (pjUri.queryParameters['pjos'] != null)
+            'pjos': pjUri.queryParameters['pjos']!,
+          'pj': pjUri.queryParameters['pj']!,
+        },
+      );
+      final old = bip21Uri.toString();
+      expect(old.contains('%3A%2F%2F'), isTrue, reason: ':// over-encoded');
+      expect(old.contains('HTTPS://'), isFalse);
+      expect(old.contains('pjos'), isFalse, reason: 'pjos dropped');
+    });
+  });
+
   group('generated URI is consumable by the bip21_uri decoder', () {
     test('the pj endpoint survives a decode round-trip', () {
       final generated = ReceiveState.buildPayjoinPaymentRequest(

--- a/test/features/receive/receive_payjoin_uri_test.dart
+++ b/test/features/receive/receive_payjoin_uri_test.dart
@@ -1,0 +1,97 @@
+import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
+import 'package:bip21_uri/bip21_uri.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A complete, valid BIP21 payjoin URI as produced by the payjoin PDK:
+// uppercase scheme+host, '+' fragment separators, '#' as %23, clean '://'.
+const pdkPjUri =
+    'bitcoin:tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p'
+    '?pj=HTTPS://PAYJO.IN/TXJCGKTKXLUUZ'
+    '%23EX1WKV8CEC+OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ'
+    '+RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV';
+
+const pj =
+    'HTTPS://PAYJO.IN/TXJCGKTKXLUUZ'
+    '%23EX1WKV8CEC+OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ'
+    '+RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV';
+
+void main() {
+  group('ReceiveState.buildPayjoinPaymentRequest', () {
+    test('keeps the pj endpoint byte-identical (no over-encoding)', () {
+      final out = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: pdkPjUri,
+        amountBtc: 0,
+        note: '',
+      );
+      expect(out.contains('HTTPS://'), isTrue);
+      expect(out.contains('%3A%2F%2F'), isFalse, reason: ':// not encoded');
+      expect(out.contains('pj=$pj'), isTrue, reason: 'pj unchanged');
+    });
+
+    test('injects pjos=0 when the PDK omits it', () {
+      final out = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: pdkPjUri,
+        amountBtc: 0,
+        note: '',
+      );
+      expect(out.contains('pjos=0'), isTrue);
+    });
+
+    test('does not duplicate pjos when the PDK already supplied it', () {
+      final withPjos =
+          'bitcoin:tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p?pjos=1&pj=$pj';
+      final out = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: withPjos,
+        amountBtc: 0,
+        note: '',
+      );
+      expect('pjos='.allMatches(out).length, equals(1));
+      expect(out.contains('pjos=1'), isTrue);
+    });
+
+    test('appends amount and message, with pj remaining last', () {
+      final out = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: pdkPjUri,
+        amountBtc: 0.00666666,
+        note: 'Order 9XWGG',
+      );
+      expect(out.contains('amount=0.00666666'), isTrue);
+      expect(out.contains('message=Order+9XWGG'), isTrue);
+      expect(out.contains('pjos=0'), isTrue);
+      // pj must be the final parameter (BIP-77 SHOULD) and still clean.
+      expect(out.endsWith('pj=$pj'), isTrue);
+      expect(out.contains('%3A%2F%2F'), isFalse);
+    });
+
+    test('returns the URI untouched when there is nothing to add', () {
+      final withPjos =
+          'bitcoin:tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p?pjos=0&pj=$pj';
+      final out = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: withPjos,
+        amountBtc: 0,
+        note: '',
+      );
+      expect(out, equals(withPjos));
+    });
+  });
+
+  group('generated URI is consumable by the bip21_uri decoder', () {
+    test('the pj endpoint survives a decode round-trip', () {
+      final generated = ReceiveState.buildPayjoinPaymentRequest(
+        pjUri: pdkPjUri,
+        amountBtc: 0.00666666,
+        note: 'Order 9XWGG',
+      );
+
+      final decoded = bip21.decode(generated);
+      // pj is already in the canonical (uppercase, '+') form the decoder
+      // normalizes to, so it must come back byte-identical.
+      expect(decoded.options['pj'], equals(pj));
+      expect(decoded.options['pjos'], equals('0'));
+      expect(decoded.amount, equals(0.00666666));
+      expect(decoded.message, equals('Order 9XWGG'));
+      expect(decoded.address,
+          equals('tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p'));
+    });
+  });
+}


### PR DESCRIPTION
## Payjoin receive URI — fix + current limitation

### What was wrong
Our receive payment request was rebuilt through `dart:core Uri`, which
percent-encoded the pj endpoint's `://` (`HTTPS%3A%2F%2F…`) and dropped
`pjos`. The result was an out-of-spec, malformed BIP21 URI.

### The fix
We now take the PDK-produced URI (already valid) and append `amount`/`message`
verbatim instead of re-encoding it. The pj endpoint stays byte-identical and
last (BIP-77 SHOULD), and we advertise `pjos=0` when the PDK omits it — which
matches our receiver, since it never substitutes outputs. Covered by unit
tests: old-behavior characterization, new generator, and a decode round-trip.

- The over-encoding and missing `pjos` were **our** bug (BULL generation), not
  the `bip21_uri` package — the package's encoder keeps `://` clean.
- The package's *decoder* does mutate the pj (force-uppercase, `-`→`+`). That's
  a separate, known issue, documented as skipped tests.

### ⚠️ Still locked on payjoin 0.23.0
We have not changed the payjoin engine. 0.23.0 uses the **old `+` fragment
separator**; final BIP-77 uses `-`. So:
- This fix makes our URI clean and in-spec *for the 0.23 wire format* — it does
  **not** fix cross-version interop.
- The `bip21_uri` decoder's `-`→`+` rewrite is currently **load-bearing**: it's
  what lets us accept a final-BIP-77 (`-`) URI on the send path against the 0.23
  PDK. Removing it before upgrading would break sending.
- So the package cleanup and the PDK upgrade to a final-BIP-77 release **must
  land together** — not before.

