### PR TITLE
feat(settings): add Novlang store-compliance vocabulary

### DIFF
--- a/lib/features/settings/public/novlang_x.dart
+++ b/lib/features/settings/public/novlang_x.dart
@@ -2,34 +2,30 @@ import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dar
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:novlang/novlang.dart';
 
-/// Store-compliance vocabulary policy ("Novlang", ref. Orwell's Newspeak).
+/// Applies the store-compliance vocabulary ("Novlang", ref. Orwell's Newspeak)
+/// to a sensitive string.
 ///
 /// Some words the app really uses (e.g. "Exchange") are not allowed by an app
-/// store's review policy, which forces a euphemism ("Account"). Instead of
+/// store's review policy, which forces a euphemism ("Account"). Rather than
 /// editing the real strings, each sensitive string keeps its real l10n key and
-/// gains a store-suffixed twin (`<key>NewspeakApple`, and later
-/// `<key>NewspeakGoogle`). This enum selects which twin — if any — the UI shows.
+/// gains a store-suffixed twin (`<key>NewspeakApple`, later `<key>NewspeakGoogle`).
 ///
-/// The policy is derived, not stored: it is the platform's default store policy
-/// unless the hidden superuser mode is unlocked, which reveals the real words
-/// everywhere ([NewspeakPolicy.none]).
-enum NewspeakPolicy { none, apple, google }
-
+/// The pure selection logic lives in `package:novlang`; this extension only
+/// resolves the active [NewspeakPolicy] from the platform and the hidden
+/// superuser toggle, then delegates to [NewspeakPolicy.pick].
 extension NovlangX on BuildContext {
   /// The active [NewspeakPolicy] for the current platform + superuser state.
   ///
   /// Superuser unlocked → [NewspeakPolicy.none] (real words). Otherwise the
-  /// platform's store policy: iOS → [NewspeakPolicy.apple], Android →
-  /// [NewspeakPolicy.google], anything else → [NewspeakPolicy.none].
+  /// platform's store policy: iOS → apple, Android → google, else none.
   ///
   /// Reads `isSuperuser` with `select` so a screen rebuilds when superuser is
   /// toggled (a `read` would leave stale text on screen). Uses
   /// [defaultTargetPlatform] rather than `dart:io` `Platform` so widget tests
   /// can drive it with `debugDefaultTargetPlatformOverride`.
-  ///
-  /// Must be called from `build` (like any `select`), not from a callback.
-  NewspeakPolicy get novlangPolicy {
+  NewspeakPolicy get _novlangPolicy {
     final isSuperuser =
         select((SettingsCubit cubit) => cubit.state.isSuperuser) ?? false;
     if (isSuperuser) return NewspeakPolicy.none;
@@ -47,6 +43,8 @@ extension NovlangX on BuildContext {
   /// twin (or the `none` policy) falls back to [real], so a caller that only
   /// has an Apple twin simply omits `google` and Android shows the real word.
   ///
+  /// Must be called from `build` (like any `select`), not from a callback.
+  ///
   /// ```dart
   /// Text(context.novlang(
   ///   real: context.loc.settingsExchangeSettingsTitle,
@@ -54,10 +52,6 @@ extension NovlangX on BuildContext {
   /// ))
   /// ```
   String novlang({required String real, String? apple, String? google}) {
-    return switch (novlangPolicy) {
-      NewspeakPolicy.apple => apple ?? real,
-      NewspeakPolicy.google => google ?? real,
-      NewspeakPolicy.none => real,
-    };
+    return _novlangPolicy.pick(real: real, apple: apple, google: google);
   }
 }

--- a/lib/features/settings/public/novlang_x.dart
+++ b/lib/features/settings/public/novlang_x.dart
@@ -1,0 +1,63 @@
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Store-compliance vocabulary policy ("Novlang", ref. Orwell's Newspeak).
+///
+/// Some words the app really uses (e.g. "Exchange") are not allowed by an app
+/// store's review policy, which forces a euphemism ("Account"). Instead of
+/// editing the real strings, each sensitive string keeps its real l10n key and
+/// gains a store-suffixed twin (`<key>NewspeakApple`, and later
+/// `<key>NewspeakGoogle`). This enum selects which twin — if any — the UI shows.
+///
+/// The policy is derived, not stored: it is the platform's default store policy
+/// unless the hidden superuser mode is unlocked, which reveals the real words
+/// everywhere ([NewspeakPolicy.none]).
+enum NewspeakPolicy { none, apple, google }
+
+extension NovlangX on BuildContext {
+  /// The active [NewspeakPolicy] for the current platform + superuser state.
+  ///
+  /// Superuser unlocked → [NewspeakPolicy.none] (real words). Otherwise the
+  /// platform's store policy: iOS → [NewspeakPolicy.apple], Android →
+  /// [NewspeakPolicy.google], anything else → [NewspeakPolicy.none].
+  ///
+  /// Reads `isSuperuser` with `select` so a screen rebuilds when superuser is
+  /// toggled (a `read` would leave stale text on screen). Uses
+  /// [defaultTargetPlatform] rather than `dart:io` `Platform` so widget tests
+  /// can drive it with `debugDefaultTargetPlatformOverride`.
+  ///
+  /// Must be called from `build` (like any `select`), not from a callback.
+  NewspeakPolicy get novlangPolicy {
+    final isSuperuser =
+        select((SettingsCubit cubit) => cubit.state.isSuperuser) ?? false;
+    if (isSuperuser) return NewspeakPolicy.none;
+
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.iOS => NewspeakPolicy.apple,
+      TargetPlatform.android => NewspeakPolicy.google,
+      _ => NewspeakPolicy.none,
+    };
+  }
+
+  /// Picks the store-compliant wording for a sensitive string.
+  ///
+  /// Pass the real string plus whichever store twins exist. A store with no
+  /// twin (or the `none` policy) falls back to [real], so a caller that only
+  /// has an Apple twin simply omits `google` and Android shows the real word.
+  ///
+  /// ```dart
+  /// Text(context.novlang(
+  ///   real: context.loc.settingsExchangeSettingsTitle,
+  ///   apple: context.loc.settingsExchangeSettingsTitleNewspeakApple,
+  /// ))
+  /// ```
+  String novlang({required String real, String? apple, String? google}) {
+    return switch (novlangPolicy) {
+      NewspeakPolicy.apple => apple ?? real,
+      NewspeakPolicy.google => google ?? real,
+      NewspeakPolicy.none => real,
+    };
+  }
+}

--- a/lib/features/settings/public/settings_facade.dart
+++ b/lib/features/settings/public/settings_facade.dart
@@ -1,0 +1,11 @@
+/// Public contract of the settings feature.
+///
+/// The only surface other features (and this feature's own UI) should import
+/// to reach settings capabilities. Internals under `presentation/`, `domain/`
+/// and `ui/` are not importable directly.
+///
+/// For now this exposes the Novlang store-vocabulary helper; grow the export
+/// block as more of settings becomes a published contract.
+library;
+
+export 'package:bb_mobile/features/settings/public/novlang_x.dart';

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_support_chat/ui/exchange_support_chat_router.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/settings/public/novlang_x.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/router.dart';
@@ -63,9 +64,11 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
               children: [
                 SettingsEntryItem(
                   icon: Icons.currency_exchange,
-                  title: Platform.isIOS && !isSuperuser
-                      ? context.loc.settingsAccountSettingsTitle
-                      : context.loc.settingsExchangeSettingsTitle,
+                  title: context.novlang(
+                    real: context.loc.settingsExchangeSettingsTitle,
+                    apple:
+                        context.loc.settingsExchangeSettingsTitleNewspeakApple,
+                  ),
                   onTap: () {
                     if (Platform.isIOS) {
                       if (isSuperuser) {

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_support_chat/ui/exchange_support_chat_router.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
-import 'package:bb_mobile/features/settings/public/novlang_x.dart';
+import 'package:bb_mobile/features/settings/public/settings_facade.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
 import 'package:bb_mobile/features/status_check/router.dart';

--- a/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
+++ b/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/pay/ui/pay_router.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/settings/public/novlang_x.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -28,9 +29,10 @@ class ExchangeSettingsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          isSuperuser
-              ? context.loc.settingsExchangeSettingsTitle
-              : context.loc.settingsAccountSettingsTitle,
+          context.novlang(
+            real: context.loc.settingsExchangeSettingsTitle,
+            apple: context.loc.settingsExchangeSettingsTitleNewspeakApple,
+          ),
         ),
       ),
       body: SafeArea(

--- a/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
+++ b/lib/features/settings/ui/screens/exchange/exchange_settings_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/pay/ui/pay_router.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
-import 'package:bb_mobile/features/settings/public/novlang_x.dart';
+import 'package:bb_mobile/features/settings/public/settings_facade.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12938,5 +12938,6 @@
   "logsShareOptionShare": "مشاركة",
   "logsShareOptionExport": "تصدير",
   "logsExportedMessage": "تم تصدير السجلات بنجاح",
-  "logsExportFailedMessage": "فشل تصدير السجلات"
+  "logsExportFailedMessage": "فشل تصدير السجلات",
+  "settingsExchangeSettingsTitleNewspeakApple": "إعدادات الحساب"
 }

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -10052,5 +10052,6 @@
   "logsShareOptionShare": "শ্বেয়াৰ কৰক",
   "logsShareOptionExport": "ৰপ্তানি কৰক",
   "logsExportedMessage": "লগসমূহ সফলভাৱে ৰপ্তানি কৰা হৈছে",
-  "logsExportFailedMessage": "লগ ৰপ্তানি কৰিবলৈ বিফল হৈছে"
+  "logsExportFailedMessage": "লগ ৰপ্তানি কৰিবলৈ বিফল হৈছে",
+  "settingsExchangeSettingsTitleNewspeakApple": "একাউণ্ট ছেটিংছ"
 }

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -10084,5 +10084,6 @@
   "logsShareOptionShare": "Споделяне",
   "logsShareOptionExport": "Експортиране",
   "logsExportedMessage": "Журналите са експортирани успешно",
-  "logsExportFailedMessage": "Неуспешно експортиране на журналите"
+  "logsExportFailedMessage": "Неуспешно експортиране на журналите",
+  "settingsExchangeSettingsTitleNewspeakApple": "Настройки на акаунта"
 }

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -13222,5 +13222,6 @@
   "logsShareOptionShare": "শেয়ার করুন",
   "logsShareOptionExport": "এক্সপোর্ট করুন",
   "logsExportedMessage": "লগ সফলভাবে এক্সপোর্ট হয়েছে",
-  "logsExportFailedMessage": "লগ এক্সপোর্ট করতে ব্যর্থ হয়েছে"
+  "logsExportFailedMessage": "লগ এক্সপোর্ট করতে ব্যর্থ হয়েছে",
+  "settingsExchangeSettingsTitleNewspeakApple": "অ্যাকাউন্ট সেটিংস"
 }

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -13052,5 +13052,6 @@
   "logsShareOptionShare": "Sdílet",
   "logsShareOptionExport": "Exportovat",
   "logsExportedMessage": "Záznamy byly úspěšně exportovány",
-  "logsExportFailedMessage": "Export záznamů se nezdařil"
+  "logsExportFailedMessage": "Export záznamů se nezdařil",
+  "settingsExchangeSettingsTitleNewspeakApple": "Nastavení účtu"
 }

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -5090,5 +5090,6 @@
         "type": "String"
       }
     }
-  }
+  },
+  "settingsExchangeSettingsTitleNewspeakApple": "Kontoeinstellungen"
 }

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -13052,5 +13052,6 @@
   "logsShareOptionShare": "Κοινοποίηση",
   "logsShareOptionExport": "Εξαγωγή",
   "logsExportedMessage": "Τα αρχεία καταγραφής εξήχθησαν επιτυχώς",
-  "logsExportFailedMessage": "Αποτυχία εξαγωγής αρχείων καταγραφής"
+  "logsExportFailedMessage": "Αποτυχία εξαγωγής αρχείων καταγραφής",
+  "settingsExchangeSettingsTitleNewspeakApple": "Ρυθμίσεις λογαριασμού"
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -13349,7 +13349,7 @@
   },
   "settingsAccountSettingsTitle": "Account Settings",
   "@settingsAccountSettingsTitle": {
-    "description": "Title for the account settings screen (shown to non-superusers)"
+    "description": "DEPRECATED: replaced by settingsExchangeSettingsTitleNewspeakApple (novlang twin). Kept until translation sync confirms; remove in a follow-up PR."
   },
   "exchangeSettingsDeleteAccountTitle": "Delete Account",
   "@exchangeSettingsDeleteAccountTitle": {
@@ -14751,5 +14751,9 @@
   "coinsErrorUnexpected": "Something went wrong. Please try again.",
   "@coinsErrorUnexpected": {
     "description": "Generic Coins error message for unexpected failures"
+  },
+  "settingsExchangeSettingsTitleNewspeakApple": "Account Settings",
+  "@settingsExchangeSettingsTitleNewspeakApple": {
+    "description": "Apple App Store store-compliance twin of settingsExchangeSettingsTitle (real term: Exchange Settings). Shown to non-superusers on iOS via context.novlang()."
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -5100,5 +5100,6 @@
   "logsShareOptionShare": "Compartir",
   "logsShareOptionExport": "Exportar",
   "logsExportedMessage": "Registros exportados correctamente",
-  "logsExportFailedMessage": "Error al exportar los registros"
+  "logsExportFailedMessage": "Error al exportar los registros",
+  "settingsExchangeSettingsTitleNewspeakApple": "Ajustes de la cuenta"
 }

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12934,5 +12934,6 @@
   "logsShareOptionShare": "اشتراک‌گذاری",
   "logsShareOptionExport": "صدور",
   "logsExportedMessage": "گزارش‌ها با موفقیت صادر شدند",
-  "logsExportFailedMessage": "صدور گزارش‌ها ناموفق بود"
+  "logsExportFailedMessage": "صدور گزارش‌ها ناموفق بود",
+  "settingsExchangeSettingsTitleNewspeakApple": "تنظیمات حساب"
 }

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -5086,5 +5086,6 @@
   "logsShareOptionShare": "Jaa",
   "logsShareOptionExport": "Vie",
   "logsExportedMessage": "Lokit viety onnistuneesti",
-  "logsExportFailedMessage": "Lokien vienti epäonnistui"
+  "logsExportFailedMessage": "Lokien vienti epäonnistui",
+  "settingsExchangeSettingsTitleNewspeakApple": "Tilin asetukset"
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -5083,5 +5083,6 @@
   "logsShareOptionShare": "Partager",
   "logsShareOptionExport": "Exporter",
   "logsExportedMessage": "Journaux exportés avec succès",
-  "logsExportFailedMessage": "Échec de l'exportation des journaux"
+  "logsExportFailedMessage": "Échec de l'exportation des journaux",
+  "settingsExchangeSettingsTitleNewspeakApple": "Paramètres du compte"
 }

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -13202,5 +13202,6 @@
   "logsShareOptionShare": "शेयर करें",
   "logsShareOptionExport": "निर्यात करें",
   "logsExportedMessage": "लॉग सफलतापूर्वक निर्यात किए गए",
-  "logsExportFailedMessage": "लॉग निर्यात करने में विफल"
+  "logsExportFailedMessage": "लॉग निर्यात करने में विफल",
+  "settingsExchangeSettingsTitleNewspeakApple": "खाता सेटिंग्स"
 }

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -13389,5 +13389,6 @@
   "logsShareOptionShare": "Share karein",
   "logsShareOptionExport": "Export karein",
   "logsExportedMessage": "Logs safaltaapoorvak export kiye gaye",
-  "logsExportFailedMessage": "Logs export karne mein vifal"
+  "logsExportFailedMessage": "Logs export karne mein vifal",
+  "settingsExchangeSettingsTitleNewspeakApple": "Account Settings"
 }

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -582,5 +582,6 @@
   "logsShareOptionShare": "Կիսվել",
   "logsShareOptionExport": "Արտահանել",
   "logsExportedMessage": "Մատյանները հաջողությամբ արտահանվեցին",
-  "logsExportFailedMessage": "Մատյանների արտահանումը ձախողվեց"
+  "logsExportFailedMessage": "Մատյանների արտահանումը ձախողվեց",
+  "settingsExchangeSettingsTitleNewspeakApple": "Հաշվի կարգավորումներ"
 }

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -5094,5 +5094,6 @@
   "logsShareOptionShare": "Condividi",
   "logsShareOptionExport": "Esporta",
   "logsExportedMessage": "Registri esportati con successo",
-  "logsExportFailedMessage": "Esportazione dei registri non riuscita"
+  "logsExportFailedMessage": "Esportazione dei registri non riuscita",
+  "settingsExchangeSettingsTitleNewspeakApple": "Impostazioni account"
 }

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -794,5 +794,6 @@
   "logsShareOptionShare": "გაზიარება",
   "logsShareOptionExport": "ექსპორტი",
   "logsExportedMessage": "ჟურნალები წარმატებით ექსპორტირებულია",
-  "logsExportFailedMessage": "ჟურნალების ექსპორტი ვერ მოხერხდა"
+  "logsExportFailedMessage": "ჟურნალების ექსპორტი ვერ მოხერხდა",
+  "settingsExchangeSettingsTitleNewspeakApple": "ანგარიშის პარამეტრები"
 }

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12934,5 +12934,6 @@
   "logsShareOptionShare": "공유",
   "logsShareOptionExport": "내보내기",
   "logsExportedMessage": "로그를 성공적으로 내보냈습니다",
-  "logsExportFailedMessage": "로그 내보내기에 실패했습니다"
+  "logsExportFailedMessage": "로그 내보내기에 실패했습니다",
+  "settingsExchangeSettingsTitleNewspeakApple": "계정 설정"
 }

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -5149,5 +5149,6 @@
   "logsShareOptionShare": "Partilhar",
   "logsShareOptionExport": "Exportar",
   "logsExportedMessage": "Registos exportados com sucesso",
-  "logsExportFailedMessage": "Falha ao exportar os registos"
+  "logsExportFailedMessage": "Falha ao exportar os registos",
+  "settingsExchangeSettingsTitleNewspeakApple": "Definições da conta"
 }

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -13048,5 +13048,6 @@
   "logsShareOptionShare": "Compartilhar",
   "logsShareOptionExport": "Exportar",
   "logsExportedMessage": "Registros exportados com sucesso",
-  "logsExportFailedMessage": "Falha ao exportar os registros"
+  "logsExportFailedMessage": "Falha ao exportar os registros",
+  "settingsExchangeSettingsTitleNewspeakApple": "Configurações da conta"
 }

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -5103,5 +5103,6 @@
   "logsShareOptionShare": "Поделиться",
   "logsShareOptionExport": "Экспорт",
   "logsExportedMessage": "Журналы успешно экспортированы",
-  "logsExportFailedMessage": "Не удалось экспортировать журналы"
+  "logsExportFailedMessage": "Не удалось экспортировать журналы",
+  "settingsExchangeSettingsTitleNewspeakApple": "Настройки аккаунта"
 }

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -602,5 +602,6 @@
   "logsShareOptionShare": "Shiriki",
   "logsShareOptionExport": "Hamisha",
   "logsExportedMessage": "Kumbukumbu zimehamiishwa kwa mafanikio",
-  "logsExportFailedMessage": "Imeshindwa kuhamisha kumbukumbu"
+  "logsExportFailedMessage": "Imeshindwa kuhamisha kumbukumbu",
+  "settingsExchangeSettingsTitleNewspeakApple": "Mipangilio ya akaunti"
 }

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12934,5 +12934,6 @@
   "logsShareOptionShare": "แชร์",
   "logsShareOptionExport": "ส่งออก",
   "logsExportedMessage": "ส่งออกบันทึกสำเร็จแล้ว",
-  "logsExportFailedMessage": "ส่งออกบันทึกไม่สำเร็จ"
+  "logsExportFailedMessage": "ส่งออกบันทึกไม่สำเร็จ",
+  "settingsExchangeSettingsTitleNewspeakApple": "การตั้งค่าบัญชี"
 }

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12934,5 +12934,6 @@
   "logsShareOptionShare": "Paylaş",
   "logsShareOptionExport": "Dışa Aktar",
   "logsExportedMessage": "Kayıtlar başarıyla dışa aktarıldı",
-  "logsExportFailedMessage": "Kayıtlar dışa aktarılamadı"
+  "logsExportFailedMessage": "Kayıtlar dışa aktarılamadı",
+  "settingsExchangeSettingsTitleNewspeakApple": "Hesap ayarları"
 }

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -5091,5 +5091,6 @@
   "logsShareOptionShare": "Поділитися",
   "logsShareOptionExport": "Експорт",
   "logsExportedMessage": "Журнали успішно експортовано",
-  "logsExportFailedMessage": "Не вдалося експортувати журнали"
+  "logsExportFailedMessage": "Не вдалося експортувати журнали",
+  "settingsExchangeSettingsTitleNewspeakApple": "Налаштування облікового запису"
 }

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -582,5 +582,6 @@
   "logsShareOptionShare": "Chia sẻ",
   "logsShareOptionExport": "Xuất",
   "logsExportedMessage": "Nhật ký đã được xuất thành công",
-  "logsExportFailedMessage": "Xuất nhật ký thất bại"
+  "logsExportFailedMessage": "Xuất nhật ký thất bại",
+  "settingsExchangeSettingsTitleNewspeakApple": "Cài đặt tài khoản"
 }

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -4976,5 +4976,6 @@
   "logsShareOptionShare": "分享",
   "logsShareOptionExport": "导出",
   "logsExportedMessage": "日志导出成功",
-  "logsExportFailedMessage": "日志导出失败"
+  "logsExportFailedMessage": "日志导出失败",
+  "settingsExchangeSettingsTitleNewspeakApple": "账户设置"
 }

--- a/packages/novlang/analysis_options.yaml
+++ b/packages/novlang/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    # A shared-foundation package is held to a stricter bar than the app.
+    - prefer_const_constructors
+    - prefer_const_declarations
+    - require_trailing_commas
+    - prefer_final_locals
+    - prefer_single_quotes
+    - unnecessary_parenthesis

--- a/packages/novlang/lib/novlang.dart
+++ b/packages/novlang/lib/novlang.dart
@@ -1,0 +1,8 @@
+/// Store-compliance vocabulary policy (Newspeak) — pure selection logic.
+///
+/// Import this single barrel. The host app resolves the active
+/// [NewspeakPolicy] (from platform + its own "real words" toggle) and calls
+/// [NewspeakPolicy.pick] to choose the store-compliant wording.
+library;
+
+export 'src/newspeak_policy.dart';

--- a/packages/novlang/lib/src/newspeak_policy.dart
+++ b/packages/novlang/lib/src/newspeak_policy.dart
@@ -1,0 +1,33 @@
+/// Store-compliance vocabulary policy ("Novlang", ref. Orwell's Newspeak).
+///
+/// Some words the app really uses (e.g. "Exchange") are not allowed by an app
+/// store's review policy, which forces a euphemism ("Account"). Rather than
+/// editing the real strings, each sensitive string keeps its real value and is
+/// given store-specific twins; this enum selects which twin — if any — to show.
+///
+/// This package holds only the pure selection logic: it has no knowledge of
+/// Flutter, the platform, or where the "real words" toggle lives. The host app
+/// resolves the active policy and calls [NewspeakPolicy.pick].
+enum NewspeakPolicy {
+  /// Show the real words (no store restriction, or restrictions bypassed).
+  none,
+
+  /// Apple App Store vocabulary.
+  apple,
+
+  /// Google Play Store vocabulary.
+  google;
+
+  /// Returns the store-compliant wording for a sensitive string.
+  ///
+  /// Pass the real value plus whichever store twins exist. A store with no twin
+  /// (or [NewspeakPolicy.none]) falls back to [real], so a caller that only has
+  /// an Apple twin simply omits [google].
+  String pick({required String real, String? apple, String? google}) {
+    return switch (this) {
+      NewspeakPolicy.apple => apple ?? real,
+      NewspeakPolicy.google => google ?? real,
+      NewspeakPolicy.none => real,
+    };
+  }
+}

--- a/packages/novlang/pubspec.yaml
+++ b/packages/novlang/pubspec.yaml
@@ -1,0 +1,12 @@
+name: novlang
+description: Store-compliance vocabulary policy (Newspeak) — pure selection logic.
+publish_to: "none"
+version: 0.0.1
+resolution: workspace
+
+environment:
+  sdk: "3.12.2"
+
+dev_dependencies:
+  test: ^1.31.0
+  lints: ^6.0.0

--- a/packages/novlang/test/newspeak_policy_test.dart
+++ b/packages/novlang/test/newspeak_policy_test.dart
@@ -1,0 +1,39 @@
+import 'package:novlang/novlang.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NewspeakPolicy.pick', () {
+    test('apple uses the apple twin', () {
+      expect(
+        NewspeakPolicy.apple.pick(real: 'real', apple: 'apple', google: 'goog'),
+        'apple',
+      );
+    });
+
+    test('apple falls back to real when no apple twin', () {
+      expect(NewspeakPolicy.apple.pick(real: 'real', google: 'goog'), 'real');
+    });
+
+    test('google uses the google twin', () {
+      expect(
+        NewspeakPolicy.google.pick(real: 'real', apple: 'apple', google: 'g'),
+        'g',
+      );
+    });
+
+    test('google falls back to real when no google twin', () {
+      expect(NewspeakPolicy.google.pick(real: 'real', apple: 'apple'), 'real');
+    });
+
+    test('none always returns real', () {
+      expect(
+        NewspeakPolicy.none.pick(real: 'real', apple: 'apple', google: 'goog'),
+        'real',
+      );
+    });
+
+    test('none returns real even with no twins', () {
+      expect(NewspeakPolicy.none.pick(real: 'real'), 'real');
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,13 @@ workspace:
   # lockfile resolves it; the app NEVER lists bull_ui_catalogue as a
   # dependency, so it is not compiled into the APK (zero build impact).
   - packages/bull_ui_catalogue
+  - packages/novlang
 
 dependencies:
   flutter:
     sdk: flutter
   bull_ui:
+  novlang:
   flutter_bloc: ^9.1.1
   freezed: ^3.2.3
   get_it: ^9.1.1

--- a/test/features/settings/novlang_x_test.dart
+++ b/test/features/settings/novlang_x_test.dart
@@ -1,0 +1,251 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/settings/public/novlang_x.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A minimal stand-in for [SettingsCubit] that only carries state. The real
+/// cubit needs a dozen use-case dependencies; the novlang helper only reads
+/// `state.isSuperuser`, so a stateful [Cubit] is enough. `noSuchMethod`
+/// satisfies the `implements` contract without stubbing every method.
+class _FakeSettingsCubit extends Cubit<SettingsState> implements SettingsCubit {
+  _FakeSettingsCubit(super.initialState);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+SettingsState _stateWithSuperuser(bool? isSuperuser) {
+  return SettingsState(
+    storedSettings: SettingsEntity(
+      environment: Environment.mainnet,
+      bitcoinUnit: BitcoinUnit.sats,
+      currencyCode: 'CAD',
+      isSuperuser: isSuperuser,
+    ),
+  );
+}
+
+void main() {
+  // Resolves `context.novlangPolicy` under a given platform + state.
+  //
+  // The platform override must be reset before the test body returns:
+  // flutter_test asserts all foundation debug vars are unset at the end of the
+  // body, which runs *before* tearDowns — so we reset in a finally here.
+  Future<NewspeakPolicy> resolvePolicy(
+    WidgetTester tester, {
+    required SettingsState state,
+    required TargetPlatform platform,
+  }) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      late NewspeakPolicy policy;
+      await tester.pumpWidget(
+        BlocProvider<SettingsCubit>.value(
+          value: _FakeSettingsCubit(state),
+          child: Builder(
+            builder: (context) {
+              policy = context.novlangPolicy;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      return policy;
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }
+
+  // Renders `context.novlang(...)` and returns the chosen string.
+  Future<String> resolveNovlang(
+    WidgetTester tester, {
+    required SettingsState state,
+    required TargetPlatform platform,
+    String? apple,
+    String? google,
+  }) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      late String rendered;
+      await tester.pumpWidget(
+        BlocProvider<SettingsCubit>.value(
+          value: _FakeSettingsCubit(state),
+          child: Builder(
+            builder: (context) {
+              rendered = context.novlang(
+                real: 'real',
+                apple: apple,
+                google: google,
+              );
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      return rendered;
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }
+
+  group('novlangPolicy', () {
+    testWidgets('iOS non-superuser → apple', (tester) async {
+      expect(
+        await resolvePolicy(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.iOS,
+        ),
+        NewspeakPolicy.apple,
+      );
+    });
+
+    testWidgets('Android non-superuser → google', (tester) async {
+      expect(
+        await resolvePolicy(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.android,
+        ),
+        NewspeakPolicy.google,
+      );
+    });
+
+    testWidgets('superuser → none even on iOS', (tester) async {
+      expect(
+        await resolvePolicy(
+          tester,
+          state: _stateWithSuperuser(true),
+          platform: TargetPlatform.iOS,
+        ),
+        NewspeakPolicy.none,
+      );
+    });
+
+    testWidgets('null superuser is treated as non-superuser', (tester) async {
+      expect(
+        await resolvePolicy(
+          tester,
+          state: _stateWithSuperuser(null),
+          platform: TargetPlatform.iOS,
+        ),
+        NewspeakPolicy.apple,
+      );
+    });
+
+    testWidgets('desktop platform → none', (tester) async {
+      expect(
+        await resolvePolicy(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.macOS,
+        ),
+        NewspeakPolicy.none,
+      );
+    });
+  });
+
+  group('novlang selector', () {
+    testWidgets('apple policy uses the apple twin', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.iOS,
+          apple: 'apple',
+          google: 'google',
+        ),
+        'apple',
+      );
+    });
+
+    testWidgets('apple policy falls back to real when no apple twin', (
+      tester,
+    ) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.iOS,
+          google: 'google',
+        ),
+        'real',
+      );
+    });
+
+    testWidgets('google policy uses the google twin', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.android,
+          apple: 'apple',
+          google: 'google',
+        ),
+        'google',
+      );
+    });
+
+    testWidgets('google policy falls back to real when no google twin', (
+      tester,
+    ) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.android,
+          apple: 'apple',
+        ),
+        'real',
+      );
+    });
+
+    testWidgets('none policy (superuser) always returns real', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(true),
+          platform: TargetPlatform.iOS,
+          apple: 'apple',
+          google: 'google',
+        ),
+        'real',
+      );
+    });
+  });
+
+  group('reactivity', () {
+    testWidgets('text switches when superuser toggles', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final cubit = _FakeSettingsCubit(_stateWithSuperuser(false));
+      addTearDown(cubit.close);
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: BlocProvider<SettingsCubit>.value(
+              value: cubit,
+              child: Builder(
+                builder: (context) => Text(
+                  context.novlang(real: 'real', apple: 'apple'),
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('apple'), findsOneWidget);
+
+        cubit.emit(_stateWithSuperuser(true));
+        await tester.pump();
+
+        expect(find.text('real'), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  });
+}

--- a/test/features/settings/novlang_x_test.dart
+++ b/test/features/settings/novlang_x_test.dart
@@ -44,11 +44,13 @@ void main() {
     String? google,
   }) async {
     debugDefaultTargetPlatformOverride = platform;
+    final cubit = _FakeSettingsCubit(state);
+    addTearDown(cubit.close);
     try {
       late String rendered;
       await tester.pumpWidget(
         BlocProvider<SettingsCubit>.value(
-          value: _FakeSettingsCubit(state),
+          value: cubit,
           child: Builder(
             builder: (context) {
               rendered = context.novlang(

--- a/test/features/settings/novlang_x_test.dart
+++ b/test/features/settings/novlang_x_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// A minimal stand-in for [SettingsCubit] that only carries state. The real
-/// cubit needs a dozen use-case dependencies; the novlang helper only reads
+/// cubit needs a dozen use-case dependencies; the novlang extension only reads
 /// `state.isSuperuser`, so a stateful [Cubit] is enough. `noSuchMethod`
 /// satisfies the `implements` contract without stubbing every method.
 class _FakeSettingsCubit extends Cubit<SettingsState> implements SettingsCubit {
@@ -29,37 +29,13 @@ SettingsState _stateWithSuperuser(bool? isSuperuser) {
 }
 
 void main() {
-  // Resolves `context.novlangPolicy` under a given platform + state.
+  // Renders `context.novlang(...)` under a given platform + state and returns
+  // the chosen string. Exercises the extension's policy resolution (platform +
+  // superuser); the pure pick() table is covered in package:novlang's tests.
   //
-  // The platform override must be reset before the test body returns:
-  // flutter_test asserts all foundation debug vars are unset at the end of the
-  // body, which runs *before* tearDowns — so we reset in a finally here.
-  Future<NewspeakPolicy> resolvePolicy(
-    WidgetTester tester, {
-    required SettingsState state,
-    required TargetPlatform platform,
-  }) async {
-    debugDefaultTargetPlatformOverride = platform;
-    try {
-      late NewspeakPolicy policy;
-      await tester.pumpWidget(
-        BlocProvider<SettingsCubit>.value(
-          value: _FakeSettingsCubit(state),
-          child: Builder(
-            builder: (context) {
-              policy = context.novlangPolicy;
-              return const SizedBox();
-            },
-          ),
-        ),
-      );
-      return policy;
-    } finally {
-      debugDefaultTargetPlatformOverride = null;
-    }
-  }
-
-  // Renders `context.novlang(...)` and returns the chosen string.
+  // The platform override is reset before the test body returns: flutter_test
+  // asserts all foundation debug vars are unset at the end of the body, which
+  // runs *before* tearDowns — so we reset in a finally here.
   Future<String> resolveNovlang(
     WidgetTester tester, {
     required SettingsState state,
@@ -91,65 +67,8 @@ void main() {
     }
   }
 
-  group('novlangPolicy', () {
-    testWidgets('iOS non-superuser → apple', (tester) async {
-      expect(
-        await resolvePolicy(
-          tester,
-          state: _stateWithSuperuser(false),
-          platform: TargetPlatform.iOS,
-        ),
-        NewspeakPolicy.apple,
-      );
-    });
-
-    testWidgets('Android non-superuser → google', (tester) async {
-      expect(
-        await resolvePolicy(
-          tester,
-          state: _stateWithSuperuser(false),
-          platform: TargetPlatform.android,
-        ),
-        NewspeakPolicy.google,
-      );
-    });
-
-    testWidgets('superuser → none even on iOS', (tester) async {
-      expect(
-        await resolvePolicy(
-          tester,
-          state: _stateWithSuperuser(true),
-          platform: TargetPlatform.iOS,
-        ),
-        NewspeakPolicy.none,
-      );
-    });
-
-    testWidgets('null superuser is treated as non-superuser', (tester) async {
-      expect(
-        await resolvePolicy(
-          tester,
-          state: _stateWithSuperuser(null),
-          platform: TargetPlatform.iOS,
-        ),
-        NewspeakPolicy.apple,
-      );
-    });
-
-    testWidgets('desktop platform → none', (tester) async {
-      expect(
-        await resolvePolicy(
-          tester,
-          state: _stateWithSuperuser(false),
-          platform: TargetPlatform.macOS,
-        ),
-        NewspeakPolicy.none,
-      );
-    });
-  });
-
-  group('novlang selector', () {
-    testWidgets('apple policy uses the apple twin', (tester) async {
+  group('policy resolution', () {
+    testWidgets('iOS non-superuser → apple twin', (tester) async {
       expect(
         await resolveNovlang(
           tester,
@@ -162,21 +81,7 @@ void main() {
       );
     });
 
-    testWidgets('apple policy falls back to real when no apple twin', (
-      tester,
-    ) async {
-      expect(
-        await resolveNovlang(
-          tester,
-          state: _stateWithSuperuser(false),
-          platform: TargetPlatform.iOS,
-          google: 'google',
-        ),
-        'real',
-      );
-    });
-
-    testWidgets('google policy uses the google twin', (tester) async {
+    testWidgets('Android non-superuser → google twin', (tester) async {
       expect(
         await resolveNovlang(
           tester,
@@ -189,27 +94,50 @@ void main() {
       );
     });
 
-    testWidgets('google policy falls back to real when no google twin', (
-      tester,
-    ) async {
-      expect(
-        await resolveNovlang(
-          tester,
-          state: _stateWithSuperuser(false),
-          platform: TargetPlatform.android,
-          apple: 'apple',
-        ),
-        'real',
-      );
-    });
-
-    testWidgets('none policy (superuser) always returns real', (tester) async {
+    testWidgets('superuser → real even on iOS', (tester) async {
       expect(
         await resolveNovlang(
           tester,
           state: _stateWithSuperuser(true),
           platform: TargetPlatform.iOS,
           apple: 'apple',
+          google: 'google',
+        ),
+        'real',
+      );
+    });
+
+    testWidgets('null superuser is treated as non-superuser', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(null),
+          platform: TargetPlatform.iOS,
+          apple: 'apple',
+        ),
+        'apple',
+      );
+    });
+
+    testWidgets('desktop platform → real', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.macOS,
+          apple: 'apple',
+          google: 'google',
+        ),
+        'real',
+      );
+    });
+
+    testWidgets('iOS with no apple twin falls back to real', (tester) async {
+      expect(
+        await resolveNovlang(
+          tester,
+          state: _stateWithSuperuser(false),
+          platform: TargetPlatform.iOS,
           google: 'google',
         ),
         'real',


### PR DESCRIPTION
Introduces **Novlang** (ref. Orwell's Newspeak): a mechanism to show store-forbidden words (e.g. "Exchange") as store-compliant euphemisms (e.g. "Account") to pass App Store / Play Store review, while keeping the real words in the source strings and revealing them to superusers.

## How

- **`packages/novlang`** — new Flutter-free package holding the pure selection logic: `NewspeakPolicy { none, apple, google }` + `pick({real, apple, google})`. Reusable, correct dependency direction (app → package).
- **`NovlangX` extension** (`settings/public/`) — resolves the active policy from platform (`defaultTargetPlatform`) + hidden superuser toggle, then delegates to the package. `context.novlang(real:, apple:, google:)` is the single public entry point, exposed via `settings_facade.dart`.
- **Policy**: derived, not stored — iOS → `apple`, Android → `google`, superuser unlocked → `none` (real words). No DB/migration.
- **Applied** to the exchange settings title (two render sites), migrating the pre-existing ad-hoc key-swap onto the unified mechanism.


## Bug fixed

`exchange_settings_screen` gated its title on `isSuperuser` alone, so an **Android** non-superuser wrongly saw the Apple euphemism "Account Settings". Deriving the policy from the platform fixes this — Android now correctly shows "Exchange Settings".

## Commits

| Commit | |
|---|---|
| `feat(settings)` | novlang selector helper derived from superuser |
| `chore(l10n)` | `NewspeakApple` twin for exchange settings title |
| `feat(settings)` | render exchange settings title via novlang |
| `feat(novlang)` | pure-logic Newspeak policy package |
| `refactor(settings)` | delegate to package + expose via facade |

## Follow-ups (not in this PR)

- Delete deprecated `settingsAccountSettingsTitle` after translation sync confirms (`arb.dart dead --list` → `delete`).
- Compliance review of the iOS wall screen (`ExchangeLandingScreenV2`) which intentionally renders "Buy/Sell/Exchange".
- Possible full `packages/novlang` (incl. policy resolution) once the superuser/Novlang toggle state is extracted into a package.