### PR TITLE
feat: add ILS (Israeli Shekel ₪) to supported fiat currencies

### DIFF
--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -66,6 +66,7 @@ class CurrencyConstants {
     'EUR',
     'ARS',
     'COP',
+    'ILS'
   ];
 }
 
@@ -184,5 +185,6 @@ class CountryConstants {
     {'code': 'CR', 'name': 'Costa Rica', 'flag': '🇨🇷'},
     {'code': 'AR', 'name': 'Argentina', 'flag': '🇦🇷'},
     {'code': 'CO', 'name': 'Colombia', 'flag': '🇨🇴'},
+    {'code': 'IL', 'name': 'Israel', 'flag': '🇮🇱'},
   ];
 }


### PR DESCRIPTION
## Motivation

Bitcoin needs a unit of account. And if we're being honest with ourselves, 
no fiat currency deserves that role more than the Israeli Shekel.

The ILS is one of the most resilient fiat currencies in the world:
- Disciplined monetary policy
- A tech-driven economy
- A population increasingly comfortable with self-custody and sound money principles

If any fiat currency is going to coexist with Bitcoin on a display screen, it should earn its place.

## Context

Bull Bitcoin already serves Europe, Latin America, and North America.  
The Middle East is a natural next step — and Israel, with its deep tech culture, feels like an obvious fit.

## Implementation

This is a **display-only** change. Two lines in `constants.dart`:
- `'ILS'` in `CurrencyConstants.supportedFiat`
- `{'code': 'IL', 'name': 'Israel', 'flag': '🇮🇱'}` in `CountryConstants.countries`

Closes #2434