### PR TITLE
chore(l10n): remove dead localization keys from non-en arb files

### DIFF
--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -11852,10 +11852,6 @@
   "@informationWillNotLeave": {
     "description": "First part of privacy assurance message"
   },
-  "autoswapWarningTriggerAmount": "الرصيد الأقصى البالغ 0.02",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "pleaseWaitFetching": "من فضلك انتظر بينما نحضر ملفك الإحتياطي.",
   "@pleaseWaitFetching": {
     "description": "Message asking user to wait while fetching backup"
@@ -12278,10 +12274,6 @@
   "@savingToDevice": {
     "description": "Message shown when saving to device"
   },
-  "autoswapWarningBaseBalance": "الرصيد المستهدف",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "importQrDevicePassportStep8": "على جهازك المحمول، اضغطي \"كاميرا مفتوحة\"",
   "@importQrDevicePassportStep8": {
     "description": "Passport instruction step 8"
@@ -12490,30 +12482,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "عاجل: النسخ الاحتياطي وإعادة التثبيت مطلوبان",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "التطبيق الذي تستخدمه يعتمد على برنامج سيتوقف قريباً. يرجى اتباع الخطوات التالية:\n\n1. احتفظ بنسخة احتياطية من محفظتك\n2. قم بإلغاء تثبيت التطبيق. احذفه بالكامل من هاتفك.\n3. أعد تثبيت أحدث إصدار من التطبيق\n4. استخدم خيار الاسترداد بدلاً من \"إنشاء محفظة جديدة\".\n\nأموالك في أمان ويمكنك الاستمرار في استخدام التطبيق الآن، لكن قم بذلك في أقرب وقت ممكن لمنع تعطل التطبيق في المستقبل القريب.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "إجراء مطلوب: إعادة تثبيت التطبيق",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "التطبيق الذي تستخدمه يعتمد على برنامج سيتوقف قريباً. يرجى اتباع الخطوات التالية:\n\n1. احتفظ بنسخة احتياطية من محفظتك\n2. قم بإلغاء تثبيت التطبيق. احذفه بالكامل من هاتفك.\n3. أعد تثبيت أحدث إصدار من التطبيق\n4. استخدم خيار الاسترداد بدلاً من \"إنشاء محفظة جديدة\".\n\nأموالك في أمان ويمكنك الاستمرار في استخدام التطبيق الآن، لكن قم بذلك في أقرب وقت ممكن لمنع تعطل التطبيق في المستقبل القريب.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "احتياطي الآن",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "لاحقاً",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "رجوع",
   "@backButton": {
     "description": "Generic back button label"
@@ -12545,10 +12513,6 @@
   "errorReportingStandardLogsTitle": "السجلات القياسية",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "مفعّل دائمًا — يتيح لنا التأكد من انتقال محفظتك بأمان بين إصدارات التطبيق.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "استخدم نسختك الاحتياطية",
   "@appInitErrorHasBackupTitle": {

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -176,7 +176,6 @@
   "legacyStorageHasBackupImportantBody": "এই প্ৰক্ৰিয়া এৰি নাযাব যদিহে আপুনি ৱালেট জৰুৰীভাৱে ব্যৱহাৰ কৰাটো অত্যাৱশ্যক নহয় বা এটা স্বেপ সম্পূৰ্ণ হোৱালৈ অপেক্ষা কৰি আছে।",
   "legacyStorageRiskAckButtonHasBackup": "মই বিপদটো বুজি পাইছোঁ",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "২৪ ঘণ্টার মধ্যে আপনার অ্যাপ খুলে আপনার সোয়াপ সম্পন্ন করুন।",
   "appStartupErrorMessage": "অ্যাপ চালু হতে ব্যর্থ হয়েছে। অ্যাপ সম্পূর্ণভাবে বন্ধ করে পুনরায় চালু করার চেষ্টা করুন। যদি সমস্যা থেকে যায়, সাপোর্টের সাথে যোগাযোগ করুন এবং আপনার লগ শেয়ার করুন।",
   "importMnemonicDuplicateError": "এই নেমনিক ইতিমধ্যে বিদ্যমান",
   "translationWarningTitle": "AI-দ্বাৰা উৎপাদিত অনুবাদ",

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -2790,10 +2790,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "Максимален баланс от 0.02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "legacySeedViewScreenTitle": "Стари семена",
   "@legacySeedViewScreenTitle": {
     "description": "AppBar title for legacy seeds screen"
@@ -7351,10 +7347,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "Целевият баланс 0.01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "transactionDetailLabelPayoutAmount": "Сума за изплащане",
   "@transactionDetailLabelPayoutAmount": {
     "description": "Label for payout amount"
@@ -9497,30 +9489,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Спешно: Необходимо е архивиране и преинсталиране",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Приложението, което използвате, работи на софтуер, който скоро ще бъде прекратен. Моля, следвайте тези стъпки:\n\n1. Архивирайте портфейла си\n2. Деинсталирайте приложението. Изтрийте го напълно от телефона си.\n3. Инсталирайте отново най-новата версия на приложението\n4. Използвайте опцията за възстановяване вместо \"създаване на нов портфейл\".\n\nВашите средства са в безопасност и можете да продължите да използвате приложението сега, но го направете възможно най-скоро, за да предотвратите срив на приложението в близко бъдеще.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Необходимо действие: Преинсталирайте приложението",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Приложението, което използвате, работи на софтуер, който скоро ще бъде прекратен. Моля, следвайте тези стъпки:\n\n1. Архивирайте портфейла си\n2. Деинсталирайте приложението. Изтрийте го напълно от телефона си.\n3. Инсталирайте отново най-новата версия на приложението\n4. Използвайте опцията за възстановяване вместо \"създаване на нов портфейл\".\n\nВашите средства са в безопасност и можете да продължите да използвате приложението сега, но го направете възможно най-скоро, за да предотвратите срив на приложението в близко бъдеще.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Архивирай сега",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "По-късно",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Назад",
   "@backButton": {
     "description": "Generic back button label"
@@ -9552,10 +9520,6 @@
   "errorReportingStandardLogsTitle": "Стандартни логове",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Винаги активно — ни позволява да видим дали портфейлът ви мигрира безопасно между версиите на приложението.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Използвайте резервното си копие",
   "@appInitErrorHasBackupTitle": {
@@ -9640,7 +9604,6 @@
   "legacyStorageHasBackupImportantBody": "Моля, не пропускайте този процес, освен ако наистина не се налага спешно да използвате портфейла или не чакате суап да приключи.",
   "legacyStorageRiskAckButtonHasBackup": "Разбирам риска",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Отворете приложението в рамките на 24 часа, за да завършите вашия суап.",
   "appStartupErrorMessage": "Приложението не успя да стартира. Опитайте да го затворите напълно и да го рестартирате. Ако грешката продължи, свържете се с поддръжка и споделете логовете си.",
   "importMnemonicDuplicateError": "Тази мнемонична фраза вече съществува",
   "coreScreensResolvingInputs": "Разрешаване на входовете на транзакцията...",

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12171,30 +12171,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "জরুরি: ব্যাকআপ ও পুনরায় ইনস্টল প্রয়োজন",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "আপনি যে অ্যাপটি ব্যবহার করছেন তা এমন সফটওয়্যার ব্যবহার করছে যা শীঘ্রই বাতিল হয়ে যাবে। অনুগ্রহ করে এই পদক্ষেপগুলি অনুসরণ করুন:\n\n1. আপনার ওয়ালেট ব্যাকআপ করুন\n2. অ্যাপটি আনইনস্টল করুন। আপনার ফোন থেকে সম্পূর্ণরূপে মুছে দিন।\n3. অ্যাপের সর্বশেষ সংস্করণ পুনরায় ইনস্টল করুন\n4. \"নতুন ওয়ালেট তৈরি করুন\" এর পরিবর্তে রিকভারি বিকল্প ব্যবহার করুন।\n\nআপনার অর্থ নিরাপদ এবং আপনি এখনই অ্যাপটি ব্যবহার চালিয়ে যেতে পারেন, তবে অ্যাপটি অচল হওয়ার আগে যত দ্রুত সম্ভব এটি করুন।",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "পদক্ষেপ প্রয়োজন: অ্যাপ পুনরায় ইনস্টল করুন",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "আপনি যে অ্যাপটি ব্যবহার করছেন তা এমন সফটওয়্যার ব্যবহার করছে যা শীঘ্রই বাতিল হয়ে যাবে। অনুগ্রহ করে এই পদক্ষেপগুলি অনুসরণ করুন:\n\n1. আপনার ওয়ালেট ব্যাকআপ করুন\n2. অ্যাপটি আনইনস্টল করুন। আপনার ফোন থেকে সম্পূর্ণরূপে মুছে দিন।\n3. অ্যাপের সর্বশেষ সংস্করণ পুনরায় ইনস্টল করুন\n4. \"নতুন ওয়ালেট তৈরি করুন\" এর পরিবর্তে রিকভারি বিকল্প ব্যবহার করুন।\n\nআপনার অর্থ নিরাপদ এবং আপনি এখনই অ্যাপটি ব্যবহার চালিয়ে যেতে পারেন, তবে অ্যাপটি অচল হওয়ার আগে যত দ্রুত সম্ভব এটি করুন।",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "এখনই ব্যাকআপ করুন",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "পরে",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "পিছনে",
   "@backButton": {
     "description": "Generic back button label"
@@ -12226,10 +12202,6 @@
   "errorReportingStandardLogsTitle": "স্ট্যান্ডার্ড লগ",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "সবসময় সক্রিয় — অ্যাপের সংস্করণগুলির মধ্যে আপনার ওয়ালেট নিরাপদে মাইগ্রেট হচ্ছে কিনা তা আমাদের দেখতে দেয়।",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "আপনার ব্যাকআপ ব্যবহার করুন",
   "@appInitErrorHasBackupTitle": {
@@ -12314,7 +12286,6 @@
   "legacyStorageHasBackupImportantBody": "এই প্রক্রিয়াটি এড়িয়ে যাবেন না যদি না আপনার জরুরিভাবে ওয়ালেট ব্যবহার করার একান্ত প্রয়োজন হয় অথবা একটি স্বপ সম্পন্ন হওয়ার জন্য অপেক্ষা করছেন।",
   "legacyStorageRiskAckButtonHasBackup": "আমি ঝুঁকি বুঝতে পারছি",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "আপনার সুয়াপ সম্পূর্ণ করতে ২৪ ঘণ্টার মধ্যে অ্যাপটি খুলুন।",
   "importMnemonicDuplicateError": "এই নেমোনিক ইতিমধ্যে বিদ্যমান",
   "recoverbullBalance": "ব্যালেন্স: {balance}",
   "@recoverbullBalance": {

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -3472,10 +3472,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "Maximální zůstatek 0,02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "legacySeedViewScreenTitle": "Legacy Seeds",
   "@legacySeedViewScreenTitle": {
     "description": "AppBar title for legacy seeds screen"
@@ -9534,10 +9530,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "Cílová rovnováha 0.01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "transactionDetailLabelPayoutAmount": "Výplatní částka",
   "@transactionDetailLabelPayoutAmount": {
     "description": "Label for payout amount"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Naléhavé: Je vyžadována záloha a přeinstalace",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Aplikace, kterou používáte, využívá software, který bude brzy ukončen. Postupujte prosím podle těchto kroků:\n\n1. Zálohujte svou peněženku\n2. Odinstalujte aplikaci. Zcela ji smažte ze svého telefonu.\n3. Přeinstalujte nejnovější verzi aplikace\n4. Použijte možnost obnovení místo \"vytvoření nové peněženky\".\n\nVaše prostředky jsou v bezpečí a aplikaci můžete nyní nadále používat, ale proveďte to co nejdříve, abyste zabránili selhání aplikace v blízké budoucnosti.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Vyžadována akce: Přeinstalujte aplikaci",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Aplikace, kterou používáte, využívá software, který bude brzy ukončen. Postupujte prosím podle těchto kroků:\n\n1. Zálohujte svou peněženku\n2. Odinstalujte aplikaci. Zcela ji smažte ze svého telefonu.\n3. Přeinstalujte nejnovější verzi aplikace\n4. Použijte možnost obnovení místo \"vytvoření nové peněženky\".\n\nVaše prostředky jsou v bezpečí a aplikaci můžete nyní nadále používat, ale proveďte to co nejdříve, abyste zabránili selhání aplikace v blízké budoucnosti.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Zálohovat nyní",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Později",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Zpět",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "Standardní protokoly",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Vždy zapnuto — umožňuje nám vidět, zda se vaše peněženka bezpečně migruje mezi verzemi aplikace.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Použijte svou zálohu",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "Tento proces nepřeskakujte, pokud nezbytně nepotřebujete peněženku použít naléhavě nebo nečekáte na dokončení swapu.",
   "legacyStorageRiskAckButtonHasBackup": "Rozumím riziku",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Otevřete aplikaci do 24 hodin, abyste dokončili svůj swap.",
   "importMnemonicDuplicateError": "Tato mnemotechnická fráze již existuje",
   "coreScreensResolvingInputs": "Načítání vstupů transakce...",
   "coreScreensFeeRateLabel": "Sazba poplatku",

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -1091,7 +1091,6 @@
   "doNotShareWarning": "NICHT MIT ANDEREN TEILEN.",
   "torSettingsPortNumber": "Portnummer",
   "payNameHint": "Empfängername eingeben",
-  "autoswapWarningTriggerAmount": "Maximaler Kontostand von 0,02 BTC.",
   "legacySeedViewScreenTitle": "Legacy Seeds",
   "pleaseWaitFetching": "Bitte warten Sie, während Ihre Sicherungsdatei abgerufen wird.",
   "backupWalletPhysicalBackupTag": "Vertrauenslos (nehmen Sie sich die Zeit)",
@@ -3165,7 +3164,6 @@
   "bitboxActionImportWalletButton": "Import starten",
   "fundExchangeLabelSwiftCode": "SWIFT-Code",
   "buyEnterBitcoinAddress": "Bitcoin-Adresse eingeben",
-  "autoswapWarningBaseBalance": "Zielsaldo 0,01 BTC.",
   "transactionDetailLabelPayoutAmount": "Auszahlungsbetrag",
   "importQrDeviceSpecterStep6": "Wählen Sie „Einzelschlüssel“",
   "importQrDeviceJadeStep10": "Das ist es!",
@@ -4393,30 +4391,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Dringend: Backup und Neuinstallation erforderlich",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Die App, die Sie verwenden, nutzt Software, die bald veraltet sein wird. Bitte führen Sie folgende Schritte durch:\n\n1. Sichern Sie Ihre Wallet\n2. Deinstallieren Sie die App. Löschen Sie sie vollständig von Ihrem Telefon.\n3. Installieren Sie die neueste Version der App erneut\n4. Verwenden Sie die Wiederherstellungsoption anstatt \"neue Wallet erstellen\".\n\nIhre Gelder sind sicher und Sie können die App jetzt weiter nutzen, aber erledigen Sie dies so bald wie möglich, um zu verhindern, dass die App in naher Zukunft nicht mehr funktioniert.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Aktion erforderlich: App neu installieren",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Die App, die Sie verwenden, nutzt Software, die bald veraltet sein wird. Bitte führen Sie folgende Schritte durch:\n\n1. Sichern Sie Ihre Wallet\n2. Deinstallieren Sie die App. Löschen Sie sie vollständig von Ihrem Telefon.\n3. Installieren Sie die neueste Version der App erneut\n4. Verwenden Sie die Wiederherstellungsoption anstatt \"neue Wallet erstellen\".\n\nIhre Gelder sind sicher und Sie können die App jetzt weiter nutzen, aber erledigen Sie dies so bald wie möglich, um zu verhindern, dass die App in naher Zukunft nicht mehr funktioniert.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Jetzt sichern",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Später",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Zurück",
   "@backButton": {
     "description": "Generic back button label"
@@ -4448,10 +4422,6 @@
   "errorReportingStandardLogsTitle": "Standardprotokolle",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Immer aktiv — ermöglicht uns zu sehen, ob deine Wallet sicher zwischen App-Versionen migriert",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Nutze dein Backup",
   "@appInitErrorHasBackupTitle": {
@@ -4536,7 +4506,6 @@
   "legacyStorageHasBackupImportantBody": "Bitte überspringen Sie diesen Vorgang nur, wenn Sie die Wallet unbedingt dringend verwenden müssen oder auf den Abschluss eines Swaps warten.",
   "legacyStorageRiskAckButtonHasBackup": "Ich verstehe das Risiko",
   "walletSetupErrorTryAgain": "Beim Einrichten Ihrer Wallet ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
-  "transactionSwapOpenWithin24Hours": "Öffne die App innerhalb von 24 Stunden, um deinen Swap abzuschließen.",
   "importMnemonicDuplicateError": "Diese Mnemonic existiert bereits",
   "coreScreensResolvingInputs": "Transaktionseingaben werden aufgelöst...",
   "coreScreensFeeRateLabel": "Gebührenrate",

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -2784,10 +2784,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "Μέγιστη ισορροπία 0,02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "backupWalletPhysicalBackupTag": "Εμπιστοσύνη (πάρτε το χρόνο σας)",
   "@backupWalletPhysicalBackupTag": {
     "description": "Tag indicating difficulty and trust model for physical backup"
@@ -8043,10 +8039,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "Target Balance 0,01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "importQrDeviceSpecterStep6": "Επιλέξτε \"Single key\"",
   "@importQrDeviceSpecterStep6": {
     "description": "Specter instruction step 6"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Επείγον: Απαιτείται αντίγραφο ασφαλείας και επανεγκατάσταση",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Η εφαρμογή που χρησιμοποιείτε βασίζεται σε λογισμικό που σύντομα θα καταργηθεί. Παρακαλούμε ακολουθήστε τα παρακάτω βήματα:\n\n1. Δημιουργήστε αντίγραφο ασφαλείας του πορτοφολιού σας\n2. Απεγκαταστήστε την εφαρμογή. Διαγράψτε τη πλήρως από το τηλέφωνό σας.\n3. Επανεγκαταστήστε την πιο πρόσφατη έκδοση της εφαρμογής\n4. Χρησιμοποιήστε την επιλογή ανάκτησης αντί για \"δημιουργία νέου πορτοφολιού\".\n\nΤα χρήματά σας είναι ασφαλή και μπορείτε να συνεχίσετε να χρησιμοποιείτε την εφαρμογή τώρα, αλλά κάντε το το συντομότερο δυνατό για να αποτρέψετε τη διακοπή λειτουργίας της εφαρμογής στο άμεσο μέλλον.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Απαιτείται ενέργεια: Επανεγκατάσταση εφαρμογής",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Η εφαρμογή που χρησιμοποιείτε βασίζεται σε λογισμικό που σύντομα θα καταργηθεί. Παρακαλούμε ακολουθήστε τα παρακάτω βήματα:\n\n1. Δημιουργήστε αντίγραφο ασφαλείας του πορτοφολιού σας\n2. Απεγκαταστήστε την εφαρμογή. Διαγράψτε τη πλήρως από το τηλέφωνό σας.\n3. Επανεγκαταστήστε την πιο πρόσφατη έκδοση της εφαρμογής\n4. Χρησιμοποιήστε την επιλογή ανάκτησης αντί για \"δημιουργία νέου πορτοφολιού\".\n\nΤα χρήματά σας είναι ασφαλή και μπορείτε να συνεχίσετε να χρησιμοποιείτε την εφαρμογή τώρα, αλλά κάντε το το συντομότερο δυνατό για να αποτρέψετε τη διακοπή λειτουργίας της εφαρμογής στο άμεσο μέλλον.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Δημιουργία αντιγράφου τώρα",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Αργότερα",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Πίσω",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "Τυπικά αρχεία καταγραφής",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Πάντα ενεργό — μας επιτρέπει να βλέπουμε αν το πορτοφόλι σας μεταφέρεται με ασφάλεια μεταξύ εκδόσεων της εφαρμογής.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Χρησιμοποιήστε το αντίγραφο ασφαλείας σας",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "Παρακαλώ μην παραλείψετε αυτή τη διαδικασία εκτός εάν είναι απολύτως απαραίτητο να χρησιμοποιήσετε επειγόντως το πορτοφόλι ή περιμένετε να ολοκληρωθεί ένα swap.",
   "legacyStorageRiskAckButtonHasBackup": "Κατανοώ τον κίνδυνο",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Ανοίξτε την εφαρμογή μέσα σε 24 ώρες για να ολοκληρώσετε το swap σας.",
   "importMnemonicDuplicateError": "Αυτή η μνημονική φράση υπάρχει ήδη",
   "coreScreensResolvingInputs": "Επίλυση εισόδων συναλλαγής...",
   "coreScreensFeeRateLabel": "Ποσοστό χρέωσης",

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -1492,8 +1492,6 @@
   "autoswapWarningCardSubtitle": "Se disparará un intercambio si el saldo de su billetera de pagos instantáneos supera 0'02 BTC.",
   "autoswapWarningDescription": "Autoswap garantiza que no mantengas accidentalmente demasiado dinero en la billetera de pagos instantáneos, lo cual no es seguro para el almacenamiento a largo plazo.",
   "autoswapWarningTitle": "La transferencia automática está habilitada con la siguiente configuración:",
-  "autoswapWarningBaseBalance": "Saldo Objetivo 0'01 BTC",
-  "autoswapWarningTriggerAmount": "Saldo máximo de 0.02 BTC",
   "autoswapWarningExplanation": "Cuando tu saldo supere el saldo máximo, se activará un intercambio. El saldo destino se mantendrá en tu billetera de pagos instantáneos y el monto restante se intercambiará en tu billetera de Bitcoin segura.",
   "autoswapWarningDontShowAgain": "No volver a mostrar esta advertencia.",
   "autoswapWarningSettingsLink": "Llévame a la configuración de transferencia automática",
@@ -4506,30 +4504,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Urgente: Se requiere copia de seguridad y reinstalación",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "La aplicación que estás usando utiliza un software que pronto quedará obsoleto. Por favor, sigue estos pasos:\n\n1. Haz una copia de seguridad de tu billetera\n2. Desinstala la aplicación. Elimínala completamente de tu teléfono.\n3. Reinstala la versión más reciente de la aplicación\n4. Usa la opción de recuperación en lugar de \"crear nueva billetera\".\n\nTus fondos están seguros y puedes continuar usando la aplicación ahora mismo, pero hazlo lo antes posible para evitar que la aplicación falle en un futuro próximo.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Acción requerida: Reinstalar aplicación",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "La aplicación que estás usando utiliza un software que pronto quedará obsoleto. Por favor, sigue estos pasos:\n\n1. Haz una copia de seguridad de tu billetera\n2. Desinstala la aplicación. Elimínala completamente de tu teléfono.\n3. Reinstala la versión más reciente de la aplicación\n4. Usa la opción de recuperación en lugar de \"crear nueva billetera\".\n\nTus fondos están seguros y puedes continuar usando la aplicación ahora mismo, pero hazlo lo antes posible para evitar que la aplicación falle en un futuro próximo.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Respaldar ahora",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Más tarde",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Atrás",
   "@backButton": {
     "description": "Generic back button label"
@@ -4561,10 +4535,6 @@
   "errorReportingStandardLogsTitle": "Registros estándar",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Siempre activo — nos permite saber si tu billetera migra de forma segura entre versiones de la aplicación.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Usa tu copia de seguridad",
   "@appInitErrorHasBackupTitle": {
@@ -4649,7 +4619,6 @@
   "legacyStorageHasBackupImportantBody": "Por favor, no omita este proceso a menos que necesite usar la billetera urgentemente o esté esperando a que se complete un intercambio.",
   "legacyStorageRiskAckButtonHasBackup": "Entiendo el riesgo",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Abre la aplicación dentro de 24 horas para completar tu swap.",
   "importMnemonicDuplicateError": "Esta frase mnemónica ya existe",
   "coreScreensResolvingInputs": "Resolviendo entradas de la transacción...",
   "coreScreensFeeRateLabel": "Tasa de comisión",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -11734,10 +11734,6 @@
   "@transactionSwapDescLnSendCompleted": {
     "description": "Description for completed Lightning send swap"
   },
-  "autoswapWarningTriggerAmount": "حداکثر تعادل 0.02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "informationWillNotLeave": "این اطلاعات ",
   "@informationWillNotLeave": {
     "description": "First part of privacy assurance message"
@@ -12236,10 +12232,6 @@
   "@importQrDeviceSeedsignerStep8": {
     "description": "SeedSigner instruction step 8"
   },
-  "autoswapWarningBaseBalance": "هدف قرار دادن تعادل 0.01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "savingToDevice": "پس انداز برای دستگاه شما.",
   "@savingToDevice": {
     "description": "Message shown when saving to device"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "فوری: پشتیبان‌گیری و نصب مجدد الزامی است",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "برنامه‌ای که استفاده می‌کنید از نرم‌افزاری استفاده می‌کند که به زودی منسوخ خواهد شد. لطفاً این مراحل را دنبال کنید:\n\n1. از کیف‌پول خود پشتیبان‌گیری کنید\n2. برنامه را حذف کنید. آن را به‌طور کامل از گوشی خود پاک کنید.\n3. آخرین نسخه برنامه را مجدداً نصب کنید\n4. به جای \"ایجاد کیف‌پول جدید\" از گزینه بازیابی استفاده کنید.\n\nدارایی‌های شما در امنیت هستند و می‌توانید همین الان به استفاده از برنامه ادامه دهید، اما این کار را هرچه زودتر انجام دهید تا از خرابی برنامه در آینده نزدیک جلوگیری شود.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "اقدام لازم: نصب مجدد برنامه",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "برنامه‌ای که استفاده می‌کنید از نرم‌افزاری استفاده می‌کند که به زودی منسوخ خواهد شد. لطفاً این مراحل را دنبال کنید:\n\n1. از کیف‌پول خود پشتیبان‌گیری کنید\n2. برنامه را حذف کنید. آن را به‌طور کامل از گوشی خود پاک کنید.\n3. آخرین نسخه برنامه را مجدداً نصب کنید\n4. به جای \"ایجاد کیف‌پول جدید\" از گزینه بازیابی استفاده کنید.\n\nدارایی‌های شما در امنیت هستند و می‌توانید همین الان به استفاده از برنامه ادامه دهید، اما این کار را هرچه زودتر انجام دهید تا از خرابی برنامه در آینده نزدیک جلوگیری شود.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "اکنون پشتیبان بگیر",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "بعداً",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "بازگشت",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "گزارش‌های استاندارد",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "همیشه روشن — به ما اجازه می‌دهد ببینیم آیا کیف پول شما به‌طور ایمن بین نسخه‌های برنامه منتقل می‌شود.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "از نسخه پشتیبان خود استفاده کنید",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "لطفاً این فرآیند را رد نکنید مگر اینکه واقعاً نیاز فوری به استفاده از کیف پول داشته باشید یا منتظر تکمیل یک سواپ هستید.",
   "legacyStorageRiskAckButtonHasBackup": "خطر را درک می‌کنم",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "برای تکمیل سواپ خود، ظرف ۲۴ ساعت برنامه را باز کنید",
   "importMnemonicDuplicateError": "این عبارت یادگاری از قبل وجود دارد",
   "transactionStatusPayjoinCompleted": "Payjoin تکمیل شد",
   "coreScreensResolvingInputs": "در حال تحلیل ورودی‌های تراکنش...",

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4140,8 +4140,6 @@
   "autoswapBaseBalanceInfoText": "Pikaisen maksulompakon saldo palaa tähän tavoitesaldoon automaattisen swapin jälkeen.",
   "autoswapWarningDescription": "Autoswap varmistaa, ettei vahingossa pidä liikaa rahaa Pikaisen maksulompakon sisällä, mikä ei ole turvallista pitkäaikaiseen säilytykseen.",
   "autoswapWarningTitle": "Autoswap on käytössä seuraavilla asetuksilla:",
-  "autoswapWarningBaseBalance": "Tavoitesaldo 0,01 BTC",
-  "autoswapWarningTriggerAmount": "Maksimi-saldo 0,02 BTC",
   "autoswapWarningExplanation": "Kun saldosi ylittää maksimin saldon, käynnistyy swap. Tavoitesaldo pidetään Pikaisen maksulompakon sisällä ja jäljelle jäävä summa vaihdetaan Turvalliseen Bitcoin-lompakkoosi.",
   "autoswapWarningDontShowAgain": "Älä näytä tätä varoitusta uudelleen.",
   "autoswapWarningSettingsLink": "Vie minut autoswap-asetuksiin",
@@ -4492,30 +4490,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Kiireellinen: Varmuuskopio ja uudelleenasennus vaaditaan",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Käyttämäsi sovellus käyttää ohjelmistoa, joka poistuu käytöstä pian. Noudata näitä ohjeita:\n\n1. Varmuuskopioi lompakkosi\n2. Poista sovellus. Poista se kokonaan puhelimestasi.\n3. Asenna sovelluksen uusin versio uudelleen\n4. Käytä palautusvaihtoehtoa \"luo uusi lompakko\" -vaihtoehdon sijaan.\n\nVaroosi ovat turvassa ja voit jatkaa sovelluksen käyttöä nyt, mutta tee tämä mahdollisimman pian estääksesi sovelluksen toiminnan lakkaamisen lähitulevaisuudessa.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Toimenpide vaaditaan: Asenna sovellus uudelleen",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Käyttämäsi sovellus käyttää ohjelmistoa, joka poistuu käytöstä pian. Noudata näitä ohjeita:\n\n1. Varmuuskopioi lompakkosi\n2. Poista sovellus. Poista se kokonaan puhelimestasi.\n3. Asenna sovelluksen uusin versio uudelleen\n4. Käytä palautusvaihtoehtoa \"luo uusi lompakko\" -vaihtoehdon sijaan.\n\nVaroosi ovat turvassa ja voit jatkaa sovelluksen käyttöä nyt, mutta tee tämä mahdollisimman pian estääksesi sovelluksen toiminnan lakkaamisen lähitulevaisuudessa.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Varmuuskopioi nyt",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Myöhemmin",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Takaisin",
   "@backButton": {
     "description": "Generic back button label"
@@ -4547,10 +4521,6 @@
   "errorReportingStandardLogsTitle": "Peruslokit",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Aina päällä — näemme, siirtyykö lompakkosi turvallisesti sovellusversioiden välillä.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Käytä varmuuskopiotasi",
   "@appInitErrorHasBackupTitle": {
@@ -4635,7 +4605,6 @@
   "legacyStorageHasBackupImportantBody": "Älä ohita tätä prosessia, ellet ehdottomasti tarvitse lompakkoa kiireellisesti tai odota swapin valmistumista.",
   "legacyStorageRiskAckButtonHasBackup": "Ymmärrän riskin",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Avaa sovellus 24 tunnin kuluessa viimeistelläksesi swapin.",
   "importMnemonicDuplicateError": "Tämä muistilause on jo olemassa",
   "coreScreensResolvingInputs": "Selvitetään tapahtuman syötteitä...",
   "coreScreensFeeRateLabel": "Palkkioprosentti",

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -1489,8 +1489,6 @@
   "autoswapWarningCardSubtitle": "Un échange sera déclenché si le solde de votre portefeuille de paiements instantanés dépasse 0,02 BTC.",
   "autoswapWarningDescription": "L'échange automatique vous empêche de garder trop d'argent dans le portefeuille de paiement instantané, ce qui n'est pas sûr pour le stockage à long terme.",
   "autoswapWarningTitle": "Le transfert automatique est activé avec les paramètres suivants :",
-  "autoswapWarningBaseBalance": "Solde cible 0,01 BTC",
-  "autoswapWarningTriggerAmount": "Solde maximal de 0,02 BTC",
   "autoswapWarningExplanation": "Lorsque votre solde dépasse le solde maximal, un échange sera déclenché. Le solde cible sera conservé dans votre portefeuille de paiement instantané et le montant restant sera échangé dans votre portefeuille Bitcoin sécurisé.",
   "autoswapWarningDontShowAgain": "Ne plus afficher cet avertissement.",
   "autoswapWarningSettingsLink": "Me conduire aux paramètres de transfert automatique",
@@ -4489,30 +4487,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Urgent : Sauvegarde et réinstallation requises",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "L'application que vous utilisez repose sur un logiciel qui sera bientôt obsolète. Veuillez suivre ces étapes :\n\n1. Sauvegardez votre portefeuille\n2. Désinstallez l'application. Supprimez-la complètement de votre téléphone.\n3. Réinstallez la dernière version de l'application\n4. Utilisez l'option de récupération plutôt que « créer un nouveau portefeuille ».\n\nVos fonds sont en sécurité et vous pouvez continuer à utiliser l'application dès maintenant, mais faites-le dès que possible pour éviter que l'application ne tombe en panne dans un proche avenir.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Action requise : Réinstaller l'application",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "L'application que vous utilisez repose sur un logiciel qui sera bientôt obsolète. Veuillez suivre ces étapes :\n\n1. Sauvegardez votre portefeuille\n2. Désinstallez l'application. Supprimez-la complètement de votre téléphone.\n3. Réinstallez la dernière version de l'application\n4. Utilisez l'option de récupération plutôt que « créer un nouveau portefeuille ».\n\nVos fonds sont en sécurité et vous pouvez continuer à utiliser l'application dès maintenant, mais faites-le dès que possible pour éviter que l'application ne tombe en panne dans un proche avenir.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Sauvegarder maintenant",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Plus tard",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Retour",
   "@backButton": {
     "description": "Generic back button label"
@@ -4544,10 +4518,6 @@
   "errorReportingStandardLogsTitle": "Journaux standard",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Toujours actif — nous permet de vérifier que votre portefeuille migre en toute sécurité entre les versions de l'application.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Utilisez votre sauvegarde",
   "@appInitErrorHasBackupTitle": {
@@ -4632,7 +4602,6 @@
   "legacyStorageHasBackupImportantBody": "Veuillez ne pas ignorer ce processus, sauf si vous devez absolument utiliser le portefeuille en urgence ou si vous attendez qu'un swap se termine.",
   "legacyStorageRiskAckButtonHasBackup": "Je comprends le risque",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Ouvrez l'application dans les 24 heures pour terminer votre swap.",
   "importMnemonicDuplicateError": "Cette phrase mnémotechnique existe déjà",
   "coreScreensResolvingInputs": "Résolution des entrées de la transaction...",
   "coreScreensFeeRateLabel": "Taux de frais",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12479,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "अत्यावश्यक: बैकअप और पुनः इंस्टॉलेशन आवश्यक",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "आप जो ऐप उपयोग कर रहे हैं वह ऐसे सॉफ़्टवेयर का उपयोग करता है जो जल्द ही बंद हो जाएगा। कृपया इन चरणों का पालन करें:\n\n1. अपने वॉलेट का बैकअप लें\n2. ऐप को अनइंस्टॉल करें। इसे अपने फ़ोन से पूरी तरह हटा दें।\n3. ऐप का नवीनतम संस्करण फिर से इंस्टॉल करें\n4. \"नया वॉलेट बनाएं\" के बजाय रिकवरी विकल्प का उपयोग करें।\n\nआपके फंड सुरक्षित हैं और आप अभी ऐप का उपयोग जारी रख सकते हैं, लेकिन निकट भविष्य में ऐप बंद होने से पहले यह जितनी जल्दी हो सके करें।",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "कार्रवाई आवश्यक: ऐप पुनः इंस्टॉल करें",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "आप जो ऐप उपयोग कर रहे हैं वह ऐसे सॉफ़्टवेयर का उपयोग करता है जो जल्द ही बंद हो जाएगा। कृपया इन चरणों का पालन करें:\n\n1. अपने वॉलेट का बैकअप लें\n2. ऐप को अनइंस्टॉल करें। इसे अपने फ़ोन से पूरी तरह हटा दें।\n3. ऐप का नवीनतम संस्करण फिर से इंस्टॉल करें\n4. \"नया वॉलेट बनाएं\" के बजाय रिकवरी विकल्प का उपयोग करें।\n\nआपके फंड सुरक्षित हैं और आप अभी ऐप का उपयोग जारी रख सकते हैं, लेकिन निकट भविष्य में ऐप बंद होने से पहले यह जितनी जल्दी हो सके करें।",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "अभी बैकअप करें",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "बाद में",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "वापस",
   "@backButton": {
     "description": "Generic back button label"
@@ -12534,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "मानक लॉग",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "हमेशा चालू — हमें यह देखने देता है कि आपका वॉलेट ऐप संस्करणों के बीच सुरक्षित रूप से माइग्रेट होता है या नहीं।",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "अपने बैकअप का उपयोग करें",
   "@appInitErrorHasBackupTitle": {
@@ -12622,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "कृपया इस प्रक्रिया को न छोड़ें जब तक कि आपको तत्काल वॉलेट का उपयोग करने की नितांत आवश्यकता न हो या आप किसी स्वैप के पूरा होने की प्रतीक्षा कर रहे हों।",
   "legacyStorageRiskAckButtonHasBackup": "मैं जोखिम समझता हूँ",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "अपने स्वैप को पूरा करने के लिए 24 घंटों के भीतर ऐप खोलें।",
   "importMnemonicDuplicateError": "यह नेमोनिक पहले से मौजूद है",
   "recoverbullBalance": "शेष: {balance}",
   "@recoverbullBalance": {

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -63,30 +63,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Շտապ. Անհրաժեշտ է կրկնօրինակել և վերատեղադրել",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Ձeр кoghmiц охадvar hавelваcн аshхатum е ծраграйин апаhовман вра, вором шутов кhнана. Хndrum ек hетевел hетевял каyllerin.\n\n1. Крkнорinакете дзер драмапанакы\n2. Апателhадрум hавелвацы. Амбоghутьямб джнджек айн дзер hераховос.\n3. Верателhадрум hавелвацы верджин тарберакы\n4. Огtвек веракангнман чнтранутюниц \"нор драмапанак ствцел\" похарен.\n\nДзер мидзоцнере апаhов ен ев карог ек шарункакнел огтвел hавелвацум hима, сайн да арек hним колкин hнараvор мжамад, арнатесел hавелвацун мот апайцум.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Անhраժешт е горцогутюн. Верателhадрете hавелвацы",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Ձeр кoghmiц охадvar hавelваcн аshхатum е ծраграйин апаhовман вра, вором шутов кhнана. Хndrum ек hетевел hетевял каyllerin.\n\n1. Крkнорinакете дзер драмапанакы\n2. Апателhадрум hавелвацы. Амбоghутьямб джнджек айн дзер hераховос.\n3. Верателhадрум hавелвацы верджин тарберакы\n4. Огtвек веракангнман чнтранутюниц \"нор драмапанак ствцел\" похарен.\n\nДзер мидзоцнере апаhов ен ев карог ек шарункакнел огтвел hавелвацум hима, сайн да арек hним колкин hнараvор мжамад, арнатесел hавелвацун мот апайцум.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Կրկnоrinakel hima",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Aveli ush",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "pinCodeBackupRequiredWarning": "Խնդրում ենք ավարտել դրամապանակի կրկնօրինակումը PIN-ը սահմանելուց առաջ",
   "backButton": "Ետ",
   "@backButton": {
@@ -119,10 +95,6 @@
   "errorReportingStandardLogsTitle": "Ստանդարտ գրառումներ",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Միշտ միացված — թույլ է տալիս տեսնել՝ ձեր դրամապանակը ապահով է տեղափոխվում հավելվածի տարբերակների միջև։",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Օգտագործեք ձեր պահուստը",
   "@appInitErrorHasBackupTitle": {
@@ -207,7 +179,6 @@
   "legacyStorageHasBackupImportantBody": "Խնդրում ենք բաց չթողնել այս գործընթացը, եթե ձեզ հրատապ չի անհրաժեշտ օգտագործել դրամապանակը կամ սպասում եք սվոփի ավարտին։",
   "legacyStorageRiskAckButtonHasBackup": "Ես հասկանում եմ ռիսկը",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Բացեք հավելվածը 24 ժամվա ընթացքում՝ ձեր սվափը ավարտելու համար։",
   "appStartupErrorMessage": "Հավելվածը չհաջողվեց գործարկել։ Փորձեք ամբողջությամբ փակել և նորից բացել այն։ Եթե սխալը շարունակվում է, կապվեք աջակցության հետ և կիսվեք ձեր լոգերով։",
   "importMnemonicDuplicateError": "Այս մնեմոնիկն արդեն գոյություն ունի",
   "transactionStatusPayjoinCompleted": "Payjoin ավարտված է",

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -1113,7 +1113,6 @@
   "doNotShareWarning": "NON CONDIVIDI CON NESSUNO",
   "torSettingsPortNumber": "Numero della porta",
   "payNameHint": "Inserisci il nome del destinatario",
-  "autoswapWarningTriggerAmount": "Saldo massimo di 0,02 BTC",
   "legacySeedViewScreenTitle": "Legacy Seeds",
   "pleaseWaitFetching": "Per favore, aspettate mentre prendiamo il vostro file di backup.",
   "backupWalletPhysicalBackupTag": "Senza fiducia (prendi il tuo tempo)",
@@ -3208,7 +3207,6 @@
   "bitboxActionImportWalletButton": "Inizio Importazione",
   "fundExchangeLabelSwiftCode": "Codice SWIFT",
   "buyEnterBitcoinAddress": "Inserisci l'indirizzo bitcoin",
-  "autoswapWarningBaseBalance": "Saldo obiettivo 0,01 BTC",
   "transactionDetailLabelPayoutAmount": "Importo di pagamento",
   "importQrDeviceSpecterStep6": "Scegliere \"Single key\"",
   "importQrDeviceJadeStep10": "Basta!",
@@ -4500,30 +4498,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Urgente: Backup e reinstallazione richiesti",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "L'app che stai usando utilizza un software che sarà presto deprecato. Segui questi passaggi:\n\n1. Esegui il backup del tuo portafoglio\n2. Disinstalla l'app. Eliminala completamente dal tuo telefono.\n3. Reinstalla l'ultima versione dell'app\n4. Usa l'opzione di recupero invece di \"crea nuovo portafoglio\".\n\nI tuoi fondi sono al sicuro e puoi continuare a usare l'app adesso, ma fallo il prima possibile per evitare che l'app smetta di funzionare nel prossimo futuro.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Azione richiesta: Reinstalla l'app",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "L'app che stai usando utilizza un software che sarà presto deprecato. Segui questi passaggi:\n\n1. Esegui il backup del tuo portafoglio\n2. Disinstalla l'app. Eliminala completamente dal tuo telefono.\n3. Reinstalla l'ultima versione dell'app\n4. Usa l'opzione di recupero invece di \"crea nuovo portafoglio\".\n\nI tuoi fondi sono al sicuro e puoi continuare a usare l'app adesso, ma fallo il prima possibile per evitare che l'app smetta di funzionare nel prossimo futuro.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Esegui backup ora",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Più tardi",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Indietro",
   "@backButton": {
     "description": "Generic back button label"
@@ -4555,10 +4529,6 @@
   "errorReportingStandardLogsTitle": "Log standard",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Sempre attivo — ci permette di verificare che il tuo portafoglio migri in sicurezza tra le versioni dell'app.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Usa il tuo backup",
   "@appInitErrorHasBackupTitle": {
@@ -4643,7 +4613,6 @@
   "legacyStorageHasBackupImportantBody": "Si prega di non saltare questo processo a meno che non sia assolutamente necessario utilizzare il portafoglio con urgenza o si stia aspettando il completamento di uno swap.",
   "legacyStorageRiskAckButtonHasBackup": "Capisco il rischio",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Apri l'app entro 24 ore per completare il tuo swap.",
   "importMnemonicDuplicateError": "Questo mnemonic esiste già",
   "coreScreensResolvingInputs": "Risoluzione degli input della transazione...",
   "coreScreensFeeRateLabel": "Tasso commissione",

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -275,30 +275,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "სასწრაფო: საჭიროა სარეზერვო ასლი და ხელახლა ინსტალაცია",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "თქვენ მიერ გამოყენებული აპლიკაცია მუშაობს პროგრამულ უზრუნველყოფაზე, რომელიც მალე მოძველდება. გთხოვთ, მიჰყვეთ ამ ნაბიჯებს:\n\n1. შექმენით სარეზერვო ასლი თქვენი საფულიდან\n2. წაშალეთ აპლიკაცია. სრულად წაშალეთ ის თქვენი ტელეფონიდან.\n3. ხელახლა დააინსტალირეთ აპლიკაციის უახლესი ვერსია\n4. გამოიყენეთ აღდგენის ვარიანტი \"ახალი საფულის შექმნის\" ნაცვლად.\n\nთქვენი სახსრები უსაფრთხოა და შეგიძლიათ გამოიყენოთ აპლიკაცია ახლავე, მაგრამ გააკეთეთ ეს რაც შეიძლება მალე, რათა თავიდან აიცილოთ აპლიკაციის გამართულობის დარღვევა მომავალში.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "საჭიროა მოქმედება: ხელახლა დააინსტალირეთ აპლიკაცია",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "თქვენ მიერ გამოყენებული აპლიკაცია მუშაობს პროგრამულ უზრუნველყოფაზე, რომელიც მალე მოძველდება. გთხოვთ, მიჰყვეთ ამ ნაბიჯებს:\n\n1. შექმენით სარეზერვო ასლი თქვენი საფულიდან\n2. წაშალეთ აპლიკაცია. სრულად წაშალეთ ის თქვენი ტელეფონიდან.\n3. ხელახლა დააინსტალირეთ აპლიკაციის უახლესი ვერსია\n4. გამოიყენეთ აღდგენის ვარიანტი \"ახალი საფულის შექმნის\" ნაცვლად.\n\nთქვენი სახსრები უსაფრთხოა და შეგიძლიათ გამოიყენოთ აპლიკაცია ახლავე, მაგრამ გააკეთეთ ეს რაც შეიძლება მალე, რათა თავიდან აიცილოთ აპლიკაციის გამართულობის დარღვევა მომავალში.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "სარეზერვო ასლი ახლავე",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "მოგვიანებით",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "pinCodeBackupRequiredWarning": "გთხოვთ, PIN-ის დაყენებამდე შეასრულოთ საფულის სარეზერვო ასლი",
   "backButton": "უკან",
   "@backButton": {
@@ -331,10 +307,6 @@
   "errorReportingStandardLogsTitle": "სტანდარტული ჟურნალები",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "ყოველთვის ჩართული — საშუალებას გვაძლევს ვნახოთ, თქვენი საფულე უსაფრთხოდ გადადის აპის ვერსიებს შორის თუ არა.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "გამოიყენეთ თქვენი სარეზერვო ასლი",
   "@appInitErrorHasBackupTitle": {
@@ -419,7 +391,6 @@
   "legacyStorageHasBackupImportantBody": "გთხოვთ, არ გამოტოვოთ ეს პროცესი, თუ არ გჭირდებათ საფულის გადაუდებელი გამოყენება ან არ ელოდებით სვოპის დასრულებას.",
   "legacyStorageRiskAckButtonHasBackup": "მესმის რისკი",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "გახსენით აპი 24 საათის განმავლობაში, რათა დაასრულოთ თქვენი სვოპი.",
   "appStartupErrorMessage": "აპის გაშვება ვერ მოხერხდა. სცადეთ მისი სრულად დახურვა და თავიდან გაშვება. თუ შეცდომა გაგრძელდა, დაუკავშირდით მხარდაჭერას და გააზიარეთ ლოგები.",
   "importMnemonicDuplicateError": "ეს მნემონიკი უკვე არსებობს",
   "transactionStatusPayjoinCompleted": "Payjoin დასრულდა",

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -3321,10 +3321,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "최대 0.02 BTC의 균형",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "legacySeedViewScreenTitle": "레거시 씨앗",
   "@legacySeedViewScreenTitle": {
     "description": "AppBar title for legacy seeds screen"
@@ -9719,10 +9715,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "목표 균형 0.01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "transactionDetailLabelPayoutAmount": "결제 금액",
   "@transactionDetailLabelPayoutAmount": {
     "description": "Label for payout amount"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "긴급: 백업 및 재설치 필요",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "사용 중인 앱은 곧 지원이 중단될 소프트웨어를 사용하고 있습니다. 다음 단계를 따라 주세요:\n\n1. 지갑을 백업하세요\n2. 앱을 삭제하세요. 폰에서 완전히 제거하세요.\n3. 최신 버전의 앱을 재설치하세요\n4. \"새 지갑 만들기\" 대신 복구 옵션을 사용하세요.\n\n자금은 안전하며 지금 당장 앱을 계속 사용할 수 있지만, 가까운 미래에 앱이 작동하지 않게 되는 것을 방지하려면 가능한 한 빨리 이 작업을 수행하세요.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "조치 필요: 앱 재설치",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "사용 중인 앱은 곧 지원이 중단될 소프트웨어를 사용하고 있습니다. 다음 단계를 따라 주세요:\n\n1. 지갑을 백업하세요\n2. 앱을 삭제하세요. 폰에서 완전히 제거하세요.\n3. 최신 버전의 앱을 재설치하세요\n4. \"새 지갑 만들기\" 대신 복구 옵션을 사용하세요.\n\n자금은 안전하며 지금 당장 앱을 계속 사용할 수 있지만, 가까운 미래에 앱이 작동하지 않게 되는 것을 방지하려면 가능한 한 빨리 이 작업을 수행하세요.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "지금 백업",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "나중에",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "뒤로",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "기본 로그",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "항상 켜짐 — 앱 버전 간에 지갑이 안전하게 마이그레이션되는지 확인할 수 있게 해줍니다.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "백업을 사용하세요",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "지갑을 긴급하게 사용해야 하거나 스왑이 완료되기를 기다리는 경우가 아니라면 이 과정을 건너뛰지 마세요.",
   "legacyStorageRiskAckButtonHasBackup": "위험을 이해합니다",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "스왑을 완료하려면 24시간 이내에 앱을 여세요.",
   "importMnemonicDuplicateError": "이 니모닉은 이미 존재합니다",
   "transactionStatusPayjoinCompleted": "Payjoin 완료됨",
   "coreScreensResolvingInputs": "거래 입력을 확인하는 중...",

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -1110,7 +1110,6 @@
   "doNotShareWarning": "NÃO COMPLEMENTAR COM NINGUÉM",
   "torSettingsPortNumber": "Número de porta",
   "payNameHint": "Digite o nome do destinatário",
-  "autoswapWarningTriggerAmount": "Classificação de 0,02 BTC",
   "legacySeedViewScreenTitle": "Sementes Legacy",
   "pleaseWaitFetching": "Por favor, espere enquanto buscamos seu arquivo de backup.",
   "backupWalletPhysicalBackupTag": "Trustless (ter o seu tempo)",
@@ -3186,7 +3185,6 @@
   "bitboxActionImportWalletButton": "Importação de início",
   "fundExchangeLabelSwiftCode": "Código SWIFT",
   "buyEnterBitcoinAddress": "Digite o endereço bitcoin",
-  "autoswapWarningBaseBalance": "Equilíbrio base 0.01 BTC",
   "transactionDetailLabelPayoutAmount": "Quantidade de pagamento",
   "importQrDeviceSpecterStep6": "Escolha \"Chave única\"",
   "importQrDeviceJadeStep10": "É isso!",
@@ -4555,30 +4553,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Urgente: Backup e reinstalação necessários",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "A aplicação que está a usar utiliza um software que em breve ficará obsoleto. Por favor, siga estes passos:\n\n1. Faça uma cópia de segurança da sua carteira\n2. Desinstale a aplicação. Elimine-a completamente do seu telemóvel.\n3. Reinstale a versão mais recente da aplicação\n4. Use a opção de recuperação em vez de \"criar nova carteira\".\n\nOs seus fundos estão seguros e pode continuar a usar a aplicação agora, mas faça isso o mais rapidamente possível para evitar que a aplicação deixe de funcionar num futuro próximo.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Ação necessária: Reinstalar a aplicação",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "A aplicação que está a usar utiliza um software que em breve ficará obsoleto. Por favor, siga estes passos:\n\n1. Faça uma cópia de segurança da sua carteira\n2. Desinstale a aplicação. Elimine-a completamente do seu telemóvel.\n3. Reinstale a versão mais recente da aplicação\n4. Use a opção de recuperação em vez de \"criar nova carteira\".\n\nOs seus fundos estão seguros e pode continuar a usar a aplicação agora, mas faça isso o mais rapidamente possível para evitar que a aplicação deixe de funcionar num futuro próximo.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Fazer backup agora",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Mais tarde",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Voltar",
   "@backButton": {
     "description": "Generic back button label"
@@ -4610,10 +4584,6 @@
   "errorReportingStandardLogsTitle": "Registos padrão",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Sempre ativo — permite-nos ver se a sua carteira migra em segurança entre versões da aplicação.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Use a sua cópia de segurança",
   "@appInitErrorHasBackupTitle": {
@@ -4698,7 +4668,6 @@
   "legacyStorageHasBackupImportantBody": "Por favor, não ignore este processo, a menos que precise mesmo de usar a carteira urgentemente ou esteja à espera que uma troca seja concluída.",
   "legacyStorageRiskAckButtonHasBackup": "Compreendo o risco",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Abra a aplicação dentro de 24 horas para concluir o seu swap.",
   "importMnemonicDuplicateError": "Esta mnemônica já existe",
   "coreScreensResolvingInputs": "Resolvendo entradas da transação...",
   "coreScreensFeeRateLabel": "Taxa de comissão",

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -2877,10 +2877,6 @@
   "@fundExchangeHelpBeneficiaryName": {
     "description": "Help text for beneficiary name field"
   },
-  "autoswapWarningTriggerAmount": "Equilíbrio máximo de 0,02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "sendNetworkFees": "Taxas de rede",
   "@sendNetworkFees": {
     "description": "Label for network transaction fees"
@@ -9748,10 +9744,6 @@
   "@onboardingPhysicalBackup": {
     "description": "Title for the physical backup recovery option in onboarding"
   },
-  "autoswapWarningBaseBalance": "Equilíbrio de alvo 0,01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "sendInsufficientFunds": "Fundos insuficientes",
   "@sendInsufficientFunds": {
     "description": "Error when balance too low"
@@ -12483,30 +12475,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Urgente: Backup e reinstalação necessários",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "O aplicativo que você está usando utiliza um software que em breve será descontinuado. Por favor, siga estas etapas:\n\n1. Faça backup da sua carteira\n2. Desinstale o aplicativo. Delete-o completamente do seu celular.\n3. Reinstale a versão mais recente do aplicativo\n4. Use a opção de recuperação em vez de \"criar nova carteira\".\n\nSeus fundos estão seguros e você pode continuar usando o aplicativo agora, mas faça isso o mais rápido possível para evitar que o aplicativo pare de funcionar em breve.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Ação necessária: Reinstalar aplicativo",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "O aplicativo que você está usando utiliza um software que em breve será descontinuado. Por favor, siga estas etapas:\n\n1. Faça backup da sua carteira\n2. Desinstale o aplicativo. Delete-o completamente do seu celular.\n3. Reinstale a versão mais recente do aplicativo\n4. Use a opção de recuperação em vez de \"criar nova carteira\".\n\nSeus fundos estão seguros e você pode continuar usando o aplicativo agora, mas faça isso o mais rápido possível para evitar que o aplicativo pare de funcionar em breve.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Fazer backup agora",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Mais tarde",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Voltar",
   "@backButton": {
     "description": "Generic back button label"
@@ -12538,10 +12506,6 @@
   "errorReportingStandardLogsTitle": "Logs padrão",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Sempre ativo — permite que vejamos se sua carteira migra com segurança entre versões do aplicativo.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Use seu backup",
   "@appInitErrorHasBackupTitle": {
@@ -12626,7 +12590,6 @@
   "legacyStorageHasBackupImportantBody": "Por favor, não pule este processo, a menos que você precise usar a carteira urgentemente ou esteja esperando uma troca ser concluída.",
   "legacyStorageRiskAckButtonHasBackup": "Eu entendo o risco",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Abra o aplicativo em até 24 horas para concluir seu swap.",
   "importMnemonicDuplicateError": "Esta mnemônica já existe",
   "coreScreensResolvingInputs": "Resolvendo entradas da transação...",
   "coreScreensFeeRateLabel": "Taxa de comissão",

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -1110,7 +1110,6 @@
   "doNotShareWarning": "НЕ С КЕМ БЫ ТО НИ БЫЛО",
   "torSettingsPortNumber": "Номер порта",
   "payNameHint": "Имя получателя",
-  "autoswapWarningTriggerAmount": "Максимальный баланс 0,02 BTC",
   "legacySeedViewScreenTitle": "Наследные семена",
   "pleaseWaitFetching": "Подождите, пока мы заберем ваш архив.",
   "backupWalletPhysicalBackupTag": "Неверный (примите свое время)",
@@ -3206,7 +3205,6 @@
   "bitboxActionImportWalletButton": "Начало",
   "fundExchangeLabelSwiftCode": "Код SWIFT",
   "buyEnterBitcoinAddress": "Введите адрес биткойна",
-  "autoswapWarningBaseBalance": "Целевой баланс 0,01 BTC",
   "transactionDetailLabelPayoutAmount": "Сумма выплат",
   "importQrDeviceSpecterStep6": "Выберите \"Сингл ключ\"",
   "importQrDeviceJadeStep10": "Вот так!",
@@ -4509,30 +4507,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Срочно: требуется резервное копирование и переустановка",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Приложение, которое вы используете, работает на программном обеспечении, которое скоро устареет. Пожалуйста, выполните следующие шаги:\n\n1. Создайте резервную копию вашего кошелька\n2. Удалите приложение. Полностью сотрите его с вашего телефона.\n3. Переустановите последнюю версию приложения\n4. Используйте функцию восстановления вместо «создания нового кошелька».\n\nВаши средства в безопасности, и вы можете продолжать пользоваться приложением прямо сейчас, но сделайте это как можно скорее, чтобы предотвратить неисправность приложения в ближайшем будущем.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Требуется действие: Переустановите приложение",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Приложение, которое вы используете, работает на программном обеспечении, которое скоро устареет. Пожалуйста, выполните следующие шаги:\n\n1. Создайте резервную копию вашего кошелька\n2. Удалите приложение. Полностью сотрите его с вашего телефона.\n3. Переустановите последнюю версию приложения\n4. Используйте функцию восстановления вместо «создания нового кошелька».\n\nВаши средства в безопасности, и вы можете продолжать пользоваться приложением прямо сейчас, но сделайте это как можно скорее, чтобы предотвратить неисправность приложения в ближайшем будущем.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Создать копию сейчас",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Позже",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Назад",
   "@backButton": {
     "description": "Generic back button label"
@@ -4564,10 +4538,6 @@
   "errorReportingStandardLogsTitle": "Стандартные журналы",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Всегда включено — позволяет нам видеть, безопасно ли мигрирует ваш кошелёк между версиями приложения.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Используйте резервную копию",
   "@appInitErrorHasBackupTitle": {
@@ -4652,7 +4622,6 @@
   "legacyStorageHasBackupImportantBody": "Пожалуйста, не пропускайте этот процесс, если только вам не нужно срочно использовать кошелёк или вы не ждёте завершения свопа.",
   "legacyStorageRiskAckButtonHasBackup": "Я понимаю риск",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Откройте приложение в течение 24 часов, чтобы завершить своп.",
   "importMnemonicDuplicateError": "Эта мнемоническая фраза уже существует",
   "coreScreensResolvingInputs": "Разрешение входов транзакции...",
   "coreScreensFeeRateLabel": "Ставка комиссии",

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -83,30 +83,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Haraka: Nakala Rudufu na Usakinishaji Upya Unahitajika",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Programu unayoitumia inatumia programu ya kompyuta ambayo hivi karibuni itakuwa ya zamani. Tafadhali fuata hatua hizi:\n\n1. Hifadhi nakala rudufu ya pochi yako\n2. Sakinua programu. Ifute kabisa kutoka kwenye simu yako.\n3. Sakinisha upya toleo jipya zaidi la programu\n4. Tumia chaguo la uokoaji badala ya \"tengeneza pochi mpya\".\n\nFedha zako ziko salama na unaweza kuendelea kutumia programu sasa hivi, lakini fanya hivyo haraka iwezekanavyo kuzuia programu isiharibike katika siku zijazo za karibu.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Hatua Inahitajika: Sakinisha Upya Programu",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Programu unayoitumia inatumia programu ya kompyuta ambayo hivi karibuni itakuwa ya zamani. Tafadhali fuata hatua hizi:\n\n1. Hifadhi nakala rudufu ya pochi yako\n2. Sakinua programu. Ifute kabisa kutoka kwenye simu yako.\n3. Sakinisha upya toleo jipya zaidi la programu\n4. Tumia chaguo la uokoaji badala ya \"tengeneza pochi mpya\".\n\nFedha zako ziko salama na unaweza kuendelea kutumia programu sasa hivi, lakini fanya hivyo haraka iwezekanavyo kuzuia programu isiharibike katika siku zijazo za karibu.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Hifadhi sasa",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Baadaye",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "pinCodeBackupRequiredWarning": "Tafadhali kamilisha nakala rudufu ya pochi kabla ya kuweka PIN",
   "backButton": "Rudi",
   "@backButton": {
@@ -139,10 +115,6 @@
   "errorReportingStandardLogsTitle": "Rekodi za kawaida",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Inaendelea kuwashwa — inatuwezesha kuona kama pochi yako inahama kwa usalama kati ya matoleo ya programu.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Tumia nakala rudufu yako",
   "@appInitErrorHasBackupTitle": {
@@ -227,7 +199,6 @@
   "legacyStorageHasBackupImportantBody": "Tafadhali usiruke mchakato huu isipokuwa lazima utumie pochi kwa haraka au unasubiri swap ikamilike.",
   "legacyStorageRiskAckButtonHasBackup": "Ninaelewa hatari",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Fungua programu ndani ya saa 24 ili kukamilisha swap yako.",
   "appStartupErrorMessage": "Programu imeshindwa kuanza. Jaribu kuifunga kabisa na kuanzisha upya. Ikiwa tatizo linaendelea, wasiliana na usaidizi na shiriki logi zako.",
   "importMnemonicDuplicateError": "Msemo huu tayari upo",
   "transactionStatusPayjoinCompleted": "Payjoin imekamilika",

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -3321,10 +3321,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "สมดุลสูงสุด 0.02 BTC",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "legacySeedViewScreenTitle": "เมล็ด",
   "@legacySeedViewScreenTitle": {
     "description": "AppBar title for legacy seeds screen"
@@ -9711,10 +9707,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "ตัวชี้วัดพื้นฐาน 0.01 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "transactionDetailLabelPayoutAmount": "จํานวนเงิน",
   "@transactionDetailLabelPayoutAmount": {
     "description": "Label for payout amount"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "เร่งด่วน: จำเป็นต้องสำรองข้อมูลและติดตั้งแอปใหม่",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "แอปที่คุณใช้งานอยู่นี้ใช้ซอฟต์แวร์ที่กำลังจะถูกยกเลิกในไม่ช้า กรุณาทำตามขั้นตอนเหล่านี้:\n\n1. สำรองข้อมูลกระเป๋าเงินของคุณ\n2. ถอนการติดตั้งแอป ลบออกจากโทรศัพท์ของคุณอย่างสมบูรณ์\n3. ติดตั้งแอปเวอร์ชันล่าสุดใหม่อีกครั้ง\n4. ใช้ตัวเลือกการกู้คืนแทน \"สร้างกระเป๋าเงินใหม่\"\n\nเงินของคุณปลอดภัยและคุณสามารถใช้แอปต่อไปได้ในตอนนี้ แต่ควรดำเนินการโดยเร็วที่สุดเพื่อป้องกันไม่ให้แอปหยุดทำงานในอนาคตอันใกล้นี้",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "จำเป็นต้องดำเนินการ: ติดตั้งแอปใหม่",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "แอปที่คุณใช้งานอยู่นี้ใช้ซอฟต์แวร์ที่กำลังจะถูกยกเลิกในไม่ช้า กรุณาทำตามขั้นตอนเหล่านี้:\n\n1. สำรองข้อมูลกระเป๋าเงินของคุณ\n2. ถอนการติดตั้งแอป ลบออกจากโทรศัพท์ของคุณอย่างสมบูรณ์\n3. ติดตั้งแอปเวอร์ชันล่าสุดใหม่อีกครั้ง\n4. ใช้ตัวเลือกการกู้คืนแทน \"สร้างกระเป๋าเงินใหม่\"\n\nเงินของคุณปลอดภัยและคุณสามารถใช้แอปต่อไปได้ในตอนนี้ แต่ควรดำเนินการโดยเร็วที่สุดเพื่อป้องกันไม่ให้แอปหยุดทำงานในอนาคตอันใกล้นี้",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "สำรองข้อมูลตอนนี้",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "ภายหลัง",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "ย้อนกลับ",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "บันทึกทั่วไป",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "เปิดอยู่เสมอ — ช่วยให้เราเห็นว่ากระเป๋าเงินของคุณย้ายข้อมูลระหว่างเวอร์ชันแอปอย่างปลอดภัยหรือไม่",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "ใช้ข้อมูลสำรองของคุณ",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "โปรดอย่าข้ามขั้นตอนนี้ เว้นแต่คุณจำเป็นต้องใช้กระเป๋าเงินอย่างเร่งด่วน หรือกำลังรอให้สวอปเสร็จสมบูรณ์",
   "legacyStorageRiskAckButtonHasBackup": "ฉันเข้าใจความเสี่ยง",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "เปิดแอปภายใน 24 ชั่วโมงเพื่อทำสว็อปของคุณให้เสร็จสมบูรณ์",
   "importMnemonicDuplicateError": "วลีช่วยจำนี้มีอยู่แล้ว",
   "transactionStatusPayjoinCompleted": "Payjoin เสร็จสิ้นแล้ว",
   "coreScreensResolvingInputs": "กำลังตรวจสอบอินพุตธุรกรรม...",

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -3313,10 +3313,6 @@
   "@payNameHint": {
     "description": "Hint for name input"
   },
-  "autoswapWarningTriggerAmount": "0.02 BTC'nin maksimum dengesi",
-  "@autoswapWarningTriggerAmount": {
-    "description": "Maximum balance text shown in the autoswap warning bottom sheet"
-  },
   "legacySeedViewScreenTitle": "Legacy Seeds",
   "@legacySeedViewScreenTitle": {
     "description": "AppBar title for legacy seeds screen"
@@ -9640,10 +9636,6 @@
   "@buyEnterBitcoinAddress": {
     "description": "Label for bitcoin address input field"
   },
-  "autoswapWarningBaseBalance": "Hedef Denge 0.0 BTC",
-  "@autoswapWarningBaseBalance": {
-    "description": "Target balance text shown in the autoswap warning bottom sheet"
-  },
   "transactionDetailLabelPayoutAmount": "Payout amount",
   "@transactionDetailLabelPayoutAmount": {
     "description": "Label for payout amount"
@@ -12487,30 +12479,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Acil: Yedekleme ve Yeniden Kurulum Gerekli",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Kullandığınız uygulama yakında kullanımdan kalkacak bir yazılım kullanmaktadır. Lütfen şu adımları izleyin:\n\n1. Cüzdanınızı yedekleyin\n2. Uygulamayı kaldırın. Telefonunuzdan tamamen silin.\n3. Uygulamanın en son sürümünü yeniden yükleyin\n4. \"Yeni cüzdan oluştur\" yerine kurtarma seçeneğini kullanın.\n\nParalarınız güvende ve uygulamayı şu an kullanmaya devam edebilirsiniz, ancak uygulamanın yakın gelecekte bozulmasını önlemek için bunu mümkün olan en kısa sürede yapın.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "İşlem Gerekli: Uygulamayı Yeniden Yükleyin",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Kullandığınız uygulama yakında kullanımdan kalkacak bir yazılım kullanmaktadır. Lütfen şu adımları izleyin:\n\n1. Cüzdanınızı yedekleyin\n2. Uygulamayı kaldırın. Telefonunuzdan tamamen silin.\n3. Uygulamanın en son sürümünü yeniden yükleyin\n4. \"Yeni cüzdan oluştur\" yerine kurtarma seçeneğini kullanın.\n\nParalarınız güvende ve uygulamayı şu an kullanmaya devam edebilirsiniz, ancak uygulamanın yakın gelecekte bozulmasını önlemek için bunu mümkün olan en kısa sürede yapın.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Şimdi yedekle",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Daha sonra",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Geri",
   "@backButton": {
     "description": "Generic back button label"
@@ -12542,10 +12510,6 @@
   "errorReportingStandardLogsTitle": "Standart günlükler",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Her zaman açık — cüzdanınızın uygulama sürümleri arasında güvenle taşınıp taşınmadığını görmemizi sağlar.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Yedeğinizi kullanın",
   "@appInitErrorHasBackupTitle": {
@@ -12630,7 +12594,6 @@
   "legacyStorageHasBackupImportantBody": "Cüzdanı acilen kullanmanız mutlak gerekmedikçe veya bir takasın tamamlanmasını beklemiyorsanız, lütfen bu işlemi atlamayın.",
   "legacyStorageRiskAckButtonHasBackup": "Riski anlıyorum",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Swap işlemini tamamlamak için 24 saat içinde uygulamayı açın.",
   "importMnemonicDuplicateError": "Bu anımsatıcı cümle zaten mevcut",
   "transactionStatusPayjoinCompleted": "Payjoin tamamlandı",
   "coreScreensResolvingInputs": "İşlem girdileri çözümleniyor...",

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -1937,7 +1937,6 @@
   "informationWillNotLeave": "Інформація ",
   "backupWalletInstructionSecurityRisk": "Будь-який з доступом до вашого 12 резервного копіювання може вкрасти ваші біткоїни. Приховати його добре.",
   "torSettingsPortNumber": "Номер порту",
-  "autoswapWarningTriggerAmount": "Максимальний баланс 0.02 BTC",
   "pleaseWaitFetching": "Будь ласка, почекайте, коли ми фіксуємо файл резервного копіювання.",
   "backupWalletPhysicalBackupTag": "Бездоганний (забрати час)",
   "electrumReset": "Зареєструватися",
@@ -3456,7 +3455,6 @@
   "savingToDevice": "Збереження вашого пристрою.",
   "bitboxActionImportWalletButton": "Імпорт",
   "fundExchangeLabelSwiftCode": "SWIFT код",
-  "autoswapWarningBaseBalance": "Цільовий баланс 0.01 BTC",
   "importQrDeviceSpecterStep6": "Виберіть \"Single key\"",
   "importQrDeviceJadeStep10": "Що це!",
   "importQrDevicePassportStep8": "На мобільному пристрої натисніть \"відкрита камера\"",
@@ -4497,30 +4495,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Терміново: необхідне резервне копіювання та переустановлення",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Додаток, яким ви користуєтеся, працює на програмному забезпеченні, яке незабаром застаріє. Будь ласка, виконайте такі кроки:\n\n1. Зробіть резервну копію вашого гаманця\n2. Видаліть додаток. Повністю сотріть його з телефону.\n3. Встановіть заново останню версію додатка\n4. Використовуйте опцію відновлення замість «створення нового гаманця».\n\nВаші кошти в безпеці, і ви можете продовжувати користуватися додатком прямо зараз, але зробіть це якомога швидше, щоб запобігти збою додатка найближчим часом.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Необхідна дія: Перевстановіть додаток",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Додаток, яким ви користуєтеся, працює на програмному забезпеченні, яке незабаром застаріє. Будь ласка, виконайте такі кроки:\n\n1. Зробіть резервну копію вашого гаманця\n2. Видаліть додаток. Повністю сотріть його з телефону.\n3. Встановіть заново останню версію додатка\n4. Використовуйте опцію відновлення замість «створення нового гаманця».\n\nВаші кошти в безпеці, і ви можете продовжувати користуватися додатком прямо зараз, але зробіть це якомога швидше, щоб запобігти збою додатка найближчим часом.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Зробити копію зараз",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Пізніше",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "Назад",
   "@backButton": {
     "description": "Generic back button label"
@@ -4552,10 +4526,6 @@
   "errorReportingStandardLogsTitle": "Стандартні журнали",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Завжди ввімкнено — дозволяє нам бачити, чи ваш гаманець безпечно переходить між версіями застосунку.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Використайте резервну копію",
   "@appInitErrorHasBackupTitle": {
@@ -4640,7 +4610,6 @@
   "legacyStorageHasBackupImportantBody": "Будь ласка, не пропускайте цей процес, якщо тільки вам не потрібно терміново скористатися гаманцем або ви не очікуєте на завершення свопу.",
   "legacyStorageRiskAckButtonHasBackup": "Я розумію ризик",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Відкрийте застосунок протягом 24 годин, щоб завершити своп.",
   "importMnemonicDuplicateError": "Ця мнемонічна фраза вже існує",
   "coreScreensResolvingInputs": "Розв'язання входів транзакції...",
   "coreScreensFeeRateLabel": "Ставка комісії",

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -63,30 +63,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "Khẩn cấp: Cần sao lưu và cài đặt lại",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "Ứng dụng bạn đang sử dụng đang chạy trên phần mềm sẽ sớm bị ngừng hỗ trợ. Vui lòng thực hiện các bước sau:\n\n1. Sao lưu ví của bạn\n2. Gỡ cài đặt ứng dụng. Xóa hoàn toàn khỏi điện thoại của bạn.\n3. Cài đặt lại phiên bản mới nhất của ứng dụng\n4. Sử dụng tùy chọn khôi phục thay vì \"tạo ví mới\".\n\nTài sản của bạn an toàn và bạn có thể tiếp tục sử dụng ứng dụng ngay bây giờ, nhưng hãy thực hiện điều này càng sớm càng tốt để tránh ứng dụng bị hỏng trong tương lai gần.",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "Cần thực hiện: Cài đặt lại ứng dụng",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "Ứng dụng bạn đang sử dụng đang chạy trên phần mềm sẽ sớm bị ngừng hỗ trợ. Vui lòng thực hiện các bước sau:\n\n1. Sao lưu ví của bạn\n2. Gỡ cài đặt ứng dụng. Xóa hoàn toàn khỏi điện thoại của bạn.\n3. Cài đặt lại phiên bản mới nhất của ứng dụng\n4. Sử dụng tùy chọn khôi phục thay vì \"tạo ví mới\".\n\nTài sản của bạn an toàn và bạn có thể tiếp tục sử dụng ứng dụng ngay bây giờ, nhưng hãy thực hiện điều này càng sớm càng tốt để tránh ứng dụng bị hỏng trong tương lai gần.",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "Sao lưu ngay",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "Sau",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "pinCodeBackupRequiredWarning": "Vui lòng hoàn tất sao lưu ví trước khi đặt PIN",
   "backButton": "Quay lại",
   "@backButton": {
@@ -119,10 +95,6 @@
   "errorReportingStandardLogsTitle": "Nhật ký tiêu chuẩn",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "Luôn bật — giúp chúng tôi biết ví của bạn có di chuyển an toàn giữa các phiên bản ứng dụng hay không.",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "Sử dụng bản sao lưu của bạn",
   "@appInitErrorHasBackupTitle": {
@@ -207,7 +179,6 @@
   "legacyStorageHasBackupImportantBody": "Vui lòng không bỏ qua quy trình này trừ khi bạn thực sự cần sử dụng ví khẩn cấp hoặc đang chờ một giao dịch hoán đổi hoàn tất.",
   "legacyStorageRiskAckButtonHasBackup": "Tôi hiểu rủi ro",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "Mở ứng dụng trong vòng 24 giờ để hoàn tất hoán đổi của bạn.",
   "appStartupErrorMessage": "Không thể khởi động ứng dụng. Hãy thử đóng hoàn toàn ứng dụng và khởi động lại. Nếu lỗi vẫn tiếp diễn, hãy liên hệ hỗ trợ và gửi nhật ký của bạn.",
   "importMnemonicDuplicateError": "Cụm từ ghi nhớ này đã tồn tại",
   "transactionStatusPayjoinCompleted": "Payjoin đã hoàn tất",

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -1113,7 +1113,6 @@
   "doNotShareWarning": "纽约总部",
   "torSettingsPortNumber": "港口数量",
   "payNameHint": "1. 输入者姓名",
-  "autoswapWarningTriggerAmount": "最大余额为 0.02 BTC",
   "legacySeedViewScreenTitle": "遗产种子",
   "pleaseWaitFetching": "等到我们找回文件的时候.",
   "backupWalletPhysicalBackupTag": "无信托能力(时间)",
@@ -3209,7 +3208,6 @@
   "bitboxActionImportWalletButton": "开始导入",
   "fundExchangeLabelSwiftCode": "缩略语",
   "buyEnterBitcoinAddress": "轨道硬币地址",
-  "autoswapWarningBaseBalance": "目标余额 0.01 BTC",
   "transactionDetailLabelPayoutAmount": "薪酬数额",
   "importQrDeviceSpecterStep6": "选择“关键”",
   "importQrDeviceJadeStep10": "这!",
@@ -4500,30 +4498,6 @@
   "@deleteAccountSuccessClose": {
     "description": "Close button label for delete account success bottom sheet"
   },
-  "homeLegacyStorageWithNoBackupTitle": "紧急：需要备份并重新安装",
-  "@homeLegacyStorageWithNoBackupTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageWithNoBackupDescription": "您正在使用的应用程序依赖即将被弃用的软件。请按照以下步骤操作：\n\n1. 备份您的钱包\n2. 卸载应用程序。从您的手机中完全删除。\n3. 重新安装最新版本的应用程序\n4. 使用恢复选项，而不是\"创建新钱包\"。\n\n您的资金是安全的，您现在可以继续使用该应用程序，但请尽快执行此操作，以防止应用程序在不久的将来出现故障。",
-  "@homeLegacyStorageWithNoBackupDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage AND has no backup"
-  },
-  "homeLegacyStorageTitle": "需要操作：重新安装应用程序",
-  "@homeLegacyStorageTitle": {
-    "description": "Warning card title when the wallet is on deprecated storage but has a backup"
-  },
-  "homeLegacyStorageDescription": "您正在使用的应用程序依赖即将被弃用的软件。请按照以下步骤操作：\n\n1. 备份您的钱包\n2. 卸载应用程序。从您的手机中完全删除。\n3. 重新安装最新版本的应用程序\n4. 使用恢复选项，而不是\"创建新钱包\"。\n\n您的资金是安全的，您现在可以继续使用该应用程序，但请尽快执行此操作，以防止应用程序在不久的将来出现故障。",
-  "@homeLegacyStorageDescription": {
-    "description": "Warning card description when the wallet is on deprecated storage but has a backup"
-  },
-  "legacyStorageWarningBackupNow": "立即备份",
-  "@legacyStorageWarningBackupNow": {
-    "description": "Primary action button on the legacy storage warning overlay"
-  },
-  "legacyStorageWarningLater": "稍后",
-  "@legacyStorageWarningLater": {
-    "description": "Dismiss button on the legacy storage warning overlay (only shown when backup exists)"
-  },
   "backButton": "返回",
   "@backButton": {
     "description": "Generic back button label"
@@ -4555,10 +4529,6 @@
   "errorReportingStandardLogsTitle": "标准日志",
   "@errorReportingStandardLogsTitle": {
     "description": "Title of the standard error reporting switch"
-  },
-  "errorReportingMigrationSubtitle": "始终开启 — 让我们能看到您的钱包在应用版本之间是否安全迁移。",
-  "@errorReportingMigrationSubtitle": {
-    "description": "Subtitle explaining why the migration logs switch cannot be disabled"
   },
   "appInitErrorHasBackupTitle": "使用您的备份",
   "@appInitErrorHasBackupTitle": {
@@ -4643,7 +4613,6 @@
   "legacyStorageHasBackupImportantBody": "除非您必须紧急使用钱包或正在等待一笔兑换完成，否则请不要跳过此流程。",
   "legacyStorageRiskAckButtonHasBackup": "我了解风险",
   "walletSetupErrorTryAgain": "Something went wrong setting up your wallet. Please try again.",
-  "transactionSwapOpenWithin24Hours": "请在24小时内打开应用以完成您的兑换。",
   "importMnemonicDuplicateError": "该助记词已存在",
   "transactionStatusPayjoinCompleted": "Payjoin 已完成",
   "coreScreensResolvingInputs": "正在解析交易输入...",


### PR DESCRIPTION
Thanks to @bsn21m 

Removed 10 keys (and their @metadata) that exist in translation files but not in the app_en.arb template, so no getter is generated and no Dart code references them:

- autoswapWarningTriggerAmount, autoswapWarningBaseBalance
- homeLegacyStorageWithNoBackupTitle, homeLegacyStorageWithNoBackupDescription
- homeLegacyStorageTitle, homeLegacyStorageDescription
- legacyStorageWarningBackupNow, legacyStorageWarningLater
- errorReportingMigrationSubtitle, transactionSwapOpenWithin24Hours