### PR TITLE
fix: correct dark theme colors in encrypted vault delete confirmation dialog

### DIFF
--- a/lib/features/recoverbull_google_drive/ui/drive_vaults_list_page.dart
+++ b/lib/features/recoverbull_google_drive/ui/drive_vaults_list_page.dart
@@ -46,32 +46,35 @@ class DriveVaultsListPage extends StatelessWidget {
             height: 2.0,
           ),
           Expanded(
-            child:
-                error != null
-                    ? Center(child: Text(error.toTranslated(context)))
-                    : Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: SingleChildScrollView(
-                        child: Column(
-                          children: [
-                            if (!state.isLoading && driveMetadata.isEmpty)
-                              Center(child: Text(context.loc.recoverbullGoogleDriveNoBackupsFound)),
+            child: error != null
+                ? Center(child: Text(error.toTranslated(context)))
+                : Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          if (!state.isLoading && driveMetadata.isEmpty)
+                            Center(
+                              child: Text(
+                                context
+                                    .loc
+                                    .recoverbullGoogleDriveNoBackupsFound,
+                              ),
+                            ),
 
-                            ...List.generate(driveMetadata.length, (index) {
-                              final driveBackupMetadata = driveMetadata[index];
-                              return Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 8,
-                                ),
-                                child: _DriveFileMetadataItem(
-                                  driveFileMetadata: driveBackupMetadata,
-                                ),
-                              );
-                            }),
-                          ],
-                        ),
+                          ...List.generate(driveMetadata.length, (index) {
+                            final driveBackupMetadata = driveMetadata[index];
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 8),
+                              child: _DriveFileMetadataItem(
+                                driveFileMetadata: driveBackupMetadata,
+                              ),
+                            );
+                          }),
+                        ],
                       ),
                     ),
+                  ),
           ),
         ],
       ),
@@ -93,8 +96,8 @@ class _DriveFileMetadataItem extends StatelessWidget {
           maxHeight: MediaQuery.of(context).size.height * 0.4,
         ),
         decoration: BoxDecoration(
-          color: context.appColors.onPrimary,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
+          color: context.appColors.onSecondary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
@@ -142,15 +145,18 @@ class _DriveFileMetadataItem extends StatelessWidget {
           maxHeight: MediaQuery.of(context).size.height * 0.5,
         ),
         decoration: BoxDecoration(
-          color: context.appColors.onPrimary,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
+          color: context.appColors.onSecondary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
           child: Column(
             mainAxisSize: .min,
             children: [
-              BBText(context.loc.recoverbullGoogleDriveDeleteVaultTitle, style: context.font.headlineMedium),
+              BBText(
+                context.loc.recoverbullGoogleDriveDeleteVaultTitle,
+                style: context.font.headlineMedium,
+              ),
               const Gap(16),
               BBText(
                 context.loc.recoverbullGoogleDriveDeleteConfirmation,
@@ -201,10 +207,8 @@ class _DriveFileMetadataItem extends StatelessWidget {
         maxLines: 2,
         overflow: .ellipsis,
       ),
-      onTap:
-          () => bloc.add(
-            OnSelectDriveFileMetadata(fileMetadata: driveFileMetadata),
-          ),
+      onTap: () =>
+          bloc.add(OnSelectDriveFileMetadata(fileMetadata: driveFileMetadata)),
       onLongPress: () => _showActionsBottomSheet(context),
       enabled: !state.isLoading,
     );


### PR DESCRIPTION
Fix: #2257

<img width="350" alt="Simulator Screenshot - iPhone 16e - 2026-06-08 at 15 05 08" src="https://github.com/user-attachments/assets/f80f297c-20cf-4766-b04c-c95978fd2a5d" />

<img width="350" alt="Simulator Screenshot - iPhone 16e - 2026-06-08 at 15 05 13" src="https://github.com/user-attachments/assets/ee660b85-769f-4d79-b900-3a9815ea84cb" />

