### PR TITLE
fix(frb): bump bull_sdk to boltz/lwk v0.5.0, resolving content-hash crash

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,8 +158,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bitbox-transport"
-      ref: db80946aa078f954de08f76e69b57ee047f89505
-      resolved-ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -216,8 +216,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/boltz-stream"
-      ref: db80946aa078f954de08f76e69b57ee047f89505
-      resolved-ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -305,8 +305,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bull_sdk"
-      ref: db80946aa078f954de08f76e69b57ee047f89505
-      resolved-ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "1.0.0+1"
@@ -1755,8 +1755,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/bull_sdk/rust_builder"
-      ref: db80946aa078f954de08f76e69b57ee047f89505
-      resolved-ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
@@ -1772,8 +1772,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/satoshifier"
-      ref: db80946aa078f954de08f76e69b57ee047f89505
-      resolved-ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,17 +54,17 @@ dependencies:
   bull_sdk:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
       path: packages/bull_sdk
   boltz_stream:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
       path: packages/boltz-stream
   bitbox_transport:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
   hex: ^0.2.0
@@ -119,7 +119,7 @@ dependencies:
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: db80946aa078f954de08f76e69b57ee047f89505
+      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
       path: packages/satoshifier
   flutter_nfc_kit: ^3.6.1
   ndef: ^0.4.0


### PR DESCRIPTION
Fixes the startup crash:
> Bad state: Content hash on Dart side (2124457774) is different from Rust side (-330622672), indicating out-of-sync code.

Root cause was a **stale prebuilt native library**: the loaded `.so` was compiled before the last codegen, so its content hash no longer matched the Dart bindings. The bumped `bull_sdk` (`39a964b`) additionally pins boltz and lwk to their reproducible **v0.5.0 tags** instead of moving branches, preventing the drift from recurring.

## Changes
- `pubspec.yaml`: 4 × `bull_sdk` ref `db80946` → `39a964b`
- `pubspec.lock`: relocked accordingly