### PR TITLE
ci(claude): use Fable 5 model and bump checkout to v7

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch full history for branch operations
@@ -45,6 +45,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use Claude Fable 5 — Anthropic's most capable model for review-grade
+          # reasoning. Passed through to the Claude Code CLI via claude_args.
+          claude_args: "--model claude-fable-5"
           # On PR-open the action auto-picks "agent" mode, which runs the prompt
           # but posts nothing. Forcing tag mode gives Claude the GitHub
           # review/comment tools + a tracking comment so the review is posted.


### PR DESCRIPTION
Pass `--model claude-fable-5` via claude_args so the review agent runs on Anthropic's most capable model (claude-code-action@v1 has no dedicated model input; the model is set through the CLI args). Also bump actions/checkout v6 → v7.