### PR TITLE
fix(wallet): clean up orphan seed in secure storage on wallet deletion

### DIFF
--- a/lib/core/wallet/domain/usecases/delete_wallet_usecase.dart
+++ b/lib/core/wallet/domain/usecases/delete_wallet_usecase.dart
@@ -1,14 +1,18 @@
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
 
 class DeleteWalletUsecase {
   final WalletRepository _walletRepository;
   final BoltzSwapRepository _swapRepository;
+  final SeedRepository _seedRepository;
 
   DeleteWalletUsecase({
     required this._walletRepository,
     required this._swapRepository,
+    required this._seedRepository,
   });
 
   Future<void> execute({required String walletId}) async {
@@ -30,6 +34,27 @@ class DeleteWalletUsecase {
       }
 
       await _walletRepository.deleteWallet(walletId: walletId);
+
+      // Clean up the seed in secure storage once no remaining wallet
+      // still references it. Bitcoin and Liquid default wallets share a
+      // master fingerprint, so the seed is only deleted when the last
+      // wallet derived from it is gone. Watch-only wallets have an empty
+      // master fingerprint and never own a seed entry. Issue #2324.
+      if (wallet.masterFingerprint.isNotEmpty) {
+        final remaining = await _walletRepository.getWallets();
+        final stillUsed = remaining.any(
+          (w) => w.masterFingerprint == wallet.masterFingerprint,
+        );
+        if (!stillUsed) {
+          try {
+            await _seedRepository.delete(wallet.masterFingerprint);
+          } catch (e) {
+            log.warning(
+              'DeleteWalletUsecase: failed to clean up seed for $walletId: $e',
+            );
+          }
+        }
+      }
     } on WalletError {
       rethrow;
     } catch (e) {

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -164,6 +164,7 @@ class WalletLocator {
           instanceName:
               LocatorInstanceNameConstants.boltzSwapRepositoryInstanceName,
         ),
+        seedRepository: locator<SeedRepository>(),
       ),
     );
     locator.registerFactory<GetAddressAtIndexUsecase>(


### PR DESCRIPTION
Closes #2324 

The issue here is that when deleting a wallet it removed its metadata but left the seed in `SeedRepository` so because of that the `CheckDuplicateMnemonicUsecase` is throwing the "Mnemonic already exists" toast based on the residual seed on every re-import attempt, so a user couldn't recover a wallet they had intentionally deleted before.

## Fix

Seed cleanup is added to `DeleteWalletUsecase` ([here](https://github.com/anipy1/bullbitcoin-mobile/blob/orphan-seed-fix/lib/core/wallet/domain/usecases/delete_wallet_usecase.dart#L50))