### PR TITLE
fix(wallet): unify watch-only import identity and stop silent replacement

### DIFF
--- a/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart
+++ b/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart
@@ -6,7 +6,12 @@ class WalletMetadataDatasource {
 
   WalletMetadataDatasource({required this._sqlite});
 
-  Future<void> store(WalletMetadataModel metadata) async {
+  Future<void> create(WalletMetadataModel metadata) async {
+    final companion = metadata.toSqlite();
+    await _sqlite.into(_sqlite.walletMetadatas).insert(companion);
+  }
+
+  Future<void> update(WalletMetadataModel metadata) async {
     final companion = metadata.toSqlite();
     await _sqlite
         .into(_sqlite.walletMetadatas)
@@ -14,10 +19,9 @@ class WalletMetadataDatasource {
   }
 
   Future<WalletMetadataModel?> fetch(String walletId) async {
-    final row =
-        await _sqlite.managers.walletMetadatas
-            .filter((e) => e.id(walletId))
-            .getSingleOrNull();
+    final row = await _sqlite.managers.walletMetadatas
+        .filter((e) => e.id(walletId))
+        .getSingleOrNull();
 
     if (row == null) return null;
     return WalletMetadataModelMapper.fromSqlite(row);

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -68,7 +68,6 @@ class WalletRepository {
     bool sync = false,
     DateTime? birthday,
   }) async {
-    // Derive and store the wallet metadata
     final walletLabel =
         isDefault &&
             (network == Network.bitcoinMainnet ||
@@ -99,7 +98,7 @@ class WalletRepository {
     }
 
     final balance = await _getBalance(metadata, sync: sync);
-    await _walletMetadataDatasource.store(metadata);
+    await _walletMetadataDatasource.create(metadata);
 
     return Wallet(
       origin: metadata.id,
@@ -129,12 +128,13 @@ class WalletRepository {
     // Fetch the balance (in the future maybe other details of the wallet too)
     final balance = await _getBalance(metadata, sync: sync);
 
-    final allWallets = await getWallets(onlyDefaults: true);
+    final allWallets = await getWallets();
+
     for (final wallet in allWallets) {
       if (wallet.id == metadata.id) throw 'Wallet already exists';
     }
 
-    await _walletMetadataDatasource.store(metadata);
+    await _walletMetadataDatasource.create(metadata);
 
     // Return the created wallet entity
     return Wallet(
@@ -174,12 +174,12 @@ class WalletRepository {
     // Fetch the balance (in the future maybe other details of the wallet too)
     final balance = await _getBalance(metadata, sync: sync);
 
-    final allWallets = await getWallets(onlyDefaults: true);
+    final allWallets = await getWallets();
     for (final wallet in allWallets) {
       if (wallet.id == metadata.id) throw 'Wallet already exists';
     }
 
-    await _walletMetadataDatasource.store(metadata);
+    await _walletMetadataDatasource.create(metadata);
 
     // Return the created wallet entity
     return Wallet(
@@ -317,7 +317,7 @@ class WalletRepository {
       throw WalletError.notFound(walletId);
     }
 
-    await _walletMetadataDatasource.store(
+    await _walletMetadataDatasource.update(
       metadata.copyWith(
         latestEncryptedBackup: time?.millisecondsSinceEpoch,
         isEncryptedVaultTested: time != null,
@@ -338,7 +338,7 @@ class WalletRepository {
       throw WalletError.notFound(walletId);
     }
 
-    await _walletMetadataDatasource.store(
+    await _walletMetadataDatasource.update(
       metadata.copyWith(
         isEncryptedVaultTested: isEncryptedVaultTested,
         isPhysicalBackupTested: isPhysicalBackupTested,
@@ -423,7 +423,7 @@ class WalletRepository {
 
     final updatedWalletMetadata = metadata.copyWith(syncedAt: DateTime.now());
 
-    await _walletMetadataDatasource.store(updatedWalletMetadata);
+    await _walletMetadataDatasource.update(updatedWalletMetadata);
   }
 
   Future<BalanceModel> _getBalance(

--- a/lib/core/wallet/wallet_metadata_service.dart
+++ b/lib/core/wallet/wallet_metadata_service.dart
@@ -149,7 +149,7 @@ class WalletMetadataService {
 
     return WalletMetadataModel(
       id: encodeOrigin(
-        fingerprint: seed.masterFingerprint,
+        fingerprint: xpub.fingerprintHex,
         network: network,
         scriptType: scriptType,
       ),
@@ -225,17 +225,16 @@ class WalletMetadataService {
   ) async {
     return WalletMetadataModel(
       id: WalletMetadataService.encodeOrigin(
-        fingerprint: entity.masterFingerprint,
+        fingerprint: entity.pubkeyFingerprint,
         network: entity.network,
         scriptType: entity.scriptType,
       ),
       masterFingerprint: entity.masterFingerprint,
       xpubFingerprint: entity.pubkeyFingerprint,
       signer: Signer.fromEntity(entity.signer),
-      signerDevice:
-          entity.signerDevice != null
-              ? SignerDevice.fromEntity(entity.signerDevice!)
-              : null,
+      signerDevice: entity.signerDevice != null
+          ? SignerDevice.fromEntity(entity.signerDevice!)
+          : null,
       xpub: entity.pubkey,
       externalPublicDescriptor: entity.descriptor.external,
       internalPublicDescriptor: entity.descriptor.internal,

--- a/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
@@ -33,90 +33,90 @@ class WalletDetailsScreen extends StatelessWidget {
         actions: [
           if (wallet != null && wallet.isDefault == false)
             IconButton(
-              onPressed:
-                  isDeletingWallet
-                      ? null
-                      : () => BlurredDialog.show(
-                        context: context,
-                        builder: (_) =>
-                                WalletDeletionConfirmationAlertDialog(
-                                  walletId: wallet.id,
-                                ),
+              onPressed: isDeletingWallet
+                  ? null
+                  : () => BlurredDialog.show(
+                      context: context,
+                      builder: (_) => WalletDeletionConfirmationAlertDialog(
+                        walletId: wallet.id,
                       ),
+                    ),
               icon: const Icon(CupertinoIcons.delete),
             ),
         ],
       ),
       body: SafeArea(
-        child:
-            isDeletingWallet
-                ? Center(
-                  child: Column(
-                    mainAxisAlignment: .center,
-                    children: [
-                      const CircularProgressIndicator(),
-                      const Gap(16),
-                      BBText(
-                        context.loc.walletDetailsDeletingMessage,
-                        style: context.font.bodyMedium?.copyWith(
-                          color: context.appColors.textMuted,
-                        ),
-                      ),
-                    ],
-                  ),
-                )
-                : wallet == null
-                ? Center(child: Text(context.loc.walletDeletionErrorWalletNotFound))
-                : ListView(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 24,
-                  ),
+        child: isDeletingWallet
+            ? Center(
+                child: Column(
+                  mainAxisAlignment: .center,
                   children: [
-                    _InfoField(
-                      label: context.loc.walletDetailsWalletFingerprintLabel,
-                      value: wallet.masterFingerprint,
-                    ),
-                    const SizedBox(height: 18),
-                    _CopyField(
-                      label: context.loc.walletDetailsPubkeyLabel,
-                      value: wallet.xpub,
-                      copyLabel: context.loc.walletDetailsCopyButton,
-                    ),
-                    const SizedBox(height: 18),
-                    _CopyField(
-                      label: context.loc.walletDetailsDescriptorLabel,
-                      value: wallet.externalPublicDescriptor,
-                      copyLabel: context.loc.walletDetailsCopyButton,
-                    ),
-                    const SizedBox(height: 18),
-                    _InfoField(
-                      label: context.loc.walletDetailsAddressTypeLabel,
-                      value: wallet.addressType,
-                    ),
-                    const SizedBox(height: 18),
-                    _InfoField(
-                      label: context.loc.walletDetailsNetworkLabel,
-                      value: wallet.networkString,
-                    ),
-                    const SizedBox(height: 18),
-                    _InfoField(
-                      label: context.loc.walletDetailsDerivationPathLabel,
-                      value: wallet.derivationPath,
-                    ),
-                    const SizedBox(height: 18),
-                    _InfoField(
-                      label: context.loc.walletDetailsSignerLabel,
-                      value: wallet.signer.displayName,
-                    ),
-                    const SizedBox(height: 18),
-                    _InfoField(
-                      label: context.loc.walletDetailsSignerDeviceLabel,
-                      value: wallet.signerDevice?.displayName ??
-                          context.loc.walletDetailsSignerDeviceNotSupported,
+                    const CircularProgressIndicator(),
+                    const Gap(16),
+                    BBText(
+                      context.loc.walletDetailsDeletingMessage,
+                      style: context.font.bodyMedium?.copyWith(
+                        color: context.appColors.textMuted,
+                      ),
                     ),
                   ],
                 ),
+              )
+            : wallet == null
+            ? Center(child: Text(context.loc.walletDeletionErrorWalletNotFound))
+            : ListView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 24,
+                ),
+                children: [
+                  _InfoField(
+                    label: context.loc.walletDetailsWalletFingerprintLabel,
+                    value: wallet.masterFingerprint.isEmpty
+                        ? wallet.xpubFingerprint
+                        : wallet.masterFingerprint,
+                  ),
+                  const SizedBox(height: 18),
+                  _CopyField(
+                    label: context.loc.walletDetailsPubkeyLabel,
+                    value: wallet.xpub,
+                    copyLabel: context.loc.walletDetailsCopyButton,
+                  ),
+                  const SizedBox(height: 18),
+                  _CopyField(
+                    label: context.loc.walletDetailsDescriptorLabel,
+                    value: wallet.externalPublicDescriptor,
+                    copyLabel: context.loc.walletDetailsCopyButton,
+                  ),
+                  const SizedBox(height: 18),
+                  _InfoField(
+                    label: context.loc.walletDetailsAddressTypeLabel,
+                    value: wallet.addressType,
+                  ),
+                  const SizedBox(height: 18),
+                  _InfoField(
+                    label: context.loc.walletDetailsNetworkLabel,
+                    value: wallet.networkString,
+                  ),
+                  const SizedBox(height: 18),
+                  _InfoField(
+                    label: context.loc.walletDetailsDerivationPathLabel,
+                    value: wallet.derivationPath,
+                  ),
+                  const SizedBox(height: 18),
+                  _InfoField(
+                    label: context.loc.walletDetailsSignerLabel,
+                    value: wallet.signer.displayName,
+                  ),
+                  const SizedBox(height: 18),
+                  _InfoField(
+                    label: context.loc.walletDetailsSignerDeviceLabel,
+                    value:
+                        wallet.signerDevice?.displayName ??
+                        context.loc.walletDetailsSignerDeviceNotSupported,
+                  ),
+                ],
+              ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Fixes four bugs in #1940 where importing the same key material via different paths (mnemonic, descriptor, bare xpub) produced inconsistent results, including silent data loss when imports collided with an existing wallet.

## Bugs closed

| # | Symptom |
|---|---|
| 1 | Importing the descriptor of an already-imported mnemonic wallet silently overwrites it (signing capability  lost). |
| 2 | Importing the bare xpub of the same wallet creates a brand-new wallet instead of being detected as a  duplicate. |
| 3 | xpub-imported wallet shows an empty Wallet fingerprint field in Wallet Details. |
| 4 | Re-importing the synthesized descriptor of an xpub-imported wallet silently overwrites it. |

## Root causes
1. **Wallet identity diverged across import paths.** The [mnemonic](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/wallet_metadata_service.dart#L152) and [descriptor](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/wallet_metadata_service.dart#L228) paths computed the wallet ID from the BIP32 master fingerprint; the xpub path used the [account-level xpub fingerprint ](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/wallet_metadata_service.dart#L205)(the only one derivable from a bare xpub). So the same key material landed at different wallet IDs depending on import method.

2. **Dedup guard ignored non-default wallets.** Both watch-only imports called `getWallets(onlyDefaults: true)` ([here](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/data/repositories/wallet_repository.dart#L132) and [here](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/data/repositories/wallet_repository.dart#L177)), which only returns wallets with `isDefault == true`. User imports are `isDefault: false` ([here](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/import_mnemonic/domain/import_wallet_usecase.dart#L57)), so the guard never saw them.

3. **Storage was silent upsert.** `WalletMetadataDatasource.store` used Drift's [insertOnConflictUpdate](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart#L13), which silently overwrites on PK collision.

4. **Fingerprint UI read only [masterFingerprint](https://github.com/SatoshiPortal/bullbitcoin-mobile/blob/develop/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart#L78).** For xpub-only imports that field is intentionally empty (a bare xpub has no derivable master fingerprint), and the display had no fallback.

## Fixes
- **`wallet_metadata_service.dart`**: [deriveFromSeed](http://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/wallet_metadata_service.dart#L152)`and [fromDescriptor](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/wallet_metadata_service.dart#L228) now use the account-level xpub fingerprint for the wallet ID (matching what [deriveFromXpub](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/wallet_metadata_service.dart#L205) already did). All three paths now produce the same ID for the same key material.

- **`wallet_repository.dart`** — Drop the `onlyDefaults: true` filter from the dedup check in [importDescriptor](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/data/repositories/wallet_repository.dart#L131) and [importWatchOnlyXpub](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/data/repositories/wallet_repository.dart#L177) so the guard scans every wallet.

- **`wallet_metadata_datasource.dart`** — Split `store` into [create](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart#L9) (plain `insert`, throws on PK collision) and [update](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart#L14) (keeps existing `insertOnConflictUpdate` for legitimate metadata edits). Updated all six callers to use the appropriate method in wallet repository.

- **wallet_details_screen.dart** — Fall back to [xpubFingerprint](https://github.com/anipy1/bullbitcoin-mobile/blob/watch-only-wallet-bug/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart#L76) in the Wallet fingerprint field when masterFingerprint is empty.

## Migration note
Existing wallet rows in users' databases retain their old \`masterFingerprint\`-style IDs as frozen primary keys; lookups, deletes, and sync all continue to work because every consumer reads the stored ID rather than recomputing it. The new ID scheme applies only to newly-created wallets. No migration script required.

The one edge case: if a user re-imports (via descriptor or xpub) a wallet they imported pre-merge under the old ID scheme, the dedup guard won't fire because the new ID won't match the old stored ID. This affects at most one duplicate per user per pre-existing wallet and is a one-way edge case.

Closes #1940 