### PR TITLE
chore(deps): bump bull_sdk to b40f2f2 and drop satoshifier override

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -150,8 +150,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bitbox-transport"
-      ref: main
-      resolved-ref: "6b8f54fcd7b7b7d02ef32cbcaf56943625970555"
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      resolved-ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -208,8 +208,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/boltz-stream"
-      ref: main
-      resolved-ref: "6b8f54fcd7b7b7d02ef32cbcaf56943625970555"
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      resolved-ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -297,8 +297,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bull_sdk"
-      ref: main
-      resolved-ref: "6b8f54fcd7b7b7d02ef32cbcaf56943625970555"
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      resolved-ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "1.0.0+1"
@@ -1273,10 +1273,10 @@ packages:
     dependency: transitive
     description:
       name: ledger_flutter_plus
-      sha256: "59c5a6062505c721c2ca909fa085c52cffe93de995174b8418b54a6acf52eb70"
+      sha256: e7de0cd3d450b38955c4f04a9a729235d6ed7ca0dc463907e9e1dcc080ccf51d
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.6"
+    version: "1.6.0+1"
   ledger_usb_plus:
     dependency: transitive
     description:
@@ -1723,8 +1723,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/bull_sdk/rust_builder"
-      ref: "6b8f54fcd7b7b7d02ef32cbcaf56943625970555"
-      resolved-ref: "6b8f54fcd7b7b7d02ef32cbcaf56943625970555"
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      resolved-ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
@@ -1739,28 +1739,28 @@ packages:
   satoshifier:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "535eeea782ffb610a69dbee2eac4739c6a45c99e"
-      resolved-ref: "535eeea782ffb610a69dbee2eac4739c6a45c99e"
-      url: "https://github.com/SatoshiPortal/dart-satoshifier"
+      path: "packages/satoshifier"
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      resolved-ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
   sentry:
     dependency: transitive
     description:
       name: sentry
-      sha256: "1f78300740739ff4b4920802687879231554350eab73eb229778f463aabda440"
+      sha256: "3311f89e0c964c4df5f65670348c8a11744c94ae2b57032c947cfb26bfd03ef0"
       url: "https://pub.dev"
     source: hosted
-    version: "9.19.0"
+    version: "9.22.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "168bbb120f7684dee6c0e100817f56ee1925bc2eb7fa55a71253337640c7e241"
+      sha256: efd3bebd7962438d0ecbe5c7b530de012e2e8efe14ef838b89195d7c2bb3f66c
       url: "https://pub.dev"
     source: hosted
-    version: "9.19.0"
+    version: "9.22.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -2091,10 +2091,10 @@ packages:
     dependency: transitive
     description:
       name: universal_ble
-      sha256: "8325ca9f5cce2fba2b4efef74a4fcfe7144f303b409d6fc6ed16197b00a1a241"
+      sha256: da15f61251299daf9c290bb8e40ded1e5313c4636fef6c796a7a656a06c93b4a
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.4"
   universal_io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,17 +46,17 @@ dependencies:
   bull_sdk:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: main
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       path: packages/bull_sdk
   boltz_stream:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: main
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       path: packages/boltz-stream
   bitbox_transport:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: main
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
       path: packages/bitbox-transport
   hex: ^0.2.0
   auto_size_text: ^3.0.0
@@ -109,8 +109,9 @@ dependencies:
   logging_colorful: ^1.3.2
   satoshifier:
     git:
-      url: https://github.com/SatoshiPortal/dart-satoshifier
-      ref: 535eeea782ffb610a69dbee2eac4739c6a45c99e
+      url: https://github.com/SatoshiPortal/bull_sdk
+      ref: b40f2f206e47861215ac34b0012f56bbaa5b0c8e
+      path: packages/satoshifier
   flutter_nfc_kit: ^3.6.1
   ledger_bitcoin:
     git:
@@ -136,7 +137,7 @@ dependencies:
   lints: ^6.0.0
   bloc_concurrency: ^0.3.0
   web_socket_channel: ^3.0.3
-  sentry_flutter: ^9.19.0
+  sentry_flutter: ^9.22.0
   keyboard_actions: ^4.2.1
 
 dependency_overrides:


### PR DESCRIPTION
## Summary
Repoints the app at the latest `bull_sdk` ([bull_sdk#2](https://github.com/SatoshiPortal/bull_sdk/pull/2) merged, `b40f2f2`) and removes the `bull_sdk` `dependency_overrides` entirely. `satoshifier` now ships from inside the `bull_sdk` repo, so there's a single git source at a single ref and the override is no longer needed.

## What changed
- Pin `bull_sdk`, `boltz_stream`, `bitbox_transport`, and `satoshifier` to `bull_sdk@b40f2f2`.
- `satoshifier` now sourced from `bull_sdk` (`path: packages/satoshifier`) instead of the standalone `dart-satoshifier` repo — it was inlined into the SDK repo and depends on `bull_sdk` via a local path, eliminating the git-ref mismatch.
- **Removed `dependency_overrides: bull_sdk`** (previously required to reconcile satoshifier's `bull_sdk@main` against the app's pinned SHA).
- Bumped `sentry_flutter` to `^9.22.0`.

## Why
- The override was a stopgap for a git-ref cycle (the app pinned `bull_sdk` by SHA while `satoshifier` pinned `bull_sdk@main`). Inlining satoshifier into the SDK repo with a path dependency removes that mismatch permanently — no override, no melos, single source of truth.
- The new `bull_sdk` carries the FRB 2.12.0 / Flutter 3.44.1 toolchain alignment and committed lockfiles for reproducible builds.
- `sentry_flutter 9.19.0` fails to compile under Flutter 3.44's built-in Kotlin (`Unresolved reference 'SentryFlutterReplayRecorder'`, [getsentry/sentry-dart#3695](https://github.com/getsentry/sentry-dart/issues/3695)); `9.22.0` fixes it. Independent of the bull_sdk change but required for any Android build on 3.44.1.

## Testing
- `fvm flutter pub get` resolves with **no** `bull_sdk` override; all bull_sdk-repo packages resolve to `b40f2f2`.
- `fvm flutter build apk --debug --flavor production` → green (`✓ Built app-production-debug.apk`).

## Related
- [bull_sdk#2](https://github.com/SatoshiPortal/bull_sdk/pull/2) (merged) — inlines satoshifier, switches in-repo packages to path deps.
- Part of [#2138](https://github.com/SatoshiPortal/bullbitcoin-mobile/issues/2138) (Bull SDK fixes).

## Follow-ups
- [lwk-dart#73](https://github.com/SatoshiPortal/lwk-dart/pull/73) still open — merge so lwk lands on `develop` with the others. –> @i5hi 
- Archive (not delete) `satoshifier-dart` once this merges, and close [satoshifier-dart#6](https://github.com/SatoshiPortal/satoshifier-dart/pull/6).
