### PR TITLE
fix(sync): keep pull-to-refresh spinner until all chains sync

### DIFF
--- a/lib/core/sync/sync_coordinator.dart
+++ b/lib/core/sync/sync_coordinator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:bb_mobile/core/sync/sync_kind.dart';
+import 'package:bb_mobile/core/sync/sync_trigger.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/restart_swap_watcher_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -26,8 +27,9 @@ import 'package:flutter/widgets.dart'
 ///    sync that was gated off while away (tracked via a single "was away since
 ///    last resumed" flag, independent of the exact intermediate state path);
 ///  - per-kind successes are throttled: a kind that completed within
-///    [_minSyncInterval] is skipped on the next enqueue unless the caller
-///    passes `force: true` (pull-to-refresh and other explicit gestures).
+///    [_minSyncInterval] is skipped on the next enqueue for an
+///    [SyncTrigger.automatic] request; [SyncTrigger.user] requests
+///    (pull-to-refresh and other explicit gestures) bypass the throttle.
 ///
 /// Background tasks (`lib/core/background_tasks/handler.dart`) intentionally
 /// do **not** use this coordinator — they run in a separate Dart isolate with
@@ -46,14 +48,15 @@ class SyncCoordinator {
     // the brief startup window before the first lifecycle event arrives
     // (lifecycleState is null then) so the cold-start sync isn't gated off.
     _isAppResumed =
-        lifecycleState == null ||
-        lifecycleState == AppLifecycleState.resumed;
-    _lifecycleListener = AppLifecycleListener(onStateChange: _onLifecycleChange);
+        lifecycleState == null || lifecycleState == AppLifecycleState.resumed;
+    _lifecycleListener = AppLifecycleListener(
+      onStateChange: _onLifecycleChange,
+    );
   }
 
   /// Minimum time between successful syncs of the same kind. A second
   /// `sync()` call within this window is a no-op for that kind unless the
-  /// caller passes `force: true`.
+  /// caller passes [SyncTrigger.user].
   static const Duration _minSyncInterval = Duration(seconds: 2);
 
   final GetWalletsUsecase _getWallets;
@@ -73,40 +76,63 @@ class SyncCoordinator {
   final Set<SyncKind> _enqueued = <SyncKind>{};
   SyncKind? _running;
   bool _draining = false;
-  Future<Map<SyncKind, Object>>? _activeDrain;
-  final Map<SyncKind, Object> _lastErrors = <SyncKind, Object>{};
+  Future<void>? _activeDrain;
   final Map<SyncKind, DateTime> _lastSuccessAt = <SyncKind, DateTime>{};
 
-  /// Schedule `kinds` (or all kinds when `only` is null) and resolve once the
-  /// queue has drained. Iteration order follows the [SyncKind] enum
-  /// declaration (bitcoin → liquid → swaps) regardless of how callers
-  /// constructed `only`.
+  /// Per-kind waiters. A [sync] call registers a completer for each kind it
+  /// enqueues (or that is already pending) and awaits exactly those, so it
+  /// resolves when *its* kinds settle — independent of which drain ran them.
+  /// Each completer carries the kind's error (or null on success) as its
+  /// value, never via [Completer.completeError].
+  final Map<SyncKind, List<Completer<Object?>>> _waiters =
+      <SyncKind, List<Completer<Object?>>>{};
+
+  /// Schedule `kinds` (or all kinds when `only` is null) and resolve once
+  /// every requested kind that actually runs has settled. Resolution tracks
+  /// this call's own kinds (via per-kind completers), so it is correct even
+  /// when those kinds are drained by a pass another caller started. Execution
+  /// order follows the [SyncKind] enum declaration (bitcoin → liquid → swaps).
   ///
-  /// Pass `force: true` to bypass the per-kind throttle — reserved for
+  /// Pass [SyncTrigger.user] to bypass the per-kind throttle — reserved for
   /// explicit user gestures (pull-to-refresh). Default callers (route-aware
-  /// triggers, lifecycle resumption) should leave `force` at `false`.
+  /// triggers, lifecycle resumption) use [SyncTrigger.automatic].
   ///
   /// Returns immediately if the app is not foreground-resumed or every
   /// requested kind was deduped/throttled. Throws [SyncCoordinatorException]
   /// when any requested kind failed during the drain pass that satisfied this
   /// call.
-  Future<void> sync({Set<SyncKind>? only, bool force = false}) async {
+  Future<void> sync({
+    Set<SyncKind>? only,
+    SyncTrigger trigger = SyncTrigger.automatic,
+  }) async {
     final requested = SyncKind.values
         .where((k) => only?.contains(k) ?? true)
         .toList(growable: false);
     final started = DateTime.now();
     final dropped = <String>[];
+    final waits = <SyncKind, Future<Object?>>{};
     for (final kind in requested) {
-      final reason = _enqueue(kind, force: force);
-      if (reason != null) dropped.add('${kind.name}:$reason');
+      final reason = _enqueue(kind, trigger: trigger);
+      if (reason == null || reason == 'pending') {
+        // Will run now, or is already running/queued — wait for it to settle.
+        final completer = Completer<Object?>();
+        (_waiters[kind] ??= <Completer<Object?>>[]).add(completer);
+        waits[kind] = completer.future;
+      } else {
+        // 'gated' or 'throttled': this kind won't run, so don't await it.
+        dropped.add('${kind.name}:$reason');
+      }
     }
     if (dropped.isNotEmpty) {
       log.info('[SyncCoordinator] sync dropped (${dropped.join(', ')})');
     }
-    final settledErrors = await _drain();
+    unawaited(_drain());
+    final settled = await Future.wait(
+      waits.entries.map((e) async => MapEntry(e.key, await e.value)),
+    );
     final failures = <SyncKind, Object>{
-      for (final kind in requested)
-        if (settledErrors[kind] != null) kind: settledErrors[kind]!,
+      for (final entry in settled)
+        if (entry.value != null) entry.key: entry.value!,
     };
     final elapsedMs = DateTime.now().difference(started).inMilliseconds;
     final kinds = requested.map((k) => k.name).join(', ');
@@ -130,12 +156,11 @@ class SyncCoordinator {
   /// Returns null when the kind was enqueued, or a short reason it was dropped:
   /// 'gated' (app not resumed), 'throttled' (synced within [_minSyncInterval]),
   /// or 'pending' (already running or queued).
-  String? _enqueue(SyncKind kind, {required bool force}) {
+  String? _enqueue(SyncKind kind, {required SyncTrigger trigger}) {
     if (!_isAppResumed) return 'gated';
-    if (!force) {
+    if (trigger == SyncTrigger.automatic) {
       final last = _lastSuccessAt[kind];
-      if (last != null &&
-          DateTime.now().difference(last) < _minSyncInterval) {
+      if (last != null && DateTime.now().difference(last) < _minSyncInterval) {
         return 'throttled';
       }
     }
@@ -145,7 +170,7 @@ class SyncCoordinator {
     return null;
   }
 
-  Future<Map<SyncKind, Object>> _drain() {
+  Future<void> _drain() {
     final inFlight = _activeDrain;
     if (inFlight != null) return inFlight;
     final future = _drainOnce();
@@ -160,9 +185,8 @@ class SyncCoordinator {
     });
   }
 
-  Future<Map<SyncKind, Object>> _drainOnce() async {
+  Future<void> _drainOnce() async {
     _draining = true;
-    _lastErrors.clear();
     try {
       while (_queue.isNotEmpty) {
         final kind = _queue.removeFirst();
@@ -171,15 +195,28 @@ class SyncCoordinator {
         try {
           await _runTask(kind);
           _lastSuccessAt[kind] = DateTime.now();
+          _settle(kind, null);
         } catch (e) {
-          // Stored for the single sanitized summary logged by sync().
-          _lastErrors[kind] = e;
+          // Delivered to any sync() awaiting this kind; the single sanitized
+          // summary is logged by sync().
+          _settle(kind, e);
+        } finally {
+          _running = null;
         }
-        _running = null;
       }
-      return Map<SyncKind, Object>.of(_lastErrors);
     } finally {
       _draining = false;
+    }
+  }
+
+  /// Completes (and clears) every waiter registered for [kind] with [error]
+  /// (null on success), waking any [sync] call awaiting that kind. The error
+  /// is delivered as the completer's value, so awaiting a waiter never throws.
+  void _settle(SyncKind kind, Object? error) {
+    final waiters = _waiters.remove(kind);
+    if (waiters == null) return;
+    for (final completer in waiters) {
+      if (!completer.isCompleted) completer.complete(error);
     }
   }
 

--- a/lib/core/sync/sync_trigger.dart
+++ b/lib/core/sync/sync_trigger.dart
@@ -1,0 +1,6 @@
+/// Why a sync was requested.
+///
+/// Determines the [SyncCoordinator] throttle policy: [user] gestures
+/// (pull-to-refresh and other explicit actions) bypass the per-kind throttle;
+/// [automatic] triggers (startup, navigation, lifecycle resume) respect it.
+enum SyncTrigger { user, automatic }

--- a/lib/features/coins/ui/screens/coins_screen.dart
+++ b/lib/features/coins/ui/screens/coins_screen.dart
@@ -347,9 +347,8 @@ class _SubHeader extends StatelessWidget {
           label: filter.keychain == KeychainFilter.receive
               ? loc.coinsKeychainReceive
               : loc.coinsKeychainChange,
-          onRemove: () => cubit.applyFilter(
-            filter.copyWith(keychain: KeychainFilter.all),
-          ),
+          onRemove: () =>
+              cubit.applyFilter(filter.copyWith(keychain: KeychainFilter.all)),
         ),
       );
     }
@@ -412,12 +411,10 @@ class _UtxoList extends StatelessWidget {
 
     return BullRefreshIndicator(
       onRefresh: () async {
-        final walletBloc = context.read<WalletBloc>();
-        walletBloc.add(const WalletRefreshed(force: true));
-        // Wait for the chain sync to actually finish (same pattern as wallet
-        // detail) so the pull-to-refresh spinner reflects the real sync, not
-        // just the near-instant local reload.
-        await walletBloc.stream.firstWhere((s) => !s.isRefreshing);
+        // Wait for the chain sync (bitcoin + liquid + swaps) to actually
+        // finish before reloading local UTXOs, so the spinner reflects the
+        // real sync rather than the near-instant local reload.
+        await context.read<WalletBloc>().refresh();
         await cubit.refresh();
       },
       child: ListView.builder(
@@ -445,11 +442,7 @@ class _UtxoList extends StatelessWidget {
     );
   }
 
-  Future<void> _onSwipe(
-    BuildContext context,
-    bool isFrozen,
-    String key,
-  ) async {
+  Future<void> _onSwipe(BuildContext context, bool isFrozen, String key) async {
     final cubit = context.read<CoinsCubit>();
     if (isFrozen) {
       final ok = await cubit.unfreeze([key]);
@@ -579,11 +572,7 @@ class _FilteredEmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            BullIcon(
-              BullIcons.filterAltOff,
-              size: 40,
-              color: colors.textMuted,
-            ),
+            BullIcon(BullIcons.filterAltOff, size: 40, color: colors.textMuted),
             const SizedBox(height: 12),
             Text(
               context.loc.coinsFilteredEmptyTitle,

--- a/lib/features/transactions/ui/screens/transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/transactions_screen.dart
@@ -30,9 +30,8 @@ class TransactionsScreen extends StatelessWidget {
             context.pop();
           },
           actionIcon: Icons.file_download,
-          onAction: () => context.pushNamed(
-            TransactionsRoute.exportTransactions.name,
-          ),
+          onAction: () =>
+              context.pushNamed(TransactionsRoute.exportTransactions.name),
         ),
         backgroundColor: context.appColors.onPrimary,
         elevation: 0,
@@ -50,10 +49,9 @@ class _Screen extends StatelessWidget {
     final err = context.select((TransactionsCubit cubit) => cubit.state.err);
     return BBPullableBody(
       onRefresh: () async {
-        // User gesture — bypass the coordinator throttle.
-        final bloc = context.read<WalletBloc>();
-        bloc.add(const WalletRefreshed(force: true));
-        await bloc.stream.firstWhere((state) => !state.isRefreshing);
+        // Wait for the chain sync (bitcoin + liquid + swaps) to actually
+        // finish before reloading the local tx list.
+        await context.read<WalletBloc>().refresh();
         if (!context.mounted) return;
         await context.read<TransactionsCubit>().loadTxs();
       },

--- a/lib/features/wallet/presentation/bloc/wallet_bloc.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_bloc.dart
@@ -14,6 +14,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/ensure_swap_master_key_usec
 import 'package:bb_mobile/core/swaps/domain/usecases/get_auto_swap_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/save_auto_swap_settings_usecase.dart';
 import 'package:bb_mobile/core/sync/sync_coordinator.dart';
+import 'package:bb_mobile/core/sync/sync_trigger.dart';
 import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
 import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
@@ -192,6 +193,28 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     }
   }
 
+  /// Pull-to-refresh entry point for the UI. Dispatches a user-triggered
+  /// refresh (so the data reload and `isRefreshing` transitions still happen)
+  /// and awaits the [SyncCoordinator] directly, so the returned future — and
+  /// therefore the RefreshIndicator spinner — resolves only once bitcoin,
+  /// liquid and swaps have all synced, rather than tracking the shared
+  /// `isRefreshing` flag (which a throttled background refresh can clear after
+  /// bitcoin alone). Awaiting the coordinator also bypasses the `droppable()`
+  /// event lane, so the gesture is never swallowed by an in-flight background
+  /// refresh.
+  ///
+  /// Never throws: a failed sync is already surfaced through [WalletState] by
+  /// [_onRefreshed] and logged (sanitized) by the coordinator, and a
+  /// RefreshIndicator callback must not complete with an error.
+  Future<void> refresh() async {
+    add(const WalletRefreshed(trigger: SyncTrigger.user));
+    try {
+      await _syncCoordinator.sync(trigger: SyncTrigger.user);
+    } catch (e) {
+      log.fine('[WalletBloc] pull-to-refresh sync failed: ${e.runtimeType}');
+    }
+  }
+
   Future<void> _onRefreshed(
     WalletRefreshed event,
     Emitter<WalletState> emit,
@@ -199,10 +222,10 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     emit(state.copyWith(isRefreshing: true));
     try {
       // SyncCoordinator schedules bitcoin → liquid → swaps sequentially with
-      // per-kind dedup, throttling, and a lifecycle gate. `event.force`
-      // bypasses the throttle for explicit user gestures (pull-to-refresh);
-      // route-driven navigation triggers leave it at `false`.
-      await _syncCoordinator.sync(force: event.force);
+      // per-kind dedup, throttling, and a lifecycle gate. A user-triggered
+      // refresh (pull-to-refresh) bypasses the throttle; route-driven
+      // navigation triggers use SyncTrigger.automatic.
+      await _syncCoordinator.sync(trigger: event.trigger);
 
       final wallets = await _getWalletsUsecase.execute();
       final syncStatus = {for (final wallet in wallets) wallet.id: false};

--- a/lib/features/wallet/presentation/bloc/wallet_event.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_event.dart
@@ -9,14 +9,14 @@ class WalletStarted extends WalletEvent {
 }
 
 class WalletRefreshed extends WalletEvent {
-  const WalletRefreshed({this.force = false});
+  const WalletRefreshed({this.trigger = SyncTrigger.automatic});
 
-  /// When `true`, bypasses the [SyncCoordinator] per-kind throttle. Reserved
-  /// for explicit user gestures such as pull-to-refresh. Default callers
-  /// (route-aware navigation triggers, environment changes, post-startup)
-  /// leave this `false` so back-pop-to-home doesn't burn the network on
-  /// every navigation.
-  final bool force;
+  /// Why the refresh was requested. [SyncTrigger.user] (pull-to-refresh and
+  /// other explicit gestures) bypasses the [SyncCoordinator] per-kind
+  /// throttle; [SyncTrigger.automatic] (route-aware navigation triggers,
+  /// environment changes, post-startup, post-delete) respects it so
+  /// back-pop-to-home doesn't burn the network on every navigation.
+  final SyncTrigger trigger;
 }
 
 class WalletSyncStarted extends WalletEvent {

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -62,12 +62,7 @@ class WalletDetailScreen extends StatelessWidget {
               create: (_) =>
                   locator<TransactionsCubit>(param1: walletId)..loadTxs(),
               child: BBPullableBody(
-                onRefresh: () async {
-                  // User gesture — bypass the coordinator throttle.
-                  final bloc = context.read<WalletBloc>();
-                  bloc.add(const WalletRefreshed(force: true));
-                  await bloc.stream.firstWhere((state) => !state.isRefreshing);
-                },
+                onRefresh: () => context.read<WalletBloc>().refresh(),
                 slivers: [
                   SliverToBoxAdapter(
                     child: WalletDetailBalanceCard(
@@ -78,9 +73,7 @@ class WalletDetailScreen extends StatelessWidget {
                   ),
                   if (wallet.isBitcoin) ...[
                     const SliverToBoxAdapter(child: Gap(8)),
-                    SliverToBoxAdapter(
-                      child: _CoinsEntryTile(wallet: wallet),
-                    ),
+                    SliverToBoxAdapter(child: _CoinsEntryTile(wallet: wallet)),
                   ],
                   const SliverToBoxAdapter(child: Gap(16)),
                   const WalletDetailTxsList(sliver: true),

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -132,12 +132,7 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
             ),
             BBPullableBody(
               indicatorKey: _indicatorKey,
-              onRefresh: () async {
-                // User gesture — bypass the coordinator throttle.
-                final bloc = context.read<WalletBloc>();
-                bloc.add(const WalletRefreshed(force: true));
-                await bloc.stream.firstWhere((state) => !state.isRefreshing);
-              },
+              onRefresh: () => context.read<WalletBloc>().refresh(),
               slivers: [
                 const SliverToBoxAdapter(child: WalletHomeTopSection()),
                 const SliverToBoxAdapter(child: HomeWarnings()),

--- a/test/core_test/sync/sync_coordinator_test.dart
+++ b/test/core_test/sync/sync_coordinator_test.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/sync/sync_coordinator.dart';
+import 'package:bb_mobile/core/sync/sync_kind.dart';
+import 'package:bb_mobile/core/sync/sync_trigger.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/restart_swap_watcher_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetWallets extends Mock implements GetWalletsUsecase {}
+
+class _MockSyncWallet extends Mock implements SyncWalletUsecase {}
+
+class _MockRestartSwaps extends Mock implements RestartSwapWatcherUsecase {}
+
+void main() {
+  // SyncCoordinator's constructor reads WidgetsBinding.instance and attaches
+  // an AppLifecycleListener, so the binding must exist.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockGetWallets getWallets;
+  late _MockSyncWallet syncWallet;
+  late _MockRestartSwaps restartSwaps;
+  late SyncCoordinator coordinator;
+
+  setUp(() {
+    getWallets = _MockGetWallets();
+    syncWallet = _MockSyncWallet();
+    restartSwaps = _MockRestartSwaps();
+    coordinator = SyncCoordinator(
+      getWalletsUsecase: getWallets,
+      syncWalletUsecase: syncWallet,
+      restartSwapWatcherUsecase: restartSwaps,
+    );
+  });
+
+  tearDown(() => coordinator.dispose());
+
+  // Each kind's work is gated behind a Completer so the test controls exactly
+  // when bitcoin / liquid / swaps finish. The wallet list is empty, so no real
+  // Wallet needs constructing — the gate alone paces the drain.
+  ({Completer<void> bitcoin, Completer<void> liquid, Completer<void> swaps})
+  wireGates() {
+    final bitcoin = Completer<void>();
+    final liquid = Completer<void>();
+    final swaps = Completer<void>();
+    when(() => getWallets.execute(onlyBitcoin: true)).thenAnswer((_) async {
+      await bitcoin.future;
+      return <Wallet>[];
+    });
+    when(() => getWallets.execute(onlyLiquid: true)).thenAnswer((_) async {
+      await liquid.future;
+      return <Wallet>[];
+    });
+    when(() => restartSwaps.execute()).thenAnswer((_) async {
+      await swaps.future;
+    });
+    return (bitcoin: bitcoin, liquid: liquid, swaps: swaps);
+  }
+
+  test('sync resolves only after every requested kind has settled', () async {
+    final gates = wireGates();
+
+    var done = false;
+    final future = coordinator
+        .sync(trigger: SyncTrigger.user)
+        .then((_) => done = true);
+
+    await pumpEventQueue();
+    expect(done, isFalse, reason: 'bitcoin still in flight');
+
+    gates.bitcoin.complete();
+    await pumpEventQueue();
+    expect(done, isFalse, reason: 'liquid still in flight');
+
+    gates.liquid.complete();
+    await pumpEventQueue();
+    expect(done, isFalse, reason: 'swaps still in flight');
+
+    gates.swaps.complete();
+    await future;
+    expect(done, isTrue);
+  });
+
+  test(
+    'a sync awaits the kinds IT requested even when it joins an in-flight '
+    'drain that is about to finish (regression: spinner stopped after bitcoin)',
+    () async {
+      final gates = wireGates();
+
+      // First caller drains bitcoin only.
+      var firstDone = false;
+      final first = coordinator
+          .sync(only: {SyncKind.bitcoin})
+          .then((_) => firstDone = true);
+      await pumpEventQueue(); // bitcoin now running, gated.
+
+      // Second caller joins while bitcoin is in flight and adds liquid + swaps.
+      var secondDone = false;
+      final second = coordinator
+          .sync(only: {SyncKind.liquid, SyncKind.swaps})
+          .then((_) => secondDone = true);
+
+      gates.bitcoin.complete();
+      await first;
+      expect(firstDone, isTrue, reason: 'first only asked for bitcoin');
+      expect(secondDone, isFalse, reason: 'liquid + swaps still pending');
+
+      gates.liquid.complete();
+      await pumpEventQueue();
+      expect(secondDone, isFalse, reason: 'swaps still in flight');
+
+      gates.swaps.complete();
+      await second;
+      expect(secondDone, isTrue);
+    },
+  );
+
+  test('automatic re-sync within the throttle window is skipped; '
+      'a user sync bypasses it', () async {
+    // No gating: each kind completes immediately so _lastSuccessAt is set.
+    when(
+      () => getWallets.execute(onlyBitcoin: true),
+    ).thenAnswer((_) async => <Wallet>[]);
+    when(
+      () => getWallets.execute(onlyLiquid: true),
+    ).thenAnswer((_) async => <Wallet>[]);
+    when(() => restartSwaps.execute()).thenAnswer((_) async {});
+
+    await coordinator.sync(trigger: SyncTrigger.automatic);
+    // Immediately again (well within the 2s window) — every kind is throttled.
+    await coordinator.sync(trigger: SyncTrigger.automatic);
+
+    verify(() => getWallets.execute(onlyBitcoin: true)).called(1);
+    verify(() => getWallets.execute(onlyLiquid: true)).called(1);
+    verify(() => restartSwaps.execute()).called(1);
+
+    // A user gesture bypasses the throttle and re-runs every kind.
+    await coordinator.sync(trigger: SyncTrigger.user);
+
+    verify(() => getWallets.execute(onlyBitcoin: true)).called(1);
+    verify(() => getWallets.execute(onlyLiquid: true)).called(1);
+    verify(() => restartSwaps.execute()).called(1);
+  });
+}


### PR DESCRIPTION
Spinner released after bitcoin sync, not all kinds: the forced refresh could be dropped by droppable() while a throttled bitcoin-only background refresh ran, and sync() awaited the shared drain rather than its own requested kinds.

sync() now awaits its own kinds via per-kind completers (resolves once they settle regardless of which drain ran them; errors flow through the completers). Replaces the ambiguous `force` bool with SyncTrigger { user, automatic }. Adds WalletBloc.refresh(): awaits the coordinator directly so the spinner tracks real all-kind completion and bypasses the droppable lane; never throws. The 4 pull-to-refresh screens now await it. Adds SyncCoordinator unit tests incl. the join-in-flight regression.

   <table><tr>
   <td>

   https://github.com/user-attachments/assets/7b131754-1680-40cc-8c1c-0355f800fc36

   </td>
   <td>

   https://github.com/user-attachments/assets/665594ed-9906-429a-8a8a-8a32208afaa8

   </td>
   </tr></table>
   

