### PR TITLE
chore(devcontainer): fix wayland socket forwarding via host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,47 +1,47 @@
 {
-    "name": "${localWorkspaceFolderBasename}",
-    "build": {
-        "dockerfile": "../Containerfile.tools",
-        "args": {
-            "USERNAME": "${localEnv:USER}"
-        }
+  "name": "${localWorkspaceFolderBasename}",
+  "build": {
+    "dockerfile": "../Containerfile.tools",
+    "args": {
+      "USERNAME": "${localEnv:USER}",
     },
-    "remoteUser": "${localEnv:USER}",
-    "updateRemoteUserUID": true,
-    "shutdownAction": "stopContainer",
-    "initializeCommand": "sh -c '.devcontainer/init-ssh-agent.sh && .devcontainer/init-adb.sh'",
-    "runArgs": [
-        "--name",
-        "${localWorkspaceFolderBasename}",
-        "--hostname",
-        "bull",
-        "--memory=8g",
-        "--device=/dev/dri",
-        "--dns",
-        "1.1.1.1",
-        "--dns",
-        "9.9.9.9",
-        "--security-opt",
-        "label=disable"
-    ],
-    "mounts": [
-        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
-        "source=${localEnv:HOME}/.ssh-agent-devcontainer.sock,target=/ssh-agent,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
-        "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-        "source=/tmp/wayland.sock,target=/tmp/wayland.sock,type=bind,consistency=cached",
-        "source=${localWorkspaceFolderBasename}-bash-history,target=/home/${localEnv:USER}/.history,type=volume",
-        "source=${localWorkspaceFolderBasename}-keyrings,target=/home/${localEnv:USER}/.local/share/keyrings,type=volume"
-    ],
-    "containerEnv": {
-        "SSH_AUTH_SOCK": "/ssh-agent",
-        "ADB_SERVER_SOCKET": "tcp:host.containers.internal:5037",
-        "DISPLAY": "${localEnv:DISPLAY}",
-        "XDG_RUNTIME_DIR": "/tmp",
-        "WAYLAND_DISPLAY": "wayland.sock",
-        "GDK_BACKEND": "wayland,x11",
-        "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/dbus-session.sock"
-    },
-    "postCreateCommand": "sudo chown -R ${localEnv:USER}:${localEnv:USER} /home/${localEnv:USER}/.local /home/${localEnv:USER}/.history && touch /home/${localEnv:USER}/.history/bash_history",
-    "postStartCommand": ".devcontainer/init-keyring.sh"
+  },
+  "remoteUser": "${localEnv:USER}",
+  "updateRemoteUserUID": true,
+  "shutdownAction": "stopContainer",
+  "initializeCommand": "sh -c '.devcontainer/init-ssh-agent.sh && .devcontainer/init-adb.sh'",
+  "runArgs": [
+    "--name",
+    "${localWorkspaceFolderBasename}",
+    "--hostname",
+    "bull",
+    "--memory=8g",
+    "--device=/dev/dri",
+    "--dns",
+    "1.1.1.1",
+    "--dns",
+    "9.9.9.9",
+    "--security-opt",
+    "label=disable",
+  ],
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
+    "source=${localEnv:HOME}/.ssh-agent-devcontainer.sock,target=/ssh-agent,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+    "source=${localWorkspaceFolderBasename}-bash-history,target=/home/${localEnv:USER}/.history,type=volume",
+    "source=${localWorkspaceFolderBasename}-keyrings,target=/home/${localEnv:USER}/.local/share/keyrings,type=volume",
+    "source=${localEnv:XDG_RUNTIME_DIR},target=/run/host-runtime,type=bind,consistency=cached",
+  ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/ssh-agent",
+    "ADB_SERVER_SOCKET": "tcp:host.containers.internal:5037",
+    "DISPLAY": "${localEnv:DISPLAY}",
+    "XDG_RUNTIME_DIR": "/tmp",
+    "WAYLAND_DISPLAY": "/run/host-runtime/${localEnv:WAYLAND_DISPLAY}",
+    "GDK_BACKEND": "wayland,x11",
+    "DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/dbus-session.sock",
+  },
+  "postCreateCommand": "sudo chown -R ${localEnv:USER}:${localEnv:USER} /home/${localEnv:USER}/.local /home/${localEnv:USER}/.history && touch /home/${localEnv:USER}/.history/bash_history",
+  "postStartCommand": ".devcontainer/init-keyring.sh",
 }


### PR DESCRIPTION
XDG_RUNTIME_DIR

Mount host XDG_RUNTIME_DIR at /run/host-runtime and point WAYLAND_DISPLAY at the host socket instead of a hardcoded /tmp/wayland.sock. Also reformat to 2-space indent with trailing commas (JSONC).