### PR TITLE
payjoin: exclude 0-conf inputs from receiver candidates

### DIFF
--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -446,6 +446,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   ) {
     return unspent
         .where((u) => !locked.any((l) => l.txId == u.txId && l.vout == u.vout))
+        // Skip 0-conf UTXOs: temporal-fingerprint leak + parent can be RBF'd out.
+        .where((u) => u.confirmations > 0)
         .whereType<BitcoinWalletUtxoModel>()
         .map((u) => PayjoinInputPairModel.fromWalletUtxoModel(u))
         .toList();


### PR DESCRIPTION
the payjoin candidate filter never checked confirmation depth, so the receiver could contribute a 0-conf input, a temporal fingerprint (an unconfirmed-ancestor spend is observable and partitions the anonymity set by elimination), and a 0-conf parent can be RBF'd out, invalidating the payjoin.

excludes 0-conf from the payjoin candidates (`confirmations > 0`). Receiver-scoped; normal sends unaffected.

ref: https://github.com/payjoin/rust-payjoin/issues/1597#issuecomment-4649767163

closes #2430 