### PR TITLE
fix(send): surface swap limit errors on address screen

### DIFF
--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -365,6 +365,7 @@ class SendCubit extends Cubit<SendState> {
             ? SwapType.liquidToLightning
             : SwapType.bitcoinToLightning;
         await loadSwapLimits();
+        setSelectedSwapLimits();
 
         if (state.swapAmountBelowLimit) {
           final swapMinimum = state.swapMinimum;

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -197,6 +197,11 @@ abstract class SendState with _$SendState {
     return amountSat;
   }
 
+  int get effectiveAmountSat {
+    final embedded = paymentRequest?.amountSat ?? 0;
+    return embedded > 0 ? embedded : inputAmountSat;
+  }
+
   double get inputAmountBtc => ConvertAmount.satsToBtc(inputAmountSat);
 
   double get inputAmountFiat {
@@ -326,17 +331,17 @@ abstract class SendState with _$SendState {
       isLightning && selectedWallet!.network.isBitcoin;
 
   bool get swapAmountBelowLimit {
-    if (isLightning && inputAmountSat != 0) {
+    final amount = effectiveAmountSat;
+    if (isLightning && amount != 0) {
       if (selectedSwapLimits == null) return false;
       // Allow 100 sats minimum for Liquid to Lightning swaps
       final isLiquidToLightning =
           selectedWallet != null && selectedWallet!.isLiquid;
       final minLimit = isLiquidToLightning ? 100 : selectedSwapLimits!.min;
-      return inputAmountSat < minLimit;
+      return amount < minLimit;
     }
-    if (requireChainSwap && inputAmountSat != 0) {
-      return selectedSwapLimits != null &&
-          inputAmountSat < selectedSwapLimits!.min;
+    if (requireChainSwap && amount != 0) {
+      return selectedSwapLimits != null && amount < selectedSwapLimits!.min;
     }
     return false;
   }
@@ -348,13 +353,12 @@ abstract class SendState with _$SendState {
   }
 
   bool get swapAmountAboveLimit {
+    final amount = effectiveAmountSat;
     if (isLightning) {
-      return selectedSwapLimits != null &&
-          inputAmountSat > selectedSwapLimits!.max;
+      return selectedSwapLimits != null && amount > selectedSwapLimits!.max;
     }
-    if (requireChainSwap && inputAmountSat != 0) {
-      return selectedSwapLimits != null &&
-          inputAmountSat > selectedSwapLimits!.max;
+    if (requireChainSwap && amount != 0) {
+      return selectedSwapLimits != null && amount > selectedSwapLimits!.max;
     }
     return false;
   }

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -228,6 +228,9 @@ class AddressErrorSection extends StatelessWidget {
     final balanceError = context.select(
       (SendCubit cubit) => cubit.state.insufficientBalanceException,
     );
+    final swapLimitsError = context.select(
+      (SendCubit cubit) => cubit.state.swapLimitsException,
+    );
     final swapError = context.select(
       (SendCubit cubit) => cubit.state.swapCreationException,
     );
@@ -244,6 +247,15 @@ class AddressErrorSection extends StatelessWidget {
           textAlign: .center,
           maxLines: 2,
         ),
+      );
+    }
+    if (swapLimitsError != null) {
+      return BBText(
+        _getSwapLimitsErrorMessage(context, swapLimitsError),
+        style: context.font.bodyMedium,
+        color: context.appColors.error,
+        textAlign: .center,
+        maxLines: 2,
       );
     }
     if (swapError != null) {


### PR DESCRIPTION
Fixes #2321 

The root cause here is that:
1. SendState.[swapAmountBelowLimit](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/send/presentation/bloc/send_state.dart#L328) / [swapAmountAboveLimit](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/send/presentation/bloc/send_state.dart#L350) compared against `inputAmountSat`, which is derived from the user's text input. In this case the user has not typed anything, so `inputAmountSat == 0` and the limit gate short-circuited to `false`.
2. `SendCubit.continueOnAddressConfirmed` called [loadSwapLimits()](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/send/presentation/bloc/send_cubit.dart#L367) in the BOLT11 branch but did not pair it with `setSelectedSwapLimits()` (as the [chain-swap branch does](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/send/presentation/bloc/send_cubit.dart#L548)), so `state.selectedSwapLimits`stayed `null`.
3. **`AddressErrorSection`** in `send_screen.dart` never rendered `swapLimitsException`.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6078d04c-1338-47e7-8bd9-08f9703f9ddd" />

## Notes / out of scope
- The generic catch-all at [send_cubit.dart](https://github.com/anipy1/bullbitcoin-mobile/blob/fix/send-bolt11-below-min-swap-error/lib/features/send/presentation/bloc/send_cubit.dart#L440) still swallows any other (non-limit) Boltz failures into the same string. Surfacing the real error message there is a worthwhile follow-up but is intentionally **not** part of this PR to keep the diff focused.