### PR TITLE
ci: split analyze_and_test at the FRB boundary + optimization pass (~13min signal instead of ~33min)

### DIFF
--- a/.github/actions/flutter-setup/action.yml
+++ b/.github/actions/flutter-setup/action.yml
@@ -80,6 +80,7 @@ runs:
           **/*.g.dart
           **/*.freezed.dart
           **/*.mocks.dart
+          !packages/bull_ui_catalogue/lib/main.directories.g.dart
         key: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-${{ github.sha }}
         restore-keys: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-
 

--- a/.github/actions/flutter-setup/action.yml
+++ b/.github/actions/flutter-setup/action.yml
@@ -1,0 +1,71 @@
+# Shared Flutter toolchain setup for the analyze_and_test jobs. Both jobs pay
+# this prefix (checks needs generated code for analyze/tests; integration needs
+# it to build the app), so it lives here to keep the two copies from drifting.
+#
+# Cache notes: keys derive from lockfiles, so they self-invalidate when deps
+# change. When both parallel jobs miss the same key (lockfile just changed),
+# both build and both try to save — the first save wins, the second logs a
+# benign "cache already exists" warning. No restore-keys on the pub cache on
+# purpose: it holds the bull_sdk git clone, and a fuzzy fallback can restore a
+# checkout from an OLDER lock whose pinned commit differs; pub then resolves
+# against that stale clone and `pub get --enforce-lockfile` fails wanting to
+# drop deps. The exact key already pins the commit via pubspec.lock.
+name: Flutter setup
+description: FVM + pub caches, FVM install, deps, build_runner, translations
+
+inputs:
+  cargo-cache:
+    description: Also restore the Cargo cache (only the integration job compiles the FRB native crates)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Flutter SDK (FVM)
+      uses: actions/cache@v6
+      with:
+        path: ~/fvm/versions
+        key: fvm-${{ runner.os }}-${{ hashFiles('.fvmrc') }}
+
+    - name: Cache pub (hosted + git deps)
+      uses: actions/cache@v6
+      with:
+        path: ~/.pub-cache
+        key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+
+    - name: Cache Cargo (FRB native crates)
+      if: ${{ inputs.cargo-cache == 'true' }}
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: cargo-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+        restore-keys: cargo-${{ runner.os }}-
+
+    - name: Install FVM
+      shell: bash
+      run: |
+        curl -fsSL https://fvm.app/install.sh | bash -s -- 4.1.1
+        echo "$HOME/fvm/bin" >> $GITHUB_PATH
+
+    - name: Check Flutter version
+      shell: bash
+      run: make fvm-check
+
+    - name: Get dependencies
+      shell: bash
+      run: make deps
+
+    - name: Generate code (build_runner)
+      shell: bash
+      run: make build-runner
+
+    - name: Generate translations
+      shell: bash
+      run: make translations
+
+    - name: Disk telemetry (for trimming free-disk later)
+      shell: bash
+      run: df -h /

--- a/.github/actions/flutter-setup/action.yml
+++ b/.github/actions/flutter-setup/action.yml
@@ -22,11 +22,15 @@ inputs:
 runs:
   using: composite
   steps:
+    # runner.arch is in the FVM key because the SDK is native binaries — an
+    # x64 SDK restored on an arm64 runner is broken. pub/cargo caches hold
+    # sources only (arch-independent), so they keep os-only keys and stay
+    # shared across arches.
     - name: Cache Flutter SDK (FVM)
       uses: actions/cache@v6
       with:
         path: ~/fvm/versions
-        key: fvm-${{ runner.os }}-${{ hashFiles('.fvmrc') }}
+        key: fvm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.fvmrc') }}
 
     - name: Cache pub (hosted + git deps)
       uses: actions/cache@v6
@@ -57,6 +61,22 @@ runs:
     - name: Get dependencies
       shell: bash
       run: make deps
+
+    # build_runner's incremental cache. The key ends in github.sha so it never
+    # exact-hits and every run saves a fresh snapshot at job end; restore-keys
+    # falls back to the newest cache for the same lockfile, so build_runner
+    # only regenerates outputs whose inputs changed (it hashes inputs itself —
+    # staleness is its own invariant to keep). Arch is in the key defensively:
+    # the build cache holds kernel/asset hashes we don't want shared across
+    # arches. Cross-PR note: PR-saved caches are branch-scoped; the
+    # cache-warmer workflow on develop pushes seeds a base cache all PRs can
+    # restore.
+    - name: Cache build_runner outputs
+      uses: actions/cache@v6
+      with:
+        path: .dart_tool/build
+        key: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-${{ github.sha }}
+        restore-keys: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-
 
     - name: Generate code (build_runner)
       shell: bash

--- a/.github/actions/flutter-setup/action.yml
+++ b/.github/actions/flutter-setup/action.yml
@@ -62,19 +62,24 @@ runs:
       shell: bash
       run: make deps
 
-    # build_runner's incremental cache. The key ends in github.sha so it never
-    # exact-hits and every run saves a fresh snapshot at job end; restore-keys
-    # falls back to the newest cache for the same lockfile, so build_runner
-    # only regenerates outputs whose inputs changed (it hashes inputs itself —
-    # staleness is its own invariant to keep). Arch is in the key defensively:
-    # the build cache holds kernel/asset hashes we don't want shared across
-    # arches. Cross-PR note: PR-saved caches are branch-scoped; the
-    # cache-warmer workflow on develop pushes seeds a base cache all PRs can
-    # restore.
-    - name: Cache build_runner outputs
-      uses: actions/cache@v6
+    # build_runner's incremental cache — RESTORE ONLY. PR jobs never save (a
+    # sha-keyed save per push would blow the 10GB repo cache quota and evict
+    # the FVM/pub/cargo caches); only the cache-warmer workflow saves, on
+    # develop pushes, so all PRs restore develop's latest warm snapshot.
+    # Generated source files are cached alongside .dart_tool/build so the
+    # restored state is self-consistent (outputs present + asset graph
+    # present); build_runner hashes inputs itself and regenerates what
+    # changed. Arch is in the key defensively: the build cache holds
+    # kernel/asset hashes we don't want shared across arches. Keep path + key
+    # in sync with the save step in cache-warmer.yml.
+    - name: Restore build_runner cache
+      uses: actions/cache/restore@v6
       with:
-        path: .dart_tool/build
+        path: |
+          .dart_tool/build
+          **/*.g.dart
+          **/*.freezed.dart
+          **/*.mocks.dart
         key: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-${{ github.sha }}
         restore-keys: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-
 

--- a/.github/workflows/analyze_and_test.yml
+++ b/.github/workflows/analyze_and_test.yml
@@ -134,6 +134,20 @@ jobs:
           sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache /usr/share/dotnet /opt/ghc || true
           df -h /
 
+      # cargokit builds the FRB crates via `rustup run stable cargo`; the
+      # leaner arm64 partner image may lack rustup (the x64 image ships it).
+      # Idempotent: installs rustup if absent, then ensures the stable
+      # toolchain exists either way (newer rustup does not auto-install
+      # toolchains on `rustup run`).
+      - name: Ensure rustup + stable toolchain
+        run: |
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          else
+            rustup toolchain install stable --profile minimal
+          fi
+
       - name: Flutter setup
         uses: ./.github/actions/flutter-setup
         with:
@@ -174,6 +188,11 @@ jobs:
           TEST_BOB_MNEMONIC: ${{ secrets.ENV_TEST_BOB_MNEMONIC }}
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
+          # sccache cannot cache incremental compilation artifacts; disabling
+          # incremental makes every rustc invocation cacheable (and is the
+          # standard sccache-in-CI pairing — CI never reuses incremental state
+          # anyway).
+          CARGO_INCREMENTAL: "0"
         run: |
           xvfb-run -a dbus-run-session -- bash -c '
             echo "" | gnome-keyring-daemon --unlock --daemonize --components=secrets

--- a/.github/workflows/analyze_and_test.yml
+++ b/.github/workflows/analyze_and_test.yml
@@ -10,24 +10,33 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on the same PR — this build is heavy (Rust FRB crates +
-# Flutter SDK + Linux GTK app + integration tests), so don't run stale commits to
-# completion when newer ones are pushed.
+# Cancel superseded runs on the same PR — these builds are heavy (Rust FRB
+# crates + Flutter SDK + Linux GTK app + integration tests), so don't run stale
+# commits to completion when newer ones are pushed.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Two independent jobs split at the FRB boundary. `checks` (analyze + fix +
+# format + unit tests) never compiles the Rust FRB crates — unit tests run on
+# the Dart VM against the bindings' Dart side only — so it reports in ~11min.
+# `integration` builds and launches the real Linux GTK app (Rust + GTK), the
+# ~28min long pole, in parallel. Both pay the same setup prefix (composite
+# action below); build_runner (~6.5min) dominates it — caching its output is
+# the known follow-up. Neither job `needs:` the other on purpose: the split
+# exists so the fast signal never waits for the slow one.
 jobs:
-  analyze_and_test:
+  checks:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      # The job builds the FRB Rust crates, the Flutter SDK toolchain, the
-      # Linux desktop app and runs integration tests on one runner; the stock
-      # ubuntu-24.04 image fills up and the runner dies with "No space left on
-      # device". Reclaim the unused pre-installed toolchains first.
+      # Kept in v1 for safety (FVM SDK + pub cache + build_runner output on a
+      # stock runner is probably fine, but not proven). The setup action logs
+      # `df -h` — once a few runs show comfortable headroom, drop this step
+      # here (NOT in integration, which genuinely needs the space).
       - name: Free disk space
         # Pinned to a commit SHA (not the mutable v1.3.1 tag): third-party action
         # on a runner that can hold PR test secrets — a retag must not run here.
@@ -40,55 +49,24 @@ jobs:
           large-packages: true
           swap-storage: false
 
-      # Caches below are restored before any toolchain step that uses
-      # them, so the SDK download / pub resolve / crate fetch on a cold
-      # runner only pays out on a cache miss. The pub cache also holds the
-      # bull_sdk git clone; the Cargo cache holds its transitive crates.io
-      # deps. All three keys derive from lockfiles, so they self-invalidate
-      # when deps change. pubspec.lock pins the bull_sdk commit, so it is
-      # the right key for the Cargo cache (there is no repo-root Cargo.lock).
-      - name: Cache Flutter SDK (FVM)
-        uses: actions/cache@v6
-        with:
-          path: ~/fvm/versions
-          key: fvm-${{ runner.os }}-${{ hashFiles('.fvmrc') }}
+      # The gates below reference steps.setup.outcome — if this `id` is ever
+      # renamed, the expression silently evaluates to '' and every check
+      # SKIPS (job goes green with nothing run). Keep id and gates in sync.
+      - name: Flutter setup
+        id: setup
+        uses: ./.github/actions/flutter-setup
 
-      # No restore-keys here on purpose: the pub cache holds the bull_sdk git
-      # clone, and a fuzzy fallback can restore a checkout from an OLDER lock
-      # whose pinned commit differs. pub then resolves against that stale clone,
-      # so `pub get --enforce-lockfile` sees deps the committed lock doesn't (it
-      # fails wanting to drop them). The exact key already pins the commit via
-      # pubspec.lock, so an unchanged lock still hits; a changed lock does one
-      # clean fetch and re-caches.
-      - name: Cache pub (hosted + git deps)
-        uses: actions/cache@v6
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-
-      - name: Cache Cargo (FRB native crates)
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
-
-      - name: Install FVM
-        run: |
-          curl -fsSL https://fvm.app/install.sh | bash -s -- 4.1.1
-          echo "$HOME/fvm/bin" >> $GITHUB_PATH
-
-      - run: make fvm-check
-      - run: make deps
-      - run: make build-runner
-      - run: make translations
-
+      # The four static checks are gated on `!cancelled()` + setup success
+      # instead of the implicit success(): one CI run surfaces ALL static
+      # failures instead of stopping at the first (they're independent and
+      # cheap, ~1.5min combined). `!cancelled()` (not `always()`) so a
+      # superseded run cancelled by the concurrency group stops immediately.
       - name: Linter shouldn't raise errors, warnings or infos
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: make analyze
 
       - name: bull_ui import boundary (coins/ui imports only package:bull_ui)
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: |
           if grep -rEl "package:flutter/(material|cupertino|widgets)\.dart" lib/features/coins/ui; then
             echo "lib/features/coins/ui must import only package:bull_ui/bull_ui.dart, not Flutter UI directly"
@@ -96,6 +74,7 @@ jobs:
           fi
 
       - name: dart fix should have nothing to suggest
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: |
           output=$(fvm dart fix --dry-run)
           echo "$output"
@@ -113,11 +92,42 @@ jobs:
       # `bash -e`, no pipefail): if `git ls-files` or `grep` errored, `xargs -r`
       # would no-op and exit 0, silently passing the gate. pipefail closes that.
       - name: dart format should have nothing to change
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
         run: git ls-files '*.dart' | grep -vE '\.(g|freezed|gr|config|mocks|steps)\.dart$|/generated/' | xargs -r fvm dart format --output=none --set-exit-if-changed
 
+      # Default success() gate on purpose: if any static check above is red,
+      # skip the tests — the PR needs another push anyway.
       - name: Unit tests must pass
         run: make unit-test
+
+  integration:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # This job builds the FRB Rust crates, the Flutter SDK toolchain and the
+      # Linux desktop app on one runner; the stock ubuntu-24.04 image fills up
+      # and the runner dies with "No space left on device". Reclaim the unused
+      # pre-installed toolchains first.
+      - name: Free disk space
+        # Pinned to a commit SHA (not the mutable v1.3.1 tag): third-party action
+        # on a runner that can hold PR test secrets — a retag must not run here.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
+      - name: Flutter setup
+        uses: ./.github/actions/flutter-setup
+        with:
+          cargo-cache: 'true'
 
       - name: Install Linux desktop for integration tests
         run: |

--- a/.github/workflows/analyze_and_test.yml
+++ b/.github/workflows/analyze_and_test.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
       - develop
+    # Docs-only PRs skip both jobs entirely. Safe because develop has no
+    # required status checks (verified via the API) — a skipped run can't
+    # strand a PR on "Expected — waiting". If checks are ever made required,
+    # this needs the paths-filter + always-green sentinel pattern instead.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.git-blame-ignore-revs'
+      - '.github/ISSUE_TEMPLATE/**'
 
 # Checkout + tests only; no writes to the repo via the token.
 permissions:
@@ -33,10 +44,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      # Kept in v1 for safety (FVM SDK + pub cache + build_runner output on a
-      # stock runner is probably fine, but not proven). The setup action logs
-      # `df -h` — once a few runs show comfortable headroom, drop this step
-      # here (NOT in integration, which genuinely needs the space).
+      # Kept deliberately: a local .dart_tool can reach 16GB and a stock x64
+      # runner has ~21GB free, so dropping this risks turning every PR red on
+      # "No space left on device". The setup action logs `df -h` — only drop
+      # this once a few runs prove comfortable headroom.
       - name: Free disk space
         # Pinned to a commit SHA (not the mutable v1.3.1 tag): third-party action
         # on a runner that can hold PR test secrets — a retag must not run here.
@@ -102,32 +113,39 @@ jobs:
         run: make unit-test
 
   integration:
-    runs-on: ubuntu-24.04
+    # arm64: free 4-vCPU runners for public repos, native arm execution — the
+    # Rust FRB compile is exactly the workload that benefits. If this arch
+    # surfaces a toolchain wart, revert this job to ubuntu-24.04 + the
+    # jlumbroso free-disk-space step (see checks job) in one commit.
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
       # This job builds the FRB Rust crates, the Flutter SDK toolchain and the
-      # Linux desktop app on one runner; the stock ubuntu-24.04 image fills up
-      # and the runner dies with "No space left on device". Reclaim the unused
-      # pre-installed toolchains first.
-      - name: Free disk space
-        # Pinned to a commit SHA (not the mutable v1.3.1 tag): third-party action
-        # on a runner that can hold PR test secrets — a retag must not run here.
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: false
+      # Linux desktop app on one runner. The arm64 partner image is leaner
+      # than x64 (more free space, and the x64-oriented free-disk-space action
+      # doesn't apply), so reclaim the few big preinstalled dirs inline;
+      # `|| true` because they may not exist on this image. The setup action
+      # logs `df -h` to confirm headroom.
+      - name: Free disk space (inline, arch-agnostic)
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache /usr/share/dotnet /opt/ghc || true
+          df -h /
 
       - name: Flutter setup
         uses: ./.github/actions/flutter-setup
         with:
           cargo-cache: 'true'
+
+      # Compiler cache for the FRB Rust crates (the dominant cost of the app
+      # build), backed by the GitHub Actions cache. Pinned to a commit SHA:
+      # third-party action on a runner that holds PR test secrets.
+      # RUSTC_WRAPPER is exported at the test step below; cargokit's cargo
+      # inherits it from the environment.
+      - name: Setup sccache
+        uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install Linux desktop for integration tests
         run: |
@@ -154,6 +172,8 @@ jobs:
         env:
           TEST_ALICE_MNEMONIC: ${{ secrets.ENV_TEST_ALICE_MNEMONIC }}
           TEST_BOB_MNEMONIC: ${{ secrets.ENV_TEST_BOB_MNEMONIC }}
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
         run: |
           xvfb-run -a dbus-run-session -- bash -c '
             echo "" | gnome-keyring-daemon --unlock --daemonize --components=secrets

--- a/.github/workflows/cache-warmer.yml
+++ b/.github/workflows/cache-warmer.yml
@@ -34,6 +34,9 @@ concurrency:
 jobs:
   warm:
     strategy:
+      # The two arch legs are fully independent seeds — one arch's transient
+      # failure must not cancel the other's warm.
+      fail-fast: false
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runner }}
@@ -78,4 +81,5 @@ jobs:
             **/*.g.dart
             **/*.freezed.dart
             **/*.mocks.dart
+            !packages/bull_ui_catalogue/lib/main.directories.g.dart
           key: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-${{ github.sha }}

--- a/.github/workflows/cache-warmer.yml
+++ b/.github/workflows/cache-warmer.yml
@@ -1,0 +1,59 @@
+name: Cache Warmer
+
+# PR-saved Actions caches are scoped to the PR branch — they are NOT shared
+# between PRs. Caches saved on the base branch ARE visible to every PR
+# targeting it. This workflow runs the shared setup (FVM SDK, pub, build_runner
+# outputs) on each develop push so every fresh PR restores warm caches instead
+# of paying the full ~10min prefix. Matrix over both arches because the
+# analyze_and_test jobs run on x64 (checks) and arm64 (integration), and the
+# FVM + build_runner caches are arch-keyed. The Cargo cache is NOT warmed here:
+# it only fills during an actual Rust build, which this workflow deliberately
+# avoids.
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+# Only the newest develop push matters for cache freshness.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    strategy:
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # x64 stock images are tight on disk once the SDK + pub + build_runner
+      # output land (see the checks job in analyze_and_test.yml); the arm64
+      # partner image is leaner and the action is x64-oriented, so clean up
+      # inline there instead.
+      - name: Free disk space (x64)
+        if: ${{ runner.arch == 'X64' }}
+        # Pinned to a commit SHA (not the mutable v1.3.1 tag): third-party action.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
+      - name: Free disk space (arm64, inline)
+        if: ${{ runner.arch == 'ARM64' }}
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache /usr/share/dotnet /opt/ghc || true
+          df -h /
+
+      - name: Flutter setup
+        uses: ./.github/actions/flutter-setup

--- a/.github/workflows/cache-warmer.yml
+++ b/.github/workflows/cache-warmer.yml
@@ -13,6 +13,15 @@ on:
   push:
     branches:
       - develop
+    # Docs-only merges don't change any cache input — skip the ~2x10min warm.
+    # Keep in sync with the paths-ignore in analyze_and_test.yml.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.git-blame-ignore-revs'
+      - '.github/ISSUE_TEMPLATE/**'
 
 permissions:
   contents: read
@@ -57,3 +66,16 @@ jobs:
 
       - name: Flutter setup
         uses: ./.github/actions/flutter-setup
+
+      # The composite only RESTORES the build_runner cache (PR jobs must never
+      # save — quota); this workflow is the single writer. Keep path + key in
+      # sync with the restore step in .github/actions/flutter-setup/action.yml.
+      - name: Save build_runner cache
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            .dart_tool/build
+            **/*.g.dart
+            **/*.freezed.dart
+            **/*.mocks.dart
+          key: buildrunner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.lock') }}-${{ github.sha }}

--- a/makefile
+++ b/makefile
@@ -46,7 +46,7 @@ analyze:
 
 build-runner:
 	@echo "🏗️ Build runner for json_serializable and flutter_gen"
-	@fvm dart run build_runner build --force-jit
+	@fvm dart run build_runner build --force-jit --delete-conflicting-outputs
 
 build-runner-watch:
 	@echo "🏗️ Build runner for json_serializable and flutter_gen (watch mode)"


### PR DESCRIPTION
## Problem

`analyze_and_test` is one sequential job; the latest develop run took **33m44s** (build_runner 7m26s, Rust FRB + GTK app build inside the 18m21s integration step). A contributor waits that long to learn about an analyze/format/unit failure that was actually decided in the first half of the run.

## What

### 1. Split at the FRB boundary (`05a6065c3`)

Two independent parallel jobs — neither `needs:` the other, so the fast signal never waits for the slow one:

- **`checks`** (x64, ~13min cold): analyze, bull_ui import boundary, `dart fix`, `dart format`, unit tests. Never compiles the Rust FRB crates — unit tests run on the Dart VM against the bindings' Dart side only (verified: in prior runs unit tests passed before any Rust build happened).
- **`integration`** (~28min, parallel): builds and launches the real Linux GTK app + integration tests. Only this job restores the Cargo cache.

The shared setup prefix (FVM/pub caches, FVM install, deps, build_runner, translations) lives in a local composite action (`.github/actions/flutter-setup`) so the two jobs can't drift. The four static checks are gated on `!cancelled()` + setup outcome, so one run surfaces **all** static failures instead of stopping at the first; unit tests keep the default `success()` gate. Side effect: the PR checks list now shows *which* job failed.

### 2. Optimization pass (`f4ea1842e`)

- **Docs-only PRs skip CI** via `paths-ignore` — safe without a sentinel job: develop has **no required status checks** (verified via the API).
- **`integration` moves to `ubuntu-24.04-arm`** — GA and free for public repos (4 vCPU, native arm): the Rust FRB compile is exactly the workload that benefits. FVM cache keys gain `runner.arch` (SDK binaries are arch-specific); pub/cargo caches stay arch-free (sources only).
- **build_runner incremental cache** on `.dart_tool/build` + generated sources, keyed on lockfile.
- **`cache-warmer.yml`**: PR-saved caches are branch-scoped, so a small workflow on develop pushes (both arches) seeds the caches every PR restores.
- **sccache** (`Mozilla-Actions/sccache-action`, SHA-pinned) for the FRB Rust build, GHA-cache backed.

### 3. Audit fixes (`9c570d274`)

Adversarial review of the pass produced: an idempotent **rustup-ensure** step (the leaner arm64 image may lack it; cargokit needs `rustup run stable`); **`--delete-conflicting-outputs`** on `make build-runner` + generated sources cached alongside the asset graph (cold-restore consistency); **`CARGO_INCREMENTAL=0`** (sccache can't cache incremental artifacts); build_runner cache made **restore-only in PR jobs** with the warmer as single writer (a per-push save would blow the 10GB quota and evict the FVM/pub/cargo caches); `paths-ignore` on the warmer.

## Versions audited (July 2026)

`ubuntu-24.04-arm` GA + free for public repos; `checkout@v7`, `cache@v6` latest majors; `free-disk-space` v1.3.1 and `sccache-action` v0.0.10 SHA-pinned. `ubuntu-26.04` deliberately avoided while in preview.

## What the first runs decide

- `checks` wall-clock ≈13min cold — the split's headline number.
- Integration green on arm64 — if the arch surfaces a toolchain wart, the revert is the one-line `runs-on` + restoring the free-disk step.
- sccache hit/miss stats (end of integration log) — first run is all-miss; the second push shows the real gain.
- `df -h` telemetry in both jobs — decides dropping the 78s free-disk step from `checks` in a follow-up.
- The warmer only fires on develop pushes, so **cross-PR cache benefits start after this merges**; expected steady state is `checks` ≈6min.
