### PR TITLE
fix(deps): bump bull_sdk to bd4835c for the rustls crypto-provider crash fix

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,8 +158,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bitbox-transport"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -216,8 +216,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/boltz-stream"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -305,8 +305,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bull_sdk"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "1.0.0+1"
@@ -1755,8 +1755,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/bull_sdk/rust_builder"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
@@ -1772,8 +1772,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/satoshifier"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,17 +54,17 @@ dependencies:
   bull_sdk:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       path: packages/bull_sdk
   boltz_stream:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       path: packages/boltz-stream
   bitbox_transport:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
   hex: ^0.2.0
@@ -119,7 +119,7 @@ dependencies:
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
       path: packages/satoshifier
   flutter_nfc_kit: ^3.6.1
   ndef: ^0.4.0


### PR DESCRIPTION

# Crash on first secure connection (SIGABRT) — what happened & how we fixed it

## TL;DR
The app could crash the instant it opened its first encrypted (TLS) connection. It wasn't a bug in any single wallet library — it emerged from **bundling them together**. The fix: make each library pick its encryption backend explicitly before connecting.

## What was happening
On `6.12.0+191`, some sessions crashed immediately (native `SIGABRT`) on the first TLS network call — on both Android and iOS, but **only with developer options enabled**.

## Why it happened (the important part)
The app's Rust core bundles several wallet libraries (Ark, Boltz, LWK…) into one binary. When combined, that binary ended up containing **two different TLS encryption backends** (`ring` and `aws-lc-rs`). With both present, the TLS library (rustls) refuses to guess which to use and **aborts the process** on the first connection — unless the app explicitly picks one at startup.

Two things worth being precise about:
- **This is a property of the combined binary, not of one library.** Each library on its own resolves to a single backend and is fine. The second backend only appears once they're merged (dependency feature-merging pulls it in via the HTTP/electrum stacks). So it isn't "Ark's bug" or "Boltz's bug" — it's the combination.
- **Which connection crashes is a race.** Whichever library connects first decides it. LWK already picks a backend on its connections and usually "wins the race," masking the problem. The crash happens when an *unguarded* path connects first.

In the reported crash, that first path was **Ark's dev-mode health-check** (a status probe that quietly connects to the Ark server when you open Settings). But Boltz's connection path was equally capable of triggering the identical crash — Ark just happened to go first here. Removing Ark would **not** have fixed it.

Nothing in our code regressed. Merging the libraries into one binary is what first put the two backends together; the flaw was latent since `6.11.X` then and only surfaced now, on a dev build, when an unguarded path won the race.

## How we fixed it
Because no single library "owns" the flaw, the fix goes into **each** connecting library: explicitly select the `ring` backend before opening any connection. Nothing left to guess, no race, on any platform:

- **Boltz** — [boltz-dart#55](https://github.com/SatoshiPortal/boltz-dart/pull/55), released as [v0.5.1](https://github.com/SatoshiPortal/boltz-dart/tree/v0.5.1)
- **Ark** — [ark-wallet-dart@52961f9](https://github.com/SatoshiPortal/ark-wallet-dart/commit/52961f968385717ebce440a8cba54681f92e0736)
- **LWK** — already had this guard, no change needed
- **SDK bundle** — [bull_sdk#8](https://github.com/SatoshiPortal/bull_sdk/pull/8) repins Boltz/Ark to the fixed versions
- **App** — bumps bull_sdk to the fixed bundle: [PR to `main`](https://github.com/SatoshiPortal/bullbitcoin-mobile/compare/main...fix/bump-bull-sdk-rustls-crypto-provider?expand=1) *(final step)*

## Technical note (for devs)
In the merged binary, rustls 0.23 has both its `ring` and `aws-lc-rs` provider features enabled — feature unification pulls `aws-lc-rs` in through `electrum-client` and `hyper-rustls`' default backend, while other crates select `ring`. With both on, `CryptoProvider::get_default_or_install_from_crate_features()` returns `None` and the `.expect()` aborts (compounded by `panic = "abort"`). The binary shows no aws-lc symbols only because LTO dead-strips the unused `aws_lc_rs` provider (nothing reachable calls it once auto-detect bails). The fix calls `rustls::crypto::ring::default_provider().install_default()` once per package before its first TLS call, so `get_default()` returns `Some` and auto-detection is never consulted.

This now leads with "it's the combination, not one library," states plainly that Boltz could have triggered it and that removing Ark wouldn't help, and pushes the cargo tree / LTO / feature-unification detail into a short dev-only note so product can stop reading after "Impact." Want it any shorter, or the technical note dropped for a product-only version?