### PR TITLE
chore(core): source bdk_dart from bitcoindevkit rc.3 via bull_sdk

### DIFF
--- a/lib/core/bbqr/bbqr.dart
+++ b/lib/core/bbqr/bbqr.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/bbqr/bbqr_options.dart';
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:convert/convert.dart';
 import 'package:bull_sdk/bbqr.dart' as bbqr;
 

--- a/lib/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart
+++ b/lib/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 
 class BdkBitcoinBlockchainDatasource {
   const BdkBitcoinBlockchainDatasource();

--- a/lib/core/ledger/data/datasources/ledger_device_datasource.dart
+++ b/lib/core/ledger/data/datasources/ledger_device_datasource.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/ledger/domain/entities/ledger_device_entity.dart'
 import 'package:bb_mobile/core/ledger/domain/errors/ledger_errors.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:convert/convert.dart' as convert;
 import 'package:flutter/foundation.dart';
 import 'package:ledger_bitcoin/ledger_bitcoin.dart';

--- a/lib/core/seed/data/services/mnemonic_generator.dart
+++ b/lib/core/seed/data/services/mnemonic_generator.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 
 class MnemonicGenerator {
   const MnemonicGenerator();

--- a/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_address.dart
+++ b/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_address.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: invalid_annotation_target
 
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'old_address.freezed.dart';

--- a/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_transaction.dart
+++ b/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_transaction.dart
@@ -2,7 +2,7 @@
 
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_address.dart';
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_swap.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:timeago/timeago.dart' as timeago;

--- a/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_wallet.dart
+++ b/lib/core/storage/migrations/005_hive_to_sqlite/old/entities/old_wallet.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entitie
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_swap.dart';
 import 'package:bb_mobile/core/storage/migrations/005_hive_to_sqlite/old/entities/old_transaction.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:crypto/crypto.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/core/transactions/adapters/transaction_mapper.dart
+++ b/lib/core/transactions/adapters/transaction_mapper.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:bb_mobile/core/transactions/domain/entities/bitcoin_transaction.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart' as btc_utils;
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:convert/convert.dart';
 
 /// Maps the BDK utility class [btc_utils.BitcoinTx] to the domain entity

--- a/lib/core/utils/address_script_conversions.dart
+++ b/lib/core/utils/address_script_conversions.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/foundation.dart';
 
 class AddressScriptConversions {

--- a/lib/core/utils/bitcoin_tx.dart
+++ b/lib/core/utils/bitcoin_tx.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'bitcoin_tx.freezed.dart';

--- a/lib/core/utils/descriptor_derivation.dart
+++ b/lib/core/utils/descriptor_derivation.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:bull_sdk/lwk.dart' as lwk;
 
 class DescriptorDerivation {

--- a/lib/core/utils/payment_request.dart
+++ b/lib/core/utils/payment_request.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:bip21_uri/bip21_uri.dart';
 import 'package:bull_sdk/boltz.dart' as boltz;
 import 'package:freezed_annotation/freezed_annotation.dart';

--- a/lib/core/wallet/data/datasources/bdk_facade.dart
+++ b/lib/core/wallet/data/datasources/bdk_facade.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:path_provider/path_provider.dart';
 
 class BdkFacade {

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -15,7 +15,7 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_transaction_model.dart'
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
+++ b/lib/features/broadcast_signed_tx/presentation/broadcast_signed_tx_cubit.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/domain/broadcast_signed_tx_failure.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/presentation/broadcast_signed_tx_state.dart';
 import 'package:bb_mobile/features/broadcast_signed_tx/type.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:bitcoin_base/bitcoin_base.dart';
 import 'package:convert/convert.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/lib/features/replace_by_fee/domain/bump_fee_usecase.dart
+++ b/lib/features/replace_by_fee/domain/bump_fee_usecase.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/features/replace_by_fee/domain/replace_by_fee_failure.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:meta/meta.dart';
 
 class BumpFeeUsecase {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,14 +98,14 @@ packages:
     source: hosted
     version: "2.0.1"
   bdk_dart:
-    dependency: "direct main"
+    dependency: transitive
     description:
       path: "."
-      ref: a3873c06f0892cb5ea2549ad5368951a9df57f00
-      resolved-ref: a3873c06f0892cb5ea2549ad5368951a9df57f00
-      url: "https://github.com/ethicnology/bdk-dart"
+      ref: fbf8952ed7056c9663e4bd47dddc8b4994580532
+      resolved-ref: fbf8952ed7056c9663e4bd47dddc8b4994580532
+      url: "https://github.com/bitcoindevkit/bdk-dart"
     source: git
-    version: "1.0.0-rc.2"
+    version: "1.0.0-rc.3"
   bech32:
     dependency: transitive
     description:
@@ -158,8 +158,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bitbox-transport"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
+      resolved-ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -216,8 +216,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/boltz-stream"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
+      resolved-ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -305,8 +305,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bull_sdk"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
+      resolved-ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "1.0.0+1"
@@ -1755,8 +1755,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/bull_sdk/rust_builder"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
+      resolved-ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
@@ -1772,8 +1772,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/satoshifier"
-      ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
-      resolved-ref: "39a964bdd1296a32fde514ffa450522c3bac576b"
+      ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
+      resolved-ref: "507c54893f561a339b8da787cf9b2e0cd9ab9659"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,10 +17,6 @@ dependencies:
   flutter:
     sdk: flutter
   bull_ui:
-  bdk_dart:
-    git:
-      url: https://github.com/ethicnology/bdk-dart
-      ref: a3873c06f0892cb5ea2549ad5368951a9df57f00
   flutter_bloc: ^9.1.1
   freezed: ^3.2.3
   get_it: ^9.1.1
@@ -54,17 +50,17 @@ dependencies:
   bull_sdk:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: 507c54893f561a339b8da787cf9b2e0cd9ab9659
       path: packages/bull_sdk
   boltz_stream:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: 507c54893f561a339b8da787cf9b2e0cd9ab9659
       path: packages/boltz-stream
   bitbox_transport:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: 507c54893f561a339b8da787cf9b2e0cd9ab9659
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
   hex: ^0.2.0
@@ -119,7 +115,7 @@ dependencies:
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: 39a964bdd1296a32fde514ffa450522c3bac576b
+      ref: 507c54893f561a339b8da787cf9b2e0cd9ab9659
       path: packages/satoshifier
   flutter_nfc_kit: ^3.6.1
   ndef: ^0.4.0
@@ -149,17 +145,6 @@ dependencies:
   web_socket_channel: ^3.0.3
   sentry_flutter: ^9.22.0
   keyboard_actions: ^4.2.1
-
-# Force a single bdk_dart across the whole graph onto the reproducible-build fork.
-# satoshifier (from bull_sdk) transitively pins bitcoindevkit/bdk-dart@1377091;
-# ethicnology/bdk-dart@a3873c0 is that same commit plus a committed Cargo.lock and
-# codegen-units=1 (no Dart API change, same 1.0.0-rc.2), so the override is safe and
-# makes libbdk_dart_ffi.so reproducible.
-dependency_overrides:
-  bdk_dart:
-    git:
-      url: https://github.com/ethicnology/bdk-dart
-      ref: a3873c06f0892cb5ea2549ad5368951a9df57f00
 
 dev_dependencies:
   build_runner: ^2.10.4

--- a/test/features/replace_by_fee/domain/bump_fee_usecase_test.dart
+++ b/test/features/replace_by_fee/domain/bump_fee_usecase_test.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/replace_by_fee/domain/bump_fee_usecase.dart';
 import 'package:bb_mobile/features/replace_by_fee/domain/replace_by_fee_failure.dart';
-import 'package:bdk_dart/bdk.dart' as bdk;
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Drops the ethicnology/bdk-dart fork (and its dependency_overrides) in favour of upstream bitcoindevkit/bdk-dart v1.0.0-rc.3, now pinned once in bull_sdk and re-exported as package:bull_sdk/bdk.dart. The 16 consumers import through that barrel instead of bdk_dart directly.

rc.3 makes libbdk_dart_ffi.so reproducible upstream (commits native/Cargo.lock, pins codegen-units=1 in the crate), which is exactly what the fork provided. Its Dart bindings are byte-identical to rc.2, so no code changes were needed beyond the import path. Bumps the four bull_sdk-repo deps to the commit carrying the rc.3 pin + re-export.