### PR TITLE
[privacy] Implement Joinstr coinjoin (proof of concept)

### DIFF
--- a/lib/core/electrum/domain/value_objects/electrum_url.dart
+++ b/lib/core/electrum/domain/value_objects/electrum_url.dart
@@ -1,0 +1,40 @@
+/// Canonical parse of a stored electrum server url into host, port and TLS
+/// intent. Lives in the electrum module so every consumer shares one rule
+/// instead of re-implementing scheme and port handling.
+class ElectrumUrl {
+  final String host;
+  final int port;
+
+  /// True when the url carries an `ssl://` scheme. Consumers that speak to
+  /// TLS-only servers (e.g. `:50002`) must preserve this rather than silently
+  /// downgrading to plaintext.
+  final bool useSsl;
+
+  const ElectrumUrl._({
+    required this.host,
+    required this.port,
+    required this.useSsl,
+  });
+
+  /// Parses `[scheme://]host:port`. Returns null when the host is empty, the
+  /// port is missing, or the port is outside 1-65535.
+  static ElectrumUrl? tryParse(String url) {
+    final trimmed = url.trim();
+    final schemeEnd = trimmed.indexOf('://');
+    final scheme = schemeEnd == -1
+        ? ''
+        : trimmed.substring(0, schemeEnd).toLowerCase();
+    final hostPort = schemeEnd == -1
+        ? trimmed
+        : trimmed.substring(schemeEnd + 3);
+
+    final colon = hostPort.lastIndexOf(':');
+    if (colon <= 0 || colon == hostPort.length - 1) return null;
+
+    final host = hostPort.substring(0, colon);
+    final port = int.tryParse(hostPort.substring(colon + 1));
+    if (port == null || port < 1 || port > 65535) return null;
+
+    return ElectrumUrl._(host: host, port: port, useSsl: scheme == 'ssl');
+  }
+}

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -86,6 +86,9 @@ class PayjoinConstants {
 }
 
 class ApiServiceConstants {
+  // Nostr relay used to advertise and discover joinstr coinjoin pools.
+  static const String defaultNostrRelayUrl = 'wss://nos.lol';
+
   // Bitcoin mempool
   static const bbMempoolUrlPath = 'mempool.bullbitcoin.com';
   static const publicMempoolUrlPath = 'mempool.space'; // note: not used

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/electrum/domain/electrum_fallback_runner.dart';
+import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
@@ -169,7 +170,7 @@ class JoinstrDatasource {
     yield* _run(
       jns.initiateCoinjoin(
         config: jns.FfiPoolConfig(
-          denominationBtc: Joinstr.denominationBtc(denominationSat),
+          denominationBtc: ConvertAmount.satsToBtc(denominationSat),
           fee: feeRateSatPerVb,
           maxDuration: BigInt.from(maxDuration.inSeconds),
           peers: peers,

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -8,15 +8,28 @@ import 'package:joinstr_flutter/joinstr_flutter.dart' as jns;
 class JoinstrDatasource {
   const JoinstrDatasource();
 
+  /// Runs an FFI call, translating the binding's `JoinstrError` into a domain
+  /// [JoinstrException] that carries its real message. Without this the error
+  /// surfaces as `JoinstrError.toString()`, i.e. "Instance of 'JoinstrError'".
+  Future<T> _call<T>(Future<T> Function() ffi) async {
+    try {
+      return await ffi();
+    } on jns.JoinstrError catch (e) {
+      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.message);
+    }
+  }
+
   Future<List<JoinstrPool>> listPools({
     required String relay,
     required Duration back,
     required Duration wait,
   }) async {
-    final pools = await jns.listPools(
-      back: BigInt.from(back.inSeconds),
-      timeout: BigInt.from(wait.inMicroseconds),
-      relay: relay,
+    final pools = await _call(
+      () => jns.listPools(
+        back: BigInt.from(back.inSeconds),
+        timeout: BigInt.from(wait.inMicroseconds),
+        relay: relay,
+      ),
     );
 
     // `FfiPool.network` is not trustworthy: pools published by the rust
@@ -47,16 +60,17 @@ class JoinstrDatasource {
     required String outputAddress,
     required String electrumUrl,
   }) async {
-    final peer = await _peerConfig(
-      wallet: wallet,
-      mnemonic: mnemonic,
-      outputAddress: outputAddress,
-      electrumUrl: electrumUrl,
-      relay: pool.relay,
-      denominationSat: pool.denominationSat,
-    );
-
-    return jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer);
+    return _call(() async {
+      final peer = await _peerConfig(
+        wallet: wallet,
+        mnemonic: mnemonic,
+        outputAddress: outputAddress,
+        electrumUrl: electrumUrl,
+        relay: pool.relay,
+        denominationSat: pool.denominationSat,
+      );
+      return jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer);
+    });
   }
 
   Future<String> initiatePool({
@@ -70,25 +84,26 @@ class JoinstrDatasource {
     required int peers,
     required Duration maxDuration,
   }) async {
-    final peer = await _peerConfig(
-      wallet: wallet,
-      mnemonic: mnemonic,
-      outputAddress: outputAddress,
-      electrumUrl: electrumUrl,
-      relay: relay,
-      denominationSat: denominationSat,
-    );
-
-    return jns.initiateCoinjoin(
-      config: jns.FfiPoolConfig(
-        denominationBtc: Joinstr.denominationBtc(denominationSat),
-        fee: feeRateSatPerVb,
-        maxDuration: BigInt.from(maxDuration.inSeconds),
-        peers: peers,
-        network: _network(wallet.network),
-      ),
-      peer: peer,
-    );
+    return _call(() async {
+      final peer = await _peerConfig(
+        wallet: wallet,
+        mnemonic: mnemonic,
+        outputAddress: outputAddress,
+        electrumUrl: electrumUrl,
+        relay: relay,
+        denominationSat: denominationSat,
+      );
+      return jns.initiateCoinjoin(
+        config: jns.FfiPoolConfig(
+          denominationBtc: Joinstr.denominationBtc(denominationSat),
+          fee: feeRateSatPerVb,
+          maxDuration: BigInt.from(maxDuration.inSeconds),
+          peers: peers,
+          network: _network(wallet.network),
+        ),
+        peer: peer,
+      );
+    });
   }
 
   Future<jns.FfiPeerConfig> _peerConfig({

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -23,12 +23,14 @@ class JoinstrDatasource {
     required String relay,
     required Duration back,
     required Duration wait,
+    String? proxy,
   }) async {
     final pools = await _call(
       () => jns.listPools(
         back: BigInt.from(back.inSeconds),
         timeout: BigInt.from(wait.inMicroseconds),
         relay: relay,
+        proxy: proxy,
       ),
     );
 
@@ -59,6 +61,7 @@ class JoinstrDatasource {
     required String mnemonic,
     required String outputAddress,
     required String electrumUrl,
+    String? proxy,
   }) async {
     return _call(() async {
       final peer = await _peerConfig(
@@ -68,6 +71,7 @@ class JoinstrDatasource {
         electrumUrl: electrumUrl,
         relay: pool.relay,
         denominationSat: pool.denominationSat,
+        proxy: proxy,
       );
       return jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer);
     });
@@ -83,6 +87,7 @@ class JoinstrDatasource {
     required int feeRateSatPerVb,
     required int peers,
     required Duration maxDuration,
+    String? proxy,
   }) async {
     return _call(() async {
       final peer = await _peerConfig(
@@ -92,6 +97,7 @@ class JoinstrDatasource {
         electrumUrl: electrumUrl,
         relay: relay,
         denominationSat: denominationSat,
+        proxy: proxy,
       );
       return jns.initiateCoinjoin(
         config: jns.FfiPoolConfig(
@@ -113,6 +119,7 @@ class JoinstrDatasource {
     required String electrumUrl,
     required String relay,
     required int denominationSat,
+    String? proxy,
   }) async {
     final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
     final network = _network(wallet.network);
@@ -124,6 +131,7 @@ class JoinstrDatasource {
       rangeStart: 0,
       rangeEnd: Joinstr.scanDepth,
       network: network,
+      proxy: proxy,
     );
 
     // The window is enforced by every other peer only *after* we broadcast a
@@ -148,6 +156,7 @@ class JoinstrDatasource {
       outputAddress: outputAddress,
       relay: relay,
       network: network,
+      proxy: proxy,
     );
   }
 

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -1,3 +1,6 @@
+import 'package:bb_mobile/core/electrum/domain/electrum_fallback_runner.dart';
+import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
+import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
@@ -22,7 +25,38 @@ class JoinstrDatasource {
       return await ffi();
     } on jns.JoinstrError catch (e) {
       throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.message);
+    } on AllElectrumServersFailedException catch (e) {
+      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.message);
     }
+  }
+
+  /// Runs the FFI coin scan against the active servers in priority order,
+  /// falling back to the next server when one fails, and returns the winning
+  /// endpoint alongside the coins so a round talks to the server that worked.
+  Future<(({String address, int port}), List<jns.FfiCoin>)> _scanCoins({
+    required String mnemonic,
+    required List<ElectrumServer> electrumServers,
+    required jns.BitcoinNetwork network,
+    String? proxy,
+  }) {
+    return runElectrumFallback(
+      servers: electrumServers,
+      urlOf: (s) => s.url,
+      isCustomOf: (s) => s.isCustom,
+      operation: (server) async {
+        final endpoint = Joinstr.parseElectrumUrl(server.url);
+        final coins = await jns.listCoins(
+          mnemonic: mnemonic,
+          electrumAddress: endpoint.address,
+          electrumPort: endpoint.port,
+          rangeStart: 0,
+          rangeEnd: Joinstr.scanDepth,
+          network: network,
+          proxy: proxy,
+        );
+        return (endpoint, coins);
+      },
+    );
   }
 
   Future<List<JoinstrPool>> listPools({
@@ -64,17 +98,13 @@ class JoinstrDatasource {
   Future<List<JoinstrCoin>> listCoins({
     required Wallet wallet,
     required String mnemonic,
-    required String electrumUrl,
+    required List<ElectrumServer> electrumServers,
     String? proxy,
   }) async {
-    final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
-    final coins = await _call(
-      () => jns.listCoins(
+    final (_, coins) = await _call(
+      () => _scanCoins(
         mnemonic: mnemonic,
-        electrumAddress: endpoint.address,
-        electrumPort: endpoint.port,
-        rangeStart: 0,
-        rangeEnd: Joinstr.scanDepth,
+        electrumServers: electrumServers,
         network: _network(wallet.network),
         proxy: proxy,
       ),
@@ -96,7 +126,7 @@ class JoinstrDatasource {
     required Wallet wallet,
     required String mnemonic,
     required String outputAddress,
-    required String electrumUrl,
+    required List<ElectrumServer> electrumServers,
     required String inputOutpoint,
     String? proxy,
   }) async* {
@@ -104,7 +134,7 @@ class JoinstrDatasource {
       wallet: wallet,
       mnemonic: mnemonic,
       outputAddress: outputAddress,
-      electrumUrl: electrumUrl,
+      electrumServers: electrumServers,
       relay: pool.relay,
       denominationSat: pool.denominationSat,
       inputOutpoint: inputOutpoint,
@@ -117,7 +147,7 @@ class JoinstrDatasource {
     required Wallet wallet,
     required String mnemonic,
     required String outputAddress,
-    required String electrumUrl,
+    required List<ElectrumServer> electrumServers,
     required String relay,
     required int denominationSat,
     required int feeRateSatPerVb,
@@ -130,7 +160,7 @@ class JoinstrDatasource {
       wallet: wallet,
       mnemonic: mnemonic,
       outputAddress: outputAddress,
-      electrumUrl: electrumUrl,
+      electrumServers: electrumServers,
       relay: relay,
       denominationSat: denominationSat,
       inputOutpoint: inputOutpoint,
@@ -183,24 +213,21 @@ class JoinstrDatasource {
     required Wallet wallet,
     required String mnemonic,
     required String outputAddress,
-    required String electrumUrl,
+    required List<ElectrumServer> electrumServers,
     required String relay,
     required int denominationSat,
     required String inputOutpoint,
     String? proxy,
   }) async {
-    await jns.JoinstrFlutter.init();
-    final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
     final network = _network(wallet.network);
 
-    final coins = await jns.listCoins(
-      mnemonic: mnemonic,
-      electrumAddress: endpoint.address,
-      electrumPort: endpoint.port,
-      rangeStart: 0,
-      rangeEnd: Joinstr.scanDepth,
-      network: network,
-      proxy: proxy,
+    final (endpoint, coins) = await _call(
+      () => _scanCoins(
+        mnemonic: mnemonic,
+        electrumServers: electrumServers,
+        network: network,
+        proxy: proxy,
+      ),
     );
 
     // Use the coin the user picked. Re-listing here keeps it fresh: a coin that

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -190,6 +190,9 @@ class JoinstrDatasource {
           step: _step(u.step),
           txId: u.txid,
           errorMessage: u.error,
+          outputEventId: u.outputEventId,
+          inputEventId: u.inputEventId,
+          psbt: u.psbt,
         );
       }
     } on jns.JoinstrError catch (e) {

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -1,0 +1,145 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:joinstr_flutter/joinstr_flutter.dart' as jns;
+
+/// Wraps the joinstr bindings. Everything above this layer works in satoshis
+/// and domain entities; the `Ffi*` types and the BTC-denominated pool config
+/// do not escape it.
+class JoinstrDatasource {
+  const JoinstrDatasource();
+
+  Future<List<JoinstrPool>> listPools({
+    required String relay,
+    required Duration back,
+    required Duration wait,
+  }) async {
+    final pools = await jns.listPools(
+      back: BigInt.from(back.inSeconds),
+      timeout: BigInt.from(wait.inMicroseconds),
+      relay: relay,
+    );
+
+    // `FfiPool.network` is not trustworthy: pools published by the rust
+    // implementation omit the field, so it decodes as mainnet regardless of
+    // origin. It is deliberately not mapped onto the domain entity.
+    return pools
+        .map(
+          (p) => JoinstrPool(
+            id: p.id,
+            rawJson: p.rawJson,
+            denominationSat: p.denominationSat.toInt(),
+            peers: p.peers,
+            expiresAtUnixSec: p.expiresAtUnixSec.toInt(),
+            relay: p.relay,
+            feeRateSatPerVb: p.feeRate,
+            publicKey: p.publicKey,
+          ),
+        )
+        .toList();
+  }
+
+  /// Blocks until the coinjoin broadcasts or the pool times out, then returns
+  /// the txid.
+  Future<String> joinPool({
+    required JoinstrPool pool,
+    required Wallet wallet,
+    required String mnemonic,
+    required String outputAddress,
+    required String electrumUrl,
+  }) async {
+    final peer = await _peerConfig(
+      wallet: wallet,
+      mnemonic: mnemonic,
+      outputAddress: outputAddress,
+      electrumUrl: electrumUrl,
+      relay: pool.relay,
+      denominationSat: pool.denominationSat,
+    );
+
+    return jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer);
+  }
+
+  Future<String> initiatePool({
+    required Wallet wallet,
+    required String mnemonic,
+    required String outputAddress,
+    required String electrumUrl,
+    required String relay,
+    required int denominationSat,
+    required int feeRateSatPerVb,
+    required int peers,
+    required Duration maxDuration,
+  }) async {
+    final peer = await _peerConfig(
+      wallet: wallet,
+      mnemonic: mnemonic,
+      outputAddress: outputAddress,
+      electrumUrl: electrumUrl,
+      relay: relay,
+      denominationSat: denominationSat,
+    );
+
+    return jns.initiateCoinjoin(
+      config: jns.FfiPoolConfig(
+        denominationBtc: Joinstr.denominationBtc(denominationSat),
+        fee: feeRateSatPerVb,
+        maxDuration: BigInt.from(maxDuration.inSeconds),
+        peers: peers,
+        network: _network(wallet.network),
+      ),
+      peer: peer,
+    );
+  }
+
+  Future<jns.FfiPeerConfig> _peerConfig({
+    required Wallet wallet,
+    required String mnemonic,
+    required String outputAddress,
+    required String electrumUrl,
+    required String relay,
+    required int denominationSat,
+  }) async {
+    final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
+    final network = _network(wallet.network);
+
+    final coins = await jns.listCoins(
+      mnemonic: mnemonic,
+      electrumAddress: endpoint.address,
+      electrumPort: endpoint.port,
+      rangeStart: 0,
+      rangeEnd: Joinstr.scanDepth,
+      network: network,
+    );
+
+    // The window is enforced by every other peer only *after* we broadcast a
+    // SIGHASH_ALL|SIGHASH_ANYONECANPAY signature over the coin, so an
+    // ineligible coin must never reach the signer.
+    final index = Joinstr.selectEligibleCoin(
+      coinValuesSat: coins.map((c) => c.valueSat.toInt()).toList(),
+      denominationSat: denominationSat,
+    );
+    if (index == null) {
+      throw JoinstrException(
+        JoinstrIssue.noEligibleCoin,
+        denominationSat: denominationSat,
+      );
+    }
+
+    return jns.FfiPeerConfig(
+      mnemonic: mnemonic,
+      electrumAddress: endpoint.address,
+      electrumPort: endpoint.port,
+      input: coins[index],
+      outputAddress: outputAddress,
+      relay: relay,
+      network: network,
+    );
+  }
+
+  jns.BitcoinNetwork _network(Network network) => switch (network) {
+    Network.bitcoinMainnet => jns.BitcoinNetwork.bitcoin,
+    Network.bitcoinTestnet => jns.BitcoinNetwork.testnet,
+    Network.liquidMainnet ||
+    Network.liquidTestnet => throw JoinstrException(JoinstrIssue.bitcoinOnly),
+  };
+}

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -1,5 +1,8 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:joinstr_flutter/joinstr_flutter.dart' as jns;
 
 /// Wraps the joinstr bindings. Everything above this layer works in satoshis
@@ -53,31 +56,61 @@ class JoinstrDatasource {
         .toList();
   }
 
-  /// Blocks until the coinjoin broadcasts or the pool times out, then returns
-  /// the txid.
-  Future<String> joinPool({
+  /// Lists the wallet's spendable coins by scanning electrum over Tor. The
+  /// caller filters these to the coins eligible for a given denomination.
+  Future<List<JoinstrCoin>> listCoins({
+    required Wallet wallet,
+    required String mnemonic,
+    required String electrumUrl,
+    String? proxy,
+  }) async {
+    final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
+    final coins = await _call(
+      () => jns.listCoins(
+        mnemonic: mnemonic,
+        electrumAddress: endpoint.address,
+        electrumPort: endpoint.port,
+        rangeStart: 0,
+        rangeEnd: Joinstr.scanDepth,
+        network: _network(wallet.network),
+        proxy: proxy,
+      ),
+    );
+    return coins
+        .map(
+          (c) => JoinstrCoin(
+            txid: c.txid,
+            vout: c.vout,
+            valueSat: c.valueSat.toInt(),
+          ),
+        )
+        .toList();
+  }
+
+  /// Streams coinjoin progress until it broadcasts or the pool times out.
+  Stream<JoinstrProgress> joinPool({
     required JoinstrPool pool,
     required Wallet wallet,
     required String mnemonic,
     required String outputAddress,
     required String electrumUrl,
+    required String inputOutpoint,
     String? proxy,
-  }) async {
-    return _call(() async {
-      final peer = await _peerConfig(
-        wallet: wallet,
-        mnemonic: mnemonic,
-        outputAddress: outputAddress,
-        electrumUrl: electrumUrl,
-        relay: pool.relay,
-        denominationSat: pool.denominationSat,
-        proxy: proxy,
-      );
-      return jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer);
-    });
+  }) async* {
+    final peer = await _peerConfig(
+      wallet: wallet,
+      mnemonic: mnemonic,
+      outputAddress: outputAddress,
+      electrumUrl: electrumUrl,
+      relay: pool.relay,
+      denominationSat: pool.denominationSat,
+      inputOutpoint: inputOutpoint,
+      proxy: proxy,
+    );
+    yield* _run(jns.joinCoinjoin(poolRawJson: pool.rawJson, peer: peer));
   }
 
-  Future<String> initiatePool({
+  Stream<JoinstrProgress> initiatePool({
     required Wallet wallet,
     required String mnemonic,
     required String outputAddress,
@@ -87,19 +120,21 @@ class JoinstrDatasource {
     required int feeRateSatPerVb,
     required int peers,
     required Duration maxDuration,
+    required String inputOutpoint,
     String? proxy,
-  }) async {
-    return _call(() async {
-      final peer = await _peerConfig(
-        wallet: wallet,
-        mnemonic: mnemonic,
-        outputAddress: outputAddress,
-        electrumUrl: electrumUrl,
-        relay: relay,
-        denominationSat: denominationSat,
-        proxy: proxy,
-      );
-      return jns.initiateCoinjoin(
+  }) async* {
+    final peer = await _peerConfig(
+      wallet: wallet,
+      mnemonic: mnemonic,
+      outputAddress: outputAddress,
+      electrumUrl: electrumUrl,
+      relay: relay,
+      denominationSat: denominationSat,
+      inputOutpoint: inputOutpoint,
+      proxy: proxy,
+    );
+    yield* _run(
+      jns.initiateCoinjoin(
         config: jns.FfiPoolConfig(
           denominationBtc: Joinstr.denominationBtc(denominationSat),
           fee: feeRateSatPerVb,
@@ -108,9 +143,38 @@ class JoinstrDatasource {
           network: _network(wallet.network),
         ),
         peer: peer,
-      );
-    });
+      ),
+    );
   }
+
+  /// Maps the binding's progress stream onto the domain, translating a binding
+  /// error into a [JoinstrException] the way [_call] does for one-shot calls.
+  Stream<JoinstrProgress> _run(Stream<jns.FfiCoinjoinUpdate> updates) async* {
+    try {
+      await for (final u in updates) {
+        yield JoinstrProgress(
+          step: _step(u.step),
+          txId: u.txid,
+          errorMessage: u.error,
+        );
+      }
+    } on jns.JoinstrError catch (e) {
+      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.message);
+    }
+  }
+
+  JoinstrRoundStep _step(jns.FfiCoinjoinStep step) => switch (step) {
+    jns.FfiCoinjoinStep.connecting => JoinstrRoundStep.connecting,
+    jns.FfiCoinjoinStep.posting => JoinstrRoundStep.posting,
+    jns.FfiCoinjoinStep.outputRegistration =>
+      JoinstrRoundStep.outputRegistration,
+    jns.FfiCoinjoinStep.inputRegistration => JoinstrRoundStep.inputRegistration,
+    jns.FfiCoinjoinStep.broadcast => JoinstrRoundStep.broadcast,
+    jns.FfiCoinjoinStep.mined => JoinstrRoundStep.mined,
+    jns.FfiCoinjoinStep.done => JoinstrRoundStep.done,
+    jns.FfiCoinjoinStep.failed => JoinstrRoundStep.failed,
+    jns.FfiCoinjoinStep.other => JoinstrRoundStep.other,
+  };
 
   Future<jns.FfiPeerConfig> _peerConfig({
     required Wallet wallet,
@@ -119,6 +183,7 @@ class JoinstrDatasource {
     required String electrumUrl,
     required String relay,
     required int denominationSat,
+    required String inputOutpoint,
     String? proxy,
   }) async {
     final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
@@ -134,14 +199,26 @@ class JoinstrDatasource {
       proxy: proxy,
     );
 
+    // Use the coin the user picked. Re-listing here keeps it fresh: a coin that
+    // was spent since the picker loaded is simply gone from the wallet.
+    jns.FfiCoin? input;
+    for (final c in coins) {
+      if ('${c.txid}:${c.vout}' == inputOutpoint) {
+        input = c;
+        break;
+      }
+    }
+    if (input == null) {
+      throw JoinstrException(JoinstrIssue.coinUnavailable);
+    }
+
     // The window is enforced by every other peer only *after* we broadcast a
     // SIGHASH_ALL|SIGHASH_ANYONECANPAY signature over the coin, so an
     // ineligible coin must never reach the signer.
-    final index = Joinstr.selectEligibleCoin(
-      coinValuesSat: coins.map((c) => c.valueSat.toInt()).toList(),
+    if (!Joinstr.isEligibleCoin(
+      valueSat: input.valueSat.toInt(),
       denominationSat: denominationSat,
-    );
-    if (index == null) {
+    )) {
       throw JoinstrException(
         JoinstrIssue.noEligibleCoin,
         denominationSat: denominationSat,
@@ -152,7 +229,7 @@ class JoinstrDatasource {
       mnemonic: mnemonic,
       electrumAddress: endpoint.address,
       electrumPort: endpoint.port,
-      input: coins[index],
+      input: input,
       outputAddress: outputAddress,
       relay: relay,
       network: network,

--- a/lib/features/joinstr/data/joinstr_datasource.dart
+++ b/lib/features/joinstr/data/joinstr_datasource.dart
@@ -15,6 +15,9 @@ class JoinstrDatasource {
   /// [JoinstrException] that carries its real message. Without this the error
   /// surfaces as `JoinstrError.toString()`, i.e. "Instance of 'JoinstrError'".
   Future<T> _call<T>(Future<T> Function() ffi) async {
+    // Loads the native library on first use; memoized and retry-safe in the
+    // bindings, so app startup does not pay for it.
+    await jns.JoinstrFlutter.init();
     try {
       return await ffi();
     } on jns.JoinstrError catch (e) {
@@ -186,6 +189,7 @@ class JoinstrDatasource {
     required String inputOutpoint,
     String? proxy,
   }) async {
+    await jns.JoinstrFlutter.init();
     final endpoint = Joinstr.parseElectrumUrl(electrumUrl);
     final network = _network(wallet.network);
 

--- a/lib/features/joinstr/data/joinstr_store.dart
+++ b/lib/features/joinstr/data/joinstr_store.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+
+/// Persists the joinstr relay preference and coinjoin history. Backed by the
+/// app's secure key-value storage: which coins were mixed and when is exactly
+/// the linkage a coinjoin exists to hide, so it never lands in plain storage.
+class JoinstrStore {
+  static const relayKey = 'joinstr_relay';
+  static const historyKey = 'joinstr_history';
+
+  final KeyValueStorageDatasource<String> _storage;
+
+  const JoinstrStore(this._storage);
+
+  Future<String?> getRelay() => _storage.getValue(relayKey);
+
+  Future<void> saveRelay(String relay) =>
+      _storage.saveValue(key: relayKey, value: relay.trim());
+
+  Future<List<JoinstrHistoryEntry>> getHistory() async {
+    final raw = await _storage.getValue(historyKey);
+    if (raw == null || raw.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<Map<String, dynamic>>()
+          .map(JoinstrHistoryEntry.fromJson)
+          .whereType<JoinstrHistoryEntry>()
+          .toList();
+    } on FormatException {
+      return const [];
+    }
+  }
+
+  Future<void> appendHistory(JoinstrHistoryEntry entry) async {
+    final history = await getHistory();
+    final updated = [entry, ...history];
+    await _storage.saveValue(
+      key: historyKey,
+      value: jsonEncode(updated.map((e) => e.toJson()).toList()),
+    );
+  }
+}

--- a/lib/features/joinstr/data/joinstr_store.dart
+++ b/lib/features/joinstr/data/joinstr_store.dart
@@ -12,7 +12,11 @@ class JoinstrStore {
 
   final KeyValueStorageDatasource<String> _storage;
 
-  const JoinstrStore(this._storage);
+  /// Chains history writes: append is a read-modify-write, and several rounds
+  /// can complete at once, so unserialized appends could drop an entry.
+  Future<void> _historyWrites = Future.value();
+
+  JoinstrStore(this._storage);
 
   Future<String?> getRelay() => _storage.getValue(relayKey);
 
@@ -35,12 +39,17 @@ class JoinstrStore {
     }
   }
 
-  Future<void> appendHistory(JoinstrHistoryEntry entry) async {
-    final history = await getHistory();
-    final updated = [entry, ...history];
-    await _storage.saveValue(
-      key: historyKey,
-      value: jsonEncode(updated.map((e) => e.toJson()).toList()),
-    );
+  Future<void> appendHistory(JoinstrHistoryEntry entry) {
+    final write = _historyWrites.then((_) async {
+      final history = await getHistory();
+      final updated = [entry, ...history];
+      await _storage.saveValue(
+        key: historyKey,
+        value: jsonEncode(updated.map((e) => e.toJson()).toList()),
+      );
+    });
+    // A failed write must not poison later appends on the chain.
+    _historyWrites = write.then((_) {}, onError: (_) {});
+    return write;
   }
 }

--- a/lib/features/joinstr/data/joinstr_store.dart
+++ b/lib/features/joinstr/data/joinstr_store.dart
@@ -9,7 +9,6 @@ import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 class JoinstrStore {
   static const relayKey = 'joinstr_relay';
   static const historyKey = 'joinstr_history';
-  static const reservedAddressKey = 'joinstr_reserved_address';
 
   final KeyValueStorageDatasource<String> _storage;
 
@@ -19,18 +18,6 @@ class JoinstrStore {
 
   Future<void> saveRelay(String relay) =>
       _storage.saveValue(key: relayKey, value: relay.trim());
-
-  /// The receive address reserved for the current round. It is reused across
-  /// retries so repeated failed attempts do not walk the receive chain toward
-  /// the gap limit, and cleared on a successful broadcast so the next round
-  /// gets a fresh address rather than reusing a now-funded one on-chain.
-  Future<String?> getReservedAddress() => _storage.getValue(reservedAddressKey);
-
-  Future<void> saveReservedAddress(String address) =>
-      _storage.saveValue(key: reservedAddressKey, value: address);
-
-  Future<void> clearReservedAddress() =>
-      _storage.deleteValue(reservedAddressKey);
 
   Future<List<JoinstrHistoryEntry>> getHistory() async {
     final raw = await _storage.getValue(historyKey);

--- a/lib/features/joinstr/data/joinstr_store.dart
+++ b/lib/features/joinstr/data/joinstr_store.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 class JoinstrStore {
   static const relayKey = 'joinstr_relay';
   static const historyKey = 'joinstr_history';
+  static const reservedAddressKey = 'joinstr_reserved_address';
 
   final KeyValueStorageDatasource<String> _storage;
 
@@ -18,6 +19,18 @@ class JoinstrStore {
 
   Future<void> saveRelay(String relay) =>
       _storage.saveValue(key: relayKey, value: relay.trim());
+
+  /// The receive address reserved for the current round. It is reused across
+  /// retries so repeated failed attempts do not walk the receive chain toward
+  /// the gap limit, and cleared on a successful broadcast so the next round
+  /// gets a fresh address rather than reusing a now-funded one on-chain.
+  Future<String?> getReservedAddress() => _storage.getValue(reservedAddressKey);
+
+  Future<void> saveReservedAddress(String address) =>
+      _storage.saveValue(key: reservedAddressKey, value: address);
+
+  Future<void> clearReservedAddress() =>
+      _storage.deleteValue(reservedAddressKey);
 
   Future<List<JoinstrHistoryEntry>> getHistory() async {
     final raw = await _storage.getValue(historyKey);

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -10,6 +10,7 @@ enum JoinstrIssue {
   invalidElectrumUrl,
   invalidPoolConfig,
   invalidRelayUrl,
+  torUnavailable,
   poolNotFound,
   coinjoinFailed,
 }

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -53,10 +53,8 @@ class JoinstrPool {
   });
 
   /// Seconds until the pool expires relative to [now], clamped at zero.
-  int secondsUntilExpiry(DateTime now) {
-    final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
-    return remaining > 0 ? remaining : 0;
-  }
+  int secondsUntilExpiry(DateTime now) =>
+      Joinstr.secondsUntilExpiry(expiresAtUnixSec, now);
 }
 
 abstract final class Joinstr {
@@ -115,6 +113,13 @@ abstract final class Joinstr {
       address: parsed.useSsl ? 'ssl://${parsed.host}' : parsed.host,
       port: parsed.port,
     );
+  }
+
+  /// Seconds until [expiresAtUnixSec] relative to [now], clamped at zero.
+  /// Shared by pools and rounds.
+  static int secondsUntilExpiry(int expiresAtUnixSec, DateTime now) {
+    final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
+    return remaining > 0 ? remaining : 0;
   }
 
   /// Formats a remaining duration for pool tiles, e.g. "1h 5m", "12m 30s",

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_url.dart';
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 
@@ -99,33 +100,21 @@ abstract final class Joinstr {
     return denom > 0 ? denom : null;
   }
 
-  /// Splits a stored electrum url into the address and port the bindings take.
+  /// Splits a stored electrum url into the address and port the bindings
+  /// take, via the electrum module's canonical [ElectrumUrl] parse.
   ///
   /// The `ssl://` prefix is deliberately preserved: joinstr only negotiates TLS
   /// when the address starts with it, so stripping the scheme would silently
   /// downgrade an SSL-only server such as `:50002` to plaintext.
   static ({String address, int port}) parseElectrumUrl(String url) {
-    final trimmed = url.trim();
-    final schemeEnd = trimmed.indexOf('://');
-    final scheme = schemeEnd == -1
-        ? ''
-        : trimmed.substring(0, schemeEnd).toLowerCase();
-    final hostPort = schemeEnd == -1
-        ? trimmed
-        : trimmed.substring(schemeEnd + 3);
-
-    final colon = hostPort.lastIndexOf(':');
-    if (colon <= 0 || colon == hostPort.length - 1) {
+    final parsed = ElectrumUrl.tryParse(url);
+    if (parsed == null) {
       throw JoinstrException(JoinstrIssue.invalidElectrumUrl, detail: url);
     }
-
-    final host = hostPort.substring(0, colon);
-    final port = int.tryParse(hostPort.substring(colon + 1));
-    if (port == null || port < 1 || port > 65535) {
-      throw JoinstrException(JoinstrIssue.invalidElectrumUrl, detail: url);
-    }
-
-    return (address: scheme == 'ssl' ? 'ssl://$host' : host, port: port);
+    return (
+      address: parsed.useSsl ? 'ssl://${parsed.host}' : parsed.host,
+      port: parsed.port,
+    );
   }
 
   /// Formats a remaining duration for pool tiles, e.g. "1h 5m", "12m 30s",

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -1,0 +1,149 @@
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+
+enum JoinstrIssue {
+  bitcoinOnly,
+  mainnetNotSupported,
+  watchOnlyWallet,
+  unsupportedScriptType,
+  noEligibleCoin,
+  invalidElectrumUrl,
+  invalidPoolConfig,
+  poolNotFound,
+  coinjoinFailed,
+}
+
+class JoinstrException extends BullException {
+  final JoinstrIssue issue;
+  final int? denominationSat;
+  final String? detail;
+
+  JoinstrException(this.issue, {this.denominationSat, this.detail})
+    : super('Joinstr: ${issue.name}');
+}
+
+/// A coinjoin pool advertised on a nostr relay.
+class JoinstrPool {
+  final String id;
+
+  /// Canonical JSON, passed back to the bindings to join.
+  final String rawJson;
+  final int denominationSat;
+  final int peers;
+
+  /// When the pool expires, as a unix timestamp in seconds (absolute, not a
+  /// duration).
+  final int expiresAtUnixSec;
+  final String relay;
+  final int feeRateSatPerVb;
+  final String publicKey;
+
+  const JoinstrPool({
+    required this.id,
+    required this.rawJson,
+    required this.denominationSat,
+    required this.peers,
+    required this.expiresAtUnixSec,
+    required this.relay,
+    required this.feeRateSatPerVb,
+    required this.publicKey,
+  });
+
+  /// Seconds until the pool expires relative to [now], clamped at zero.
+  int secondsUntilExpiry(DateTime now) {
+    final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
+    return remaining > 0 ? remaining : 0;
+  }
+}
+
+abstract final class Joinstr {
+  /// A joinstr input must satisfy
+  /// `denomination + 500 <= value <= denomination + 5000`, enforced by every
+  /// other peer in `CoinJoin::add_input`. A coin outside this window is
+  /// rejected after we have already published a signature over it, so the
+  /// window is checked here before anything is signed.
+  static const int minInputSurplusSat = 500;
+  static const int maxInputSurplusSat = 5000;
+
+  /// Derivation indexes scanned on each branch when listing coins.
+  static const int scanDepth = 100;
+
+  /// Mainnet is withheld until the bindings can route nostr and electrum
+  /// traffic over Tor. Joining a pool over clearnet reveals the joining IP
+  /// alongside the outpoint being mixed, which defeats the point.
+  static const bool mainnetSupported = false;
+
+  static bool isEligibleCoin({
+    required int valueSat,
+    required int denominationSat,
+  }) =>
+      valueSat >= denominationSat + minInputSurplusSat &&
+      valueSat <= denominationSat + maxInputSurplusSat;
+
+  /// Index of the cheapest coin that can fund a [denominationSat] pool, or
+  /// null when no coin falls inside the window.
+  static int? selectEligibleCoin({
+    required List<int> coinValuesSat,
+    required int denominationSat,
+  }) {
+    int? best;
+    for (var i = 0; i < coinValuesSat.length; i++) {
+      final value = coinValuesSat[i];
+      if (!isEligibleCoin(valueSat: value, denominationSat: denominationSat)) {
+        continue;
+      }
+      if (best == null || value < coinValuesSat[best]) best = i;
+    }
+    return best;
+  }
+
+  /// Splits a stored electrum url into the address and port the bindings take.
+  ///
+  /// The `ssl://` prefix is deliberately preserved: joinstr only negotiates TLS
+  /// when the address starts with it, so stripping the scheme would silently
+  /// downgrade an SSL-only server such as `:50002` to plaintext.
+  static ({String address, int port}) parseElectrumUrl(String url) {
+    final trimmed = url.trim();
+    final schemeEnd = trimmed.indexOf('://');
+    final scheme = schemeEnd == -1
+        ? ''
+        : trimmed.substring(0, schemeEnd).toLowerCase();
+    final hostPort = schemeEnd == -1
+        ? trimmed
+        : trimmed.substring(schemeEnd + 3);
+
+    final colon = hostPort.lastIndexOf(':');
+    if (colon <= 0 || colon == hostPort.length - 1) {
+      throw JoinstrException(JoinstrIssue.invalidElectrumUrl, detail: url);
+    }
+
+    final host = hostPort.substring(0, colon);
+    final port = int.tryParse(hostPort.substring(colon + 1));
+    if (port == null || port < 1 || port > 65535) {
+      throw JoinstrException(JoinstrIssue.invalidElectrumUrl, detail: url);
+    }
+
+    return (address: scheme == 'ssl' ? 'ssl://$host' : host, port: port);
+  }
+
+  /// The bindings take the pool denomination as BTC in a `f64`.
+  static double denominationBtc(int denominationSat) => denominationSat / 1e8;
+
+  /// Throws unless [wallet] can take part in a coinjoin.
+  ///
+  /// joinstr signs with its own WPKH hot signer derived from the wallet's
+  /// mnemonic at `m/84'/{0,1}'/0'`, so anything that is not a locally-signed
+  /// native-segwit bitcoin wallet cannot participate.
+  static void assertWalletSupported(Wallet wallet) {
+    if (!wallet.isBitcoin) throw JoinstrException(JoinstrIssue.bitcoinOnly);
+    if (!wallet.signsLocally) {
+      throw JoinstrException(JoinstrIssue.watchOnlyWallet);
+    }
+    if (wallet.scriptType != ScriptType.bip84) {
+      throw JoinstrException(JoinstrIssue.unsupportedScriptType);
+    }
+    if (!wallet.isTestnet && !mainnetSupported) {
+      throw JoinstrException(JoinstrIssue.mainnetNotSupported);
+    }
+  }
+}

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -12,7 +12,6 @@ enum JoinstrIssue {
   invalidPoolConfig,
   invalidRelayUrl,
   torUnavailable,
-  poolNotFound,
   coinjoinFailed,
 }
 
@@ -100,23 +99,6 @@ abstract final class Joinstr {
     return denom > 0 ? denom : null;
   }
 
-  /// Index of the cheapest coin that can fund a [denominationSat] pool, or
-  /// null when no coin falls inside the window.
-  static int? selectEligibleCoin({
-    required List<int> coinValuesSat,
-    required int denominationSat,
-  }) {
-    int? best;
-    for (var i = 0; i < coinValuesSat.length; i++) {
-      final value = coinValuesSat[i];
-      if (!isEligibleCoin(valueSat: value, denominationSat: denominationSat)) {
-        continue;
-      }
-      if (best == null || value < coinValuesSat[best]) best = i;
-    }
-    return best;
-  }
-
   /// Splits a stored electrum url into the address and port the bindings take.
   ///
   /// The `ssl://` prefix is deliberately preserved: joinstr only negotiates TLS
@@ -148,27 +130,6 @@ abstract final class Joinstr {
 
   /// The bindings take the pool denomination as BTC in a `f64`.
   static double denominationBtc(int denominationSat) => denominationSat / 1e8;
-
-  /// Matches the denomination input rule used by joinstr-kmp and
-  /// floresta_wallet: up to 8 integer digits and up to 8 decimal places.
-  static final RegExp denominationBtcPattern = RegExp(r'^\d{0,8}(\.\d{0,8})?$');
-
-  /// Parses a BTC amount typed by the user into satoshis without a float
-  /// round trip. Returns null when the text is not a positive amount matching
-  /// [denominationBtcPattern].
-  static int? parseDenominationBtcToSat(String text) {
-    final trimmed = text.trim();
-    if (trimmed.isEmpty || !denominationBtcPattern.hasMatch(trimmed)) {
-      return null;
-    }
-    final parts = trimmed.split('.');
-    final intPart = parts[0].isEmpty ? '0' : parts[0];
-    final fracPart = parts.length > 1 ? parts[1].padRight(8, '0') : '';
-    final sats =
-        int.parse(intPart) * 100000000 +
-        (fracPart.isEmpty ? 0 : int.parse(fracPart));
-    return sats > 0 ? sats : null;
-  }
 
   /// Renders satoshis as a BTC string with trailing zeros trimmed, e.g.
   /// 100000 -> "0.001".

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -9,6 +9,7 @@ enum JoinstrIssue {
   noEligibleCoin,
   invalidElectrumUrl,
   invalidPoolConfig,
+  invalidRelayUrl,
   poolNotFound,
   coinjoinFailed,
 }
@@ -128,6 +129,56 @@ abstract final class Joinstr {
 
   /// The bindings take the pool denomination as BTC in a `f64`.
   static double denominationBtc(int denominationSat) => denominationSat / 1e8;
+
+  /// Matches the denomination input rule used by joinstr-kmp and
+  /// floresta_wallet: up to 8 integer digits and up to 8 decimal places.
+  static final RegExp denominationBtcPattern = RegExp(r'^\d{0,8}(\.\d{0,8})?$');
+
+  /// Parses a BTC amount typed by the user into satoshis without a float
+  /// round trip. Returns null when the text is not a positive amount matching
+  /// [denominationBtcPattern].
+  static int? parseDenominationBtcToSat(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty || !denominationBtcPattern.hasMatch(trimmed)) {
+      return null;
+    }
+    final parts = trimmed.split('.');
+    final intPart = parts[0].isEmpty ? '0' : parts[0];
+    final fracPart = parts.length > 1 ? parts[1].padRight(8, '0') : '';
+    final sats =
+        int.parse(intPart) * 100000000 +
+        (fracPart.isEmpty ? 0 : int.parse(fracPart));
+    return sats > 0 ? sats : null;
+  }
+
+  /// Renders satoshis as a BTC string with trailing zeros trimmed, e.g.
+  /// 100000 -> "0.001".
+  static String formatBtc(int sat) {
+    final whole = sat ~/ 100000000;
+    final frac = (sat % 100000000).toString().padLeft(8, '0');
+    final trimmedFrac = frac.replaceFirst(RegExp(r'0+$'), '');
+    return trimmedFrac.isEmpty ? '$whole' : '$whole.$trimmedFrac';
+  }
+
+  /// Formats a remaining duration for pool tiles, e.g. "1h 5m", "12m 30s",
+  /// "45s".
+  static String formatRemaining(int seconds) {
+    if (seconds <= 0) return '0s';
+    final h = seconds ~/ 3600;
+    final m = (seconds % 3600) ~/ 60;
+    final s = seconds % 60;
+    if (h > 0) return '${h}h ${m}m';
+    if (m > 0) return '${m}m ${s}s';
+    return '${s}s';
+  }
+
+  /// Nostr relays must be reached over a websocket.
+  static bool isValidRelayUrl(String url) {
+    final uri = Uri.tryParse(url.trim());
+    return uri != null &&
+        (uri.scheme == 'wss' || uri.scheme == 'ws') &&
+        uri.host.isNotEmpty;
+  }
 
   /// Throws unless [wallet] can take part in a coinjoin.
   ///

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -7,6 +7,7 @@ enum JoinstrIssue {
   watchOnlyWallet,
   unsupportedScriptType,
   noEligibleCoin,
+  coinUnavailable,
   invalidElectrumUrl,
   invalidPoolConfig,
   invalidRelayUrl,
@@ -81,6 +82,23 @@ abstract final class Joinstr {
   }) =>
       valueSat >= denominationSat + minInputSurplusSat &&
       valueSat <= denominationSat + maxInputSurplusSat;
+
+  /// The surplus (input value above the denomination) reserved to cover fees,
+  /// clamped to the window every other peer enforces.
+  static int surplusForFeeRate(int feeRateSatPerVb) =>
+      (feeRateSatPerVb * 100).clamp(minInputSurplusSat, maxInputSurplusSat);
+
+  /// When creating a pool the denomination follows the chosen input: it is the
+  /// coin's value minus the fee surplus, so the coin is eligible by
+  /// construction. Null when the coin is too small to leave a positive
+  /// denomination.
+  static int? deriveDenominationSat({
+    required int coinValueSat,
+    required int feeRateSatPerVb,
+  }) {
+    final denom = coinValueSat - surplusForFeeRate(feeRateSatPerVb);
+    return denom > 0 ? denom : null;
+  }
 
   /// Index of the cheapest coin that can fund a [denominationSat] pool, or
   /// null when no coin falls inside the window.

--- a/lib/features/joinstr/domain/joinstr.dart
+++ b/lib/features/joinstr/domain/joinstr.dart
@@ -128,18 +128,6 @@ abstract final class Joinstr {
     return (address: scheme == 'ssl' ? 'ssl://$host' : host, port: port);
   }
 
-  /// The bindings take the pool denomination as BTC in a `f64`.
-  static double denominationBtc(int denominationSat) => denominationSat / 1e8;
-
-  /// Renders satoshis as a BTC string with trailing zeros trimmed, e.g.
-  /// 100000 -> "0.001".
-  static String formatBtc(int sat) {
-    final whole = sat ~/ 100000000;
-    final frac = (sat % 100000000).toString().padLeft(8, '0');
-    final trimmedFrac = frac.replaceFirst(RegExp(r'0+$'), '');
-    return trimmedFrac.isEmpty ? '$whole' : '$whole.$trimmedFrac';
-  }
-
   /// Formats a remaining duration for pool tiles, e.g. "1h 5m", "12m 30s",
   /// "45s".
   static String formatRemaining(int seconds) {

--- a/lib/features/joinstr/domain/joinstr_coin.dart
+++ b/lib/features/joinstr/domain/joinstr_coin.dart
@@ -1,0 +1,17 @@
+/// A spendable wallet UTXO the user can pick as the input for a coinjoin,
+/// mirroring the "Select a UTXO" list in joinstr-kmp and floresta_wallet.
+class JoinstrCoin {
+  final String txid;
+  final int vout;
+  final int valueSat;
+
+  const JoinstrCoin({
+    required this.txid,
+    required this.vout,
+    required this.valueSat,
+  });
+
+  /// Stable identity used to pass the chosen coin down to the bindings and to
+  /// exclude coins already committed to another in-flight pool.
+  String get outpoint => '$txid:$vout';
+}

--- a/lib/features/joinstr/domain/joinstr_history_entry.dart
+++ b/lib/features/joinstr/domain/joinstr_history_entry.dart
@@ -1,0 +1,42 @@
+/// A completed coinjoin, persisted so the History tab survives restarts.
+class JoinstrHistoryEntry {
+  final int amountSat;
+  final String txId;
+  final String relay;
+  final int completedAtUnixSec;
+
+  const JoinstrHistoryEntry({
+    required this.amountSat,
+    required this.txId,
+    required this.relay,
+    required this.completedAtUnixSec,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'amountSat': amountSat,
+    'txId': txId,
+    'relay': relay,
+    'completedAtUnixSec': completedAtUnixSec,
+  };
+
+  /// Returns null for an entry that cannot be decoded, so one corrupt record
+  /// does not take the whole history down with it.
+  static JoinstrHistoryEntry? fromJson(Map<String, dynamic> json) {
+    final amountSat = json['amountSat'];
+    final txId = json['txId'];
+    final relay = json['relay'];
+    final completedAt = json['completedAtUnixSec'];
+    if (amountSat is! int ||
+        txId is! String ||
+        relay is! String ||
+        completedAt is! int) {
+      return null;
+    }
+    return JoinstrHistoryEntry(
+      amountSat: amountSat,
+      txId: txId,
+      relay: relay,
+      completedAtUnixSec: completedAt,
+    );
+  }
+}

--- a/lib/features/joinstr/domain/joinstr_progress.dart
+++ b/lib/features/joinstr/domain/joinstr_progress.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+
+/// One coinjoin progress update from the bindings: the step reached, plus the
+/// txid on `done` or the message on `failed`.
+class JoinstrProgress {
+  final JoinstrRoundStep step;
+  final String? txId;
+  final String? errorMessage;
+
+  const JoinstrProgress({required this.step, this.txId, this.errorMessage});
+}

--- a/lib/features/joinstr/domain/joinstr_progress.dart
+++ b/lib/features/joinstr/domain/joinstr_progress.dart
@@ -1,11 +1,25 @@
 import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 
 /// One coinjoin progress update from the bindings: the step reached, plus the
-/// txid on `done` or the message on `failed`.
+/// timeline detail known so far. `txId` is set on `done`; `errorMessage` on
+/// `failed`; the event ids, psbt and output address accumulate as their step is
+/// reached so the timeline can show real data like the reference wallets.
 class JoinstrProgress {
   final JoinstrRoundStep step;
   final String? txId;
   final String? errorMessage;
+  final String? outputAddress;
+  final String? outputEventId;
+  final String? inputEventId;
+  final String? psbt;
 
-  const JoinstrProgress({required this.step, this.txId, this.errorMessage});
+  const JoinstrProgress({
+    required this.step,
+    this.txId,
+    this.errorMessage,
+    this.outputAddress,
+    this.outputEventId,
+    this.inputEventId,
+    this.psbt,
+  });
 }

--- a/lib/features/joinstr/domain/joinstr_round.dart
+++ b/lib/features/joinstr/domain/joinstr_round.dart
@@ -55,6 +55,14 @@ abstract class JoinstrRound with _$JoinstrRound {
     @Default(JoinstrRoundStep.connecting) JoinstrRoundStep step,
     String? txId,
     JoinstrException? error,
+
+    /// Timeline detail, filled in as the round advances: the output address this
+    /// round registered, the relay event ids acknowledging the output and input
+    /// registrations, and the finalized psbt.
+    String? outputAddress,
+    String? outputEventId,
+    String? inputEventId,
+    String? psbt,
   }) = _JoinstrRound;
 
   const JoinstrRound._();

--- a/lib/features/joinstr/domain/joinstr_round.dart
+++ b/lib/features/joinstr/domain/joinstr_round.dart
@@ -1,66 +1,103 @@
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 
-enum JoinstrRoundStatus { waiting, broadcast, failed }
+/// The steps a coinjoin walks through, mirrored from the bindings so the UI can
+/// render a progress timeline like joinstr-kmp and floresta_wallet. `done` and
+/// `failed` are terminal.
+enum JoinstrRoundStep {
+  connecting,
+  posting,
+  outputRegistration,
+  inputRegistration,
+  broadcast,
+  mined,
+  done,
+  failed,
+  other;
 
-/// A coinjoin round this device initiated or joined. Rounds live in memory
-/// for the session; completed ones are also written to the persistent
-/// history.
+  /// The ordered steps the timeline renders. We start the timeline at pool
+  /// creation, so it carries more steps than the reference wallets (which only
+  /// begin at input registration); `done`/`failed`/`other` are not rows.
+  static const List<JoinstrRoundStep> timeline = [
+    connecting,
+    posting,
+    outputRegistration,
+    inputRegistration,
+    broadcast,
+    mined,
+  ];
+}
+
+/// A coinjoin round this device initiated or joined. Several can be in flight
+/// at once, each on its own input coin. Its [step] drives the timeline.
 class JoinstrRound {
+  /// Session-unique id so a specific round can be updated while others run.
+  final int id;
   final bool initiated;
   final int denominationSat;
   final int peers;
   final String relay;
   final int feeRateSatPerVb;
 
-  /// Initiator's nostr public key; null for a round this device initiated,
-  /// where the bindings generate the key internally.
+  /// The wallet coin (`txid:vout`) this round spends.
+  final String inputOutpoint;
+
+  /// Initiator's nostr public key; null for a round this device initiated.
   final String? publicKey;
   final int expiresAtUnixSec;
-  final JoinstrRoundStatus status;
+
+  /// The latest progress step (one of [JoinstrRoundStep.timeline]). Terminal
+  /// state is carried by [txId] (broadcast) and [error] (failed), so the
+  /// timeline keeps showing the step the round reached even after it ends.
+  final JoinstrRoundStep step;
   final String? txId;
   final JoinstrException? error;
 
   const JoinstrRound({
+    required this.id,
     required this.initiated,
     required this.denominationSat,
     required this.peers,
     required this.relay,
     required this.feeRateSatPerVb,
+    required this.inputOutpoint,
     required this.expiresAtUnixSec,
     this.publicKey,
-    this.status = JoinstrRoundStatus.waiting,
+    this.step = JoinstrRoundStep.connecting,
     this.txId,
     this.error,
   });
 
-  bool get isWaiting => status == JoinstrRoundStatus.waiting;
+  bool get isWaiting => txId == null && error == null;
+  bool get isBroadcast => txId != null;
+  bool get isFailed => error != null;
 
   int secondsUntilExpiry(DateTime now) {
     final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
     return remaining > 0 ? remaining : 0;
   }
 
-  JoinstrRound completed(String txId) => JoinstrRound(
-    initiated: initiated,
-    denominationSat: denominationSat,
-    peers: peers,
-    relay: relay,
-    feeRateSatPerVb: feeRateSatPerVb,
-    publicKey: publicKey,
-    expiresAtUnixSec: expiresAtUnixSec,
-    status: JoinstrRoundStatus.broadcast,
-    txId: txId,
-  );
+  JoinstrRound advancedTo(JoinstrRoundStep step) => _copyWith(step: step);
 
-  JoinstrRound failed(JoinstrException error) => JoinstrRound(
+  JoinstrRound completed(String txId) => _copyWith(txId: txId);
+
+  JoinstrRound failed(JoinstrException error) => _copyWith(error: error);
+
+  JoinstrRound _copyWith({
+    JoinstrRoundStep? step,
+    String? txId,
+    JoinstrException? error,
+  }) => JoinstrRound(
+    id: id,
     initiated: initiated,
     denominationSat: denominationSat,
     peers: peers,
     relay: relay,
     feeRateSatPerVb: feeRateSatPerVb,
+    inputOutpoint: inputOutpoint,
     publicKey: publicKey,
     expiresAtUnixSec: expiresAtUnixSec,
-    status: JoinstrRoundStatus.failed,
-    error: error,
+    step: step ?? this.step,
+    txId: txId ?? this.txId,
+    error: error ?? this.error,
   );
 }

--- a/lib/features/joinstr/domain/joinstr_round.dart
+++ b/lib/features/joinstr/domain/joinstr_round.dart
@@ -1,4 +1,7 @@
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'joinstr_round.freezed.dart';
 
 /// The steps a coinjoin walks through, mirrored from the bindings so the UI can
 /// render a progress timeline like joinstr-kmp and floresta_wallet. `done` and
@@ -28,76 +31,43 @@ enum JoinstrRoundStep {
 }
 
 /// A coinjoin round this device initiated or joined. Several can be in flight
-/// at once, each on its own input coin. Its [step] drives the timeline.
-class JoinstrRound {
-  /// Session-unique id so a specific round can be updated while others run.
-  final int id;
-  final bool initiated;
-  final int denominationSat;
-  final int peers;
-  final String relay;
-  final int feeRateSatPerVb;
+/// at once, each on its own input coin. Its [step] drives the timeline:
+/// terminal state is carried by [txId] (broadcast) and [error] (failed), so
+/// the timeline keeps showing the step the round reached even after it ends.
+@freezed
+abstract class JoinstrRound with _$JoinstrRound {
+  const factory JoinstrRound({
+    /// Session-unique id so a specific round can be updated while others run.
+    required int id,
+    required bool initiated,
+    required int denominationSat,
+    required int peers,
+    required String relay,
+    required int feeRateSatPerVb,
 
-  /// The wallet coin (`txid:vout`) this round spends.
-  final String inputOutpoint;
+    /// The wallet coin (`txid:vout`) this round spends.
+    required String inputOutpoint,
+    required int expiresAtUnixSec,
 
-  /// Initiator's nostr public key; null for a round this device initiated.
-  final String? publicKey;
-  final int expiresAtUnixSec;
+    /// Initiator's nostr public key; null for a round this device initiated.
+    String? publicKey,
+    @Default(JoinstrRoundStep.connecting) JoinstrRoundStep step,
+    String? txId,
+    JoinstrException? error,
+  }) = _JoinstrRound;
 
-  /// The latest progress step (one of [JoinstrRoundStep.timeline]). Terminal
-  /// state is carried by [txId] (broadcast) and [error] (failed), so the
-  /// timeline keeps showing the step the round reached even after it ends.
-  final JoinstrRoundStep step;
-  final String? txId;
-  final JoinstrException? error;
-
-  const JoinstrRound({
-    required this.id,
-    required this.initiated,
-    required this.denominationSat,
-    required this.peers,
-    required this.relay,
-    required this.feeRateSatPerVb,
-    required this.inputOutpoint,
-    required this.expiresAtUnixSec,
-    this.publicKey,
-    this.step = JoinstrRoundStep.connecting,
-    this.txId,
-    this.error,
-  });
+  const JoinstrRound._();
 
   bool get isWaiting => txId == null && error == null;
   bool get isBroadcast => txId != null;
   bool get isFailed => error != null;
 
-  int secondsUntilExpiry(DateTime now) {
-    final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
-    return remaining > 0 ? remaining : 0;
-  }
+  int secondsUntilExpiry(DateTime now) =>
+      Joinstr.secondsUntilExpiry(expiresAtUnixSec, now);
 
-  JoinstrRound advancedTo(JoinstrRoundStep step) => _copyWith(step: step);
+  JoinstrRound advancedTo(JoinstrRoundStep step) => copyWith(step: step);
 
-  JoinstrRound completed(String txId) => _copyWith(txId: txId);
+  JoinstrRound completed(String txId) => copyWith(txId: txId);
 
-  JoinstrRound failed(JoinstrException error) => _copyWith(error: error);
-
-  JoinstrRound _copyWith({
-    JoinstrRoundStep? step,
-    String? txId,
-    JoinstrException? error,
-  }) => JoinstrRound(
-    id: id,
-    initiated: initiated,
-    denominationSat: denominationSat,
-    peers: peers,
-    relay: relay,
-    feeRateSatPerVb: feeRateSatPerVb,
-    inputOutpoint: inputOutpoint,
-    publicKey: publicKey,
-    expiresAtUnixSec: expiresAtUnixSec,
-    step: step ?? this.step,
-    txId: txId ?? this.txId,
-    error: error ?? this.error,
-  );
+  JoinstrRound failed(JoinstrException error) => copyWith(error: error);
 }

--- a/lib/features/joinstr/domain/joinstr_round.dart
+++ b/lib/features/joinstr/domain/joinstr_round.dart
@@ -1,0 +1,66 @@
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+
+enum JoinstrRoundStatus { waiting, broadcast, failed }
+
+/// A coinjoin round this device initiated or joined. Rounds live in memory
+/// for the session; completed ones are also written to the persistent
+/// history.
+class JoinstrRound {
+  final bool initiated;
+  final int denominationSat;
+  final int peers;
+  final String relay;
+  final int feeRateSatPerVb;
+
+  /// Initiator's nostr public key; null for a round this device initiated,
+  /// where the bindings generate the key internally.
+  final String? publicKey;
+  final int expiresAtUnixSec;
+  final JoinstrRoundStatus status;
+  final String? txId;
+  final JoinstrException? error;
+
+  const JoinstrRound({
+    required this.initiated,
+    required this.denominationSat,
+    required this.peers,
+    required this.relay,
+    required this.feeRateSatPerVb,
+    required this.expiresAtUnixSec,
+    this.publicKey,
+    this.status = JoinstrRoundStatus.waiting,
+    this.txId,
+    this.error,
+  });
+
+  bool get isWaiting => status == JoinstrRoundStatus.waiting;
+
+  int secondsUntilExpiry(DateTime now) {
+    final remaining = expiresAtUnixSec - now.millisecondsSinceEpoch ~/ 1000;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  JoinstrRound completed(String txId) => JoinstrRound(
+    initiated: initiated,
+    denominationSat: denominationSat,
+    peers: peers,
+    relay: relay,
+    feeRateSatPerVb: feeRateSatPerVb,
+    publicKey: publicKey,
+    expiresAtUnixSec: expiresAtUnixSec,
+    status: JoinstrRoundStatus.broadcast,
+    txId: txId,
+  );
+
+  JoinstrRound failed(JoinstrException error) => JoinstrRound(
+    initiated: initiated,
+    denominationSat: denominationSat,
+    peers: peers,
+    relay: relay,
+    feeRateSatPerVb: feeRateSatPerVb,
+    publicKey: publicKey,
+    expiresAtUnixSec: expiresAtUnixSec,
+    status: JoinstrRoundStatus.failed,
+    error: error,
+  );
+}

--- a/lib/features/joinstr/domain/joinstr_round.dart
+++ b/lib/features/joinstr/domain/joinstr_round.dart
@@ -19,9 +19,10 @@ enum JoinstrRoundStep {
 
   /// The ordered steps the timeline renders. We start the timeline at pool
   /// creation, so it carries more steps than the reference wallets (which only
-  /// begin at input registration); `done`/`failed`/`other` are not rows.
+  /// begin at input registration). `connecting` is intentionally not a row: it
+  /// is transient plumbing the reference wallets do not surface either.
+  /// `done`/`failed`/`other` are not rows.
   static const List<JoinstrRoundStep> timeline = [
-    connecting,
     posting,
     outputRegistration,
     inputRegistration,

--- a/lib/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+
+class JoinstrSettings {
+  final String relay;
+  final List<JoinstrHistoryEntry> history;
+
+  const JoinstrSettings({required this.relay, required this.history});
+}
+
+class GetJoinstrSettingsUsecase {
+  final JoinstrStore _store;
+
+  GetJoinstrSettingsUsecase({required this._store});
+
+  Future<JoinstrSettings> execute() async {
+    final relay = await _store.getRelay();
+    final history = await _store.getHistory();
+    return JoinstrSettings(
+      relay: relay ?? ApiServiceConstants.defaultNostrRelayUrl,
+      history: history,
+    );
+  }
+}

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -1,0 +1,53 @@
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+
+/// Announces a pool and takes part in it. Blocks until the pool fills and the
+/// coinjoin broadcasts, or until [maxDuration] elapses.
+class InitiateJoinstrPoolUsecase {
+  final JoinstrDatasource _datasource;
+  final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
+
+  InitiateJoinstrPoolUsecase({
+    required this._datasource,
+    required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
+  }) : _resolvePeerContext = resolvePeerContextUsecase;
+
+  Future<String> execute({
+    required Wallet wallet,
+    required int denominationSat,
+    required int peers,
+    required int feeRateSatPerVb,
+    Duration maxDuration = const Duration(hours: 1),
+    String? relay,
+  }) async {
+    final context = await _resolvePeerContext.execute(wallet: wallet);
+
+    log.info(
+      'Joinstr initiating pool: $denominationSat sat, $peers peers, '
+      '${feeRateSatPerVb}s/vB',
+    );
+
+    try {
+      return await _datasource.initiatePool(
+        wallet: wallet,
+        mnemonic: context.mnemonic,
+        outputAddress: context.outputAddress,
+        electrumUrl: context.electrumUrl,
+        relay: relay ?? ApiServiceConstants.defaultNostrRelayUrl,
+        denominationSat: denominationSat,
+        feeRateSatPerVb: feeRateSatPerVb,
+        peers: peers,
+        maxDuration: maxDuration,
+      );
+    } on JoinstrException {
+      rethrow;
+    } catch (e) {
+      log.severe(error: e, trace: StackTrace.current);
+      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.toString());
+    }
+  }
+}

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -57,7 +57,7 @@ class InitiateJoinstrPoolUsecase {
       wallet: wallet,
       mnemonic: context.mnemonic,
       outputAddress: address.address,
-      electrumUrl: context.electrumUrl,
+      electrumServers: context.electrumServers,
       relay: poolRelay,
       denominationSat: denominationSat,
       feeRateSatPerVb: feeRateSatPerVb,

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -50,6 +50,7 @@ class InitiateJoinstrPoolUsecase {
         feeRateSatPerVb: feeRateSatPerVb,
         peers: peers,
         maxDuration: maxDuration,
+        proxy: context.proxy,
       );
       // Recorded here rather than in the cubit: a round outlives the screen
       // that started it, and its outcome must reach the history regardless.

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -4,9 +4,8 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/joinstr_round_history.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
 /// Announces a pool and takes part in it with a user-chosen input coin. Blocks
@@ -53,30 +52,23 @@ class InitiateJoinstrPoolUsecase {
       '${feeRateSatPerVb}s/vB, input $inputOutpoint',
     );
 
-    await for (final progress in _datasource.initiatePool(
-      wallet: wallet,
-      mnemonic: context.mnemonic,
-      outputAddress: address.address,
-      electrumServers: context.electrumServers,
+    yield* recordHistoryOnDone(
+      store: _store,
+      amountSat: denominationSat,
       relay: poolRelay,
-      denominationSat: denominationSat,
-      feeRateSatPerVb: feeRateSatPerVb,
-      peers: peers,
-      maxDuration: maxDuration,
-      inputOutpoint: inputOutpoint,
-      proxy: context.proxy,
-    )) {
-      if (progress.step == JoinstrRoundStep.done && progress.txId != null) {
-        await _store.appendHistory(
-          JoinstrHistoryEntry(
-            amountSat: denominationSat,
-            txId: progress.txId!,
-            relay: poolRelay,
-            completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          ),
-        );
-      }
-      yield progress;
-    }
+      progress: _datasource.initiatePool(
+        wallet: wallet,
+        mnemonic: context.mnemonic,
+        outputAddress: address.address,
+        electrumServers: context.electrumServers,
+        relay: poolRelay,
+        denominationSat: denominationSat,
+        feeRateSatPerVb: feeRateSatPerVb,
+        peers: peers,
+        maxDuration: maxDuration,
+        inputOutpoint: inputOutpoint,
+        proxy: context.proxy,
+      ),
+    );
   }
 }

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecas
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/joinstr_round_history.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
@@ -50,6 +51,13 @@ class InitiateJoinstrPoolUsecase {
     log.info(
       'Joinstr initiating pool: $denominationSat sat, $peers peers, '
       '${feeRateSatPerVb}s/vB, input $inputOutpoint',
+    );
+
+    // Surface the output address up front so the timeline can show it from the
+    // start; the datasource stream then carries the event ids, psbt and txid.
+    yield JoinstrProgress(
+      step: JoinstrRoundStep.connecting,
+      outputAddress: address.address,
     );
 
     yield* recordHistoryOnDone(

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -62,6 +62,9 @@ class InitiateJoinstrPoolUsecase {
           completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         ),
       );
+      // The reserved output address received this coinjoin: release it so the
+      // next round gets a fresh one instead of reusing it on-chain.
+      await _store.clearReservedAddress();
       return txId;
     } on JoinstrException {
       rethrow;

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -1,76 +1,82 @@
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
-import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
-/// Announces a pool and takes part in it. Blocks until the pool fills and the
-/// coinjoin broadcasts, or until [maxDuration] elapses.
+/// Announces a pool and takes part in it with a user-chosen input coin. Blocks
+/// until the pool fills and the coinjoin broadcasts, or until [maxDuration]
+/// elapses.
 class InitiateJoinstrPoolUsecase {
   final JoinstrDatasource _datasource;
   final JoinstrStore _store;
-  final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
+  final ResolveJoinstrNodeContextUsecase _resolveNodeContext;
+  final GetReceiveAddressUsecase _getReceiveAddressUsecase;
 
   InitiateJoinstrPoolUsecase({
     required this._datasource,
     required this._store,
-    required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
-  }) : _resolvePeerContext = resolvePeerContextUsecase;
+    required ResolveJoinstrNodeContextUsecase resolveNodeContextUsecase,
+    required this._getReceiveAddressUsecase,
+  }) : _resolveNodeContext = resolveNodeContextUsecase;
 
-  Future<String> execute({
+  Stream<JoinstrProgress> execute({
     required Wallet wallet,
     required int denominationSat,
     required int peers,
     required int feeRateSatPerVb,
+    required String inputOutpoint,
     Duration maxDuration = const Duration(hours: 1),
     String? relay,
-  }) async {
-    final context = await _resolvePeerContext.execute(wallet: wallet);
+  }) async* {
+    final context = await _resolveNodeContext.execute(wallet: wallet);
     final poolRelay =
         relay ??
         await _store.getRelay() ??
         ApiServiceConstants.defaultNostrRelayUrl;
 
-    log.info(
-      'Joinstr initiating pool: $denominationSat sat, $peers peers, '
-      '${feeRateSatPerVb}s/vB',
+    // A fresh receive address per pool, like `getNewBech32Address()` in the
+    // reference wallets: every pool the user runs receives its denominated
+    // output to a distinct address.
+    final address = await _getReceiveAddressUsecase.execute(
+      walletId: wallet.id,
+      generateNew: true,
     );
 
-    try {
-      final txId = await _datasource.initiatePool(
-        wallet: wallet,
-        mnemonic: context.mnemonic,
-        outputAddress: context.outputAddress,
-        electrumUrl: context.electrumUrl,
-        relay: poolRelay,
-        denominationSat: denominationSat,
-        feeRateSatPerVb: feeRateSatPerVb,
-        peers: peers,
-        maxDuration: maxDuration,
-        proxy: context.proxy,
-      );
-      // Recorded here rather than in the cubit: a round outlives the screen
-      // that started it, and its outcome must reach the history regardless.
-      await _store.appendHistory(
-        JoinstrHistoryEntry(
-          amountSat: denominationSat,
-          txId: txId,
-          relay: poolRelay,
-          completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        ),
-      );
-      // The reserved output address received this coinjoin: release it so the
-      // next round gets a fresh one instead of reusing it on-chain.
-      await _store.clearReservedAddress();
-      return txId;
-    } on JoinstrException {
-      rethrow;
-    } catch (e) {
-      log.severe(error: e, trace: StackTrace.current);
-      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.toString());
+    log.info(
+      'Joinstr initiating pool: $denominationSat sat, $peers peers, '
+      '${feeRateSatPerVb}s/vB, input $inputOutpoint',
+    );
+
+    await for (final progress in _datasource.initiatePool(
+      wallet: wallet,
+      mnemonic: context.mnemonic,
+      outputAddress: address.address,
+      electrumUrl: context.electrumUrl,
+      relay: poolRelay,
+      denominationSat: denominationSat,
+      feeRateSatPerVb: feeRateSatPerVb,
+      peers: peers,
+      maxDuration: maxDuration,
+      inputOutpoint: inputOutpoint,
+      proxy: context.proxy,
+    )) {
+      if (progress.step == JoinstrRoundStep.done && progress.txId != null) {
+        await _store.appendHistory(
+          JoinstrHistoryEntry(
+            amountSat: denominationSat,
+            txId: progress.txId!,
+            relay: poolRelay,
+            completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        );
+      }
+      yield progress;
     }
   }
 }

--- a/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart
@@ -2,17 +2,21 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
 
 /// Announces a pool and takes part in it. Blocks until the pool fills and the
 /// coinjoin broadcasts, or until [maxDuration] elapses.
 class InitiateJoinstrPoolUsecase {
   final JoinstrDatasource _datasource;
+  final JoinstrStore _store;
   final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
 
   InitiateJoinstrPoolUsecase({
     required this._datasource,
+    required this._store,
     required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
   }) : _resolvePeerContext = resolvePeerContextUsecase;
 
@@ -25,6 +29,10 @@ class InitiateJoinstrPoolUsecase {
     String? relay,
   }) async {
     final context = await _resolvePeerContext.execute(wallet: wallet);
+    final poolRelay =
+        relay ??
+        await _store.getRelay() ??
+        ApiServiceConstants.defaultNostrRelayUrl;
 
     log.info(
       'Joinstr initiating pool: $denominationSat sat, $peers peers, '
@@ -32,17 +40,28 @@ class InitiateJoinstrPoolUsecase {
     );
 
     try {
-      return await _datasource.initiatePool(
+      final txId = await _datasource.initiatePool(
         wallet: wallet,
         mnemonic: context.mnemonic,
         outputAddress: context.outputAddress,
         electrumUrl: context.electrumUrl,
-        relay: relay ?? ApiServiceConstants.defaultNostrRelayUrl,
+        relay: poolRelay,
         denominationSat: denominationSat,
         feeRateSatPerVb: feeRateSatPerVb,
         peers: peers,
         maxDuration: maxDuration,
       );
+      // Recorded here rather than in the cubit: a round outlives the screen
+      // that started it, and its outcome must reach the history regardless.
+      await _store.appendHistory(
+        JoinstrHistoryEntry(
+          amountSat: denominationSat,
+          txId: txId,
+          relay: poolRelay,
+          completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      );
+      return txId;
     } on JoinstrException {
       rethrow;
     } catch (e) {

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -1,0 +1,44 @@
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+
+/// Joins an advertised pool. Blocks until the coinjoin broadcasts or the pool
+/// times out, which can be the pool's full duration.
+class JoinJoinstrPoolUsecase {
+  final JoinstrDatasource _datasource;
+  final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
+
+  JoinJoinstrPoolUsecase({
+    required this._datasource,
+    required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
+  }) : _resolvePeerContext = resolvePeerContextUsecase;
+
+  Future<String> execute({
+    required Wallet wallet,
+    required JoinstrPool pool,
+  }) async {
+    final context = await _resolvePeerContext.execute(wallet: wallet);
+
+    log.info(
+      'Joinstr joining pool ${pool.id}: '
+      '${pool.denominationSat} sat, ${pool.peers} peers',
+    );
+
+    try {
+      return await _datasource.joinPool(
+        pool: pool,
+        wallet: wallet,
+        mnemonic: context.mnemonic,
+        outputAddress: context.outputAddress,
+        electrumUrl: context.electrumUrl,
+      );
+    } on JoinstrException {
+      rethrow;
+    } catch (e) {
+      log.severe(error: e, trace: StackTrace.current);
+      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.toString());
+    }
+  }
+}

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/joinstr_round_history.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
@@ -39,6 +40,12 @@ class JoinJoinstrPoolUsecase {
     log.info(
       'Joinstr joining pool ${pool.id}: '
       '${pool.denominationSat} sat, ${pool.peers} peers, input $inputOutpoint',
+    );
+
+    // Surface the output address up front for the timeline.
+    yield JoinstrProgress(
+      step: JoinstrRoundStep.connecting,
+      outputAddress: address.address,
     );
 
     yield* recordHistoryOnDone(

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -49,6 +49,9 @@ class JoinJoinstrPoolUsecase {
           completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         ),
       );
+      // The reserved output address received this coinjoin: release it so the
+      // next round gets a fresh one instead of reusing it on-chain.
+      await _store.clearReservedAddress();
       return txId;
     } on JoinstrException {
       rethrow;

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -47,7 +47,7 @@ class JoinJoinstrPoolUsecase {
       wallet: wallet,
       mnemonic: context.mnemonic,
       outputAddress: address.address,
-      electrumUrl: context.electrumUrl,
+      electrumServers: context.electrumServers,
       inputOutpoint: inputOutpoint,
       proxy: context.proxy,
     )) {

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -37,6 +37,7 @@ class JoinJoinstrPoolUsecase {
         mnemonic: context.mnemonic,
         outputAddress: context.outputAddress,
         electrumUrl: context.electrumUrl,
+        proxy: context.proxy,
       );
       // Recorded here rather than in the cubit: a round outlives the screen
       // that started it, and its outcome must reach the history regardless.

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -1,17 +1,21 @@
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
 
 /// Joins an advertised pool. Blocks until the coinjoin broadcasts or the pool
 /// times out, which can be the pool's full duration.
 class JoinJoinstrPoolUsecase {
   final JoinstrDatasource _datasource;
+  final JoinstrStore _store;
   final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
 
   JoinJoinstrPoolUsecase({
     required this._datasource,
+    required this._store,
     required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
   }) : _resolvePeerContext = resolvePeerContextUsecase;
 
@@ -27,13 +31,24 @@ class JoinJoinstrPoolUsecase {
     );
 
     try {
-      return await _datasource.joinPool(
+      final txId = await _datasource.joinPool(
         pool: pool,
         wallet: wallet,
         mnemonic: context.mnemonic,
         outputAddress: context.outputAddress,
         electrumUrl: context.electrumUrl,
       );
+      // Recorded here rather than in the cubit: a round outlives the screen
+      // that started it, and its outcome must reach the history regardless.
+      await _store.appendHistory(
+        JoinstrHistoryEntry(
+          amountSat: pool.denominationSat,
+          txId: txId,
+          relay: pool.relay,
+          completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      );
+      return txId;
     } on JoinstrException {
       rethrow;
     } catch (e) {

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -4,9 +4,8 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecas
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/joinstr_round_history.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
 /// Joins an advertised pool with a user-chosen input coin, streaming coinjoin
@@ -42,26 +41,19 @@ class JoinJoinstrPoolUsecase {
       '${pool.denominationSat} sat, ${pool.peers} peers, input $inputOutpoint',
     );
 
-    await for (final progress in _datasource.joinPool(
-      pool: pool,
-      wallet: wallet,
-      mnemonic: context.mnemonic,
-      outputAddress: address.address,
-      electrumServers: context.electrumServers,
-      inputOutpoint: inputOutpoint,
-      proxy: context.proxy,
-    )) {
-      if (progress.step == JoinstrRoundStep.done && progress.txId != null) {
-        await _store.appendHistory(
-          JoinstrHistoryEntry(
-            amountSat: pool.denominationSat,
-            txId: progress.txId!,
-            relay: pool.relay,
-            completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-          ),
-        );
-      }
-      yield progress;
-    }
+    yield* recordHistoryOnDone(
+      store: _store,
+      amountSat: pool.denominationSat,
+      relay: pool.relay,
+      progress: _datasource.joinPool(
+        pool: pool,
+        wallet: wallet,
+        mnemonic: context.mnemonic,
+        outputAddress: address.address,
+        electrumServers: context.electrumServers,
+        inputOutpoint: inputOutpoint,
+        proxy: context.proxy,
+      ),
+    );
   }
 }

--- a/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart
@@ -1,63 +1,67 @@
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
-import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 
-/// Joins an advertised pool. Blocks until the coinjoin broadcasts or the pool
-/// times out, which can be the pool's full duration.
+/// Joins an advertised pool with a user-chosen input coin, streaming coinjoin
+/// progress until it broadcasts or the pool times out.
 class JoinJoinstrPoolUsecase {
   final JoinstrDatasource _datasource;
   final JoinstrStore _store;
-  final ResolveJoinstrPeerContextUsecase _resolvePeerContext;
+  final ResolveJoinstrNodeContextUsecase _resolveNodeContext;
+  final GetReceiveAddressUsecase _getReceiveAddressUsecase;
 
   JoinJoinstrPoolUsecase({
     required this._datasource,
     required this._store,
-    required ResolveJoinstrPeerContextUsecase resolvePeerContextUsecase,
-  }) : _resolvePeerContext = resolvePeerContextUsecase;
+    required ResolveJoinstrNodeContextUsecase resolveNodeContextUsecase,
+    required this._getReceiveAddressUsecase,
+  }) : _resolveNodeContext = resolveNodeContextUsecase;
 
-  Future<String> execute({
+  Stream<JoinstrProgress> execute({
     required Wallet wallet,
     required JoinstrPool pool,
-  }) async {
-    final context = await _resolvePeerContext.execute(wallet: wallet);
+    required String inputOutpoint,
+  }) async* {
+    final context = await _resolveNodeContext.execute(wallet: wallet);
+
+    // A fresh receive address per pool, like the reference wallets.
+    final address = await _getReceiveAddressUsecase.execute(
+      walletId: wallet.id,
+      generateNew: true,
+    );
 
     log.info(
       'Joinstr joining pool ${pool.id}: '
-      '${pool.denominationSat} sat, ${pool.peers} peers',
+      '${pool.denominationSat} sat, ${pool.peers} peers, input $inputOutpoint',
     );
 
-    try {
-      final txId = await _datasource.joinPool(
-        pool: pool,
-        wallet: wallet,
-        mnemonic: context.mnemonic,
-        outputAddress: context.outputAddress,
-        electrumUrl: context.electrumUrl,
-        proxy: context.proxy,
-      );
-      // Recorded here rather than in the cubit: a round outlives the screen
-      // that started it, and its outcome must reach the history regardless.
-      await _store.appendHistory(
-        JoinstrHistoryEntry(
-          amountSat: pool.denominationSat,
-          txId: txId,
-          relay: pool.relay,
-          completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        ),
-      );
-      // The reserved output address received this coinjoin: release it so the
-      // next round gets a fresh one instead of reusing it on-chain.
-      await _store.clearReservedAddress();
-      return txId;
-    } on JoinstrException {
-      rethrow;
-    } catch (e) {
-      log.severe(error: e, trace: StackTrace.current);
-      throw JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.toString());
+    await for (final progress in _datasource.joinPool(
+      pool: pool,
+      wallet: wallet,
+      mnemonic: context.mnemonic,
+      outputAddress: address.address,
+      electrumUrl: context.electrumUrl,
+      inputOutpoint: inputOutpoint,
+      proxy: context.proxy,
+    )) {
+      if (progress.step == JoinstrRoundStep.done && progress.txId != null) {
+        await _store.appendHistory(
+          JoinstrHistoryEntry(
+            amountSat: pool.denominationSat,
+            txId: progress.txId!,
+            relay: pool.relay,
+            completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        );
+      }
+      yield progress;
     }
   }
 }

--- a/lib/features/joinstr/domain/usecases/joinstr_round_history.dart
+++ b/lib/features/joinstr/domain/usecases/joinstr_round_history.dart
@@ -1,0 +1,28 @@
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+
+/// Forwards a round's progress, persisting a history entry when it
+/// broadcasts. Shared by the initiate and join usecases so the completion
+/// bookkeeping cannot drift between the two.
+Stream<JoinstrProgress> recordHistoryOnDone({
+  required JoinstrStore store,
+  required int amountSat,
+  required String relay,
+  required Stream<JoinstrProgress> progress,
+}) async* {
+  await for (final p in progress) {
+    if (p.step == JoinstrRoundStep.done && p.txId != null) {
+      await store.appendHistory(
+        JoinstrHistoryEntry(
+          amountSat: amountSat,
+          txId: p.txId!,
+          relay: relay,
+          completedAtUnixSec: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      );
+    }
+    yield p;
+  }
+}

--- a/lib/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart
@@ -21,7 +21,7 @@ class ListJoinstrCoinsUsecase {
     final coins = await _datasource.listCoins(
       wallet: wallet,
       mnemonic: context.mnemonic,
-      electrumUrl: context.electrumUrl,
+      electrumServers: context.electrumServers,
       proxy: context.proxy,
     );
     // Largest first, on a copy so the datasource's list is never mutated.

--- a/lib/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart
@@ -1,0 +1,30 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
+
+/// Lists the wallet's spendable coins so the user can pick which one to feed
+/// into a coinjoin, like the "Select a UTXO" step in joinstr-kmp and
+/// floresta_wallet. Scanning runs over electrum through Tor, so it can take a
+/// moment on first use.
+class ListJoinstrCoinsUsecase {
+  final JoinstrDatasource _datasource;
+  final ResolveJoinstrNodeContextUsecase _resolveNodeContext;
+
+  ListJoinstrCoinsUsecase({
+    required this._datasource,
+    required ResolveJoinstrNodeContextUsecase resolveNodeContextUsecase,
+  }) : _resolveNodeContext = resolveNodeContextUsecase;
+
+  Future<List<JoinstrCoin>> execute({required Wallet wallet}) async {
+    final context = await _resolveNodeContext.execute(wallet: wallet);
+    final coins = await _datasource.listCoins(
+      wallet: wallet,
+      mnemonic: context.mnemonic,
+      electrumUrl: context.electrumUrl,
+      proxy: context.proxy,
+    );
+    // Largest first, on a copy so the datasource's list is never mutated.
+    return [...coins]..sort((a, b) => b.valueSat.compareTo(a.valueSat));
+  }
+}

--- a/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
@@ -2,12 +2,18 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 
 class ListJoinstrPoolsUsecase {
   final JoinstrDatasource _datasource;
   final JoinstrStore _store;
+  final ResolveJoinstrProxyUsecase _resolveProxy;
 
-  ListJoinstrPoolsUsecase({required this._datasource, required this._store});
+  ListJoinstrPoolsUsecase({
+    required this._datasource,
+    required this._store,
+    required ResolveJoinstrProxyUsecase resolveProxyUsecase,
+  }) : _resolveProxy = resolveProxyUsecase;
 
   Future<List<JoinstrPool>> execute({
     String? relay,
@@ -15,10 +21,14 @@ class ListJoinstrPoolsUsecase {
     Duration wait = const Duration(seconds: 5),
   }) async {
     final storedRelay = relay ?? await _store.getRelay();
+    // Listing hits the relay, so it must go over Tor like every other
+    // connection.
+    final proxy = await _resolveProxy.execute();
     final pools = await _datasource.listPools(
       relay: storedRelay ?? ApiServiceConstants.defaultNostrRelayUrl,
       back: back,
       wait: wait,
+      proxy: proxy,
     );
 
     // The relay returns every pool advertised in the last `back`, most of

--- a/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+
+class ListJoinstrPoolsUsecase {
+  final JoinstrDatasource _datasource;
+
+  ListJoinstrPoolsUsecase({required this._datasource});
+
+  Future<List<JoinstrPool>> execute({
+    String? relay,
+    Duration back = const Duration(days: 1),
+    Duration wait = const Duration(seconds: 5),
+  }) async {
+    final pools = await _datasource.listPools(
+      relay: relay ?? ApiServiceConstants.defaultNostrRelayUrl,
+      back: back,
+      wait: wait,
+    );
+    pools.sort((a, b) => a.denominationSat.compareTo(b.denominationSat));
+    return pools;
+  }
+}

--- a/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart
@@ -1,23 +1,32 @@
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 
 class ListJoinstrPoolsUsecase {
   final JoinstrDatasource _datasource;
+  final JoinstrStore _store;
 
-  ListJoinstrPoolsUsecase({required this._datasource});
+  ListJoinstrPoolsUsecase({required this._datasource, required this._store});
 
   Future<List<JoinstrPool>> execute({
     String? relay,
     Duration back = const Duration(days: 1),
     Duration wait = const Duration(seconds: 5),
   }) async {
+    final storedRelay = relay ?? await _store.getRelay();
     final pools = await _datasource.listPools(
-      relay: relay ?? ApiServiceConstants.defaultNostrRelayUrl,
+      relay: storedRelay ?? ApiServiceConstants.defaultNostrRelayUrl,
       back: back,
       wait: wait,
     );
-    pools.sort((a, b) => a.denominationSat.compareTo(b.denominationSat));
-    return pools;
+
+    // The relay returns every pool advertised in the last `back`, most of
+    // which have already expired. An expired pool can never fill, so listing
+    // it would offer a join that can only time out.
+    final now = DateTime.now();
+    final joinable = pools.where((p) => p.secondsUntilExpiry(now) > 0).toList()
+      ..sort((a, b) => a.denominationSat.compareTo(b.denominationSat));
+    return joinable;
   }
 }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart
@@ -3,47 +3,37 @@ import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_net
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
-import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 
-class JoinstrPeerContext {
+/// Everything a joinstr call needs from the wallet except the output address:
+/// the mnemonic joinstr's hot signer derives from, an electrum server to scan
+/// coins and verify peers against, and the Tor proxy to route through. Shared
+/// by coin listing and by creating/joining a pool.
+class JoinstrNodeContext {
   final String mnemonic;
   final String electrumUrl;
-  final String outputAddress;
-
-  /// SOCKS5 proxy (local Tor) every relay and electrum connection is routed
-  /// through for this round.
   final String proxy;
 
-  const JoinstrPeerContext({
+  const JoinstrNodeContext({
     required this.mnemonic,
     required this.electrumUrl,
-    required this.outputAddress,
     required this.proxy,
   });
 }
 
-/// Gathers the three things every joinstr round needs from the wallet: the
-/// mnemonic joinstr's hot signer derives from, an electrum server to verify
-/// peers against, and a fresh address to receive the denominated output.
-class ResolveJoinstrPeerContextUsecase {
+class ResolveJoinstrNodeContextUsecase {
   final SeedRepository _seedRepository;
   final ElectrumServerRepository _electrumServerRepository;
-  final GetReceiveAddressUsecase _getReceiveAddressUsecase;
   final ResolveJoinstrProxyUsecase _resolveProxy;
-  final JoinstrStore _store;
 
-  ResolveJoinstrPeerContextUsecase({
+  ResolveJoinstrNodeContextUsecase({
     required this._seedRepository,
     required this._electrumServerRepository,
-    required this._getReceiveAddressUsecase,
     required ResolveJoinstrProxyUsecase resolveProxyUsecase,
-    required this._store,
   }) : _resolveProxy = resolveProxyUsecase;
 
-  Future<JoinstrPeerContext> execute({required Wallet wallet}) async {
+  Future<JoinstrNodeContext> execute({required Wallet wallet}) async {
     Joinstr.assertWalletSupported(wallet);
 
     // Resolve Tor before anything touches the network: a round that cannot go
@@ -71,28 +61,9 @@ class ResolveJoinstrPeerContextUsecase {
       ),
     );
 
-    // Reserve one fresh address for the round and reuse it across retries.
-    // joinstr's own address-reuse check never runs here (it is gated on an
-    // electrum client the peer flow does not supply), so a fresh address still
-    // matters; but generating a new one on every attempt would walk the receive
-    // chain toward the gap limit with addresses that never see funds. The
-    // reservation is cleared on a successful broadcast (see the initiate/join
-    // usecases), so each completed coinjoin gets a distinct address and a failed
-    // round's reserved-but-unused address is reused rather than abandoned.
-    var address = await _store.getReservedAddress();
-    if (address == null) {
-      final generated = await _getReceiveAddressUsecase.execute(
-        walletId: wallet.id,
-        generateNew: true,
-      );
-      address = generated.address;
-      await _store.saveReservedAddress(address);
-    }
-
-    return JoinstrPeerContext(
+    return JoinstrNodeContext(
       mnemonic: seed.mnemonicWords.join(' '),
       electrumUrl: electrumUrl,
-      outputAddress: address,
       proxy: proxy,
     );
   }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
@@ -7,17 +8,18 @@ import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 
 /// Everything a joinstr call needs from the wallet except the output address:
-/// the mnemonic joinstr's hot signer derives from, an electrum server to scan
-/// coins and verify peers against, and the Tor proxy to route through. Shared
-/// by coin listing and by creating/joining a pool.
+/// the mnemonic joinstr's hot signer derives from, the active electrum
+/// servers in priority order to scan coins and verify peers against, and the
+/// Tor proxy to route through. Shared by coin listing and by creating/joining
+/// a pool.
 class JoinstrNodeContext {
   final String mnemonic;
-  final String electrumUrl;
+  final List<ElectrumServer> electrumServers;
   final String proxy;
 
   const JoinstrNodeContext({
     required this.mnemonic,
-    required this.electrumUrl,
+    required this.electrumServers,
     required this.proxy,
   });
 }
@@ -51,10 +53,12 @@ class ResolveJoinstrNodeContextUsecase {
         isLiquid: false,
       ),
     );
-    final electrumUrl = servers.fold(
+    // The full active set, priority-ordered, so the datasource can fall back
+    // to the next server instead of hard-failing on the first.
+    final electrumServers = servers.fold(
       (value) => value.isEmpty
           ? throw JoinstrException(JoinstrIssue.invalidElectrumUrl)
-          : value.first.url,
+          : value,
       (failure) => throw JoinstrException(
         JoinstrIssue.invalidElectrumUrl,
         detail: failure.logMessage,
@@ -63,7 +67,7 @@ class ResolveJoinstrNodeContextUsecase {
 
     return JoinstrNodeContext(
       mnemonic: seed.mnemonicWords.join(' '),
-      electrumUrl: electrumUrl,
+      electrumServers: electrumServers,
       proxy: proxy,
     );
   }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
@@ -1,0 +1,72 @@
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+
+class JoinstrPeerContext {
+  final String mnemonic;
+  final String electrumUrl;
+  final String outputAddress;
+
+  const JoinstrPeerContext({
+    required this.mnemonic,
+    required this.electrumUrl,
+    required this.outputAddress,
+  });
+}
+
+/// Gathers the three things every joinstr round needs from the wallet: the
+/// mnemonic joinstr's hot signer derives from, an electrum server to verify
+/// peers against, and a fresh address to receive the denominated output.
+class ResolveJoinstrPeerContextUsecase {
+  final SeedRepository _seedRepository;
+  final ElectrumServerRepository _electrumServerRepository;
+  final GetReceiveAddressUsecase _getReceiveAddressUsecase;
+
+  ResolveJoinstrPeerContextUsecase({
+    required this._seedRepository,
+    required this._electrumServerRepository,
+    required this._getReceiveAddressUsecase,
+  });
+
+  Future<JoinstrPeerContext> execute({required Wallet wallet}) async {
+    Joinstr.assertWalletSupported(wallet);
+
+    final seed = await _seedRepository.get(wallet.masterFingerprint);
+    if (seed is! MnemonicSeed) {
+      throw JoinstrException(JoinstrIssue.watchOnlyWallet);
+    }
+
+    final servers = await _electrumServerRepository.fetchActiveServers(
+      network: ElectrumServerNetwork.fromEnvironment(
+        isTestnet: wallet.isTestnet,
+        isLiquid: false,
+      ),
+    );
+    final electrumUrl = servers.fold(
+      (value) => value.isEmpty
+          ? throw JoinstrException(JoinstrIssue.invalidElectrumUrl)
+          : value.first.url,
+      (failure) => throw JoinstrException(
+        JoinstrIssue.invalidElectrumUrl,
+        detail: failure.logMessage,
+      ),
+    );
+
+    // A fresh address each round: joinstr's own address-reuse check is gated on
+    // an electrum client the peer flow never supplies, so it never runs.
+    final address = await _getReceiveAddressUsecase.execute(
+      walletId: wallet.id,
+      generateNew: true,
+    );
+
+    return JoinstrPeerContext(
+      mnemonic: seed.mnemonicWords.join(' '),
+      electrumUrl: electrumUrl,
+      outputAddress: address.address,
+    );
+  }
+}

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
@@ -5,16 +5,22 @@ import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 
 class JoinstrPeerContext {
   final String mnemonic;
   final String electrumUrl;
   final String outputAddress;
 
+  /// SOCKS5 proxy (local Tor) every relay and electrum connection is routed
+  /// through for this round.
+  final String proxy;
+
   const JoinstrPeerContext({
     required this.mnemonic,
     required this.electrumUrl,
     required this.outputAddress,
+    required this.proxy,
   });
 }
 
@@ -25,15 +31,21 @@ class ResolveJoinstrPeerContextUsecase {
   final SeedRepository _seedRepository;
   final ElectrumServerRepository _electrumServerRepository;
   final GetReceiveAddressUsecase _getReceiveAddressUsecase;
+  final ResolveJoinstrProxyUsecase _resolveProxy;
 
   ResolveJoinstrPeerContextUsecase({
     required this._seedRepository,
     required this._electrumServerRepository,
     required this._getReceiveAddressUsecase,
-  });
+    required ResolveJoinstrProxyUsecase resolveProxyUsecase,
+  }) : _resolveProxy = resolveProxyUsecase;
 
   Future<JoinstrPeerContext> execute({required Wallet wallet}) async {
     Joinstr.assertWalletSupported(wallet);
+
+    // Resolve Tor before anything touches the network: a round that cannot go
+    // over Tor must not proceed at all.
+    final proxy = await _resolveProxy.execute();
 
     final seed = await _seedRepository.get(wallet.masterFingerprint);
     if (seed is! MnemonicSeed) {
@@ -67,6 +79,7 @@ class ResolveJoinstrPeerContextUsecase {
       mnemonic: seed.mnemonicWords.join(' '),
       electrumUrl: electrumUrl,
       outputAddress: address.address,
+      proxy: proxy,
     );
   }
 }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 
@@ -32,12 +33,14 @@ class ResolveJoinstrPeerContextUsecase {
   final ElectrumServerRepository _electrumServerRepository;
   final GetReceiveAddressUsecase _getReceiveAddressUsecase;
   final ResolveJoinstrProxyUsecase _resolveProxy;
+  final JoinstrStore _store;
 
   ResolveJoinstrPeerContextUsecase({
     required this._seedRepository,
     required this._electrumServerRepository,
     required this._getReceiveAddressUsecase,
     required ResolveJoinstrProxyUsecase resolveProxyUsecase,
+    required this._store,
   }) : _resolveProxy = resolveProxyUsecase;
 
   Future<JoinstrPeerContext> execute({required Wallet wallet}) async {
@@ -68,17 +71,28 @@ class ResolveJoinstrPeerContextUsecase {
       ),
     );
 
-    // A fresh address each round: joinstr's own address-reuse check is gated on
-    // an electrum client the peer flow never supplies, so it never runs.
-    final address = await _getReceiveAddressUsecase.execute(
-      walletId: wallet.id,
-      generateNew: true,
-    );
+    // Reserve one fresh address for the round and reuse it across retries.
+    // joinstr's own address-reuse check never runs here (it is gated on an
+    // electrum client the peer flow does not supply), so a fresh address still
+    // matters; but generating a new one on every attempt would walk the receive
+    // chain toward the gap limit with addresses that never see funds. The
+    // reservation is cleared on a successful broadcast (see the initiate/join
+    // usecases), so each completed coinjoin gets a distinct address and a failed
+    // round's reserved-but-unused address is reused rather than abandoned.
+    var address = await _store.getReservedAddress();
+    if (address == null) {
+      final generated = await _getReceiveAddressUsecase.execute(
+        walletId: wallet.id,
+        generateNew: true,
+      );
+      address = generated.address;
+      await _store.saveReservedAddress(address);
+    }
 
     return JoinstrPeerContext(
       mnemonic: seed.mnemonicWords.join(' '),
       electrumUrl: electrumUrl,
-      outputAddress: address.address,
+      outputAddress: address,
       proxy: proxy,
     );
   }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart
@@ -5,21 +5,48 @@ import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 ///
 /// joinstr is Tor-only: the relay and the electrum server would otherwise see
 /// the joining IP next to the coin being mixed, which defeats the coinjoin.
-/// The bindings open a fresh circuit per connection, so this only needs to
-/// hand them the local Tor SOCKS address.
+/// This uses the app's embedded Tor (the same one recoverbull uses), so no
+/// external proxy such as Orbot is needed; the bindings open a fresh circuit
+/// per connection.
 class ResolveJoinstrProxyUsecase {
   final TorDatasource _torDatasource;
 
-  ResolveJoinstrProxyUsecase({required this._torDatasource});
+  /// Embedded Tor bootstrap can take a while on mobile (fetching the consensus
+  /// on first run). Wait up to this long for it to come online.
+  final Duration _timeout;
+  final Duration _pollInterval;
+
+  ResolveJoinstrProxyUsecase({
+    required this._torDatasource,
+    this._timeout = const Duration(minutes: 2),
+    this._pollInterval = const Duration(seconds: 1),
+  });
 
   Future<String> execute() async {
-    // Idempotent: returns immediately if Tor is already online. joinstr forces
-    // Tor on regardless of the app's global Tor setting.
-    await _torDatasource.start();
-    final port = _torDatasource.port;
-    if (!_torDatasource.isStarted || port == null || port <= 0) {
-      throw JoinstrException(JoinstrIssue.torUnavailable);
+    // Kick off Tor if nothing else has. `start()` is a no-op while a start is
+    // already in progress, so we then wait for bootstrap ourselves rather than
+    // trusting its early return: another caller (e.g. the pool list on screen
+    // open) may still be bootstrapping, and checking readiness immediately
+    // would wrongly report Tor as unavailable.
+    if (!_torDatasource.isStarted) {
+      try {
+        await _torDatasource.start();
+      } catch (_) {
+        // Swallow and fall through to the readiness poll: the failure may be a
+        // concurrent start still in flight, which the poll will pick up.
+      }
     }
+
+    final deadline = DateTime.now().add(_timeout);
+    while (!_torDatasource.isStarted) {
+      if (DateTime.now().isAfter(deadline)) {
+        throw JoinstrException(JoinstrIssue.torUnavailable);
+      }
+      await Future<void>.delayed(_pollInterval);
+    }
+
+    final port = _torDatasource.port ?? 0;
+    if (port <= 0) throw JoinstrException(JoinstrIssue.torUnavailable);
     return '127.0.0.1:$port';
   }
 }

--- a/lib/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/core/tor/data/datasources/tor_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+
+/// Resolves the SOCKS5 proxy every joinstr connection is routed through.
+///
+/// joinstr is Tor-only: the relay and the electrum server would otherwise see
+/// the joining IP next to the coin being mixed, which defeats the coinjoin.
+/// The bindings open a fresh circuit per connection, so this only needs to
+/// hand them the local Tor SOCKS address.
+class ResolveJoinstrProxyUsecase {
+  final TorDatasource _torDatasource;
+
+  ResolveJoinstrProxyUsecase({required this._torDatasource});
+
+  Future<String> execute() async {
+    // Idempotent: returns immediately if Tor is already online. joinstr forces
+    // Tor on regardless of the app's global Tor setting.
+    await _torDatasource.start();
+    final port = _torDatasource.port;
+    if (!_torDatasource.isStarted || port == null || port <= 0) {
+      throw JoinstrException(JoinstrIssue.torUnavailable);
+    }
+    return '127.0.0.1:$port';
+  }
+}

--- a/lib/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart
+++ b/lib/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+
+class SaveJoinstrRelayUsecase {
+  final JoinstrStore _store;
+
+  SaveJoinstrRelayUsecase({required this._store});
+
+  Future<void> execute(String relay) async {
+    if (!Joinstr.isValidRelayUrl(relay)) {
+      throw JoinstrException(JoinstrIssue.invalidRelayUrl, detail: relay);
+    }
+    await _store.saveRelay(relay);
+  }
+}

--- a/lib/features/joinstr/joinstr_locator.dart
+++ b/lib/features/joinstr/joinstr_locator.dart
@@ -1,0 +1,51 @@
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
+import 'package:get_it/get_it.dart';
+
+class JoinstrLocator {
+  static void setup(GetIt locator) {
+    locator.registerLazySingleton<JoinstrDatasource>(
+      () => const JoinstrDatasource(),
+    );
+
+    locator.registerFactory<ResolveJoinstrPeerContextUsecase>(
+      () => ResolveJoinstrPeerContextUsecase(
+        seedRepository: locator<SeedRepository>(),
+        electrumServerRepository: locator<ElectrumServerRepository>(),
+        getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
+      ),
+    );
+    locator.registerFactory<ListJoinstrPoolsUsecase>(
+      () => ListJoinstrPoolsUsecase(datasource: locator<JoinstrDatasource>()),
+    );
+    locator.registerFactory<JoinJoinstrPoolUsecase>(
+      () => JoinJoinstrPoolUsecase(
+        datasource: locator<JoinstrDatasource>(),
+        resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
+      ),
+    );
+    locator.registerFactory<InitiateJoinstrPoolUsecase>(
+      () => InitiateJoinstrPoolUsecase(
+        datasource: locator<JoinstrDatasource>(),
+        resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
+      ),
+    );
+
+    locator.registerFactory<JoinstrCubit>(
+      () => JoinstrCubit(
+        getWalletsUsecase: locator<GetWalletsUsecase>(),
+        listJoinstrPoolsUsecase: locator<ListJoinstrPoolsUsecase>(),
+        joinJoinstrPoolUsecase: locator<JoinJoinstrPoolUsecase>(),
+        initiateJoinstrPoolUsecase: locator<InitiateJoinstrPoolUsecase>(),
+      ),
+    );
+  }
+}

--- a/lib/features/joinstr/joinstr_locator.dart
+++ b/lib/features/joinstr/joinstr_locator.dart
@@ -1,12 +1,17 @@
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
 import 'package:get_it/get_it.dart';
 
@@ -14,6 +19,13 @@ class JoinstrLocator {
   static void setup(GetIt locator) {
     locator.registerLazySingleton<JoinstrDatasource>(
       () => const JoinstrDatasource(),
+    );
+    locator.registerLazySingleton<JoinstrStore>(
+      () => JoinstrStore(
+        locator<KeyValueStorageDatasource<String>>(
+          instanceName: LocatorInstanceNameConstants.secureStorageDatasource,
+        ),
+      ),
     );
 
     locator.registerFactory<ResolveJoinstrPeerContextUsecase>(
@@ -23,25 +35,41 @@ class JoinstrLocator {
         getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
       ),
     );
+    locator.registerFactory<GetJoinstrSettingsUsecase>(
+      () => GetJoinstrSettingsUsecase(store: locator<JoinstrStore>()),
+    );
+    locator.registerFactory<SaveJoinstrRelayUsecase>(
+      () => SaveJoinstrRelayUsecase(store: locator<JoinstrStore>()),
+    );
     locator.registerFactory<ListJoinstrPoolsUsecase>(
-      () => ListJoinstrPoolsUsecase(datasource: locator<JoinstrDatasource>()),
+      () => ListJoinstrPoolsUsecase(
+        datasource: locator<JoinstrDatasource>(),
+        store: locator<JoinstrStore>(),
+      ),
     );
     locator.registerFactory<JoinJoinstrPoolUsecase>(
       () => JoinJoinstrPoolUsecase(
         datasource: locator<JoinstrDatasource>(),
+        store: locator<JoinstrStore>(),
         resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
       ),
     );
     locator.registerFactory<InitiateJoinstrPoolUsecase>(
       () => InitiateJoinstrPoolUsecase(
         datasource: locator<JoinstrDatasource>(),
+        store: locator<JoinstrStore>(),
         resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
       ),
     );
 
-    locator.registerFactory<JoinstrCubit>(
+    // A singleton on purpose: a coinjoin round blocks in the bindings for up
+    // to the pool duration, and its outcome must land in state even when the
+    // user navigates away and back (see JoinstrCubit).
+    locator.registerLazySingleton<JoinstrCubit>(
       () => JoinstrCubit(
         getWalletsUsecase: locator<GetWalletsUsecase>(),
+        getJoinstrSettingsUsecase: locator<GetJoinstrSettingsUsecase>(),
+        saveJoinstrRelayUsecase: locator<SaveJoinstrRelayUsecase>(),
         listJoinstrPoolsUsecase: locator<ListJoinstrPoolsUsecase>(),
         joinJoinstrPoolUsecase: locator<JoinJoinstrPoolUsecase>(),
         initiateJoinstrPoolUsecase: locator<InitiateJoinstrPoolUsecase>(),

--- a/lib/features/joinstr/joinstr_locator.dart
+++ b/lib/features/joinstr/joinstr_locator.dart
@@ -41,6 +41,7 @@ class JoinstrLocator {
         electrumServerRepository: locator<ElectrumServerRepository>(),
         getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
         resolveProxyUsecase: locator<ResolveJoinstrProxyUsecase>(),
+        store: locator<JoinstrStore>(),
       ),
     );
     locator.registerFactory<GetJoinstrSettingsUsecase>(

--- a/lib/features/joinstr/joinstr_locator.dart
+++ b/lib/features/joinstr/joinstr_locator.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+import 'package:bb_mobile/core/tor/data/datasources/tor_datasource.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -11,6 +12,7 @@ import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
 import 'package:get_it/get_it.dart';
@@ -28,11 +30,17 @@ class JoinstrLocator {
       ),
     );
 
+    locator.registerFactory<ResolveJoinstrProxyUsecase>(
+      () => ResolveJoinstrProxyUsecase(
+        torDatasource: locator<TorDatasource>(),
+      ),
+    );
     locator.registerFactory<ResolveJoinstrPeerContextUsecase>(
       () => ResolveJoinstrPeerContextUsecase(
         seedRepository: locator<SeedRepository>(),
         electrumServerRepository: locator<ElectrumServerRepository>(),
         getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
+        resolveProxyUsecase: locator<ResolveJoinstrProxyUsecase>(),
       ),
     );
     locator.registerFactory<GetJoinstrSettingsUsecase>(
@@ -45,6 +53,7 @@ class JoinstrLocator {
       () => ListJoinstrPoolsUsecase(
         datasource: locator<JoinstrDatasource>(),
         store: locator<JoinstrStore>(),
+        resolveProxyUsecase: locator<ResolveJoinstrProxyUsecase>(),
       ),
     );
     locator.registerFactory<JoinJoinstrPoolUsecase>(

--- a/lib/features/joinstr/joinstr_locator.dart
+++ b/lib/features/joinstr/joinstr_locator.dart
@@ -10,8 +10,9 @@ import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
-import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
@@ -31,17 +32,13 @@ class JoinstrLocator {
     );
 
     locator.registerFactory<ResolveJoinstrProxyUsecase>(
-      () => ResolveJoinstrProxyUsecase(
-        torDatasource: locator<TorDatasource>(),
-      ),
+      () => ResolveJoinstrProxyUsecase(torDatasource: locator<TorDatasource>()),
     );
-    locator.registerFactory<ResolveJoinstrPeerContextUsecase>(
-      () => ResolveJoinstrPeerContextUsecase(
+    locator.registerFactory<ResolveJoinstrNodeContextUsecase>(
+      () => ResolveJoinstrNodeContextUsecase(
         seedRepository: locator<SeedRepository>(),
         electrumServerRepository: locator<ElectrumServerRepository>(),
-        getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
         resolveProxyUsecase: locator<ResolveJoinstrProxyUsecase>(),
-        store: locator<JoinstrStore>(),
       ),
     );
     locator.registerFactory<GetJoinstrSettingsUsecase>(
@@ -57,18 +54,26 @@ class JoinstrLocator {
         resolveProxyUsecase: locator<ResolveJoinstrProxyUsecase>(),
       ),
     );
+    locator.registerFactory<ListJoinstrCoinsUsecase>(
+      () => ListJoinstrCoinsUsecase(
+        datasource: locator<JoinstrDatasource>(),
+        resolveNodeContextUsecase: locator<ResolveJoinstrNodeContextUsecase>(),
+      ),
+    );
     locator.registerFactory<JoinJoinstrPoolUsecase>(
       () => JoinJoinstrPoolUsecase(
         datasource: locator<JoinstrDatasource>(),
         store: locator<JoinstrStore>(),
-        resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
+        resolveNodeContextUsecase: locator<ResolveJoinstrNodeContextUsecase>(),
+        getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
       ),
     );
     locator.registerFactory<InitiateJoinstrPoolUsecase>(
       () => InitiateJoinstrPoolUsecase(
         datasource: locator<JoinstrDatasource>(),
         store: locator<JoinstrStore>(),
-        resolvePeerContextUsecase: locator<ResolveJoinstrPeerContextUsecase>(),
+        resolveNodeContextUsecase: locator<ResolveJoinstrNodeContextUsecase>(),
+        getReceiveAddressUsecase: locator<GetReceiveAddressUsecase>(),
       ),
     );
 
@@ -81,6 +86,7 @@ class JoinstrLocator {
         getJoinstrSettingsUsecase: locator<GetJoinstrSettingsUsecase>(),
         saveJoinstrRelayUsecase: locator<SaveJoinstrRelayUsecase>(),
         listJoinstrPoolsUsecase: locator<ListJoinstrPoolsUsecase>(),
+        listJoinstrCoinsUsecase: locator<ListJoinstrCoinsUsecase>(),
         joinJoinstrPoolUsecase: locator<JoinJoinstrPoolUsecase>(),
         initiateJoinstrPoolUsecase: locator<InitiateJoinstrPoolUsecase>(),
       ),

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -234,6 +234,14 @@ class JoinstrCubit extends Cubit<JoinstrState> {
 
     try {
       await for (final p in progress) {
+        // Accumulate the timeline detail (never clearing a value already seen)
+        // so every later update carries the output address, event ids and psbt.
+        current = current.copyWith(
+          outputAddress: p.outputAddress ?? current.outputAddress,
+          outputEventId: p.outputEventId ?? current.outputEventId,
+          inputEventId: p.inputEventId ?? current.inputEventId,
+          psbt: p.psbt ?? current.psbt,
+        );
         if (p.step == JoinstrRoundStep.done) {
           final txId = p.txId;
           // A done update without a txid must not render as a broadcast

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -235,7 +235,19 @@ class JoinstrCubit extends Cubit<JoinstrState> {
     try {
       await for (final p in progress) {
         if (p.step == JoinstrRoundStep.done) {
-          update(current.completed(p.txId ?? ''));
+          final txId = p.txId;
+          // A done update without a txid must not render as a broadcast
+          // round with an empty transaction id.
+          update(
+            txId == null || txId.isEmpty
+                ? current.failed(
+                    JoinstrException(
+                      JoinstrIssue.coinjoinFailed,
+                      detail: 'the coinjoin finished without a txid',
+                    ),
+                  )
+                : current.completed(txId),
+          );
         } else if (p.step == JoinstrRoundStep.failed) {
           update(
             current.failed(

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -1,0 +1,156 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class JoinstrCubit extends Cubit<JoinstrState> {
+  JoinstrCubit({
+    required this._getWalletsUsecase,
+    required ListJoinstrPoolsUsecase listJoinstrPoolsUsecase,
+    required JoinJoinstrPoolUsecase joinJoinstrPoolUsecase,
+    required InitiateJoinstrPoolUsecase initiateJoinstrPoolUsecase,
+  }) : _listPools = listJoinstrPoolsUsecase,
+       _joinPool = joinJoinstrPoolUsecase,
+       _initiatePool = initiateJoinstrPoolUsecase,
+       super(const JoinstrState());
+
+  final GetWalletsUsecase _getWalletsUsecase;
+  final ListJoinstrPoolsUsecase _listPools;
+  final JoinJoinstrPoolUsecase _joinPool;
+  final InitiateJoinstrPoolUsecase _initiatePool;
+
+  Future<void> load() async {
+    final List<Wallet> candidates;
+    try {
+      final wallets = await _getWalletsUsecase.execute(onlyBitcoin: true);
+      candidates = wallets.where((w) => w.signsLocally).toList();
+    } catch (e) {
+      _fail(_asJoinstrException(e));
+      return;
+    }
+    if (candidates.isEmpty) {
+      _fail(JoinstrException(JoinstrIssue.watchOnlyWallet));
+      return;
+    }
+
+    // Take the first wallet joinstr can actually use rather than the first
+    // hot wallet: someone holding both a mainnet and a testnet wallet should
+    // land on the testnet one, not on "mainnet not supported".
+    Wallet? supported;
+    JoinstrException? rejection;
+    for (final wallet in candidates) {
+      try {
+        Joinstr.assertWalletSupported(wallet);
+        supported = wallet;
+        break;
+      } on JoinstrException catch (e) {
+        rejection ??= e;
+      }
+    }
+    if (supported == null) {
+      _fail(rejection!);
+      return;
+    }
+
+    if (!isClosed) emit(state.copyWith(wallet: supported));
+    await refreshPools();
+  }
+
+  Future<void> refreshPools() async {
+    if (state.isRunning) return;
+    if (!isClosed) {
+      emit(state.copyWith(status: JoinstrStatus.loadingPools, error: null));
+    }
+    try {
+      final pools = await _listPools.execute();
+      if (!isClosed) {
+        emit(state.copyWith(status: JoinstrStatus.idle, pools: pools));
+      }
+    } catch (e) {
+      _fail(_asJoinstrException(e));
+    }
+  }
+
+  void denominationChanged(String value) =>
+      emit(state.copyWith(denominationSat: _digitsOnly(value)));
+
+  void peersChanged(String value) =>
+      emit(state.copyWith(peers: _digitsOnly(value)));
+
+  void feeRateChanged(String value) =>
+      emit(state.copyWith(feeRate: _digitsOnly(value)));
+
+  Future<void> joinPool(JoinstrPool pool) async {
+    final wallet = state.wallet;
+    if (wallet == null || state.isRunning) return;
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          status: JoinstrStatus.running,
+          activePool: pool,
+          error: null,
+          txId: null,
+        ),
+      );
+    }
+    try {
+      final txId = await _joinPool.execute(wallet: wallet, pool: pool);
+      if (!isClosed) {
+        emit(state.copyWith(status: JoinstrStatus.done, txId: txId));
+      }
+    } catch (e) {
+      _fail(_asJoinstrException(e));
+    }
+  }
+
+  Future<void> initiatePool() async {
+    final wallet = state.wallet;
+    if (wallet == null || state.isRunning) return;
+
+    final denomination = int.tryParse(state.denominationSat) ?? 0;
+    final peers = int.tryParse(state.peers) ?? 0;
+    final feeRate = int.tryParse(state.feeRate) ?? 0;
+    if (denomination <= 0 || peers < 2 || feeRate <= 0) {
+      _fail(JoinstrException(JoinstrIssue.invalidPoolConfig));
+      return;
+    }
+
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          status: JoinstrStatus.running,
+          activePool: null,
+          error: null,
+          txId: null,
+        ),
+      );
+    }
+    try {
+      final txId = await _initiatePool.execute(
+        wallet: wallet,
+        denominationSat: denomination,
+        peers: peers,
+        feeRateSatPerVb: feeRate,
+      );
+      if (!isClosed) {
+        emit(state.copyWith(status: JoinstrStatus.done, txId: txId));
+      }
+    } catch (e) {
+      _fail(_asJoinstrException(e));
+    }
+  }
+
+  void _fail(JoinstrException e) {
+    if (!isClosed) emit(state.copyWith(status: JoinstrStatus.error, error: e));
+  }
+
+  JoinstrException _asJoinstrException(Object e) => e is JoinstrException
+      ? e
+      : JoinstrException(JoinstrIssue.coinjoinFailed, detail: e.toString());
+
+  String _digitsOnly(String value) => value.replaceAll(RegExp(r'[^0-9]'), '');
+}

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -128,14 +128,6 @@ class JoinstrCubit extends Cubit<JoinstrState> {
     }
   }
 
-  void denominationChanged(String value) {
-    if (value.isEmpty || Joinstr.denominationBtcPattern.hasMatch(value)) {
-      // The eligible-coin set depends on the denomination, so a coin picked for
-      // a different denomination may no longer qualify: drop it.
-      _emit(state.copyWith(denominationBtc: value, selectedCoin: null));
-    }
-  }
-
   void peersChanged(String value) =>
       _emit(state.copyWith(peers: _digitsOnly(value)));
 

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -253,6 +253,20 @@ class JoinstrCubit extends Cubit<JoinstrState> {
       update(current.failed(_asJoinstrException(e)));
     }
 
+    // The bindings send the terminal update with its result ignored, so a
+    // closed channel can end the stream without one. A round left waiting
+    // here would spin forever and keep its coin excluded from the pickers.
+    if (current.isWaiting) {
+      update(
+        current.failed(
+          JoinstrException(
+            JoinstrIssue.coinjoinFailed,
+            detail: 'the coinjoin ended without a result',
+          ),
+        ),
+      );
+    }
+
     await loadCoins();
     try {
       final settings = await _getSettings.execute();

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -1,32 +1,53 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+/// Registered as a singleton and provided with `BlocProvider.value`: a round
+/// blocks in the bindings for up to the pool duration, so the cubit must
+/// outlive the screen. Were it closed on navigation, a finished round's txid
+/// would be lost and the same coin could be offered to a second pool while
+/// the first round is still signing with it.
 class JoinstrCubit extends Cubit<JoinstrState> {
   JoinstrCubit({
-    required this._getWalletsUsecase,
+    required GetWalletsUsecase getWalletsUsecase,
+    required GetJoinstrSettingsUsecase getJoinstrSettingsUsecase,
+    required SaveJoinstrRelayUsecase saveJoinstrRelayUsecase,
     required ListJoinstrPoolsUsecase listJoinstrPoolsUsecase,
     required JoinJoinstrPoolUsecase joinJoinstrPoolUsecase,
     required InitiateJoinstrPoolUsecase initiateJoinstrPoolUsecase,
-  }) : _listPools = listJoinstrPoolsUsecase,
+  }) : _getWallets = getWalletsUsecase,
+       _getSettings = getJoinstrSettingsUsecase,
+       _saveRelay = saveJoinstrRelayUsecase,
+       _listPools = listJoinstrPoolsUsecase,
        _joinPool = joinJoinstrPoolUsecase,
        _initiatePool = initiateJoinstrPoolUsecase,
        super(const JoinstrState());
 
-  final GetWalletsUsecase _getWalletsUsecase;
+  final GetWalletsUsecase _getWallets;
+  final GetJoinstrSettingsUsecase _getSettings;
+  final SaveJoinstrRelayUsecase _saveRelay;
   final ListJoinstrPoolsUsecase _listPools;
   final JoinJoinstrPoolUsecase _joinPool;
   final InitiateJoinstrPoolUsecase _initiatePool;
 
   Future<void> load() async {
+    // A running round already holds live state; re-resolving the wallet or
+    // resetting the error here would detach the UI from it.
+    if (state.isRunning) return;
+
     final List<Wallet> candidates;
     try {
-      final wallets = await _getWalletsUsecase.execute(onlyBitcoin: true);
+      final settings = await _getSettings.execute();
+      _emit(state.copyWith(relay: settings.relay, history: settings.history));
+      final wallets = await _getWallets.execute(onlyBitcoin: true);
       candidates = wallets.where((w) => w.signsLocally).toList();
     } catch (e) {
       _fail(_asJoinstrException(e));
@@ -56,54 +77,63 @@ class JoinstrCubit extends Cubit<JoinstrState> {
       return;
     }
 
-    if (!isClosed) emit(state.copyWith(wallet: supported));
+    _emit(state.copyWith(wallet: supported));
     await refreshPools();
   }
 
   Future<void> refreshPools() async {
     if (state.isRunning) return;
-    if (!isClosed) {
-      emit(state.copyWith(status: JoinstrStatus.loadingPools, error: null));
-    }
+    _emit(state.copyWith(status: JoinstrStatus.loadingPools, error: null));
     try {
       final pools = await _listPools.execute();
-      if (!isClosed) {
-        emit(state.copyWith(status: JoinstrStatus.idle, pools: pools));
-      }
+      _emit(state.copyWith(status: JoinstrStatus.idle, pools: pools));
     } catch (e) {
       _fail(_asJoinstrException(e));
     }
   }
 
-  void denominationChanged(String value) =>
-      emit(state.copyWith(denominationSat: _digitsOnly(value)));
+  Future<void> relayChanged(String relay) async {
+    try {
+      await _saveRelay.execute(relay);
+      _emit(state.copyWith(relay: relay.trim(), error: null));
+      await refreshPools();
+    } catch (e) {
+      _fail(_asJoinstrException(e));
+    }
+  }
+
+  void denominationChanged(String value) {
+    if (value.isEmpty || Joinstr.denominationBtcPattern.hasMatch(value)) {
+      _emit(state.copyWith(denominationBtc: value));
+    }
+  }
 
   void peersChanged(String value) =>
-      emit(state.copyWith(peers: _digitsOnly(value)));
+      _emit(state.copyWith(peers: _digitsOnly(value)));
 
   void feeRateChanged(String value) =>
-      emit(state.copyWith(feeRate: _digitsOnly(value)));
+      _emit(state.copyWith(feeRate: _digitsOnly(value)));
 
   Future<void> joinPool(JoinstrPool pool) async {
     final wallet = state.wallet;
     if (wallet == null || state.isRunning) return;
-    if (!isClosed) {
-      emit(
-        state.copyWith(
-          status: JoinstrStatus.running,
-          activePool: pool,
-          error: null,
-          txId: null,
-        ),
-      );
-    }
+
+    final round = JoinstrRound(
+      initiated: false,
+      denominationSat: pool.denominationSat,
+      peers: pool.peers,
+      relay: pool.relay,
+      feeRateSatPerVb: pool.feeRateSatPerVb,
+      publicKey: pool.publicKey,
+      expiresAtUnixSec: pool.expiresAtUnixSec,
+    );
+    _emit(state.copyWith(rounds: [round, ...state.rounds], error: null));
+
     try {
       final txId = await _joinPool.execute(wallet: wallet, pool: pool);
-      if (!isClosed) {
-        emit(state.copyWith(status: JoinstrStatus.done, txId: txId));
-      }
+      await _completeWaitingRound(round.completed(txId));
     } catch (e) {
-      _fail(_asJoinstrException(e));
+      _replaceWaitingRound(round.failed(_asJoinstrException(e)));
     }
   }
 
@@ -111,41 +141,70 @@ class JoinstrCubit extends Cubit<JoinstrState> {
     final wallet = state.wallet;
     if (wallet == null || state.isRunning) return;
 
-    final denomination = int.tryParse(state.denominationSat) ?? 0;
+    final denomination = Joinstr.parseDenominationBtcToSat(
+      state.denominationBtc,
+    );
     final peers = int.tryParse(state.peers) ?? 0;
     final feeRate = int.tryParse(state.feeRate) ?? 0;
-    if (denomination <= 0 || peers < 2 || feeRate <= 0) {
+    if (denomination == null || peers < 2 || feeRate <= 0) {
       _fail(JoinstrException(JoinstrIssue.invalidPoolConfig));
       return;
     }
 
-    if (!isClosed) {
-      emit(
-        state.copyWith(
-          status: JoinstrStatus.running,
-          activePool: null,
-          error: null,
-          txId: null,
-        ),
-      );
-    }
+    const maxDuration = Duration(hours: 1);
+    final round = JoinstrRound(
+      initiated: true,
+      denominationSat: denomination,
+      peers: peers,
+      relay: state.relay,
+      feeRateSatPerVb: feeRate,
+      expiresAtUnixSec:
+          DateTime.now().millisecondsSinceEpoch ~/ 1000 + maxDuration.inSeconds,
+    );
+    _emit(state.copyWith(rounds: [round, ...state.rounds], error: null));
+
     try {
       final txId = await _initiatePool.execute(
         wallet: wallet,
         denominationSat: denomination,
         peers: peers,
         feeRateSatPerVb: feeRate,
+        maxDuration: maxDuration,
       );
-      if (!isClosed) {
-        emit(state.copyWith(status: JoinstrStatus.done, txId: txId));
-      }
+      await _completeWaitingRound(round.completed(txId));
     } catch (e) {
-      _fail(_asJoinstrException(e));
+      _replaceWaitingRound(round.failed(_asJoinstrException(e)));
     }
   }
 
-  void _fail(JoinstrException e) {
-    if (!isClosed) emit(state.copyWith(status: JoinstrStatus.error, error: e));
+  Future<void> _completeWaitingRound(JoinstrRound completed) async {
+    _replaceWaitingRound(completed);
+    // The usecase already persisted the history entry; re-read it so the
+    // History tab shows it without a manual refresh.
+    try {
+      final settings = await _getSettings.execute();
+      _emit(state.copyWith(history: settings.history));
+    } catch (_) {
+      // The round itself succeeded; a failed history read must not turn the
+      // broadcast into an error state.
+    }
+  }
+
+  /// Only one round can ever be waiting (isRunning gates the rest), so the
+  /// waiting entry is the one this outcome belongs to.
+  void _replaceWaitingRound(JoinstrRound updated) {
+    final rounds = [
+      for (final r in state.rounds)
+        if (r.isWaiting) updated else r,
+    ];
+    _emit(state.copyWith(rounds: rounds));
+  }
+
+  void _fail(JoinstrException e) =>
+      _emit(state.copyWith(status: JoinstrStatus.error, error: e));
+
+  void _emit(JoinstrState newState) {
+    if (!isClosed) emit(newState);
   }
 
   JoinstrException _asJoinstrException(Object e) => e is JoinstrException

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -44,47 +44,55 @@ class JoinstrCubit extends Cubit<JoinstrState> {
   final InitiateJoinstrPoolUsecase _initiatePool;
 
   int _nextRoundId = 0;
+  bool _loading = false;
 
   Future<void> load() async {
-    if (state.wallet != null) return; // already resolved for this session
-
-    final List<Wallet> candidates;
+    // The route builder can run more than once per navigation; the wallet
+    // guard only flips after several awaits, so an in-flight flag is needed
+    // to stop concurrent loads doubling the Tor work.
+    if (_loading || state.wallet != null) return;
+    _loading = true;
     try {
-      final settings = await _getSettings.execute();
-      _emit(state.copyWith(relay: settings.relay, history: settings.history));
-      final wallets = await _getWallets.execute(onlyBitcoin: true);
-      candidates = wallets.where((w) => w.signsLocally).toList();
-    } catch (e) {
-      _fail(_asJoinstrException(e));
-      return;
-    }
-    if (candidates.isEmpty) {
-      _fail(JoinstrException(JoinstrIssue.watchOnlyWallet));
-      return;
-    }
-
-    // Take the first wallet joinstr can actually use rather than the first
-    // hot wallet: someone holding both a mainnet and a testnet wallet should
-    // land on the testnet one, not on "mainnet not supported".
-    Wallet? supported;
-    JoinstrException? rejection;
-    for (final wallet in candidates) {
+      final List<Wallet> candidates;
       try {
-        Joinstr.assertWalletSupported(wallet);
-        supported = wallet;
-        break;
-      } on JoinstrException catch (e) {
-        rejection ??= e;
+        final settings = await _getSettings.execute();
+        _emit(state.copyWith(relay: settings.relay, history: settings.history));
+        final wallets = await _getWallets.execute(onlyBitcoin: true);
+        candidates = wallets.where((w) => w.signsLocally).toList();
+      } catch (e) {
+        _fail(_asJoinstrException(e));
+        return;
       }
-    }
-    if (supported == null) {
-      _fail(rejection!);
-      return;
-    }
+      if (candidates.isEmpty) {
+        _fail(JoinstrException(JoinstrIssue.watchOnlyWallet));
+        return;
+      }
 
-    _emit(state.copyWith(wallet: supported));
-    // Coins and pools both need Tor; kick them off together.
-    await Future.wait([loadCoins(), refreshPools()]);
+      // Take the first wallet joinstr can actually use rather than the first
+      // hot wallet: someone holding both a mainnet and a testnet wallet
+      // should land on the testnet one, not on "mainnet not supported".
+      Wallet? supported;
+      JoinstrException? rejection;
+      for (final wallet in candidates) {
+        try {
+          Joinstr.assertWalletSupported(wallet);
+          supported = wallet;
+          break;
+        } on JoinstrException catch (e) {
+          rejection ??= e;
+        }
+      }
+      if (supported == null) {
+        _fail(rejection!);
+        return;
+      }
+
+      _emit(state.copyWith(wallet: supported));
+      // Coins and pools both need Tor; kick them off together.
+      await Future.wait([loadCoins(), refreshPools()]);
+    } finally {
+      _loading = false;
+    }
   }
 
   Future<void> loadCoins() async {

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -1,10 +1,13 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
@@ -12,21 +15,22 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Registered as a singleton and provided with `BlocProvider.value`: a round
 /// blocks in the bindings for up to the pool duration, so the cubit must
-/// outlive the screen. Were it closed on navigation, a finished round's txid
-/// would be lost and the same coin could be offered to a second pool while
-/// the first round is still signing with it.
+/// outlive the screen or a finished round's txid would be lost. Several rounds
+/// can run at once, each on its own input coin.
 class JoinstrCubit extends Cubit<JoinstrState> {
   JoinstrCubit({
     required GetWalletsUsecase getWalletsUsecase,
     required GetJoinstrSettingsUsecase getJoinstrSettingsUsecase,
     required SaveJoinstrRelayUsecase saveJoinstrRelayUsecase,
     required ListJoinstrPoolsUsecase listJoinstrPoolsUsecase,
+    required ListJoinstrCoinsUsecase listJoinstrCoinsUsecase,
     required JoinJoinstrPoolUsecase joinJoinstrPoolUsecase,
     required InitiateJoinstrPoolUsecase initiateJoinstrPoolUsecase,
   }) : _getWallets = getWalletsUsecase,
        _getSettings = getJoinstrSettingsUsecase,
        _saveRelay = saveJoinstrRelayUsecase,
        _listPools = listJoinstrPoolsUsecase,
+       _listCoins = listJoinstrCoinsUsecase,
        _joinPool = joinJoinstrPoolUsecase,
        _initiatePool = initiateJoinstrPoolUsecase,
        super(const JoinstrState());
@@ -35,13 +39,14 @@ class JoinstrCubit extends Cubit<JoinstrState> {
   final GetJoinstrSettingsUsecase _getSettings;
   final SaveJoinstrRelayUsecase _saveRelay;
   final ListJoinstrPoolsUsecase _listPools;
+  final ListJoinstrCoinsUsecase _listCoins;
   final JoinJoinstrPoolUsecase _joinPool;
   final InitiateJoinstrPoolUsecase _initiatePool;
 
+  int _nextRoundId = 0;
+
   Future<void> load() async {
-    // A running round already holds live state; re-resolving the wallet or
-    // resetting the error here would detach the UI from it.
-    if (state.isRunning) return;
+    if (state.wallet != null) return; // already resolved for this session
 
     final List<Wallet> candidates;
     try {
@@ -78,11 +83,24 @@ class JoinstrCubit extends Cubit<JoinstrState> {
     }
 
     _emit(state.copyWith(wallet: supported));
-    await refreshPools();
+    // Coins and pools both need Tor; kick them off together.
+    await Future.wait([loadCoins(), refreshPools()]);
+  }
+
+  Future<void> loadCoins() async {
+    final wallet = state.wallet;
+    if (wallet == null) return;
+    _emit(state.copyWith(loadingCoins: true, error: null));
+    try {
+      final coins = await _listCoins.execute(wallet: wallet);
+      _emit(state.copyWith(coins: coins, loadingCoins: false));
+    } catch (e) {
+      _emit(state.copyWith(loadingCoins: false));
+      _fail(_asJoinstrException(e));
+    }
   }
 
   Future<void> refreshPools() async {
-    if (state.isRunning) return;
     _emit(state.copyWith(status: JoinstrStatus.loadingPools, error: null));
     try {
       final pools = await _listPools.execute();
@@ -104,7 +122,9 @@ class JoinstrCubit extends Cubit<JoinstrState> {
 
   void denominationChanged(String value) {
     if (value.isEmpty || Joinstr.denominationBtcPattern.hasMatch(value)) {
-      _emit(state.copyWith(denominationBtc: value));
+      // The eligible-coin set depends on the denomination, so a coin picked for
+      // a different denomination may no longer qualify: drop it.
+      _emit(state.copyWith(denominationBtc: value, selectedCoin: null));
     }
   }
 
@@ -114,90 +134,136 @@ class JoinstrCubit extends Cubit<JoinstrState> {
   void feeRateChanged(String value) =>
       _emit(state.copyWith(feeRate: _digitsOnly(value)));
 
-  Future<void> joinPool(JoinstrPool pool) async {
-    final wallet = state.wallet;
-    if (wallet == null || state.isRunning) return;
-
-    final round = JoinstrRound(
-      initiated: false,
-      denominationSat: pool.denominationSat,
-      peers: pool.peers,
-      relay: pool.relay,
-      feeRateSatPerVb: pool.feeRateSatPerVb,
-      publicKey: pool.publicKey,
-      expiresAtUnixSec: pool.expiresAtUnixSec,
-    );
-    _emit(state.copyWith(rounds: [round, ...state.rounds], error: null));
-
-    try {
-      final txId = await _joinPool.execute(wallet: wallet, pool: pool);
-      await _completeWaitingRound(round.completed(txId));
-    } catch (e) {
-      _replaceWaitingRound(round.failed(_asJoinstrException(e)));
-    }
-  }
+  void selectCoin(JoinstrCoin? coin) =>
+      _emit(state.copyWith(selectedCoin: coin));
 
   Future<void> initiatePool() async {
     final wallet = state.wallet;
-    if (wallet == null || state.isRunning) return;
+    if (wallet == null) return;
 
-    final denomination = Joinstr.parseDenominationBtcToSat(
-      state.denominationBtc,
-    );
     final peers = int.tryParse(state.peers) ?? 0;
     final feeRate = int.tryParse(state.feeRate) ?? 0;
-    if (denomination == null || peers < 2 || feeRate <= 0) {
+    final coin = state.selectedCoin;
+    // The denomination follows the chosen input: the coin's value minus the
+    // fee surplus, so the coin is eligible by construction.
+    final denomination = coin == null
+        ? null
+        : Joinstr.deriveDenominationSat(
+            coinValueSat: coin.valueSat,
+            feeRateSatPerVb: feeRate,
+          );
+    if (coin == null || peers < 2 || feeRate <= 0 || denomination == null) {
       _fail(JoinstrException(JoinstrIssue.invalidPoolConfig));
       return;
     }
 
     const maxDuration = Duration(hours: 1);
     final round = JoinstrRound(
+      id: _nextRoundId++,
       initiated: true,
       denominationSat: denomination,
       peers: peers,
       relay: state.relay,
       feeRateSatPerVb: feeRate,
+      inputOutpoint: coin.outpoint,
       expiresAtUnixSec:
           DateTime.now().millisecondsSinceEpoch ~/ 1000 + maxDuration.inSeconds,
     );
-    _emit(state.copyWith(rounds: [round, ...state.rounds], error: null));
+    _emit(
+      state.copyWith(
+        rounds: [round, ...state.rounds],
+        selectedCoin: null,
+        error: null,
+      ),
+    );
 
-    try {
-      final txId = await _initiatePool.execute(
+    await _consume(
+      round,
+      _initiatePool.execute(
         wallet: wallet,
         denominationSat: denomination,
         peers: peers,
         feeRateSatPerVb: feeRate,
+        inputOutpoint: coin.outpoint,
         maxDuration: maxDuration,
-      );
-      await _completeWaitingRound(round.completed(txId));
-    } catch (e) {
-      _replaceWaitingRound(round.failed(_asJoinstrException(e)));
-    }
+      ),
+    );
   }
 
-  Future<void> _completeWaitingRound(JoinstrRound completed) async {
-    _replaceWaitingRound(completed);
-    // The usecase already persisted the history entry; re-read it so the
-    // History tab shows it without a manual refresh.
+  Future<void> joinPool(JoinstrPool pool, JoinstrCoin coin) async {
+    final wallet = state.wallet;
+    if (wallet == null) return;
+
+    final round = JoinstrRound(
+      id: _nextRoundId++,
+      initiated: false,
+      denominationSat: pool.denominationSat,
+      peers: pool.peers,
+      relay: pool.relay,
+      feeRateSatPerVb: pool.feeRateSatPerVb,
+      inputOutpoint: coin.outpoint,
+      publicKey: pool.publicKey,
+      expiresAtUnixSec: pool.expiresAtUnixSec,
+    );
+    _emit(state.copyWith(rounds: [round, ...state.rounds], error: null));
+
+    await _consume(
+      round,
+      _joinPool.execute(
+        wallet: wallet,
+        pool: pool,
+        inputOutpoint: coin.outpoint,
+      ),
+    );
+  }
+
+  /// Drives a coinjoin's progress stream, advancing the round's step in state
+  /// so the timeline updates live. On completion it refreshes coins (the input
+  /// was spent) and history.
+  Future<void> _consume(
+    JoinstrRound round,
+    Stream<JoinstrProgress> progress,
+  ) async {
+    try {
+      await for (final p in progress) {
+        if (p.step == JoinstrRoundStep.done) {
+          _updateRound(round.id, round.completed(p.txId ?? ''));
+        } else if (p.step == JoinstrRoundStep.failed) {
+          _updateRound(
+            round.id,
+            round.failed(
+              JoinstrException(
+                JoinstrIssue.coinjoinFailed,
+                detail: p.errorMessage,
+              ),
+            ),
+          );
+        } else if (p.step != JoinstrRoundStep.other) {
+          _updateRound(round.id, round.advancedTo(p.step));
+        }
+      }
+    } catch (e) {
+      _updateRound(round.id, round.failed(_asJoinstrException(e)));
+    }
+
+    await loadCoins();
     try {
       final settings = await _getSettings.execute();
       _emit(state.copyWith(history: settings.history));
     } catch (_) {
-      // The round itself succeeded; a failed history read must not turn the
-      // broadcast into an error state.
+      // A failed history/coin refresh must not clobber the round's outcome.
     }
   }
 
-  /// Only one round can ever be waiting (isRunning gates the rest), so the
-  /// waiting entry is the one this outcome belongs to.
-  void _replaceWaitingRound(JoinstrRound updated) {
-    final rounds = [
-      for (final r in state.rounds)
-        if (r.isWaiting) updated else r,
-    ];
-    _emit(state.copyWith(rounds: rounds));
+  void _updateRound(int id, JoinstrRound updated) {
+    _emit(
+      state.copyWith(
+        rounds: [
+          for (final r in state.rounds)
+            if (r.id == id) updated else r,
+        ],
+      ),
+    );
   }
 
   void _fail(JoinstrException e) =>

--- a/lib/features/joinstr/presentation/joinstr_cubit.dart
+++ b/lib/features/joinstr/presentation/joinstr_cubit.dart
@@ -224,14 +224,21 @@ class JoinstrCubit extends Cubit<JoinstrState> {
     JoinstrRound round,
     Stream<JoinstrProgress> progress,
   ) async {
+    // Updates build on the latest round, not the snapshot taken at stream
+    // start, so a terminal update keeps the step the round had reached.
+    var current = round;
+    void update(JoinstrRound next) {
+      current = next;
+      _updateRound(next.id, next);
+    }
+
     try {
       await for (final p in progress) {
         if (p.step == JoinstrRoundStep.done) {
-          _updateRound(round.id, round.completed(p.txId ?? ''));
+          update(current.completed(p.txId ?? ''));
         } else if (p.step == JoinstrRoundStep.failed) {
-          _updateRound(
-            round.id,
-            round.failed(
+          update(
+            current.failed(
               JoinstrException(
                 JoinstrIssue.coinjoinFailed,
                 detail: p.errorMessage,
@@ -239,11 +246,11 @@ class JoinstrCubit extends Cubit<JoinstrState> {
             ),
           );
         } else if (p.step != JoinstrRoundStep.other) {
-          _updateRound(round.id, round.advancedTo(p.step));
+          update(current.advancedTo(p.step));
         }
       }
     } catch (e) {
-      _updateRound(round.id, round.failed(_asJoinstrException(e)));
+      update(current.failed(_asJoinstrException(e)));
     }
 
     await loadCoins();

--- a/lib/features/joinstr/presentation/joinstr_state.dart
+++ b/lib/features/joinstr/presentation/joinstr_state.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -15,9 +16,15 @@ abstract class JoinstrState with _$JoinstrState {
     @Default([]) List<JoinstrPool> pools,
     Wallet? wallet,
 
-    /// Rounds this device initiated or joined, newest first. A waiting round
-    /// blocks new interactions; completed and failed ones stay visible on the
-    /// My Pools tab for the session.
+    /// The wallet's spendable coins, for the input picker.
+    @Default([]) List<JoinstrCoin> coins,
+    @Default(false) bool loadingCoins,
+
+    /// Coin the user picked for a pool they are about to create.
+    JoinstrCoin? selectedCoin,
+
+    /// Rounds this device initiated or joined, newest first. Several can be in
+    /// flight at once; completed and failed ones stay visible on My Pools.
     @Default([]) List<JoinstrRound> rounds,
 
     /// Completed coinjoins, persisted across restarts.
@@ -31,9 +38,39 @@ abstract class JoinstrState with _$JoinstrState {
 
   const JoinstrState._();
 
-  /// A coinjoin round blocks in the bindings until it broadcasts or the pool
-  /// times out, so every other action is disabled while one is in flight.
+  /// True while at least one coinjoin is waiting. It no longer blocks the UI:
+  /// several pools can run at once, each on its own input coin.
   bool get isRunning => rounds.any((r) => r.isWaiting);
 
-  bool get canInteract => !isRunning && wallet != null;
+  bool get canInteract => wallet != null;
+
+  /// Outpoints already committed to an in-flight pool, so they are not offered
+  /// again for another one.
+  Set<String> get busyOutpoints => {
+    for (final r in rounds)
+      if (r.isWaiting) r.inputOutpoint,
+  };
+
+  /// Coins that can fund a pool of [denominationSat]: value inside the required
+  /// window and not already used by a waiting pool. Used when joining, where
+  /// the denomination is fixed by the pool.
+  List<JoinstrCoin> eligibleCoins(int denominationSat) => [
+    for (final c in coins)
+      if (Joinstr.isEligibleCoin(
+            valueSat: c.valueSat,
+            denominationSat: denominationSat,
+          ) &&
+          !busyOutpoints.contains(c.outpoint))
+        c,
+  ];
+
+  /// Coins selectable when creating a pool: not already committed to another
+  /// in-flight pool and large enough to leave a positive denomination. The
+  /// denomination is then derived from whichever coin the user picks.
+  List<JoinstrCoin> get createCoins => [
+    for (final c in coins)
+      if (!busyOutpoints.contains(c.outpoint) &&
+          c.valueSat > Joinstr.minInputSurplusSat)
+        c,
+  ];
 }

--- a/lib/features/joinstr/presentation/joinstr_state.dart
+++ b/lib/features/joinstr/presentation/joinstr_state.dart
@@ -1,0 +1,30 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'joinstr_state.freezed.dart';
+
+enum JoinstrStatus { idle, loadingPools, running, done, error }
+
+@freezed
+abstract class JoinstrState with _$JoinstrState {
+  const factory JoinstrState({
+    @Default(JoinstrStatus.idle) JoinstrStatus status,
+    @Default([]) List<JoinstrPool> pools,
+    Wallet? wallet,
+    JoinstrPool? activePool,
+    String? txId,
+    JoinstrException? error,
+    @Default('100000') String denominationSat,
+    @Default('2') String peers,
+    @Default('1') String feeRate,
+  }) = _JoinstrState;
+
+  const JoinstrState._();
+
+  bool get isRunning => status == JoinstrStatus.running;
+
+  /// A coinjoin round holds the isolate until it broadcasts or the pool times
+  /// out, so every other action is disabled while one is in flight.
+  bool get canInteract => !isRunning && wallet != null;
+}

--- a/lib/features/joinstr/presentation/joinstr_state.dart
+++ b/lib/features/joinstr/presentation/joinstr_state.dart
@@ -31,7 +31,6 @@ abstract class JoinstrState with _$JoinstrState {
     @Default([]) List<JoinstrHistoryEntry> history,
     @Default('') String relay,
     JoinstrException? error,
-    @Default('0.001') String denominationBtc,
     @Default('2') String peers,
     @Default('1') String feeRate,
   }) = _JoinstrState;

--- a/lib/features/joinstr/presentation/joinstr_state.dart
+++ b/lib/features/joinstr/presentation/joinstr_state.dart
@@ -1,10 +1,12 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'joinstr_state.freezed.dart';
 
-enum JoinstrStatus { idle, loadingPools, running, done, error }
+enum JoinstrStatus { idle, loadingPools, error }
 
 @freezed
 abstract class JoinstrState with _$JoinstrState {
@@ -12,19 +14,26 @@ abstract class JoinstrState with _$JoinstrState {
     @Default(JoinstrStatus.idle) JoinstrStatus status,
     @Default([]) List<JoinstrPool> pools,
     Wallet? wallet,
-    JoinstrPool? activePool,
-    String? txId,
+
+    /// Rounds this device initiated or joined, newest first. A waiting round
+    /// blocks new interactions; completed and failed ones stay visible on the
+    /// My Pools tab for the session.
+    @Default([]) List<JoinstrRound> rounds,
+
+    /// Completed coinjoins, persisted across restarts.
+    @Default([]) List<JoinstrHistoryEntry> history,
+    @Default('') String relay,
     JoinstrException? error,
-    @Default('100000') String denominationSat,
+    @Default('0.001') String denominationBtc,
     @Default('2') String peers,
     @Default('1') String feeRate,
   }) = _JoinstrState;
 
   const JoinstrState._();
 
-  bool get isRunning => status == JoinstrStatus.running;
+  /// A coinjoin round blocks in the bindings until it broadcasts or the pool
+  /// times out, so every other action is disabled while one is in flight.
+  bool get isRunning => rounds.any((r) => r.isWaiting);
 
-  /// A coinjoin round holds the isolate until it broadcasts or the pool times
-  /// out, so every other action is disabled while one is in flight.
   bool get canInteract => !isRunning && wallet != null;
 }

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -136,7 +136,7 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
           ),
         ],
       ),
-    );
+    ).whenComplete(controller.dispose);
   }
 }
 

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -252,7 +252,7 @@ class _CreateInputPicker extends StatelessWidget {
     if (coins.isEmpty) {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Text(context.loc.joinstrNoEligibleCoins),
+        child: Text(context.loc.joinstrNoSpendableCoins),
       );
     }
     return Column(

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -25,6 +25,17 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
   JoinstrException? _seenError;
 
   @override
+  void initState() {
+    super.initState();
+    // The cubit is a singleton that outlives the screen: seed from its
+    // current state so re-entering does not misread existing rounds as new
+    // (spurious created-snackbar and tab jump) or an old error as fresh.
+    final state = context.read<JoinstrCubit>().state;
+    _seenRounds = state.rounds.length;
+    _seenError = state.error;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: 4,

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:bb_mobile/core/utils/amount_conversions.dart';
+import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
@@ -203,9 +205,7 @@ class _CreatePoolTab extends StatelessWidget {
         if (denomination != null) ...[
           const Gap(12),
           Text(
-            context.loc.joinstrDenominationLine(
-              Joinstr.formatBtc(denomination),
-            ),
+            context.loc.joinstrDenominationLine(_btc(denomination)),
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ],
@@ -291,7 +291,7 @@ class _CoinTile extends StatelessWidget {
           selected ? Icons.radio_button_checked : Icons.radio_button_off,
         ),
         title: Text(
-          '${Joinstr.formatBtc(coin.valueSat)} BTC',
+          _btc(coin.valueSat),
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
         subtitle: Text(
@@ -377,7 +377,7 @@ class _RoundCard extends StatelessWidget {
     return Card(
       child: ListTile(
         title: Text(
-          loc.joinstrDenominationLine(Joinstr.formatBtc(round.denominationSat)),
+          loc.joinstrDenominationLine(_btc(round.denominationSat)),
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
         subtitle: Text(
@@ -443,7 +443,7 @@ class _RoundDetail extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          loc.joinstrDenominationLine(Joinstr.formatBtc(round.denominationSat)),
+          loc.joinstrDenominationLine(_btc(round.denominationSat)),
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
         const Gap(4),
@@ -642,9 +642,7 @@ class _PoolCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              loc.joinstrDenominationLine(
-                Joinstr.formatBtc(pool.denominationSat),
-              ),
+              loc.joinstrDenominationLine(_btc(pool.denominationSat)),
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             const Gap(4),
@@ -783,9 +781,7 @@ class _HistoryTab extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  context.loc.joinstrAmountLine(
-                    Joinstr.formatBtc(entry.amountSat),
-                  ),
+                  context.loc.joinstrAmountLine(_btc(entry.amountSat)),
                   style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
                 const Gap(4),
@@ -825,6 +821,8 @@ class _EmptyState extends StatelessWidget {
     );
   }
 }
+
+String _btc(int sat) => FormatAmount.btc(ConvertAmount.satsToBtc(sat));
 
 String joinstrErrorMessage(BuildContext context, JoinstrException error) {
   return switch (error.issue) {

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -10,10 +10,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
-/// Tab layout mirrors joinstr-kmp and floresta_wallet: Create New Pool,
-/// My Pools, View Other Pools, History.
-class JoinstrScreen extends StatelessWidget {
+/// Tab layout, labels and dialogs mirror joinstr-kmp and floresta_wallet:
+/// Create New Pool, My Pools, View Other Pools, History; a waiting dialog
+/// while a round is in flight; snackbars for outcomes.
+class JoinstrScreen extends StatefulWidget {
   const JoinstrScreen({super.key});
+
+  @override
+  State<JoinstrScreen> createState() => _JoinstrScreenState();
+}
+
+class _JoinstrScreenState extends State<JoinstrScreen> {
+  bool _waitingDialogOpen = false;
 
   @override
   Widget build(BuildContext context) {
@@ -39,29 +47,93 @@ class JoinstrScreen extends StatelessWidget {
             ],
           ),
         ),
-        body: BlocBuilder<JoinstrCubit, JoinstrState>(
+        body: BlocConsumer<JoinstrCubit, JoinstrState>(
+          listenWhen: (prev, curr) =>
+              prev.isRunning != curr.isRunning || prev.error != curr.error,
+          listener: _onStateChange,
           builder: (context, state) {
-            return Column(
+            // A wallet-level problem (watch-only, mainnet, none eligible) is
+            // terminal: the feature cannot be used, so show it in place rather
+            // than as a transient snackbar.
+            if (state.wallet == null && state.error != null) {
+              return _EmptyState(
+                message: joinstrErrorMessage(context, state.error!),
+              );
+            }
+            return TabBarView(
               children: [
-                const _JoinstrNotice(),
-                if (state.error != null) _JoinstrError(error: state.error!),
-                if (state.isRunning) const _JoinstrRunning(),
-                Expanded(
-                  child: TabBarView(
-                    children: [
-                      _CreatePoolTab(state: state),
-                      _MyPoolsTab(rounds: state.rounds),
-                      _OtherPoolsTab(state: state),
-                      _HistoryTab(history: state.history),
-                    ],
-                  ),
-                ),
+                _CreatePoolTab(state: state),
+                _MyPoolsTab(rounds: state.rounds),
+                _OtherPoolsTab(state: state),
+                _HistoryTab(history: state.history),
               ],
             );
           },
         ),
       ),
     );
+  }
+
+  void _onStateChange(BuildContext context, JoinstrState state) {
+    if (state.isRunning && !_waitingDialogOpen) {
+      _openWaitingDialog(context);
+      return;
+    }
+    if (!state.isRunning && _waitingDialogOpen) {
+      _closeWaitingDialog(context);
+    }
+    // A round that just finished, or a validation error that never started a
+    // round, surfaces as a snackbar like the reference wallets.
+    final round = state.rounds.isNotEmpty ? state.rounds.first : null;
+    if (round != null && round.status == JoinstrRoundStatus.broadcast) {
+      _snack(context, context.loc.joinstrCoinjoinBroadcast(round.txId!));
+    } else if (round != null && round.status == JoinstrRoundStatus.failed) {
+      _snack(context, joinstrErrorMessage(context, round.error!));
+    } else if (state.wallet != null && state.error != null) {
+      _snack(context, joinstrErrorMessage(context, state.error!));
+    }
+  }
+
+  void _openWaitingDialog(BuildContext context) {
+    _waitingDialogOpen = true;
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(dialogContext.loc.joinstrPoolRequest),
+        content: Row(
+          children: [
+            const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const Gap(16),
+            Expanded(
+              child: Text(dialogContext.loc.joinstrWaitingForCredentials),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => _closeWaitingDialog(context),
+            child: Text(dialogContext.loc.joinstrRunInBackground),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _closeWaitingDialog(BuildContext context) {
+    if (!_waitingDialogOpen) return;
+    _waitingDialogOpen = false;
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+
+  void _snack(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _showRelaySettings(BuildContext context) {
@@ -90,66 +162,6 @@ class JoinstrScreen extends StatelessWidget {
             child: Text(dialogContext.loc.joinstrSave),
           ),
         ],
-      ),
-    );
-  }
-}
-
-/// Joinstr traffic is not routed over Tor yet, so the relay and the electrum
-/// server both see the joining IP next to the outpoint being mixed. The
-/// feature is therefore testnet-only for now.
-class _JoinstrNotice extends StatelessWidget {
-  const _JoinstrNotice();
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-      color: Theme.of(context).colorScheme.surfaceContainerHighest,
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Row(
-          children: [
-            const Icon(Icons.science_outlined),
-            const Gap(12),
-            Expanded(child: Text(context.loc.joinstrExperimentalNotice)),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _JoinstrRunning extends StatelessWidget {
-  const _JoinstrRunning();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-      child: Column(
-        children: [
-          const LinearProgressIndicator(),
-          const Gap(8),
-          Text(context.loc.joinstrRunning, textAlign: TextAlign.center),
-        ],
-      ),
-    );
-  }
-}
-
-class _JoinstrError extends StatelessWidget {
-  const _JoinstrError({required this.error});
-
-  final JoinstrException error;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
-      child: Text(
-        joinstrErrorMessage(context, error),
-        style: TextStyle(color: Theme.of(context).colorScheme.error),
       ),
     );
   }
@@ -547,7 +559,11 @@ class _EmptyState extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
-        child: Text(message, style: Theme.of(context).textTheme.bodyLarge),
+        child: Text(
+          message,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
       ),
     );
   }
@@ -566,6 +582,7 @@ String joinstrErrorMessage(BuildContext context, JoinstrException error) {
     JoinstrIssue.invalidElectrumUrl => context.loc.joinstrErrorElectrum,
     JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,
     JoinstrIssue.invalidRelayUrl => context.loc.joinstrErrorRelay,
+    JoinstrIssue.torUnavailable => context.loc.joinstrErrorTor,
     JoinstrIssue.poolNotFound => context.loc.joinstrErrorPoolNotFound,
     JoinstrIssue.coinjoinFailed => context.loc.joinstrErrorFailed(
       error.detail ?? '',

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -390,7 +390,16 @@ class _OtherPoolsTab extends StatelessWidget {
         ),
         Expanded(
           child: state.status == JoinstrStatus.loadingPools
-              ? const Center(child: CircularProgressIndicator())
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const CircularProgressIndicator(),
+                      const Gap(12),
+                      Text(context.loc.joinstrConnectingTor),
+                    ],
+                  ),
+                )
               : state.pools.isEmpty
               ? _EmptyState(message: context.loc.joinstrNoActivePools)
               : ListView.separated(

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -872,7 +872,6 @@ String joinstrErrorMessage(BuildContext context, JoinstrException error) {
     JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,
     JoinstrIssue.invalidRelayUrl => context.loc.joinstrErrorRelay,
     JoinstrIssue.torUnavailable => context.loc.joinstrErrorTor,
-    JoinstrIssue.poolNotFound => context.loc.joinstrErrorPoolNotFound,
     JoinstrIssue.coinjoinFailed => context.loc.joinstrErrorFailed(
       error.detail ?? '',
     ),

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
@@ -10,9 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
-/// Tab layout, labels and dialogs mirror joinstr-kmp and floresta_wallet:
-/// Create New Pool, My Pools, View Other Pools, History; a waiting dialog
-/// while a round is in flight; snackbars for outcomes.
+/// Tabs, labels, the input picker and the coinjoin timeline mirror joinstr-kmp
+/// and floresta_wallet: Create New Pool, My Pools, View Other Pools, History.
 class JoinstrScreen extends StatefulWidget {
   const JoinstrScreen({super.key});
 
@@ -21,10 +21,7 @@ class JoinstrScreen extends StatefulWidget {
 }
 
 class _JoinstrScreenState extends State<JoinstrScreen> {
-  // Snapshot used to fire snackbars exactly once per transition, rather than
-  // on every rebuild.
   int _seenRounds = 0;
-  JoinstrRoundStatus? _seenTopStatus;
   JoinstrException? _seenError;
 
   @override
@@ -54,13 +51,9 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
         body: BlocConsumer<JoinstrCubit, JoinstrState>(
           listenWhen: (prev, curr) =>
               prev.rounds.length != curr.rounds.length ||
-              _topStatus(prev) != _topStatus(curr) ||
               prev.error != curr.error,
           listener: _onStateChange,
           builder: (context, state) {
-            // A wallet-level problem (watch-only, mainnet, none eligible) is
-            // terminal: the feature cannot be used, so show it in place rather
-            // than as a transient snackbar.
             if (state.wallet == null && state.error != null) {
               return _EmptyState(
                 message: joinstrErrorMessage(context, state.error!),
@@ -80,17 +73,9 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
     );
   }
 
-  /// A coinjoin round is created or joined without blocking the screen: it
-  /// runs in the background and shows up on the My Pools tab. This only turns
-  /// state transitions into one-shot snackbars, and jumps to My Pools when a
-  /// round starts so the user sees the pool they just created/joined.
-  JoinstrRoundStatus? _topStatus(JoinstrState state) =>
-      state.rounds.isEmpty ? null : state.rounds.first.status;
-
   void _onStateChange(BuildContext context, JoinstrState state) {
-    final top = state.rounds.isEmpty ? null : state.rounds.first;
-
-    if (state.rounds.length > _seenRounds && top != null) {
+    if (state.rounds.length > _seenRounds && state.rounds.isNotEmpty) {
+      final top = state.rounds.first;
       _snack(
         context,
         top.initiated
@@ -98,20 +83,12 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
             : context.loc.joinstrJoinRequestSnack,
       );
       DefaultTabController.of(context).animateTo(1); // My Pools
-    } else if (top != null && top.status != _seenTopStatus) {
-      if (top.status == JoinstrRoundStatus.broadcast) {
-        _snack(context, context.loc.joinstrCoinjoinBroadcast(top.txId!));
-      } else if (top.status == JoinstrRoundStatus.failed) {
-        _snack(context, joinstrErrorMessage(context, top.error!));
-      }
     } else if (state.wallet != null &&
         state.error != null &&
         state.error != _seenError) {
       _snack(context, joinstrErrorMessage(context, state.error!));
     }
-
     _seenRounds = state.rounds.length;
-    _seenTopStatus = top?.status;
     _seenError = state.error;
   }
 
@@ -160,23 +137,46 @@ class _CreatePoolTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cubit = context.read<JoinstrCubit>();
+    final feeRate = int.tryParse(state.feeRate) ?? 0;
+    final coin = state.selectedCoin;
+    final denomination = coin == null || feeRate <= 0
+        ? null
+        : Joinstr.deriveDenominationSat(
+            coinValueSat: coin.valueSat,
+            feeRateSatPerVb: feeRate,
+          );
+    final ready =
+        coin != null &&
+        (int.tryParse(state.peers) ?? 0) >= 2 &&
+        feeRate > 0 &&
+        denomination != null;
 
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        Text(
-          context.loc.joinstrPoolDetails,
-          style: Theme.of(context).textTheme.titleMedium,
+        // Coin first: the denomination is derived from whichever input the
+        // user picks, so there is nothing to type and no ineligible-coin trap.
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              context.loc.joinstrSelectInput,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: context.loc.joinstrRefreshCoins,
+              onPressed: state.loadingCoins ? null : cubit.loadCoins,
+            ),
+          ],
         ),
-        const Gap(12),
-        _FilteredTextField(
-          value: state.denominationBtc,
-          label: context.loc.joinstrDenomination,
-          helper: context.loc.joinstrDenominationSupport,
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          onChanged: cubit.denominationChanged,
+        const Gap(4),
+        _CreateInputPicker(
+          state: state,
+          selected: coin,
+          onSelect: cubit.selectCoin,
         ),
-        const Gap(12),
+        const Gap(16),
         _FilteredTextField(
           value: state.peers,
           label: context.loc.joinstrPeers,
@@ -190,44 +190,119 @@ class _CreatePoolTab extends StatelessWidget {
           keyboardType: TextInputType.number,
           onChanged: cubit.feeRateChanged,
         ),
-        const Gap(16),
-        FilledButton(
-          onPressed:
-              state.canInteract &&
-                  state.denominationBtc.isNotEmpty &&
-                  state.peers.isNotEmpty
-              ? cubit.initiatePool
-              : null,
-          child: Text(context.loc.joinstrCreate),
-        ),
-        if (state.isRunning) ...[
-          const Gap(8),
+        if (denomination != null) ...[
+          const Gap(12),
           Text(
-            context.loc.joinstrRoundInProgress,
-            style: Theme.of(context).textTheme.bodySmall,
-            textAlign: TextAlign.center,
+            context.loc.joinstrDenominationLine(
+              Joinstr.formatBtc(denomination),
+            ),
+            style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ],
+        const Gap(16),
+        FilledButton(
+          onPressed: ready ? cubit.initiatePool : null,
+          child: Text(context.loc.joinstrCreate),
+        ),
       ],
     );
   }
 }
 
-/// A text field that stays in sync with the cubit's filtered value: when the
-/// cubit rejects input (a letter in a numeric field), the field snaps back
-/// instead of displaying text the state does not hold.
+/// The coin picker for creating a pool: every spendable coin large enough to
+/// form a pool. Whichever the user taps sets the denomination.
+class _CreateInputPicker extends StatelessWidget {
+  const _CreateInputPicker({
+    required this.state,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  final JoinstrState state;
+  final JoinstrCoin? selected;
+  final ValueChanged<JoinstrCoin?> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.loadingCoins) {
+      return Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const Gap(12),
+            Text(context.loc.joinstrLoadingCoins),
+          ],
+        ),
+      );
+    }
+    final coins = state.createCoins;
+    if (coins.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text(context.loc.joinstrNoEligibleCoins),
+      );
+    }
+    return Column(
+      children: [
+        for (final coin in coins)
+          _CoinTile(
+            coin: coin,
+            selected: coin.outpoint == selected?.outpoint,
+            onTap: () => onSelect(coin),
+          ),
+      ],
+    );
+  }
+}
+
+class _CoinTile extends StatelessWidget {
+  const _CoinTile({
+    required this.coin,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final JoinstrCoin coin;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: selected ? Theme.of(context).colorScheme.primaryContainer : null,
+      child: ListTile(
+        onTap: onTap,
+        leading: Icon(
+          selected ? Icons.radio_button_checked : Icons.radio_button_off,
+        ),
+        title: Text(
+          '${Joinstr.formatBtc(coin.valueSat)} BTC',
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        subtitle: Text(
+          '${coin.txid.substring(0, 16)}…:${coin.vout}',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ),
+    );
+  }
+}
+
 class _FilteredTextField extends StatefulWidget {
   const _FilteredTextField({
     required this.value,
     required this.label,
     required this.keyboardType,
     required this.onChanged,
-    this.helper,
   });
 
   final String value;
   final String label;
-  final String? helper;
   final TextInputType keyboardType;
   final ValueChanged<String> onChanged;
 
@@ -266,10 +341,7 @@ class _FilteredTextFieldState extends State<_FilteredTextField> {
     return TextField(
       controller: _controller,
       keyboardType: widget.keyboardType,
-      decoration: InputDecoration(
-        labelText: widget.label,
-        helperText: widget.helper,
-      ),
+      decoration: InputDecoration(labelText: widget.label),
       onChanged: widget.onChanged,
     );
   }
@@ -294,6 +366,7 @@ class _MyPoolsTab extends StatelessWidget {
   }
 }
 
+/// A compact My Pools row. Tapping it opens the round's coinjoin timeline.
 class _RoundCard extends StatelessWidget {
   const _RoundCard({required this.round});
 
@@ -302,72 +375,229 @@ class _RoundCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final Widget trailing;
+    if (round.isBroadcast) {
+      trailing = Icon(
+        Icons.check_circle,
+        color: Theme.of(context).colorScheme.primary,
+      );
+    } else if (round.isFailed) {
+      trailing = Icon(
+        Icons.error_outline,
+        color: Theme.of(context).colorScheme.error,
+      );
+    } else {
+      trailing = const SizedBox(
+        width: 18,
+        height: 18,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    }
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              loc.joinstrDenominationLine(
-                Joinstr.formatBtc(round.denominationSat),
-              ),
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-            const Gap(4),
-            Text(loc.joinstrPeersLine(round.peers)),
-            Text(
-              loc.joinstrRelayLine(round.relay),
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            if (round.publicKey != null)
-              Text(
-                loc.joinstrPublicKeyLine(_short(round.publicKey!)),
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            const Gap(4),
-            switch (round.status) {
-              // A pool this device created waits for peers; a pool it is
-              // joining waits for the initiator's credentials. These are
-              // different states in the protocol and must not read alike.
-              JoinstrRoundStatus.waiting => Row(
-                children: [
-                  const SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  const Gap(8),
-                  Expanded(
-                    child: Text(
-                      round.initiated
-                          ? loc.joinstrWaitingForPeers
-                          : loc.joinstrWaitingForCredentials,
-                    ),
-                  ),
-                ],
-              ),
-              JoinstrRoundStatus.broadcast => Text(
-                '${loc.joinstrBroadcast}: ${_short(round.txId!)}',
-              ),
-              JoinstrRoundStatus.failed => Text(
-                joinstrErrorMessage(context, round.error!),
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-            },
-            if (round.isWaiting) ...[
-              const Gap(2),
-              _CountdownText(expiresAtUnixSec: round.expiresAtUnixSec),
-            ],
-          ],
+      child: ListTile(
+        title: Text(
+          loc.joinstrDenominationLine(Joinstr.formatBtc(round.denominationSat)),
+          style: const TextStyle(fontWeight: FontWeight.bold),
         ),
+        subtitle: Text(
+          round.isWaiting
+              ? _stepLabel(context, round.step)
+              : round.isBroadcast
+              ? loc.joinstrBroadcast
+              : joinstrErrorMessage(context, round.error!),
+        ),
+        trailing: trailing,
+        onTap: () {
+          final cubit = context.read<JoinstrCubit>();
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => BlocProvider.value(
+                value: cubit,
+                child: _RoundTimelineScreen(roundId: round.id),
+              ),
+            ),
+          );
+        },
       ),
     );
   }
-
-  String _short(String value) =>
-      value.length <= 20 ? value : '${value.substring(0, 20)}…';
 }
+
+/// Full-screen coinjoin timeline for one round, rebuilt live from the cubit so
+/// the steps advance while it is open.
+class _RoundTimelineScreen extends StatelessWidget {
+  const _RoundTimelineScreen({required this.roundId});
+
+  final int roundId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<JoinstrCubit, JoinstrState>(
+      builder: (context, state) {
+        final matches = state.rounds.where((r) => r.id == roundId).toList();
+        final round = matches.isEmpty ? null : matches.first;
+        return Scaffold(
+          appBar: AppBar(title: Text(context.loc.joinstrTitle)),
+          body: round == null
+              ? const SizedBox.shrink()
+              : ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [_RoundDetail(round: round)],
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _RoundDetail extends StatelessWidget {
+  const _RoundDetail({required this.round});
+
+  final JoinstrRound round;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          loc.joinstrDenominationLine(Joinstr.formatBtc(round.denominationSat)),
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const Gap(4),
+        Text(loc.joinstrPeersLine(round.peers)),
+        Text(
+          loc.joinstrInputLine(round.inputOutpoint),
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        Text(
+          loc.joinstrRelayLine(round.relay),
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        if (round.isWaiting) ...[
+          const Gap(4),
+          _CountdownText(expiresAtUnixSec: round.expiresAtUnixSec),
+        ],
+        const Gap(16),
+        _CoinjoinTimeline(round: round),
+        if (round.isBroadcast) ...[
+          const Gap(12),
+          SelectableText(
+            '${loc.joinstrBroadcast}: ${round.txId}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+        if (round.isFailed) ...[
+          const Gap(12),
+          Text(
+            joinstrErrorMessage(context, round.error!),
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The coinjoin progress timeline from the reference wallets: each step is
+/// checked off as the round advances, the current one spins, later ones wait.
+class _CoinjoinTimeline extends StatelessWidget {
+  const _CoinjoinTimeline({required this.round});
+
+  final JoinstrRound round;
+
+  @override
+  Widget build(BuildContext context) {
+    const steps = JoinstrRoundStep.timeline;
+    final currentIndex = round.isBroadcast
+        ? steps
+              .length // every step done
+        : steps.indexOf(round.step).clamp(0, steps.length - 1);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final (i, step) in steps.indexed)
+          _TimelineRow(
+            label: _stepLabel(context, step),
+            done: i < currentIndex,
+            current: i == currentIndex && !round.isBroadcast && !round.isFailed,
+            failed: round.isFailed && i == currentIndex,
+          ),
+      ],
+    );
+  }
+}
+
+class _TimelineRow extends StatelessWidget {
+  const _TimelineRow({
+    required this.label,
+    required this.done,
+    required this.current,
+    required this.failed,
+  });
+
+  final String label;
+  final bool done;
+  final bool current;
+  final bool failed;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final Widget marker;
+    if (failed) {
+      marker = Icon(Icons.error_outline, size: 18, color: scheme.error);
+    } else if (done) {
+      marker = Icon(Icons.check_circle, size: 18, color: scheme.primary);
+    } else if (current) {
+      marker = const SizedBox(
+        width: 16,
+        height: 16,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    } else {
+      marker = Icon(
+        Icons.radio_button_unchecked,
+        size: 18,
+        color: scheme.outlineVariant,
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(width: 18, child: Center(child: marker)),
+          const Gap(12),
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(
+                color: (done || current) ? null : scheme.outline,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _stepLabel(BuildContext context, JoinstrRoundStep step) =>
+    switch (step) {
+      JoinstrRoundStep.connecting => context.loc.joinstrStepConnecting,
+      JoinstrRoundStep.posting => context.loc.joinstrStepPosting,
+      JoinstrRoundStep.outputRegistration =>
+        context.loc.joinstrStepOutputRegistration,
+      JoinstrRoundStep.inputRegistration =>
+        context.loc.joinstrStepInputRegistration,
+      JoinstrRoundStep.broadcast => context.loc.joinstrStepBroadcast,
+      JoinstrRoundStep.mined => context.loc.joinstrStepMined,
+      JoinstrRoundStep.done ||
+      JoinstrRoundStep.failed ||
+      JoinstrRoundStep.other => '',
+    };
 
 class _OtherPoolsTab extends StatelessWidget {
   const _OtherPoolsTab({required this.state});
@@ -406,10 +636,8 @@ class _OtherPoolsTab extends StatelessWidget {
                   padding: const EdgeInsets.all(16),
                   itemCount: state.pools.length,
                   separatorBuilder: (_, _) => const Gap(12),
-                  itemBuilder: (context, index) => _PoolCard(
-                    pool: state.pools[index],
-                    enabled: state.canInteract,
-                  ),
+                  itemBuilder: (context, index) =>
+                      _PoolCard(pool: state.pools[index], state: state),
                 ),
         ),
       ],
@@ -418,10 +646,10 @@ class _OtherPoolsTab extends StatelessWidget {
 }
 
 class _PoolCard extends StatelessWidget {
-  const _PoolCard({required this.pool, required this.enabled});
+  const _PoolCard({required this.pool, required this.state});
 
   final JoinstrPool pool;
-  final bool enabled;
+  final JoinstrState state;
 
   @override
   Widget build(BuildContext context) {
@@ -450,7 +678,9 @@ class _PoolCard extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: enabled ? () => _confirmJoin(context, pool) : null,
+                onPressed: state.canInteract
+                    ? () => _pickInputAndJoin(context, pool)
+                    : null,
                 child: Text(loc.joinstrJoin),
               ),
             ),
@@ -460,35 +690,58 @@ class _PoolCard extends StatelessWidget {
     );
   }
 
-  /// Matches the references: joining is confirmed against the initiator's
-  /// nostr public key, the only identity a pool announcement carries.
-  void _confirmJoin(BuildContext context, JoinstrPool pool) {
+  /// Joining also needs a user-chosen input coin, so present the same picker
+  /// filtered to this pool's denomination before starting the join.
+  void _pickInputAndJoin(BuildContext context, JoinstrPool pool) {
     final cubit = context.read<JoinstrCubit>();
-    showDialog<void>(
+    final coins = state.eligibleCoins(pool.denominationSat);
+    showModalBottomSheet<void>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(dialogContext.loc.joinstrJoin),
-        content: Text(dialogContext.loc.joinstrPublicKeyLine(pool.publicKey)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: Text(dialogContext.loc.joinstrCancel),
+      builder: (sheetContext) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                sheetContext.loc.joinstrPublicKeyLine(pool.publicKey),
+                style: Theme.of(sheetContext).textTheme.bodySmall,
+              ),
+              const Gap(12),
+              Text(
+                sheetContext.loc.joinstrSelectInput,
+                style: Theme.of(sheetContext).textTheme.titleMedium,
+              ),
+              const Gap(8),
+              if (coins.isEmpty)
+                Text(sheetContext.loc.joinstrNoEligibleCoins)
+              else
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        for (final coin in coins)
+                          _CoinTile(
+                            coin: coin,
+                            selected: false,
+                            onTap: () {
+                              Navigator.of(sheetContext).pop();
+                              cubit.joinPool(pool, coin);
+                            },
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
           ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-              cubit.joinPool(pool);
-            },
-            child: Text(dialogContext.loc.joinstrContinue),
-          ),
-        ],
+        ),
       ),
     );
   }
 }
 
-/// Ticks once a second while the pool is live, like the countdowns in
-/// joinstr-kmp and floresta_wallet.
 class _CountdownText extends StatefulWidget {
   const _CountdownText({required this.expiresAtUnixSec});
 
@@ -603,6 +856,7 @@ String joinstrErrorMessage(BuildContext context, JoinstrException error) {
       (error.denominationSat ?? 0) + Joinstr.maxInputSurplusSat,
       Joinstr.scanDepth,
     ),
+    JoinstrIssue.coinUnavailable => context.loc.joinstrErrorCoinUnavailable,
     JoinstrIssue.invalidElectrumUrl => context.loc.joinstrErrorElectrum,
     JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,
     JoinstrIssue.invalidRelayUrl => context.loc.joinstrErrorRelay,

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -1,0 +1,246 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
+
+class JoinstrScreen extends StatelessWidget {
+  const JoinstrScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.loc.joinstrTitle),
+        actions: [
+          BlocBuilder<JoinstrCubit, JoinstrState>(
+            buildWhen: (a, b) => a.canInteract != b.canInteract,
+            builder: (context, state) => IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: state.canInteract
+                  ? () => context.read<JoinstrCubit>().refreshPools()
+                  : null,
+            ),
+          ),
+        ],
+      ),
+      body: BlocBuilder<JoinstrCubit, JoinstrState>(
+        builder: (context, state) {
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              const _JoinstrNotice(),
+              const Gap(16),
+              if (state.error != null) ...[
+                _JoinstrError(error: state.error!),
+                const Gap(16),
+              ],
+              if (state.txId != null) ...[
+                _JoinstrSuccess(txId: state.txId!),
+                const Gap(16),
+              ],
+              if (state.isRunning) ...[const _JoinstrRunning(), const Gap(16)],
+              Text(
+                context.loc.joinstrAvailablePools,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const Gap(8),
+              if (state.status == JoinstrStatus.loadingPools)
+                const Center(child: CircularProgressIndicator())
+              else if (state.pools.isEmpty)
+                Text(context.loc.joinstrNoPools)
+              else
+                for (final pool in state.pools)
+                  _PoolTile(pool: pool, enabled: state.canInteract),
+              const Gap(24),
+              const Divider(),
+              const Gap(8),
+              Text(
+                context.loc.joinstrCreatePool,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const Gap(8),
+              const _CreatePoolForm(),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Joinstr traffic is not routed over Tor yet, so the relay and the electrum
+/// server both see the joining IP next to the outpoint being mixed. The
+/// feature is therefore testnet-only for now.
+class _JoinstrNotice extends StatelessWidget {
+  const _JoinstrNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            const Icon(Icons.science_outlined),
+            const Gap(12),
+            Expanded(child: Text(context.loc.joinstrExperimentalNotice)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _JoinstrRunning extends StatelessWidget {
+  const _JoinstrRunning();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const LinearProgressIndicator(),
+        const Gap(8),
+        Text(context.loc.joinstrRunning, textAlign: TextAlign.center),
+      ],
+    );
+  }
+}
+
+class _JoinstrSuccess extends StatelessWidget {
+  const _JoinstrSuccess({required this.txId});
+
+  final String txId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.check_circle_outline),
+        title: Text(context.loc.joinstrBroadcast),
+        subtitle: Text(txId),
+      ),
+    );
+  }
+}
+
+class _JoinstrError extends StatelessWidget {
+  const _JoinstrError({required this.error});
+
+  final JoinstrException error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      joinstrErrorMessage(context, error),
+      style: TextStyle(color: Theme.of(context).colorScheme.error),
+    );
+  }
+}
+
+class _PoolTile extends StatelessWidget {
+  const _PoolTile({required this.pool, required this.enabled});
+
+  final JoinstrPool pool;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(
+          context.loc.joinstrPoolSummary(pool.denominationSat, pool.peers),
+        ),
+        subtitle: Text(
+          context.loc.joinstrPoolDetail(
+            pool.feeRateSatPerVb,
+            pool.secondsUntilExpiry(DateTime.now()),
+          ),
+        ),
+        trailing: FilledButton(
+          onPressed: enabled
+              ? () => context.read<JoinstrCubit>().joinPool(pool)
+              : null,
+          child: Text(context.loc.joinstrJoin),
+        ),
+      ),
+    );
+  }
+}
+
+class _CreatePoolForm extends StatelessWidget {
+  const _CreatePoolForm();
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<JoinstrCubit>();
+    final state = context.watch<JoinstrCubit>().state;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextFormField(
+          initialValue: state.denominationSat,
+          keyboardType: TextInputType.number,
+          decoration: InputDecoration(
+            labelText: context.loc.joinstrDenomination,
+          ),
+          onChanged: cubit.denominationChanged,
+        ),
+        const Gap(8),
+        Row(
+          children: [
+            Expanded(
+              child: TextFormField(
+                initialValue: state.peers,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: context.loc.joinstrPeers,
+                ),
+                onChanged: cubit.peersChanged,
+              ),
+            ),
+            const Gap(16),
+            Expanded(
+              child: TextFormField(
+                initialValue: state.feeRate,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: context.loc.joinstrFeeRate,
+                ),
+                onChanged: cubit.feeRateChanged,
+              ),
+            ),
+          ],
+        ),
+        const Gap(12),
+        FilledButton(
+          onPressed: state.canInteract ? cubit.initiatePool : null,
+          child: Text(context.loc.joinstrCreatePool),
+        ),
+      ],
+    );
+  }
+}
+
+String joinstrErrorMessage(BuildContext context, JoinstrException error) {
+  return switch (error.issue) {
+    JoinstrIssue.bitcoinOnly => context.loc.joinstrErrorBitcoinOnly,
+    JoinstrIssue.mainnetNotSupported => context.loc.joinstrErrorMainnet,
+    JoinstrIssue.watchOnlyWallet => context.loc.joinstrErrorWatchOnly,
+    JoinstrIssue.unsupportedScriptType => context.loc.joinstrErrorScriptType,
+    JoinstrIssue.noEligibleCoin => context.loc.joinstrErrorNoEligibleCoin(
+      (error.denominationSat ?? 0) + Joinstr.minInputSurplusSat,
+      (error.denominationSat ?? 0) + Joinstr.maxInputSurplusSat,
+    ),
+    JoinstrIssue.invalidElectrumUrl => context.loc.joinstrErrorElectrum,
+    JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,
+    JoinstrIssue.poolNotFound => context.loc.joinstrErrorPoolNotFound,
+    JoinstrIssue.coinjoinFailed => context.loc.joinstrErrorFailed(
+      error.detail ?? '',
+    ),
+  };
+}

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -380,7 +380,7 @@ class _RoundCard extends StatelessWidget {
         ),
         subtitle: Text(
           round.isWaiting
-              ? _stepLabel(context, round.step)
+              ? _stepLabel(context, round.step, initiated: round.initiated)
               : round.isBroadcast
               ? loc.joinstrBroadcast
               : joinstrErrorMessage(context, round.error!),
@@ -499,10 +499,14 @@ class _CoinjoinTimeline extends StatelessWidget {
       children: [
         for (final (i, step) in steps.indexed)
           _TimelineRow(
-            label: _stepLabel(context, step),
+            label: _stepLabel(context, step, initiated: round.initiated),
+            description: i <= currentIndex
+                ? _stepDescription(context, step, round)
+                : null,
             done: i < currentIndex,
             current: i == currentIndex && !round.isBroadcast && !round.isFailed,
             failed: round.isFailed && i == currentIndex,
+            last: i == steps.length - 1,
           ),
       ],
     );
@@ -512,19 +516,24 @@ class _CoinjoinTimeline extends StatelessWidget {
 class _TimelineRow extends StatelessWidget {
   const _TimelineRow({
     required this.label,
+    required this.description,
     required this.done,
     required this.current,
     required this.failed,
+    required this.last,
   });
 
   final String label;
+  final String? description;
   final bool done;
   final bool current;
   final bool failed;
+  final bool last;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+    final reached = done || current || failed;
     final Widget marker;
     if (failed) {
       marker = Icon(Icons.error_outline, size: 18, color: scheme.error);
@@ -543,17 +552,51 @@ class _TimelineRow extends StatelessWidget {
         color: scheme.outlineVariant,
       );
     }
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+    // A marker column with the connecting line drawn between markers, so the
+    // rows read as one continuous vertical timeline like the reference wallets.
+    return IntrinsicHeight(
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SizedBox(width: 18, child: Center(child: marker)),
+          Column(
+            children: [
+              SizedBox(width: 18, height: 24, child: Center(child: marker)),
+              if (!last)
+                Expanded(
+                  child: Container(
+                    width: 2,
+                    color: done ? scheme.primary : scheme.outlineVariant,
+                  ),
+                ),
+            ],
+          ),
           const Gap(12),
           Expanded(
-            child: Text(
-              label,
-              style: TextStyle(
-                color: (done || current) ? null : scheme.outline,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 3),
+                    child: Text(
+                      label,
+                      style: TextStyle(
+                        fontWeight: current ? FontWeight.bold : FontWeight.w500,
+                        color: reached ? null : scheme.outline,
+                      ),
+                    ),
+                  ),
+                  if (description != null && description!.isNotEmpty) ...[
+                    const Gap(2),
+                    Text(
+                      description!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: scheme.outline,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
           ),
@@ -563,10 +606,17 @@ class _TimelineRow extends StatelessWidget {
   }
 }
 
-String _stepLabel(BuildContext context, JoinstrRoundStep step) =>
-    switch (step) {
+String _stepLabel(
+  BuildContext context,
+  JoinstrRoundStep step, {
+  bool initiated = true,
+}) => switch (step) {
       JoinstrRoundStep.connecting => context.loc.joinstrStepConnecting,
-      JoinstrRoundStep.posting => context.loc.joinstrStepPosting,
+      // Posting only happens for the creator (a joiner skips to registration),
+      // so name the first row for what the joiner actually did.
+      JoinstrRoundStep.posting => initiated
+          ? context.loc.joinstrStepPosting
+          : context.loc.joinstrStepJoinPool,
       JoinstrRoundStep.outputRegistration =>
         context.loc.joinstrStepOutputRegistration,
       JoinstrRoundStep.inputRegistration =>
@@ -577,6 +627,31 @@ String _stepLabel(BuildContext context, JoinstrRoundStep step) =>
       JoinstrRoundStep.failed ||
       JoinstrRoundStep.other => '',
     };
+
+/// The line under each timeline step, mirroring the reference wallets: a short
+/// status, carrying the real input outpoint and broadcast txid where we have
+/// them.
+String _stepDescription(
+  BuildContext context,
+  JoinstrRoundStep step,
+  JoinstrRound round,
+) => switch (step) {
+  JoinstrRoundStep.posting => round.initiated
+      ? context.loc.joinstrStepPostingDesc
+      : context.loc.joinstrStepJoinPoolDesc,
+  JoinstrRoundStep.outputRegistration =>
+    context.loc.joinstrStepOutputRegistrationDesc,
+  JoinstrRoundStep.inputRegistration => context.loc
+      .joinstrStepInputRegistrationDesc(round.inputOutpoint),
+  JoinstrRoundStep.broadcast => context.loc.joinstrStepBroadcastDesc,
+  JoinstrRoundStep.mined => round.txId != null
+      ? context.loc.joinstrStepMinedDesc(round.txId!)
+      : '',
+  JoinstrRoundStep.connecting ||
+  JoinstrRoundStep.done ||
+  JoinstrRoundStep.failed ||
+  JoinstrRoundStep.other => '',
+};
 
 class _OtherPoolsTab extends StatelessWidget {
   const _OtherPoolsTab({required this.state});

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -21,7 +21,11 @@ class JoinstrScreen extends StatefulWidget {
 }
 
 class _JoinstrScreenState extends State<JoinstrScreen> {
-  bool _waitingDialogOpen = false;
+  // Snapshot used to fire snackbars exactly once per transition, rather than
+  // on every rebuild.
+  int _seenRounds = 0;
+  JoinstrRoundStatus? _seenTopStatus;
+  JoinstrException? _seenError;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +53,9 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
         ),
         body: BlocConsumer<JoinstrCubit, JoinstrState>(
           listenWhen: (prev, curr) =>
-              prev.isRunning != curr.isRunning || prev.error != curr.error,
+              prev.rounds.length != curr.rounds.length ||
+              _topStatus(prev) != _topStatus(curr) ||
+              prev.error != curr.error,
           listener: _onStateChange,
           builder: (context, state) {
             // A wallet-level problem (watch-only, mainnet, none eligible) is
@@ -74,60 +80,39 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
     );
   }
 
+  /// A coinjoin round is created or joined without blocking the screen: it
+  /// runs in the background and shows up on the My Pools tab. This only turns
+  /// state transitions into one-shot snackbars, and jumps to My Pools when a
+  /// round starts so the user sees the pool they just created/joined.
+  JoinstrRoundStatus? _topStatus(JoinstrState state) =>
+      state.rounds.isEmpty ? null : state.rounds.first.status;
+
   void _onStateChange(BuildContext context, JoinstrState state) {
-    if (state.isRunning && !_waitingDialogOpen) {
-      _openWaitingDialog(context);
-      return;
-    }
-    if (!state.isRunning && _waitingDialogOpen) {
-      _closeWaitingDialog(context);
-    }
-    // A round that just finished, or a validation error that never started a
-    // round, surfaces as a snackbar like the reference wallets.
-    final round = state.rounds.isNotEmpty ? state.rounds.first : null;
-    if (round != null && round.status == JoinstrRoundStatus.broadcast) {
-      _snack(context, context.loc.joinstrCoinjoinBroadcast(round.txId!));
-    } else if (round != null && round.status == JoinstrRoundStatus.failed) {
-      _snack(context, joinstrErrorMessage(context, round.error!));
-    } else if (state.wallet != null && state.error != null) {
+    final top = state.rounds.isEmpty ? null : state.rounds.first;
+
+    if (state.rounds.length > _seenRounds && top != null) {
+      _snack(
+        context,
+        top.initiated
+            ? context.loc.joinstrPoolCreatedSnack
+            : context.loc.joinstrJoinRequestSnack,
+      );
+      DefaultTabController.of(context).animateTo(1); // My Pools
+    } else if (top != null && top.status != _seenTopStatus) {
+      if (top.status == JoinstrRoundStatus.broadcast) {
+        _snack(context, context.loc.joinstrCoinjoinBroadcast(top.txId!));
+      } else if (top.status == JoinstrRoundStatus.failed) {
+        _snack(context, joinstrErrorMessage(context, top.error!));
+      }
+    } else if (state.wallet != null &&
+        state.error != null &&
+        state.error != _seenError) {
       _snack(context, joinstrErrorMessage(context, state.error!));
     }
-  }
 
-  void _openWaitingDialog(BuildContext context) {
-    _waitingDialogOpen = true;
-    showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(dialogContext.loc.joinstrPoolRequest),
-        content: Row(
-          children: [
-            const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
-            const Gap(16),
-            Expanded(
-              child: Text(dialogContext.loc.joinstrWaitingForCredentials),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => _closeWaitingDialog(context),
-            child: Text(dialogContext.loc.joinstrRunInBackground),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _closeWaitingDialog(BuildContext context) {
-    if (!_waitingDialogOpen) return;
-    _waitingDialogOpen = false;
-    Navigator.of(context, rootNavigator: true).pop();
+    _seenRounds = state.rounds.length;
+    _seenTopStatus = top?.status;
+    _seenError = state.error;
   }
 
   void _snack(BuildContext context, String message) {
@@ -215,6 +200,14 @@ class _CreatePoolTab extends StatelessWidget {
               : null,
           child: Text(context.loc.joinstrCreate),
         ),
+        if (state.isRunning) ...[
+          const Gap(8),
+          Text(
+            context.loc.joinstrRoundInProgress,
+            style: Theme.of(context).textTheme.bodySmall,
+            textAlign: TextAlign.center,
+          ),
+        ],
       ],
     );
   }
@@ -334,8 +327,25 @@ class _RoundCard extends StatelessWidget {
               ),
             const Gap(4),
             switch (round.status) {
-              JoinstrRoundStatus.waiting => _CountdownText(
-                expiresAtUnixSec: round.expiresAtUnixSec,
+              // A pool this device created waits for peers; a pool it is
+              // joining waits for the initiator's credentials. These are
+              // different states in the protocol and must not read alike.
+              JoinstrRoundStatus.waiting => Row(
+                children: [
+                  const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const Gap(8),
+                  Expanded(
+                    child: Text(
+                      round.initiated
+                          ? loc.joinstrWaitingForPeers
+                          : loc.joinstrWaitingForCredentials,
+                    ),
+                  ),
+                ],
               ),
               JoinstrRoundStatus.broadcast => Text(
                 '${loc.joinstrBroadcast}: ${_short(round.txId!)}',
@@ -345,6 +355,10 @@ class _RoundCard extends StatelessWidget {
                 style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
             },
+            if (round.isWaiting) ...[
+              const Gap(2),
+              _CountdownText(expiresAtUnixSec: round.expiresAtUnixSec),
+            ],
           ],
         ),
       ),

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -1,71 +1,95 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
+/// Tab layout mirrors joinstr-kmp and floresta_wallet: Create New Pool,
+/// My Pools, View Other Pools, History.
 class JoinstrScreen extends StatelessWidget {
   const JoinstrScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(context.loc.joinstrTitle),
-        actions: [
-          BlocBuilder<JoinstrCubit, JoinstrState>(
-            buildWhen: (a, b) => a.canInteract != b.canInteract,
-            builder: (context, state) => IconButton(
-              icon: const Icon(Icons.refresh),
-              onPressed: state.canInteract
-                  ? () => context.read<JoinstrCubit>().refreshPools()
-                  : null,
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(context.loc.joinstrTitle),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.settings_outlined),
+              onPressed: () => _showRelaySettings(context),
             ),
+          ],
+          bottom: TabBar(
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
+            tabs: [
+              Tab(text: context.loc.joinstrTabCreate),
+              Tab(text: context.loc.joinstrTabMyPools),
+              Tab(text: context.loc.joinstrTabOtherPools),
+              Tab(text: context.loc.joinstrTabHistory),
+            ],
+          ),
+        ),
+        body: BlocBuilder<JoinstrCubit, JoinstrState>(
+          builder: (context, state) {
+            return Column(
+              children: [
+                const _JoinstrNotice(),
+                if (state.error != null) _JoinstrError(error: state.error!),
+                if (state.isRunning) const _JoinstrRunning(),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      _CreatePoolTab(state: state),
+                      _MyPoolsTab(rounds: state.rounds),
+                      _OtherPoolsTab(state: state),
+                      _HistoryTab(history: state.history),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _showRelaySettings(BuildContext context) {
+    final cubit = context.read<JoinstrCubit>();
+    final controller = TextEditingController(text: cubit.state.relay);
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(dialogContext.loc.joinstrNostrRelay),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(hintText: 'wss://'),
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(dialogContext.loc.joinstrCancel),
+          ),
+          TextButton(
+            onPressed: () {
+              cubit.relayChanged(controller.text);
+              Navigator.of(dialogContext).pop();
+            },
+            child: Text(dialogContext.loc.joinstrSave),
           ),
         ],
-      ),
-      body: BlocBuilder<JoinstrCubit, JoinstrState>(
-        builder: (context, state) {
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: [
-              const _JoinstrNotice(),
-              const Gap(16),
-              if (state.error != null) ...[
-                _JoinstrError(error: state.error!),
-                const Gap(16),
-              ],
-              if (state.txId != null) ...[
-                _JoinstrSuccess(txId: state.txId!),
-                const Gap(16),
-              ],
-              if (state.isRunning) ...[const _JoinstrRunning(), const Gap(16)],
-              Text(
-                context.loc.joinstrAvailablePools,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const Gap(8),
-              if (state.status == JoinstrStatus.loadingPools)
-                const Center(child: CircularProgressIndicator())
-              else if (state.pools.isEmpty)
-                Text(context.loc.joinstrNoPools)
-              else
-                for (final pool in state.pools)
-                  _PoolTile(pool: pool, enabled: state.canInteract),
-              const Gap(24),
-              const Divider(),
-              const Gap(8),
-              Text(
-                context.loc.joinstrCreatePool,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const Gap(8),
-              const _CreatePoolForm(),
-            ],
-          );
-        },
       ),
     );
   }
@@ -80,6 +104,7 @@ class _JoinstrNotice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
+      margin: const EdgeInsets.fromLTRB(16, 12, 16, 4),
       color: Theme.of(context).colorScheme.surfaceContainerHighest,
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -100,28 +125,14 @@ class _JoinstrRunning extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        const LinearProgressIndicator(),
-        const Gap(8),
-        Text(context.loc.joinstrRunning, textAlign: TextAlign.center),
-      ],
-    );
-  }
-}
-
-class _JoinstrSuccess extends StatelessWidget {
-  const _JoinstrSuccess({required this.txId});
-
-  final String txId;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      child: ListTile(
-        leading: const Icon(Icons.check_circle_outline),
-        title: Text(context.loc.joinstrBroadcast),
-        subtitle: Text(txId),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Column(
+        children: [
+          const LinearProgressIndicator(),
+          const Gap(8),
+          Text(context.loc.joinstrRunning, textAlign: TextAlign.center),
+        ],
       ),
     );
   }
@@ -134,94 +145,410 @@ class _JoinstrError extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      joinstrErrorMessage(context, error),
-      style: TextStyle(color: Theme.of(context).colorScheme.error),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Text(
+        joinstrErrorMessage(context, error),
+        style: TextStyle(color: Theme.of(context).colorScheme.error),
+      ),
     );
   }
 }
 
-class _PoolTile extends StatelessWidget {
-  const _PoolTile({required this.pool, required this.enabled});
+class _CreatePoolTab extends StatelessWidget {
+  const _CreatePoolTab({required this.state});
+
+  final JoinstrState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<JoinstrCubit>();
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          context.loc.joinstrPoolDetails,
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const Gap(12),
+        _FilteredTextField(
+          value: state.denominationBtc,
+          label: context.loc.joinstrDenomination,
+          helper: context.loc.joinstrDenominationSupport,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          onChanged: cubit.denominationChanged,
+        ),
+        const Gap(12),
+        _FilteredTextField(
+          value: state.peers,
+          label: context.loc.joinstrPeers,
+          keyboardType: TextInputType.number,
+          onChanged: cubit.peersChanged,
+        ),
+        const Gap(12),
+        _FilteredTextField(
+          value: state.feeRate,
+          label: context.loc.joinstrFeeRate,
+          keyboardType: TextInputType.number,
+          onChanged: cubit.feeRateChanged,
+        ),
+        const Gap(16),
+        FilledButton(
+          onPressed:
+              state.canInteract &&
+                  state.denominationBtc.isNotEmpty &&
+                  state.peers.isNotEmpty
+              ? cubit.initiatePool
+              : null,
+          child: Text(context.loc.joinstrCreate),
+        ),
+      ],
+    );
+  }
+}
+
+/// A text field that stays in sync with the cubit's filtered value: when the
+/// cubit rejects input (a letter in a numeric field), the field snaps back
+/// instead of displaying text the state does not hold.
+class _FilteredTextField extends StatefulWidget {
+  const _FilteredTextField({
+    required this.value,
+    required this.label,
+    required this.keyboardType,
+    required this.onChanged,
+    this.helper,
+  });
+
+  final String value;
+  final String label;
+  final String? helper;
+  final TextInputType keyboardType;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_FilteredTextField> createState() => _FilteredTextFieldState();
+}
+
+class _FilteredTextFieldState extends State<_FilteredTextField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value);
+  }
+
+  @override
+  void didUpdateWidget(_FilteredTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value != _controller.text) {
+      _controller.value = TextEditingValue(
+        text: widget.value,
+        selection: TextSelection.collapsed(offset: widget.value.length),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _controller,
+      keyboardType: widget.keyboardType,
+      decoration: InputDecoration(
+        labelText: widget.label,
+        helperText: widget.helper,
+      ),
+      onChanged: widget.onChanged,
+    );
+  }
+}
+
+class _MyPoolsTab extends StatelessWidget {
+  const _MyPoolsTab({required this.rounds});
+
+  final List<JoinstrRound> rounds;
+
+  @override
+  Widget build(BuildContext context) {
+    if (rounds.isEmpty) {
+      return _EmptyState(message: context.loc.joinstrNoActivePools);
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: rounds.length,
+      separatorBuilder: (_, _) => const Gap(12),
+      itemBuilder: (context, index) => _RoundCard(round: rounds[index]),
+    );
+  }
+}
+
+class _RoundCard extends StatelessWidget {
+  const _RoundCard({required this.round});
+
+  final JoinstrRound round;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              loc.joinstrDenominationLine(
+                Joinstr.formatBtc(round.denominationSat),
+              ),
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const Gap(4),
+            Text(loc.joinstrPeersLine(round.peers)),
+            Text(
+              loc.joinstrRelayLine(round.relay),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (round.publicKey != null)
+              Text(
+                loc.joinstrPublicKeyLine(_short(round.publicKey!)),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            const Gap(4),
+            switch (round.status) {
+              JoinstrRoundStatus.waiting => _CountdownText(
+                expiresAtUnixSec: round.expiresAtUnixSec,
+              ),
+              JoinstrRoundStatus.broadcast => Text(
+                '${loc.joinstrBroadcast}: ${_short(round.txId!)}',
+              ),
+              JoinstrRoundStatus.failed => Text(
+                joinstrErrorMessage(context, round.error!),
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            },
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _short(String value) =>
+      value.length <= 20 ? value : '${value.substring(0, 20)}…';
+}
+
+class _OtherPoolsTab extends StatelessWidget {
+  const _OtherPoolsTab({required this.state});
+
+  final JoinstrState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: OutlinedButton(
+            onPressed: state.canInteract
+                ? () => context.read<JoinstrCubit>().refreshPools()
+                : null,
+            child: Text(context.loc.joinstrRefresh),
+          ),
+        ),
+        Expanded(
+          child: state.status == JoinstrStatus.loadingPools
+              ? const Center(child: CircularProgressIndicator())
+              : state.pools.isEmpty
+              ? _EmptyState(message: context.loc.joinstrNoActivePools)
+              : ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: state.pools.length,
+                  separatorBuilder: (_, _) => const Gap(12),
+                  itemBuilder: (context, index) => _PoolCard(
+                    pool: state.pools[index],
+                    enabled: state.canInteract,
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PoolCard extends StatelessWidget {
+  const _PoolCard({required this.pool, required this.enabled});
 
   final JoinstrPool pool;
   final bool enabled;
 
   @override
   Widget build(BuildContext context) {
+    final loc = context.loc;
     return Card(
-      child: ListTile(
-        title: Text(
-          context.loc.joinstrPoolSummary(pool.denominationSat, pool.peers),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              loc.joinstrDenominationLine(
+                Joinstr.formatBtc(pool.denominationSat),
+              ),
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const Gap(4),
+            Text(loc.joinstrPeersLine(pool.peers)),
+            Text(loc.joinstrFeeRateLine(pool.feeRateSatPerVb)),
+            Text(
+              loc.joinstrRelayLine(pool.relay),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            _CountdownText(expiresAtUnixSec: pool.expiresAtUnixSec),
+            const Gap(8),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: enabled ? () => _confirmJoin(context, pool) : null,
+                child: Text(loc.joinstrJoin),
+              ),
+            ),
+          ],
         ),
-        subtitle: Text(
-          context.loc.joinstrPoolDetail(
-            pool.feeRateSatPerVb,
-            pool.secondsUntilExpiry(DateTime.now()),
+      ),
+    );
+  }
+
+  /// Matches the references: joining is confirmed against the initiator's
+  /// nostr public key, the only identity a pool announcement carries.
+  void _confirmJoin(BuildContext context, JoinstrPool pool) {
+    final cubit = context.read<JoinstrCubit>();
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(dialogContext.loc.joinstrJoin),
+        content: Text(dialogContext.loc.joinstrPublicKeyLine(pool.publicKey)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(dialogContext.loc.joinstrCancel),
           ),
-        ),
-        trailing: FilledButton(
-          onPressed: enabled
-              ? () => context.read<JoinstrCubit>().joinPool(pool)
-              : null,
-          child: Text(context.loc.joinstrJoin),
-        ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              cubit.joinPool(pool);
+            },
+            child: Text(dialogContext.loc.joinstrContinue),
+          ),
+        ],
       ),
     );
   }
 }
 
-class _CreatePoolForm extends StatelessWidget {
-  const _CreatePoolForm();
+/// Ticks once a second while the pool is live, like the countdowns in
+/// joinstr-kmp and floresta_wallet.
+class _CountdownText extends StatefulWidget {
+  const _CountdownText({required this.expiresAtUnixSec});
+
+  final int expiresAtUnixSec;
+
+  @override
+  State<_CountdownText> createState() => _CountdownTextState();
+}
+
+class _CountdownTextState extends State<_CountdownText> {
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final cubit = context.read<JoinstrCubit>();
-    final state = context.watch<JoinstrCubit>().state;
+    final remaining =
+        widget.expiresAtUnixSec - DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final text = remaining > 0
+        ? context.loc.joinstrTimeRemaining(Joinstr.formatRemaining(remaining))
+        : context.loc.joinstrExpired;
+    return Text(text, style: Theme.of(context).textTheme.bodySmall);
+  }
+}
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        TextFormField(
-          initialValue: state.denominationSat,
-          keyboardType: TextInputType.number,
-          decoration: InputDecoration(
-            labelText: context.loc.joinstrDenomination,
+class _HistoryTab extends StatelessWidget {
+  const _HistoryTab({required this.history});
+
+  final List<JoinstrHistoryEntry> history;
+
+  @override
+  Widget build(BuildContext context) {
+    if (history.isEmpty) {
+      return _EmptyState(message: context.loc.joinstrNoHistory);
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: history.length,
+      separatorBuilder: (_, _) => const Gap(12),
+      itemBuilder: (context, index) {
+        final entry = history[index];
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  context.loc.joinstrAmountLine(
+                    Joinstr.formatBtc(entry.amountSat),
+                  ),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const Gap(4),
+                Text(
+                  context.loc.joinstrTxLine(entry.txId),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                Text(
+                  context.loc.joinstrRelayLine(entry.relay),
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
           ),
-          onChanged: cubit.denominationChanged,
-        ),
-        const Gap(8),
-        Row(
-          children: [
-            Expanded(
-              child: TextFormField(
-                initialValue: state.peers,
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: context.loc.joinstrPeers,
-                ),
-                onChanged: cubit.peersChanged,
-              ),
-            ),
-            const Gap(16),
-            Expanded(
-              child: TextFormField(
-                initialValue: state.feeRate,
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: context.loc.joinstrFeeRate,
-                ),
-                onChanged: cubit.feeRateChanged,
-              ),
-            ),
-          ],
-        ),
-        const Gap(12),
-        FilledButton(
-          onPressed: state.canInteract ? cubit.initiatePool : null,
-          child: Text(context.loc.joinstrCreatePool),
-        ),
-      ],
+        );
+      },
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(message, style: Theme.of(context).textTheme.bodyLarge),
+      ),
     );
   }
 }
@@ -238,6 +565,7 @@ String joinstrErrorMessage(BuildContext context, JoinstrException error) {
     ),
     JoinstrIssue.invalidElectrumUrl => context.loc.joinstrErrorElectrum,
     JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,
+    JoinstrIssue.invalidRelayUrl => context.loc.joinstrErrorRelay,
     JoinstrIssue.poolNotFound => context.loc.joinstrErrorPoolNotFound,
     JoinstrIssue.coinjoinFailed => context.loc.joinstrErrorFailed(
       error.detail ?? '',

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -578,6 +578,7 @@ String joinstrErrorMessage(BuildContext context, JoinstrException error) {
     JoinstrIssue.noEligibleCoin => context.loc.joinstrErrorNoEligibleCoin(
       (error.denominationSat ?? 0) + Joinstr.minInputSurplusSat,
       (error.denominationSat ?? 0) + Joinstr.maxInputSurplusSat,
+      Joinstr.scanDepth,
     ),
     JoinstrIssue.invalidElectrumUrl => context.loc.joinstrErrorElectrum,
     JoinstrIssue.invalidPoolConfig => context.loc.joinstrErrorPoolConfig,

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
@@ -90,7 +91,7 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
   void _onStateChange(BuildContext context, JoinstrState state) {
     if (state.rounds.length > _seenRounds && state.rounds.isNotEmpty) {
       final top = state.rounds.first;
-      _snack(
+      SnackBarUtils.showSnackBar(
         context,
         top.initiated
             ? context.loc.joinstrPoolCreatedSnack
@@ -100,16 +101,13 @@ class _JoinstrScreenState extends State<JoinstrScreen> {
     } else if (state.wallet != null &&
         state.error != null &&
         state.error != _seenError) {
-      _snack(context, joinstrErrorMessage(context, state.error!));
+      SnackBarUtils.showSnackBar(
+        context,
+        joinstrErrorMessage(context, state.error!),
+      );
     }
     _seenRounds = state.rounds.length;
     _seenError = state.error;
-  }
-
-  void _snack(BuildContext context, String message) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _showRelaySettings(BuildContext context) {

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
@@ -188,17 +189,15 @@ class _CreatePoolTab extends StatelessWidget {
           onSelect: cubit.selectCoin,
         ),
         const Gap(16),
-        _FilteredTextField(
+        _NumberField(
           value: state.peers,
           label: context.loc.joinstrPeers,
-          keyboardType: TextInputType.number,
           onChanged: cubit.peersChanged,
         ),
         const Gap(12),
-        _FilteredTextField(
+        _NumberField(
           value: state.feeRate,
           label: context.loc.joinstrFeeRate,
-          keyboardType: TextInputType.number,
           onChanged: cubit.feeRateChanged,
         ),
         if (denomination != null) ...[
@@ -304,56 +303,27 @@ class _CoinTile extends StatelessWidget {
   }
 }
 
-class _FilteredTextField extends StatefulWidget {
-  const _FilteredTextField({
+/// Labelled numeric input on top of the app-wide [BBInputText].
+class _NumberField extends StatelessWidget {
+  const _NumberField({
     required this.value,
     required this.label,
-    required this.keyboardType,
     required this.onChanged,
   });
 
   final String value;
   final String label;
-  final TextInputType keyboardType;
   final ValueChanged<String> onChanged;
 
   @override
-  State<_FilteredTextField> createState() => _FilteredTextFieldState();
-}
-
-class _FilteredTextFieldState extends State<_FilteredTextField> {
-  late final TextEditingController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = TextEditingController(text: widget.value);
-  }
-
-  @override
-  void didUpdateWidget(_FilteredTextField oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.value != _controller.text) {
-      _controller.value = TextEditingValue(
-        text: widget.value,
-        selection: TextSelection.collapsed(offset: widget.value.length),
-      );
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: _controller,
-      keyboardType: widget.keyboardType,
-      decoration: InputDecoration(labelText: widget.label),
-      onChanged: widget.onChanged,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: Theme.of(context).textTheme.labelMedium),
+        const Gap(4),
+        BBInputText(value: value, onChanged: onChanged, onlyNumbers: true),
+      ],
     );
   }
 }

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -611,10 +611,11 @@ String _stepLabel(
   JoinstrRoundStep step, {
   bool initiated = true,
 }) => switch (step) {
-      JoinstrRoundStep.connecting => context.loc.joinstrStepConnecting,
-      // Posting only happens for the creator (a joiner skips to registration),
-      // so name the first row for what the joiner actually did.
-      JoinstrRoundStep.posting => initiated
+      // `connecting` is transient plumbing we never surface as a status; a fresh
+      // round shows the first real step instead of "Connecting". Posting only
+      // happens for the creator (a joiner skips to registration), so name the
+      // first row for what the joiner actually did.
+      JoinstrRoundStep.connecting || JoinstrRoundStep.posting => initiated
           ? context.loc.joinstrStepPosting
           : context.loc.joinstrStepJoinPool,
       JoinstrRoundStep.outputRegistration =>

--- a/lib/features/joinstr/ui/screens/joinstr_screen.dart
+++ b/lib/features/joinstr/ui/screens/joinstr_screen.dart
@@ -636,23 +636,40 @@ String _stepDescription(
   BuildContext context,
   JoinstrRoundStep step,
   JoinstrRound round,
-) => switch (step) {
-  JoinstrRoundStep.posting => round.initiated
-      ? context.loc.joinstrStepPostingDesc
-      : context.loc.joinstrStepJoinPoolDesc,
-  JoinstrRoundStep.outputRegistration =>
-    context.loc.joinstrStepOutputRegistrationDesc,
-  JoinstrRoundStep.inputRegistration => context.loc
-      .joinstrStepInputRegistrationDesc(round.inputOutpoint),
-  JoinstrRoundStep.broadcast => context.loc.joinstrStepBroadcastDesc,
-  JoinstrRoundStep.mined => round.txId != null
-      ? context.loc.joinstrStepMinedDesc(round.txId!)
-      : '',
-  JoinstrRoundStep.connecting ||
-  JoinstrRoundStep.done ||
-  JoinstrRoundStep.failed ||
-  JoinstrRoundStep.other => '',
-};
+) {
+  final loc = context.loc;
+  switch (step) {
+    case JoinstrRoundStep.posting:
+      return round.initiated
+          ? loc.joinstrStepPostingDesc
+          : loc.joinstrStepJoinPoolDesc;
+    case JoinstrRoundStep.outputRegistration:
+      final lines = [
+        round.outputAddress ?? loc.joinstrStepOutputRegistrationDesc,
+        if (round.outputEventId != null)
+          loc.joinstrEventIdLine(round.outputEventId!),
+      ];
+      return lines.join('\n');
+    case JoinstrRoundStep.inputRegistration:
+      final lines = [
+        loc.joinstrStepInputRegistrationDesc(round.inputOutpoint),
+        if (round.inputEventId != null)
+          loc.joinstrEventIdLine(round.inputEventId!),
+      ];
+      return lines.join('\n');
+    case JoinstrRoundStep.broadcast:
+      return round.psbt != null
+          ? loc.joinstrPsbtLine(round.psbt!)
+          : loc.joinstrStepBroadcastDesc;
+    case JoinstrRoundStep.mined:
+      return round.txId != null ? loc.joinstrStepMinedDesc(round.txId!) : '';
+    case JoinstrRoundStep.connecting:
+    case JoinstrRoundStep.done:
+    case JoinstrRoundStep.failed:
+    case JoinstrRoundStep.other:
+      return '';
+  }
+}
 
 class _OtherPoolsTab extends StatelessWidget {
   const _OtherPoolsTab({required this.state});

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -135,6 +135,14 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
                     context.pushNamed(SettingsRoute.btcMap.name);
                   },
                 ),
+                if (isSuperuser)
+                  SettingsEntryItem(
+                    icon: Icons.shuffle,
+                    title: context.loc.joinstrTitle,
+                    onTap: () {
+                      context.pushNamed(SettingsRoute.joinstr.name);
+                    },
+                  ),
                 SettingsEntryItem(
                   icon: Icons.description,
                   title: context.loc.settingsTermsOfServiceTitle,

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -135,14 +135,6 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
                     context.pushNamed(SettingsRoute.btcMap.name);
                   },
                 ),
-                if (isSuperuser)
-                  SettingsEntryItem(
-                    icon: Icons.shuffle,
-                    title: context.loc.joinstrTitle,
-                    onTap: () {
-                      context.pushNamed(SettingsRoute.joinstr.name);
-                    },
-                  ),
                 SettingsEntryItem(
                   icon: Icons.description,
                   title: context.loc.settingsTermsOfServiceTitle,

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -8,6 +8,8 @@ import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dar
 import 'package:bb_mobile/features/backup_settings/ui/screens/backup_settings_screen.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_state.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
+import 'package:bb_mobile/features/joinstr/ui/screens/joinstr_screen.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_settings/presentation/default_wallets_cubit.dart';
 import 'package:bb_mobile/features/exchange_settings/presentation/file_upload_cubit.dart';
@@ -86,7 +88,8 @@ enum SettingsRoute {
   autoswapSettings('autoswap-settings'),
   swapRestore('swap-restore'),
   swapRescue('swap-rescue'),
-  btcMap('btc-map');
+  btcMap('btc-map'),
+  joinstr('joinstr');
 
   final String path;
 
@@ -328,6 +331,14 @@ class SettingsRouter {
         path: SettingsRoute.btcMap.path,
         name: SettingsRoute.btcMap.name,
         builder: (context, state) => const BtcMapScreen(),
+      ),
+      GoRoute(
+        path: SettingsRoute.joinstr.path,
+        name: SettingsRoute.joinstr.name,
+        builder: (context, state) => BlocProvider(
+          create: (_) => locator<JoinstrCubit>()..load(),
+          child: const JoinstrScreen(),
+        ),
       ),
     ],
   );

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -335,8 +335,11 @@ class SettingsRouter {
       GoRoute(
         path: SettingsRoute.joinstr.path,
         name: SettingsRoute.joinstr.name,
-        builder: (context, state) => BlocProvider(
-          create: (_) => locator<JoinstrCubit>()..load(),
+        // BlocProvider.value so leaving the screen does not close the cubit:
+        // it is a singleton that must keep running while a round is in
+        // flight (see JoinstrCubit).
+        builder: (context, state) => BlocProvider.value(
+          value: locator<JoinstrCubit>()..load(),
           child: const JoinstrScreen(),
         ),
       ),

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/features/wallet/ui/widgets/home_errors.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_bottom_buttons.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_cards.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_home_top_section.dart';
+import 'package:bb_mobile/features/wallet/ui/widgets/wallet_joinstr_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -147,6 +148,9 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                     },
                   ),
                 ),
+                const SliverToBoxAdapter(child: WalletJoinstrTile()),
+                // Clears the bottom action bar so the last card is not hidden.
+                const SliverToBoxAdapter(child: SizedBox(height: 96)),
               ],
             ),
             Positioned(

--- a/lib/features/wallet/ui/widgets/wallet_joinstr_tile.dart
+++ b/lib/features/wallet/ui/widgets/wallet_joinstr_tile.dart
@@ -1,0 +1,33 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/settings/ui/settings_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+/// Joinstr entry on the wallet home screen. Gated on the superuser flag, like
+/// the settings entry: the feature is an experimental, testnet-only coinjoin,
+/// so it stays hidden for ordinary users until it graduates.
+class WalletJoinstrTile extends StatelessWidget {
+  const WalletJoinstrTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isSuperuser =
+        context.select((SettingsCubit cubit) => cubit.state.isSuperuser) ??
+        false;
+    if (!isSuperuser) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Card(
+        child: ListTile(
+          leading: const Icon(Icons.shuffle),
+          title: Text(context.loc.joinstrTitle),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => context.pushNamed(SettingsRoute.joinstr.name),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -19,6 +19,7 @@ import 'package:bb_mobile/features/dca/dca_locator.dart';
 import 'package:bb_mobile/features/electrum_settings/electrum_settings_locator.dart';
 import 'package:bb_mobile/features/exchange/exchange_locator.dart';
 import 'package:bb_mobile/features/exchange_settings/exchange_settings_locator.dart';
+import 'package:bb_mobile/features/joinstr/joinstr_locator.dart';
 import 'package:bb_mobile/features/mempool_settings/mempool_settings_locator.dart';
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_locator.dart';
 import 'package:bb_mobile/features/import_mnemonic/locator.dart';
@@ -86,6 +87,7 @@ class AppLocator {
     ReceiveLocator.setup(locator);
     SendLocator.setup(locator);
     CoinsLocator.setup(locator);
+    JoinstrLocator.setup(locator);
     BackupSettingsLocator.setup(locator);
     TestWalletBackupLocator.setup(locator);
     ImportWatchOnlyLocator.setup(locator);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/router.dart';
 import 'package:bitbox_transport/bitbox_transport.dart';
 import 'package:bull_sdk/bull_sdk.dart';
+import 'package:joinstr_flutter/joinstr_flutter.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -93,6 +94,7 @@ class Bull {
     final initTasks = [
       BullSdk.init(),
       PConfig.initializeApp(),
+      JoinstrFlutter.init(),
       if (Platform.isAndroid) BitBoxApi.initialize(),
     ];
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,6 @@ import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/router.dart';
 import 'package:bitbox_transport/bitbox_transport.dart';
 import 'package:bull_sdk/bull_sdk.dart';
-import 'package:joinstr_flutter/joinstr_flutter.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -94,7 +93,6 @@ class Bull {
     final initTasks = [
       BullSdk.init(),
       PConfig.initializeApp(),
-      JoinstrFlutter.init(),
       if (Platform.isAndroid) BitBoxApi.initialize(),
     ];
 

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -14,6 +14,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   flutter_zxing
   jni
+  joinstr_flutter
   payjoin_flutter
   rust_lib_bull_sdk
   tor

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -459,35 +459,111 @@
   "@joinstrExperimentalNotice": {
     "description": "Banner explaining that joinstr is experimental and testnet-only"
   },
-  "joinstrAvailablePools": "Available pools",
-  "@joinstrAvailablePools": {
-    "description": "Heading above the list of joinstr pools advertised on the relay"
+  "joinstrTabCreate": "Create New Pool",
+  "@joinstrTabCreate": {
+    "description": "Tab that announces a new joinstr pool"
   },
-  "joinstrNoPools": "No pools advertised on the relay right now. Create one below, or refresh.",
-  "@joinstrNoPools": {
-    "description": "Shown when the relay returned no joinstr pools"
+  "joinstrTabMyPools": "My Pools",
+  "@joinstrTabMyPools": {
+    "description": "Tab listing coinjoin rounds this device initiated or joined"
   },
-  "joinstrPoolSummary": "{denominationSat} sat · {peers} peers",
-  "@joinstrPoolSummary": {
-    "description": "One-line summary of a joinstr pool: its denomination and required peer count",
+  "joinstrTabOtherPools": "View Other Pools",
+  "@joinstrTabOtherPools": {
+    "description": "Tab listing joinstr pools advertised on the relay"
+  },
+  "joinstrTabHistory": "History",
+  "@joinstrTabHistory": {
+    "description": "Tab listing completed coinjoins"
+  },
+  "joinstrPoolDetails": "Pool Details",
+  "@joinstrPoolDetails": {
+    "description": "Heading above the create-pool form"
+  },
+  "joinstrNoActivePools": "No pools found",
+  "@joinstrNoActivePools": {
+    "description": "Empty state for the pool lists"
+  },
+  "joinstrNoHistory": "No history found",
+  "@joinstrNoHistory": {
+    "description": "Empty state for the coinjoin history tab"
+  },
+  "joinstrRefresh": "Refresh",
+  "@joinstrRefresh": {
+    "description": "Button that reloads the pool list from the relay"
+  },
+  "joinstrDenominationLine": "Denomination: {btc} BTC",
+  "@joinstrDenominationLine": {
+    "description": "Pool card line showing the pool denomination",
     "placeholders": {
-      "denominationSat": {
-        "type": "int"
-      },
+      "btc": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrPeersLine": "Peers: {peers}",
+  "@joinstrPeersLine": {
+    "description": "Pool card line showing the required peer count",
+    "placeholders": {
       "peers": {
         "type": "int"
       }
     }
   },
-  "joinstrPoolDetail": "{feeRate} sat/vB · expires in {secondsLeft}s",
-  "@joinstrPoolDetail": {
-    "description": "Secondary line of a joinstr pool tile: fee rate and seconds until the pool expires",
+  "joinstrFeeRateLine": "Fee rate: {feeRate} sat/vB",
+  "@joinstrFeeRateLine": {
+    "description": "Pool card line showing the pool fee rate",
     "placeholders": {
       "feeRate": {
         "type": "int"
-      },
-      "secondsLeft": {
-        "type": "int"
+      }
+    }
+  },
+  "joinstrRelayLine": "Relay: {relay}",
+  "@joinstrRelayLine": {
+    "description": "Pool card line showing the nostr relay the pool lives on",
+    "placeholders": {
+      "relay": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrPublicKeyLine": "Public Key: {key}",
+  "@joinstrPublicKeyLine": {
+    "description": "Initiator's nostr public key, shown on pool cards and in the join confirmation",
+    "placeholders": {
+      "key": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrTimeRemaining": "Time remaining: {time}",
+  "@joinstrTimeRemaining": {
+    "description": "Countdown until the pool expires",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrExpired": "Expired",
+  "@joinstrExpired": {
+    "description": "Shown when a pool's countdown reaches zero"
+  },
+  "joinstrAmountLine": "Amount: {btc} BTC",
+  "@joinstrAmountLine": {
+    "description": "History card line showing the mixed amount",
+    "placeholders": {
+      "btc": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrTxLine": "Tx: {tx}",
+  "@joinstrTxLine": {
+    "description": "History card line showing the coinjoin transaction id",
+    "placeholders": {
+      "tx": {
+        "type": "String"
       }
     }
   },
@@ -495,15 +571,39 @@
   "@joinstrJoin": {
     "description": "Button that joins the selected joinstr pool"
   },
+  "joinstrContinue": "Continue",
+  "@joinstrContinue": {
+    "description": "Confirms joining the pool shown in the dialog"
+  },
+  "joinstrCancel": "Cancel",
+  "@joinstrCancel": {
+    "description": "Dismisses the joinstr dialogs"
+  },
+  "joinstrSave": "Save",
+  "@joinstrSave": {
+    "description": "Saves the nostr relay setting"
+  },
+  "joinstrNostrRelay": "Nostr Relay",
+  "@joinstrNostrRelay": {
+    "description": "Title of the relay settings dialog"
+  },
   "joinstrCreatePool": "Create a pool",
   "@joinstrCreatePool": {
     "description": "Heading and button for announcing a new joinstr pool"
   },
-  "joinstrDenomination": "Denomination (sats)",
+  "joinstrCreate": "Create",
+  "@joinstrCreate": {
+    "description": "Button that announces the configured pool"
+  },
+  "joinstrDenomination": "Denomination (BTC)",
   "@joinstrDenomination": {
     "description": "Label for the joinstr pool denomination input"
   },
-  "joinstrPeers": "Peers (min 2)",
+  "joinstrDenominationSupport": "Enter denomination from available inputs",
+  "@joinstrDenominationSupport": {
+    "description": "Helper text under the denomination input"
+  },
+  "joinstrPeers": "Number of peers",
   "@joinstrPeers": {
     "description": "Label for the joinstr pool peer count input"
   },
@@ -554,6 +654,10 @@
   "joinstrErrorPoolConfig": "Enter a denomination above zero, at least 2 peers, and a fee rate of at least 1 sat/vB.",
   "@joinstrErrorPoolConfig": {
     "description": "Error when the create-pool form values are out of range"
+  },
+  "joinstrErrorRelay": "Enter a websocket relay url (wss://).",
+  "@joinstrErrorRelay": {
+    "description": "Error when the relay setting is not a valid websocket url"
   },
   "joinstrErrorPoolNotFound": "That pool is no longer advertised on the relay.",
   "@joinstrErrorPoolNotFound": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -565,7 +565,7 @@
   "@joinstrRefresh": {
     "description": "Button that reloads the pool list from the relay"
   },
-  "joinstrDenominationLine": "Denomination: {btc} BTC",
+  "joinstrDenominationLine": "Denomination: {btc}",
   "@joinstrDenominationLine": {
     "description": "Pool card line showing the pool denomination",
     "placeholders": {
@@ -623,7 +623,7 @@
   "@joinstrExpired": {
     "description": "Shown when a pool's countdown reaches zero"
   },
-  "joinstrAmountLine": "Amount: {btc} BTC",
+  "joinstrAmountLine": "Amount: {btc}",
   "@joinstrAmountLine": {
     "description": "History card line showing the mixed amount",
     "placeholders": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -455,14 +455,6 @@
   "@joinstrTitle": {
     "description": "Title for the joinstr coinjoin screen and the home-screen entry"
   },
-  "joinstrWaitingForPeers": "Waiting for peers",
-  "@joinstrWaitingForPeers": {
-    "description": "Status on a pool this device created, waiting for other peers to join"
-  },
-  "joinstrWaitingForCredentials": "Waiting for pool credentials",
-  "@joinstrWaitingForCredentials": {
-    "description": "Status on a pool this device is joining, waiting for the initiator's credentials"
-  },
   "joinstrPoolCreatedSnack": "New pool created!",
   "@joinstrPoolCreatedSnack": {
     "description": "Snackbar shown right after a pool is announced"
@@ -751,10 +743,6 @@
   "joinstrErrorTor": "Tor is not available. Joinstr routes all traffic over Tor and cannot run without it.",
   "@joinstrErrorTor": {
     "description": "Error when the local Tor proxy could not be started for joinstr"
-  },
-  "joinstrErrorPoolNotFound": "That pool is no longer advertised on the relay.",
-  "@joinstrErrorPoolNotFound": {
-    "description": "Error when the selected joinstr pool has disappeared"
   },
   "joinstrErrorFailed": "The coinjoin did not complete: {detail}",
   "@joinstrErrorFailed": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -451,13 +451,30 @@
   "@settingsBtcMapTitle": {
     "description": "Title for the Map screen in the settings menu"
   },
-  "joinstrTitle": "Joinstr coinjoin",
+  "joinstrTitle": "Joinstr",
   "@joinstrTitle": {
     "description": "Title for the joinstr coinjoin screen"
   },
-  "joinstrExperimentalNotice": "Experimental. Joinstr traffic is not routed over Tor yet, so the relay and Electrum server can see your IP address alongside the coin you are mixing. Testnet wallets only.",
-  "@joinstrExperimentalNotice": {
-    "description": "Banner explaining that joinstr is experimental and testnet-only"
+  "joinstrPoolRequest": "Pool Request",
+  "@joinstrPoolRequest": {
+    "description": "Title of the dialog shown while a coinjoin round is in flight"
+  },
+  "joinstrWaitingForCredentials": "Waiting for pool credentials…",
+  "@joinstrWaitingForCredentials": {
+    "description": "Body of the waiting dialog shown while a coinjoin round runs"
+  },
+  "joinstrRunInBackground": "Run in background",
+  "@joinstrRunInBackground": {
+    "description": "Button that dismisses the waiting dialog while the round keeps running"
+  },
+  "joinstrCoinjoinBroadcast": "Coinjoin broadcast: {txid}",
+  "@joinstrCoinjoinBroadcast": {
+    "description": "Snackbar shown when a coinjoin transaction is broadcast",
+    "placeholders": {
+      "txid": {
+        "type": "String"
+      }
+    }
   },
   "joinstrTabCreate": "Create New Pool",
   "@joinstrTabCreate": {
@@ -658,6 +675,10 @@
   "joinstrErrorRelay": "Enter a websocket relay url (wss://).",
   "@joinstrErrorRelay": {
     "description": "Error when the relay setting is not a valid websocket url"
+  },
+  "joinstrErrorTor": "Tor is not available. Joinstr routes all traffic over Tor and cannot run without it.",
+  "@joinstrErrorTor": {
+    "description": "Error when the local Tor proxy could not be started for joinstr"
   },
   "joinstrErrorPoolNotFound": "That pool is no longer advertised on the relay.",
   "@joinstrErrorPoolNotFound": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -475,6 +475,10 @@
   "@joinstrRoundInProgress": {
     "description": "Hint shown when the create button is disabled because a round is active"
   },
+  "joinstrConnectingTor": "Connecting to Tor and loading pools…",
+  "@joinstrConnectingTor": {
+    "description": "Shown while the embedded Tor bootstraps and the pool list loads"
+  },
   "joinstrCoinjoinBroadcast": "Coinjoin broadcast: {txid}",
   "@joinstrCoinjoinBroadcast": {
     "description": "Snackbar shown when a coinjoin transaction is broadcast",

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -451,6 +451,123 @@
   "@settingsBtcMapTitle": {
     "description": "Title for the Map screen in the settings menu"
   },
+  "joinstrTitle": "Joinstr coinjoin",
+  "@joinstrTitle": {
+    "description": "Title for the joinstr coinjoin screen"
+  },
+  "joinstrExperimentalNotice": "Experimental. Joinstr traffic is not routed over Tor yet, so the relay and Electrum server can see your IP address alongside the coin you are mixing. Testnet wallets only.",
+  "@joinstrExperimentalNotice": {
+    "description": "Banner explaining that joinstr is experimental and testnet-only"
+  },
+  "joinstrAvailablePools": "Available pools",
+  "@joinstrAvailablePools": {
+    "description": "Heading above the list of joinstr pools advertised on the relay"
+  },
+  "joinstrNoPools": "No pools advertised on the relay right now. Create one below, or refresh.",
+  "@joinstrNoPools": {
+    "description": "Shown when the relay returned no joinstr pools"
+  },
+  "joinstrPoolSummary": "{denominationSat} sat · {peers} peers",
+  "@joinstrPoolSummary": {
+    "description": "One-line summary of a joinstr pool: its denomination and required peer count",
+    "placeholders": {
+      "denominationSat": {
+        "type": "int"
+      },
+      "peers": {
+        "type": "int"
+      }
+    }
+  },
+  "joinstrPoolDetail": "{feeRate} sat/vB · expires in {secondsLeft}s",
+  "@joinstrPoolDetail": {
+    "description": "Secondary line of a joinstr pool tile: fee rate and seconds until the pool expires",
+    "placeholders": {
+      "feeRate": {
+        "type": "int"
+      },
+      "secondsLeft": {
+        "type": "int"
+      }
+    }
+  },
+  "joinstrJoin": "Join",
+  "@joinstrJoin": {
+    "description": "Button that joins the selected joinstr pool"
+  },
+  "joinstrCreatePool": "Create a pool",
+  "@joinstrCreatePool": {
+    "description": "Heading and button for announcing a new joinstr pool"
+  },
+  "joinstrDenomination": "Denomination (sats)",
+  "@joinstrDenomination": {
+    "description": "Label for the joinstr pool denomination input"
+  },
+  "joinstrPeers": "Peers (min 2)",
+  "@joinstrPeers": {
+    "description": "Label for the joinstr pool peer count input"
+  },
+  "joinstrFeeRate": "Fee rate (sat/vB)",
+  "@joinstrFeeRate": {
+    "description": "Label for the joinstr pool fee rate input"
+  },
+  "joinstrRunning": "Waiting for peers. This holds until the coinjoin broadcasts or the pool times out, and cannot be cancelled.",
+  "@joinstrRunning": {
+    "description": "Shown while a joinstr coinjoin round is in flight"
+  },
+  "joinstrBroadcast": "Coinjoin broadcast",
+  "@joinstrBroadcast": {
+    "description": "Shown with the txid once the coinjoin transaction is broadcast"
+  },
+  "joinstrErrorBitcoinOnly": "Joinstr is only available for Bitcoin wallets.",
+  "@joinstrErrorBitcoinOnly": {
+    "description": "Error when joinstr is attempted with a Liquid wallet"
+  },
+  "joinstrErrorMainnet": "Joinstr is limited to testnet until its traffic can be routed over Tor.",
+  "@joinstrErrorMainnet": {
+    "description": "Error when joinstr is attempted on a mainnet wallet"
+  },
+  "joinstrErrorWatchOnly": "Joinstr needs a wallet that signs on this device. Watch-only and hardware wallets cannot take part.",
+  "@joinstrErrorWatchOnly": {
+    "description": "Error when the wallet has no local mnemonic for joinstr to sign with"
+  },
+  "joinstrErrorScriptType": "Joinstr only supports native segwit (BIP84) wallets.",
+  "@joinstrErrorScriptType": {
+    "description": "Error when the wallet is not BIP84, which joinstr's wpkh signer requires"
+  },
+  "joinstrErrorNoEligibleCoin": "No coin between {min} and {max} sats. A joinstr transaction has no change output, so the coin must nearly match the denomination.",
+  "@joinstrErrorNoEligibleCoin": {
+    "description": "Error when no wallet coin falls inside the pool's required input value window",
+    "placeholders": {
+      "min": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "joinstrErrorElectrum": "No usable Electrum server for this network.",
+  "@joinstrErrorElectrum": {
+    "description": "Error when no Electrum server could be resolved for joinstr"
+  },
+  "joinstrErrorPoolConfig": "Enter a denomination above zero, at least 2 peers, and a fee rate of at least 1 sat/vB.",
+  "@joinstrErrorPoolConfig": {
+    "description": "Error when the create-pool form values are out of range"
+  },
+  "joinstrErrorPoolNotFound": "That pool is no longer advertised on the relay.",
+  "@joinstrErrorPoolNotFound": {
+    "description": "Error when the selected joinstr pool has disappeared"
+  },
+  "joinstrErrorFailed": "The coinjoin did not complete: {detail}",
+  "@joinstrErrorFailed": {
+    "description": "Error when a joinstr round fails or the pool times out before filling",
+    "placeholders": {
+      "detail": {
+        "type": "String"
+      }
+    }
+  },
   "settingsTermsOfServiceTitle": "Terms of Service",
   "@settingsTermsOfServiceTitle": {
     "description": "Title for the terms of service section in the settings menu"

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -652,7 +652,7 @@
   "@joinstrErrorScriptType": {
     "description": "Error when the wallet is not BIP84, which joinstr's wpkh signer requires"
   },
-  "joinstrErrorNoEligibleCoin": "No coin between {min} and {max} sats. A joinstr transaction has no change output, so the coin must nearly match the denomination.",
+  "joinstrErrorNoEligibleCoin": "No coin between {min} and {max} sats in the first {scanned} addresses. A joinstr transaction has no change output, so the coin must nearly match the denomination.",
   "@joinstrErrorNoEligibleCoin": {
     "description": "Error when no wallet coin falls inside the pool's required input value window",
     "placeholders": {
@@ -660,6 +660,9 @@
         "type": "int"
       },
       "max": {
+        "type": "int"
+      },
+      "scanned": {
         "type": "int"
       }
     }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -467,7 +467,7 @@
   "@joinstrRoundInProgress": {
     "description": "Hint shown when the create button is disabled because a round is active"
   },
-  "joinstrConnectingTor": "Connecting to Tor and loading pools…",
+  "joinstrConnectingTor": "Loading pools…",
   "@joinstrConnectingTor": {
     "description": "Shown while the embedded Tor bootstraps and the pool list loads"
   },
@@ -523,6 +523,44 @@
   "joinstrStepBroadcast": "Finalize Coinjoin Tx",
   "@joinstrStepBroadcast": {
     "description": "Coinjoin timeline step"
+  },
+  "joinstrStepPostingDesc": "Pool announced on the relay",
+  "@joinstrStepPostingDesc": {
+    "description": "Coinjoin timeline step description"
+  },
+  "joinstrStepJoinPool": "Join Pool",
+  "@joinstrStepJoinPool": {
+    "description": "Coinjoin timeline first step title for a joiner"
+  },
+  "joinstrStepJoinPoolDesc": "Join request sent",
+  "@joinstrStepJoinPoolDesc": {
+    "description": "Coinjoin timeline first step description for a joiner"
+  },
+  "joinstrStepOutputRegistrationDesc": "Output registered for coinjoin",
+  "@joinstrStepOutputRegistrationDesc": {
+    "description": "Coinjoin timeline step description"
+  },
+  "joinstrStepInputRegistrationDesc": "Input registered: {outpoint}",
+  "@joinstrStepInputRegistrationDesc": {
+    "description": "Coinjoin timeline step description with the input outpoint",
+    "placeholders": {
+      "outpoint": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrStepBroadcastDesc": "Coinjoin transaction finalized",
+  "@joinstrStepBroadcastDesc": {
+    "description": "Coinjoin timeline step description"
+  },
+  "joinstrStepMinedDesc": "Tx: {txId}",
+  "@joinstrStepMinedDesc": {
+    "description": "Coinjoin timeline step description with the broadcast txid",
+    "placeholders": {
+      "txId": {
+        "type": "String"
+      }
+    }
   },
   "joinstrStepMined": "Broadcast Tx",
   "@joinstrStepMined": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -463,11 +463,11 @@
   "@joinstrWaitingForCredentials": {
     "description": "Status on a pool this device is joining, waiting for the initiator's credentials"
   },
-  "joinstrPoolCreatedSnack": "Pool created. Waiting for peers to join.",
+  "joinstrPoolCreatedSnack": "New pool created!",
   "@joinstrPoolCreatedSnack": {
     "description": "Snackbar shown right after a pool is announced"
   },
-  "joinstrJoinRequestSnack": "Join request sent. Waiting for pool credentials.",
+  "joinstrJoinRequestSnack": "Join request sent.",
   "@joinstrJoinRequestSnack": {
     "description": "Snackbar shown right after a join request is sent"
   },
@@ -478,6 +478,59 @@
   "joinstrConnectingTor": "Connecting to Tor and loading pools…",
   "@joinstrConnectingTor": {
     "description": "Shown while the embedded Tor bootstraps and the pool list loads"
+  },
+  "joinstrSelectInput": "Select input",
+  "@joinstrSelectInput": {
+    "description": "Heading for the UTXO picker where the user chooses the coin to mix"
+  },
+  "joinstrEnterDenomFirst": "Enter a denomination above, then choose the coin to mix.",
+  "@joinstrEnterDenomFirst": {
+    "description": "Shown on the create form before a valid denomination is entered"
+  },
+  "joinstrNoEligibleCoins": "No coin matches this denomination.",
+  "@joinstrNoEligibleCoins": {
+    "description": "Shown when no wallet coin fits the denomination window"
+  },
+  "joinstrLoadingCoins": "Loading coins…",
+  "@joinstrLoadingCoins": {
+    "description": "Shown while the wallet coins are scanned over Tor"
+  },
+  "joinstrRefreshCoins": "Refresh coins",
+  "@joinstrRefreshCoins": {
+    "description": "Button that rescans the wallet coins"
+  },
+  "joinstrInputLine": "Input: {outpoint}",
+  "@joinstrInputLine": {
+    "description": "Round card line showing the input coin outpoint",
+    "placeholders": {
+      "outpoint": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrStepConnecting": "Connecting",
+  "@joinstrStepConnecting": {
+    "description": "Coinjoin timeline step"
+  },
+  "joinstrStepPosting": "Announce Pool",
+  "@joinstrStepPosting": {
+    "description": "Coinjoin timeline step"
+  },
+  "joinstrStepOutputRegistration": "Register Output",
+  "@joinstrStepOutputRegistration": {
+    "description": "Coinjoin timeline step"
+  },
+  "joinstrStepInputRegistration": "Register Input",
+  "@joinstrStepInputRegistration": {
+    "description": "Coinjoin timeline step"
+  },
+  "joinstrStepBroadcast": "Finalize Coinjoin Tx",
+  "@joinstrStepBroadcast": {
+    "description": "Coinjoin timeline step"
+  },
+  "joinstrStepMined": "Broadcast Tx",
+  "@joinstrStepMined": {
+    "description": "Coinjoin timeline step"
   },
   "joinstrCoinjoinBroadcast": "Coinjoin broadcast: {txid}",
   "@joinstrCoinjoinBroadcast": {
@@ -678,6 +731,10 @@
         "type": "int"
       }
     }
+  },
+  "joinstrErrorCoinUnavailable": "The selected coin is no longer available. Refresh coins and pick another.",
+  "@joinstrErrorCoinUnavailable": {
+    "description": "Error when the chosen input coin was spent or is missing at coinjoin time"
   },
   "joinstrErrorElectrum": "No usable Electrum server for this network.",
   "@joinstrErrorElectrum": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -562,6 +562,24 @@
       }
     }
   },
+  "joinstrEventIdLine": "Event id: {id}",
+  "@joinstrEventIdLine": {
+    "description": "Timeline line showing a nostr event id acknowledging a registration",
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "joinstrPsbtLine": "PSBT: {psbt}",
+  "@joinstrPsbtLine": {
+    "description": "Timeline line showing the finalized coinjoin psbt",
+    "placeholders": {
+      "psbt": {
+        "type": "String"
+      }
+    }
+  },
   "joinstrStepMined": "Broadcast Tx",
   "@joinstrStepMined": {
     "description": "Coinjoin timeline step"

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -481,7 +481,11 @@
   },
   "joinstrNoEligibleCoins": "No coin matches this denomination.",
   "@joinstrNoEligibleCoins": {
-    "description": "Shown when no wallet coin fits the denomination window"
+    "description": "Shown when no wallet coin fits the denomination window (join flow, where the pool fixes the denomination)"
+  },
+  "joinstrNoSpendableCoins": "No spendable coins found in this wallet.",
+  "@joinstrNoSpendableCoins": {
+    "description": "Shown on the create form when the wallet scan returned no usable coins"
   },
   "joinstrLoadingCoins": "Loading coins…",
   "@joinstrLoadingCoins": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -451,21 +451,29 @@
   "@settingsBtcMapTitle": {
     "description": "Title for the Map screen in the settings menu"
   },
-  "joinstrTitle": "Joinstr",
+  "joinstrTitle": "Coinjoin",
   "@joinstrTitle": {
-    "description": "Title for the joinstr coinjoin screen"
+    "description": "Title for the joinstr coinjoin screen and the home-screen entry"
   },
-  "joinstrPoolRequest": "Pool Request",
-  "@joinstrPoolRequest": {
-    "description": "Title of the dialog shown while a coinjoin round is in flight"
+  "joinstrWaitingForPeers": "Waiting for peers",
+  "@joinstrWaitingForPeers": {
+    "description": "Status on a pool this device created, waiting for other peers to join"
   },
-  "joinstrWaitingForCredentials": "Waiting for pool credentials…",
+  "joinstrWaitingForCredentials": "Waiting for pool credentials",
   "@joinstrWaitingForCredentials": {
-    "description": "Body of the waiting dialog shown while a coinjoin round runs"
+    "description": "Status on a pool this device is joining, waiting for the initiator's credentials"
   },
-  "joinstrRunInBackground": "Run in background",
-  "@joinstrRunInBackground": {
-    "description": "Button that dismisses the waiting dialog while the round keeps running"
+  "joinstrPoolCreatedSnack": "Pool created. Waiting for peers to join.",
+  "@joinstrPoolCreatedSnack": {
+    "description": "Snackbar shown right after a pool is announced"
+  },
+  "joinstrJoinRequestSnack": "Join request sent. Waiting for pool credentials.",
+  "@joinstrJoinRequestSnack": {
+    "description": "Snackbar shown right after a join request is sent"
+  },
+  "joinstrRoundInProgress": "A coinjoin is already in progress. See My Pools.",
+  "@joinstrRoundInProgress": {
+    "description": "Hint shown when the create button is disabled because a round is active"
   },
   "joinstrCoinjoinBroadcast": "Coinjoin broadcast: {txid}",
   "@joinstrCoinjoinBroadcast": {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "5fd842c"
-      resolved-ref: "5fd842c6adc6a851ac41088f011572efdf461590"
+      ref: "14e46f0"
+      resolved-ref: "14e46f0d951c66d4c2c3c5e103c513e1827fa058"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: c1af804
-      resolved-ref: c1af8043d0448295527a146ef1b880b0e9fadf5d
+      ref: b624c481cc3943fec3514e4d3464d430a135b3e3
+      resolved-ref: b624c481cc3943fec3514e4d3464d430a135b3e3
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "4f21626"
-      resolved-ref: "4f216263eac97f1342d1c1442b365085a7afd65b"
+      ref: "449f126"
+      resolved-ref: "449f126d0fc26c0855f3207093eda96703fdc844"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
-      resolved-ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
+      ref: c1af804
+      resolved-ref: c1af8043d0448295527a146ef1b880b0e9fadf5d
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "64342ad"
-      resolved-ref: "64342ad4afb0f58c2ffb0a0951c99f63c4874710"
+      ref: "6c284af"
+      resolved-ref: "6c284af3c2f6d4508e500f4a6283381493d02626"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "14e46f0"
-      resolved-ref: "14e46f0d951c66d4c2c3c5e103c513e1827fa058"
+      ref: "01066eb"
+      resolved-ref: "01066eb8ac04940f860951cc47c26ba5a06a5bdb"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "449f126"
-      resolved-ref: "449f126d0fc26c0855f3207093eda96703fdc844"
+      ref: "a4efdd4"
+      resolved-ref: "a4efdd4fac22d8c7663a0b356db7564e083cbad4"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: b75eea0
-      resolved-ref: b75eea009fa3f4f8ec0c70e8c9514cce3d5b8a32
+      ref: d1bb9f8
+      resolved-ref: d1bb9f867aa40af7d4480e5d09e2196e5e9b0203
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "1604653"
-      resolved-ref: "16046530d21511a7ae559a46a581ac93c4420633"
+      ref: "5fd842c"
+      resolved-ref: "5fd842c6adc6a851ac41088f011572efdf461590"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: ac4fa39
-      resolved-ref: ac4fa393b417c774b51ca4810e03a6649386b935
+      ref: "4f21626"
+      resolved-ref: "4f216263eac97f1342d1c1442b365085a7afd65b"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: d1bb9f8
-      resolved-ref: d1bb9f867aa40af7d4480e5d09e2196e5e9b0203
+      ref: ac4fa39
+      resolved-ref: ac4fa393b417c774b51ca4810e03a6649386b935
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "6c284af"
-      resolved-ref: "6c284af3c2f6d4508e500f4a6283381493d02626"
+      ref: "6e4e2e3"
+      resolved-ref: "6e4e2e387249678424add40c881c6aaba32dcd7d"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1228,6 +1228,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.2"
+  joinstr_flutter:
+    dependency: "direct main"
+    description:
+      path: dart
+      ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
+      resolved-ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
+      url: "https://github.com/rust-joinstr/joinstr"
+    source: git
+    version: "0.1.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: febc1b1
-      resolved-ref: febc1b1ce04eed3be8f40f90d020a82d14e42757
+      ref: b75eea0
+      resolved-ref: b75eea009fa3f4f8ec0c70e8c9514cce3d5b8a32
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: b624c481cc3943fec3514e4d3464d430a135b3e3
-      resolved-ref: b624c481cc3943fec3514e4d3464d430a135b3e3
+      ref: febc1b1
+      resolved-ref: febc1b1ce04eed3be8f40f90d020a82d14e42757
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "a4efdd4"
-      resolved-ref: "a4efdd4fac22d8c7663a0b356db7564e083cbad4"
+      ref: "1604653"
+      resolved-ref: "16046530d21511a7ae559a46a581ac93c4420633"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,8 +1232,8 @@ packages:
     dependency: "direct main"
     description:
       path: dart
-      ref: "01066eb"
-      resolved-ref: "01066eb8ac04940f860951cc47c26ba5a06a5bdb"
+      ref: "64342ad"
+      resolved-ref: "64342ad4afb0f58c2ffb0a0951c99f63c4874710"
       url: "https://github.com/rust-joinstr/joinstr"
     source: git
     version: "0.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: b624c481cc3943fec3514e4d3464d430a135b3e3
+      ref: febc1b1
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: b75eea0
+      ref: d1bb9f8
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: d1bb9f8
+      ref: ac4fa39
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "01066eb"
+      ref: "64342ad"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "5fd842c"
+      ref: "14e46f0"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: c1af804
+      ref: b624c481cc3943fec3514e4d3464d430a135b3e3
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
+      ref: c1af804
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "1604653"
+      ref: "5fd842c"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: 4f21626
+      ref: 449f126
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: a4efdd4
+      ref: "1604653"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "64342ad"
+      ref: "6c284af"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "14e46f0"
+      ref: "01066eb"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: "6c284af"
+      ref: "6e4e2e3"
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: febc1b1
+      ref: b75eea0
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: ac4fa39
+      ref: 4f21626
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   joinstr_flutter:
     git:
       url: https://github.com/rust-joinstr/joinstr
-      ref: 449f126
+      ref: a4efdd4
       path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,11 @@ dependencies:
     git:
       url: https://github.com/SatoshiPortal/payjoin-dart
       ref: b3bbf76fe266c145d48e1ea2b58460aae8cacb66
+  joinstr_flutter:
+    git:
+      url: https://github.com/rust-joinstr/joinstr
+      ref: e4b77ec4341eebbb22cef74b57e608841779fcd7
+      path: dart
   qr_flutter: ^4.1.0
   dio: ^5.9.0
   timeago: ^3.7.1

--- a/test/features/joinstr/data/joinstr_store_test.dart
+++ b/test/features/joinstr/data/joinstr_store_test.dart
@@ -93,5 +93,16 @@ void main() {
       await store.appendHistory(_entry('tx-1'));
       expect((await store.getHistory()).single.txId, 'tx-1');
     });
+
+    test('concurrent appends from parallel rounds keep every entry', () async {
+      await Future.wait([
+        store.appendHistory(_entry('tx-1')),
+        store.appendHistory(_entry('tx-2')),
+        store.appendHistory(_entry('tx-3')),
+      ]);
+
+      final history = await store.getHistory();
+      expect(history.map((e) => e.txId).toSet(), {'tx-1', 'tx-2', 'tx-3'});
+    });
   });
 }

--- a/test/features/joinstr/data/joinstr_store_test.dart
+++ b/test/features/joinstr/data/joinstr_store_test.dart
@@ -1,0 +1,97 @@
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _InMemoryStorage implements KeyValueStorageDatasource<String> {
+  final Map<String, String> values = {};
+
+  @override
+  Future<void> saveValue({required String key, required String value}) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<Map<String, String>> getAll() async => Map.of(values);
+
+  @override
+  Future<String?> getValue(String key) async => values[key];
+
+  @override
+  Future<bool> hasValue(String key) async => values.containsKey(key);
+
+  @override
+  Future<void> deleteValue(String key) async => values.remove(key);
+
+  @override
+  Future<void> deleteAll() async => values.clear();
+}
+
+JoinstrHistoryEntry _entry(String txId) => JoinstrHistoryEntry(
+  amountSat: 100000,
+  txId: txId,
+  relay: 'wss://nos.lol',
+  completedAtUnixSec: 1793500000,
+);
+
+void main() {
+  late _InMemoryStorage storage;
+  late JoinstrStore store;
+
+  setUp(() {
+    storage = _InMemoryStorage();
+    store = JoinstrStore(storage);
+  });
+
+  group('relay', () {
+    test('returns null before anything is saved', () async {
+      expect(await store.getRelay(), isNull);
+    });
+
+    test('round-trips and trims the saved relay', () async {
+      await store.saveRelay(' wss://relay.example ');
+      expect(await store.getRelay(), 'wss://relay.example');
+    });
+  });
+
+  group('history', () {
+    test('is empty before anything is saved', () async {
+      expect(await store.getHistory(), isEmpty);
+    });
+
+    test('appends newest first and round-trips through json', () async {
+      await store.appendHistory(_entry('tx-1'));
+      await store.appendHistory(_entry('tx-2'));
+
+      final history = await store.getHistory();
+      expect(history.map((e) => e.txId), ['tx-2', 'tx-1']);
+      expect(history.first.amountSat, 100000);
+      expect(history.first.relay, 'wss://nos.lol');
+      expect(history.first.completedAtUnixSec, 1793500000);
+    });
+
+    test('survives corrupt stored json rather than throwing', () async {
+      storage.values[JoinstrStore.historyKey] = 'not json';
+      expect(await store.getHistory(), isEmpty);
+
+      storage.values[JoinstrStore.historyKey] = '{"a":1}';
+      expect(await store.getHistory(), isEmpty);
+    });
+
+    test('drops undecodable entries without losing the rest', () async {
+      storage.values[JoinstrStore.historyKey] =
+          '[{"amountSat":"wrong type"},'
+          '{"amountSat":1,"txId":"tx-ok","relay":"wss://nos.lol",'
+          '"completedAtUnixSec":2}]';
+
+      final history = await store.getHistory();
+      expect(history.single.txId, 'tx-ok');
+    });
+
+    test('a corrupt store is overwritten by the next append', () async {
+      storage.values[JoinstrStore.historyKey] = 'not json';
+      await store.appendHistory(_entry('tx-1'));
+      expect((await store.getHistory()).single.txId, 'tx-1');
+    });
+  });
+}

--- a/test/features/joinstr/domain/joinstr_test.dart
+++ b/test/features/joinstr/domain/joinstr_test.dart
@@ -1,0 +1,234 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Wallet _wallet({
+  Network network = Network.bitcoinTestnet,
+  ScriptType scriptType = ScriptType.bip84,
+  SignerEntity signer = SignerEntity.local,
+}) {
+  return Wallet(
+    origin: 'origin',
+    network: network,
+    xpubFingerprint: 'ffffffff',
+    masterFingerprint: 'eeeeeeee',
+    scriptType: scriptType,
+    xpub: 'xpub',
+    externalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/0/*)',
+    internalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/1/*)',
+    signer: signer,
+    signerDevice: null,
+    balanceSat: BigInt.zero,
+  );
+}
+
+Matcher _throwsIssue(JoinstrIssue issue) =>
+    throwsA(isA<JoinstrException>().having((e) => e.issue, 'issue', issue));
+
+void main() {
+  group('input eligibility window', () {
+    const denomination = 100000;
+
+    test('accepts the inclusive boundaries of denomination+500..+5000', () {
+      expect(
+        Joinstr.isEligibleCoin(valueSat: 100500, denominationSat: denomination),
+        isTrue,
+      );
+      expect(
+        Joinstr.isEligibleCoin(valueSat: 105000, denominationSat: denomination),
+        isTrue,
+      );
+    });
+
+    test('rejects a coin one satoshi outside either boundary', () {
+      expect(
+        Joinstr.isEligibleCoin(valueSat: 100499, denominationSat: denomination),
+        isFalse,
+      );
+      expect(
+        Joinstr.isEligibleCoin(valueSat: 105001, denominationSat: denomination),
+        isFalse,
+      );
+    });
+
+    test('rejects a coin equal to the denomination', () {
+      expect(
+        Joinstr.isEligibleCoin(
+          valueSat: denomination,
+          denominationSat: denomination,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects an oversized coin, which would otherwise burn the surplus '
+        'to fees since a joinstr tx has no change output', () {
+      expect(
+        Joinstr.isEligibleCoin(
+          valueSat: 100000000,
+          denominationSat: denomination,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('coin selection', () {
+    test('picks the cheapest eligible coin, not the first', () {
+      final index = Joinstr.selectEligibleCoin(
+        coinValuesSat: [104000, 100600, 103000],
+        denominationSat: 100000,
+      );
+      expect(index, 1);
+    });
+
+    test('skips ineligible coins on either side of the window', () {
+      final index = Joinstr.selectEligibleCoin(
+        coinValuesSat: [100000, 500000, 102000, 100100],
+        denominationSat: 100000,
+      );
+      expect(index, 2);
+    });
+
+    test('returns null when nothing falls inside the window', () {
+      expect(
+        Joinstr.selectEligibleCoin(
+          coinValuesSat: [1000, 100000, 5000000],
+          denominationSat: 100000,
+        ),
+        isNull,
+      );
+      expect(
+        Joinstr.selectEligibleCoin(coinValuesSat: [], denominationSat: 100000),
+        isNull,
+      );
+    });
+  });
+
+  group('electrum url parsing', () {
+    test('preserves the ssl:// prefix so TLS is actually negotiated', () {
+      final endpoint = Joinstr.parseElectrumUrl(
+        'ssl://fulcrum.bullbitcoin.com:50002',
+      );
+      expect(endpoint.address, 'ssl://fulcrum.bullbitcoin.com');
+      expect(endpoint.port, 50002);
+    });
+
+    test('strips a tcp:// prefix, which must stay plaintext', () {
+      final endpoint = Joinstr.parseElectrumUrl('tcp://localhost:60001');
+      expect(endpoint.address, 'localhost');
+      expect(endpoint.port, 60001);
+    });
+
+    test('accepts a bare host:port', () {
+      final endpoint = Joinstr.parseElectrumUrl('electrum.example.com:50001');
+      expect(endpoint.address, 'electrum.example.com');
+      expect(endpoint.port, 50001);
+    });
+
+    test('is case-insensitive on the scheme', () {
+      expect(
+        Joinstr.parseElectrumUrl('SSL://host:50002').address,
+        'ssl://host',
+      );
+    });
+
+    test(
+      'rejects a url with no port, an unparseable port, or a port out of range',
+      () {
+        for (final url in [
+          'ssl://host',
+          'ssl://host:',
+          'ssl://host:abc',
+          'ssl://host:0',
+          'ssl://host:65536',
+          ':50002',
+        ]) {
+          expect(
+            () => Joinstr.parseElectrumUrl(url),
+            _throwsIssue(JoinstrIssue.invalidElectrumUrl),
+            reason: url,
+          );
+        }
+      },
+    );
+  });
+
+  group('pool expiry', () {
+    JoinstrPool poolExpiringAt(int unixSec) => JoinstrPool(
+      id: 'p',
+      rawJson: '{}',
+      denominationSat: 100000,
+      peers: 2,
+      expiresAtUnixSec: unixSec,
+      relay: 'wss://nos.lol',
+      feeRateSatPerVb: 1,
+      publicKey: 'pk',
+    );
+
+    test('reports the seconds remaining until an absolute expiry', () {
+      final now = DateTime.utc(2026, 1, 1);
+      final nowSec = now.millisecondsSinceEpoch ~/ 1000;
+      expect(poolExpiringAt(nowSec + 300).secondsUntilExpiry(now), 300);
+    });
+
+    test('clamps a past expiry to zero rather than going negative', () {
+      final now = DateTime.utc(2026, 1, 1);
+      final nowSec = now.millisecondsSinceEpoch ~/ 1000;
+      expect(poolExpiringAt(nowSec - 60).secondsUntilExpiry(now), 0);
+    });
+  });
+
+  group('denomination conversion', () {
+    test('converts satoshis to BTC for the pool config', () {
+      expect(Joinstr.denominationBtc(100000), 0.001);
+      expect(Joinstr.denominationBtc(100000000), 1.0);
+    });
+  });
+
+  group('wallet support', () {
+    test('accepts a locally-signed bip84 testnet bitcoin wallet', () {
+      expect(() => Joinstr.assertWalletSupported(_wallet()), returnsNormally);
+    });
+
+    test('rejects a liquid wallet', () {
+      expect(
+        () => Joinstr.assertWalletSupported(
+          _wallet(network: Network.liquidTestnet),
+        ),
+        _throwsIssue(JoinstrIssue.bitcoinOnly),
+      );
+    });
+
+    test('rejects a watch-only wallet, which has no mnemonic to sign with', () {
+      expect(
+        () => Joinstr.assertWalletSupported(_wallet(signer: SignerEntity.none)),
+        _throwsIssue(JoinstrIssue.watchOnlyWallet),
+      );
+      expect(
+        () =>
+            Joinstr.assertWalletSupported(_wallet(signer: SignerEntity.remote)),
+        _throwsIssue(JoinstrIssue.watchOnlyWallet),
+      );
+    });
+
+    test('rejects a non-bip84 wallet, since joinstr signs wpkh only', () {
+      expect(
+        () => Joinstr.assertWalletSupported(
+          _wallet(scriptType: ScriptType.bip49),
+        ),
+        _throwsIssue(JoinstrIssue.unsupportedScriptType),
+      );
+    });
+
+    test('rejects mainnet while the bindings cannot route over Tor', () {
+      expect(
+        () => Joinstr.assertWalletSupported(
+          _wallet(network: Network.bitcoinMainnet),
+        ),
+        _throwsIssue(JoinstrIssue.mainnetNotSupported),
+      );
+    });
+  });
+}

--- a/test/features/joinstr/domain/joinstr_test.dart
+++ b/test/features/joinstr/domain/joinstr_test.dart
@@ -187,6 +187,71 @@ void main() {
     });
   });
 
+  group('denomination input parsing', () {
+    test('parses BTC text to satoshis without float rounding', () {
+      expect(Joinstr.parseDenominationBtcToSat('0.001'), 100000);
+      expect(Joinstr.parseDenominationBtcToSat('1'), 100000000);
+      expect(Joinstr.parseDenominationBtcToSat('0.00000001'), 1);
+      expect(Joinstr.parseDenominationBtcToSat('.5'), 50000000);
+      // 0.1 has no exact double representation; string math must still land
+      // on exactly ten million sats.
+      expect(Joinstr.parseDenominationBtcToSat('0.1'), 10000000);
+      expect(Joinstr.parseDenominationBtcToSat('21000000'), 2100000000000000);
+    });
+
+    test('rejects zero, empty and malformed input', () {
+      for (final text in ['', '0', '0.0', 'abc', '1.2.3', '0,001', '-1']) {
+        expect(Joinstr.parseDenominationBtcToSat(text), isNull, reason: text);
+      }
+    });
+
+    test('rejects more than 8 decimal places or 8 integer digits', () {
+      expect(Joinstr.parseDenominationBtcToSat('0.000000001'), isNull);
+      expect(Joinstr.parseDenominationBtcToSat('100000000'), isNull);
+    });
+  });
+
+  group('btc formatting', () {
+    test('trims trailing zeros and drops the point on whole coins', () {
+      expect(Joinstr.formatBtc(100000), '0.001');
+      expect(Joinstr.formatBtc(100000000), '1');
+      expect(Joinstr.formatBtc(1), '0.00000001');
+      expect(Joinstr.formatBtc(150000000), '1.5');
+    });
+
+    test('round-trips with the input parser', () {
+      for (final sat in [1, 100000, 100000000, 2100000000000000]) {
+        expect(
+          Joinstr.parseDenominationBtcToSat(Joinstr.formatBtc(sat)),
+          sat,
+          reason: '$sat',
+        );
+      }
+    });
+  });
+
+  group('remaining time formatting', () {
+    test('renders hours, minutes and seconds at the right granularity', () {
+      expect(Joinstr.formatRemaining(45), '45s');
+      expect(Joinstr.formatRemaining(750), '12m 30s');
+      expect(Joinstr.formatRemaining(3900), '1h 5m');
+      expect(Joinstr.formatRemaining(0), '0s');
+      expect(Joinstr.formatRemaining(-5), '0s');
+    });
+  });
+
+  group('relay url validation', () {
+    test('accepts websocket urls only', () {
+      expect(Joinstr.isValidRelayUrl('wss://nos.lol'), isTrue);
+      expect(Joinstr.isValidRelayUrl('ws://localhost:8080'), isTrue);
+      expect(Joinstr.isValidRelayUrl(' wss://nos.lol '), isTrue);
+      expect(Joinstr.isValidRelayUrl('https://nos.lol'), isFalse);
+      expect(Joinstr.isValidRelayUrl('nos.lol'), isFalse);
+      expect(Joinstr.isValidRelayUrl(''), isFalse);
+      expect(Joinstr.isValidRelayUrl('wss://'), isFalse);
+    });
+  });
+
   group('wallet support', () {
     test('accepts a locally-signed bip84 testnet bitcoin wallet', () {
       expect(() => Joinstr.assertWalletSupported(_wallet()), returnsNormally);

--- a/test/features/joinstr/domain/joinstr_test.dart
+++ b/test/features/joinstr/domain/joinstr_test.dart
@@ -74,38 +74,6 @@ void main() {
     });
   });
 
-  group('coin selection', () {
-    test('picks the cheapest eligible coin, not the first', () {
-      final index = Joinstr.selectEligibleCoin(
-        coinValuesSat: [104000, 100600, 103000],
-        denominationSat: 100000,
-      );
-      expect(index, 1);
-    });
-
-    test('skips ineligible coins on either side of the window', () {
-      final index = Joinstr.selectEligibleCoin(
-        coinValuesSat: [100000, 500000, 102000, 100100],
-        denominationSat: 100000,
-      );
-      expect(index, 2);
-    });
-
-    test('returns null when nothing falls inside the window', () {
-      expect(
-        Joinstr.selectEligibleCoin(
-          coinValuesSat: [1000, 100000, 5000000],
-          denominationSat: 100000,
-        ),
-        isNull,
-      );
-      expect(
-        Joinstr.selectEligibleCoin(coinValuesSat: [], denominationSat: 100000),
-        isNull,
-      );
-    });
-  });
-
   group('electrum url parsing', () {
     test('preserves the ssl:// prefix so TLS is actually negotiated', () {
       final endpoint = Joinstr.parseElectrumUrl(
@@ -187,46 +155,12 @@ void main() {
     });
   });
 
-  group('denomination input parsing', () {
-    test('parses BTC text to satoshis without float rounding', () {
-      expect(Joinstr.parseDenominationBtcToSat('0.001'), 100000);
-      expect(Joinstr.parseDenominationBtcToSat('1'), 100000000);
-      expect(Joinstr.parseDenominationBtcToSat('0.00000001'), 1);
-      expect(Joinstr.parseDenominationBtcToSat('.5'), 50000000);
-      // 0.1 has no exact double representation; string math must still land
-      // on exactly ten million sats.
-      expect(Joinstr.parseDenominationBtcToSat('0.1'), 10000000);
-      expect(Joinstr.parseDenominationBtcToSat('21000000'), 2100000000000000);
-    });
-
-    test('rejects zero, empty and malformed input', () {
-      for (final text in ['', '0', '0.0', 'abc', '1.2.3', '0,001', '-1']) {
-        expect(Joinstr.parseDenominationBtcToSat(text), isNull, reason: text);
-      }
-    });
-
-    test('rejects more than 8 decimal places or 8 integer digits', () {
-      expect(Joinstr.parseDenominationBtcToSat('0.000000001'), isNull);
-      expect(Joinstr.parseDenominationBtcToSat('100000000'), isNull);
-    });
-  });
-
   group('btc formatting', () {
     test('trims trailing zeros and drops the point on whole coins', () {
       expect(Joinstr.formatBtc(100000), '0.001');
       expect(Joinstr.formatBtc(100000000), '1');
       expect(Joinstr.formatBtc(1), '0.00000001');
       expect(Joinstr.formatBtc(150000000), '1.5');
-    });
-
-    test('round-trips with the input parser', () {
-      for (final sat in [1, 100000, 100000000, 2100000000000000]) {
-        expect(
-          Joinstr.parseDenominationBtcToSat(Joinstr.formatBtc(sat)),
-          sat,
-          reason: '$sat',
-        );
-      }
     });
   });
 

--- a/test/features/joinstr/domain/joinstr_test.dart
+++ b/test/features/joinstr/domain/joinstr_test.dart
@@ -148,22 +148,6 @@ void main() {
     });
   });
 
-  group('denomination conversion', () {
-    test('converts satoshis to BTC for the pool config', () {
-      expect(Joinstr.denominationBtc(100000), 0.001);
-      expect(Joinstr.denominationBtc(100000000), 1.0);
-    });
-  });
-
-  group('btc formatting', () {
-    test('trims trailing zeros and drops the point on whole coins', () {
-      expect(Joinstr.formatBtc(100000), '0.001');
-      expect(Joinstr.formatBtc(100000000), '1');
-      expect(Joinstr.formatBtc(1), '0.00000001');
-      expect(Joinstr.formatBtc(150000000), '1.5');
-    });
-  });
-
   group('remaining time formatting', () {
     test('renders hours, minutes and seconds at the right granularity', () {
       expect(Joinstr.formatRemaining(45), '45s');

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -1,0 +1,327 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
+import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDatasource extends Mock implements JoinstrDatasource {}
+
+class _MockStore extends Mock implements JoinstrStore {}
+
+class _MockResolvePeerContext extends Mock
+    implements ResolveJoinstrPeerContextUsecase {}
+
+Wallet _wallet() => Wallet(
+  origin: 'origin',
+  network: Network.bitcoinTestnet,
+  xpubFingerprint: 'ffffffff',
+  masterFingerprint: 'eeeeeeee',
+  scriptType: ScriptType.bip84,
+  xpub: 'xpub',
+  externalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/0/*)',
+  internalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/1/*)',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.zero,
+);
+
+JoinstrPool _pool({
+  required int denominationSat,
+  required int expiresAtUnixSec,
+}) => JoinstrPool(
+  id: 'pool-$denominationSat',
+  rawJson: '{}',
+  denominationSat: denominationSat,
+  peers: 2,
+  expiresAtUnixSec: expiresAtUnixSec,
+  relay: 'wss://nos.lol',
+  feeRateSatPerVb: 1,
+  publicKey: 'pk',
+);
+
+void main() {
+  late _MockDatasource datasource;
+  late _MockStore store;
+  late _MockResolvePeerContext resolvePeerContext;
+
+  setUpAll(() {
+    registerFallbackValue(_wallet());
+    registerFallbackValue(
+      _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
+    );
+    registerFallbackValue(const Duration(seconds: 1));
+    registerFallbackValue(
+      const JoinstrHistoryEntry(
+        amountSat: 0,
+        txId: '',
+        relay: '',
+        completedAtUnixSec: 0,
+      ),
+    );
+  });
+
+  setUp(() {
+    datasource = _MockDatasource();
+    store = _MockStore();
+    resolvePeerContext = _MockResolvePeerContext();
+
+    when(() => store.getRelay()).thenAnswer((_) async => null);
+    when(() => store.appendHistory(any())).thenAnswer((_) async {});
+    when(
+      () => resolvePeerContext.execute(wallet: any(named: 'wallet')),
+    ).thenAnswer(
+      (_) async => const JoinstrPeerContext(
+        mnemonic: 'mnemonic',
+        electrumUrl: 'ssl://electrum.example:50002',
+        outputAddress: 'tb1qaddress',
+      ),
+    );
+  });
+
+  group('ListJoinstrPoolsUsecase', () {
+    ListJoinstrPoolsUsecase build() =>
+        ListJoinstrPoolsUsecase(datasource: datasource, store: store);
+
+    int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    test('drops expired pools, which can never fill', () async {
+      when(
+        () => datasource.listPools(
+          relay: any(named: 'relay'),
+          back: any(named: 'back'),
+          wait: any(named: 'wait'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          _pool(denominationSat: 100000, expiresAtUnixSec: nowSec() - 10),
+          _pool(denominationSat: 200000, expiresAtUnixSec: nowSec() + 600),
+        ],
+      );
+
+      final pools = await build().execute();
+      expect(pools.map((p) => p.denominationSat), [200000]);
+    });
+
+    test('sorts joinable pools by denomination', () async {
+      when(
+        () => datasource.listPools(
+          relay: any(named: 'relay'),
+          back: any(named: 'back'),
+          wait: any(named: 'wait'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          _pool(denominationSat: 500000, expiresAtUnixSec: nowSec() + 600),
+          _pool(denominationSat: 100000, expiresAtUnixSec: nowSec() + 600),
+        ],
+      );
+
+      final pools = await build().execute();
+      expect(pools.map((p) => p.denominationSat), [100000, 500000]);
+    });
+
+    test('uses the stored relay, falling back to the default', () async {
+      when(
+        () => datasource.listPools(
+          relay: any(named: 'relay'),
+          back: any(named: 'back'),
+          wait: any(named: 'wait'),
+        ),
+      ).thenAnswer((_) async => []);
+
+      await build().execute();
+      verify(
+        () => datasource.listPools(
+          relay: ApiServiceConstants.defaultNostrRelayUrl,
+          back: any(named: 'back'),
+          wait: any(named: 'wait'),
+        ),
+      ).called(1);
+
+      when(
+        () => store.getRelay(),
+      ).thenAnswer((_) async => 'wss://relay.example');
+      await build().execute();
+      verify(
+        () => datasource.listPools(
+          relay: 'wss://relay.example',
+          back: any(named: 'back'),
+          wait: any(named: 'wait'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('SaveJoinstrRelayUsecase', () {
+    SaveJoinstrRelayUsecase build() => SaveJoinstrRelayUsecase(store: store);
+
+    test('persists a valid websocket relay', () async {
+      when(() => store.saveRelay(any())).thenAnswer((_) async {});
+      await build().execute('wss://relay.example');
+      verify(() => store.saveRelay('wss://relay.example')).called(1);
+    });
+
+    test('rejects a non-websocket url without touching the store', () async {
+      await expectLater(
+        () => build().execute('https://relay.example'),
+        throwsA(
+          isA<JoinstrException>().having(
+            (e) => e.issue,
+            'issue',
+            JoinstrIssue.invalidRelayUrl,
+          ),
+        ),
+      );
+      verifyNever(() => store.saveRelay(any()));
+    });
+  });
+
+  group('JoinJoinstrPoolUsecase', () {
+    JoinJoinstrPoolUsecase build() => JoinJoinstrPoolUsecase(
+      datasource: datasource,
+      store: store,
+      resolvePeerContextUsecase: resolvePeerContext,
+    );
+
+    test('appends a history entry after the broadcast', () async {
+      when(
+        () => datasource.joinPool(
+          pool: any(named: 'pool'),
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+        ),
+      ).thenAnswer((_) async => 'txid-abc');
+
+      final txId = await build().execute(
+        wallet: _wallet(),
+        pool: _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
+      );
+
+      expect(txId, 'txid-abc');
+      final entry =
+          verify(() => store.appendHistory(captureAny())).captured.single
+              as JoinstrHistoryEntry;
+      expect(entry.txId, 'txid-abc');
+      expect(entry.amountSat, 100000);
+      expect(entry.relay, 'wss://nos.lol');
+    });
+
+    test('does not write history when the round fails', () async {
+      when(
+        () => datasource.joinPool(
+          pool: any(named: 'pool'),
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+        ),
+      ).thenThrow(JoinstrException(JoinstrIssue.coinjoinFailed));
+
+      await expectLater(
+        () => build().execute(
+          wallet: _wallet(),
+          pool: _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
+        ),
+        throwsA(isA<JoinstrException>()),
+      );
+      verifyNever(() => store.appendHistory(any()));
+    });
+  });
+
+  group('InitiateJoinstrPoolUsecase', () {
+    InitiateJoinstrPoolUsecase build() => InitiateJoinstrPoolUsecase(
+      datasource: datasource,
+      store: store,
+      resolvePeerContextUsecase: resolvePeerContext,
+    );
+
+    test('uses the stored relay and records history', () async {
+      when(
+        () => store.getRelay(),
+      ).thenAnswer((_) async => 'wss://relay.example');
+      when(
+        () => datasource.initiatePool(
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+          relay: any(named: 'relay'),
+          denominationSat: any(named: 'denominationSat'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          peers: any(named: 'peers'),
+          maxDuration: any(named: 'maxDuration'),
+        ),
+      ).thenAnswer((_) async => 'txid-abc');
+
+      await build().execute(
+        wallet: _wallet(),
+        denominationSat: 100000,
+        peers: 2,
+        feeRateSatPerVb: 1,
+      );
+
+      verify(
+        () => datasource.initiatePool(
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+          relay: 'wss://relay.example',
+          denominationSat: 100000,
+          feeRateSatPerVb: 1,
+          peers: 2,
+          maxDuration: any(named: 'maxDuration'),
+        ),
+      ).called(1);
+      final entry =
+          verify(() => store.appendHistory(captureAny())).captured.single
+              as JoinstrHistoryEntry;
+      expect(entry.relay, 'wss://relay.example');
+      expect(entry.amountSat, 100000);
+    });
+
+    test('wraps an unexpected error as coinjoinFailed', () async {
+      when(
+        () => datasource.initiatePool(
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+          relay: any(named: 'relay'),
+          denominationSat: any(named: 'denominationSat'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          peers: any(named: 'peers'),
+          maxDuration: any(named: 'maxDuration'),
+        ),
+      ).thenThrow(StateError('boom'));
+
+      await expectLater(
+        () => build().execute(
+          wallet: _wallet(),
+          denominationSat: 100000,
+          peers: 2,
+          feeRateSatPerVb: 1,
+        ),
+        throwsA(
+          isA<JoinstrException>().having(
+            (e) => e.issue,
+            'issue',
+            JoinstrIssue.coinjoinFailed,
+          ),
+        ),
+      );
+      verifyNever(() => store.appendHistory(any()));
+    });
+  });
+}

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -19,6 +20,8 @@ class _MockStore extends Mock implements JoinstrStore {}
 
 class _MockResolvePeerContext extends Mock
     implements ResolveJoinstrPeerContextUsecase {}
+
+class _MockResolveProxy extends Mock implements ResolveJoinstrProxyUsecase {}
 
 Wallet _wallet() => Wallet(
   origin: 'origin',
@@ -52,6 +55,7 @@ void main() {
   late _MockDatasource datasource;
   late _MockStore store;
   late _MockResolvePeerContext resolvePeerContext;
+  late _MockResolveProxy resolveProxy;
 
   setUpAll(() {
     registerFallbackValue(_wallet());
@@ -73,9 +77,11 @@ void main() {
     datasource = _MockDatasource();
     store = _MockStore();
     resolvePeerContext = _MockResolvePeerContext();
+    resolveProxy = _MockResolveProxy();
 
     when(() => store.getRelay()).thenAnswer((_) async => null);
     when(() => store.appendHistory(any())).thenAnswer((_) async {});
+    when(() => resolveProxy.execute()).thenAnswer((_) async => '127.0.0.1:9050');
     when(
       () => resolvePeerContext.execute(wallet: any(named: 'wallet')),
     ).thenAnswer(
@@ -83,13 +89,17 @@ void main() {
         mnemonic: 'mnemonic',
         electrumUrl: 'ssl://electrum.example:50002',
         outputAddress: 'tb1qaddress',
+        proxy: '127.0.0.1:9050',
       ),
     );
   });
 
   group('ListJoinstrPoolsUsecase', () {
-    ListJoinstrPoolsUsecase build() =>
-        ListJoinstrPoolsUsecase(datasource: datasource, store: store);
+    ListJoinstrPoolsUsecase build() => ListJoinstrPoolsUsecase(
+      datasource: datasource,
+      store: store,
+      resolveProxyUsecase: resolveProxy,
+    );
 
     int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
@@ -99,6 +109,7 @@ void main() {
           relay: any(named: 'relay'),
           back: any(named: 'back'),
           wait: any(named: 'wait'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenAnswer(
         (_) async => [
@@ -117,6 +128,7 @@ void main() {
           relay: any(named: 'relay'),
           back: any(named: 'back'),
           wait: any(named: 'wait'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenAnswer(
         (_) async => [
@@ -135,6 +147,7 @@ void main() {
           relay: any(named: 'relay'),
           back: any(named: 'back'),
           wait: any(named: 'wait'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenAnswer((_) async => []);
 
@@ -144,6 +157,7 @@ void main() {
           relay: ApiServiceConstants.defaultNostrRelayUrl,
           back: any(named: 'back'),
           wait: any(named: 'wait'),
+          proxy: any(named: 'proxy'),
         ),
       ).called(1);
 
@@ -156,6 +170,7 @@ void main() {
           relay: 'wss://relay.example',
           back: any(named: 'back'),
           wait: any(named: 'wait'),
+          proxy: any(named: 'proxy'),
         ),
       ).called(1);
     });
@@ -200,6 +215,7 @@ void main() {
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
           electrumUrl: any(named: 'electrumUrl'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenAnswer((_) async => 'txid-abc');
 
@@ -225,6 +241,7 @@ void main() {
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
           electrumUrl: any(named: 'electrumUrl'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenThrow(JoinstrException(JoinstrIssue.coinjoinFailed));
 
@@ -261,6 +278,7 @@ void main() {
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
           peers: any(named: 'peers'),
           maxDuration: any(named: 'maxDuration'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenAnswer((_) async => 'txid-abc');
 
@@ -282,6 +300,7 @@ void main() {
           feeRateSatPerVb: 1,
           peers: 2,
           maxDuration: any(named: 'maxDuration'),
+          proxy: any(named: 'proxy'),
         ),
       ).called(1);
       final entry =
@@ -303,6 +322,7 @@ void main() {
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
           peers: any(named: 'peers'),
           maxDuration: any(named: 'maxDuration'),
+          proxy: any(named: 'proxy'),
         ),
       ).thenThrow(StateError('boom'));
 

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -82,6 +82,7 @@ void main() {
     when(() => store.getRelay()).thenAnswer((_) async => null);
     when(() => store.appendHistory(any())).thenAnswer((_) async {});
     when(() => resolveProxy.execute()).thenAnswer((_) async => '127.0.0.1:9050');
+    when(() => store.clearReservedAddress()).thenAnswer((_) async {});
     when(
       () => resolvePeerContext.execute(wallet: any(named: 'wallet')),
     ).thenAnswer(

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -1,3 +1,5 @@
+import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
@@ -72,6 +74,7 @@ void main() {
       _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
     );
     registerFallbackValue(const Duration(seconds: 1));
+    registerFallbackValue(<ElectrumServer>[]);
     registerFallbackValue(
       const JoinstrHistoryEntry(
         amountSat: 0,
@@ -95,9 +98,16 @@ void main() {
       () => resolveProxy.execute(),
     ).thenAnswer((_) async => '127.0.0.1:9050');
     when(() => resolveNode.execute(wallet: any(named: 'wallet'))).thenAnswer(
-      (_) async => const JoinstrNodeContext(
+      (_) async => JoinstrNodeContext(
         mnemonic: 'mnemonic',
-        electrumUrl: 'ssl://electrum.example:50002',
+        electrumServers: [
+          ElectrumServer.existing(
+            url: 'ssl://electrum.example:50002',
+            network: ElectrumServerNetwork.bitcoinTestnet,
+            isCustom: false,
+            priority: 0,
+          ),
+        ],
         proxy: '127.0.0.1:9050',
       ),
     );
@@ -171,7 +181,7 @@ void main() {
         () => datasource.listCoins(
           wallet: any(named: 'wallet'),
           mnemonic: any(named: 'mnemonic'),
-          electrumUrl: any(named: 'electrumUrl'),
+          electrumServers: any(named: 'electrumServers'),
           proxy: any(named: 'proxy'),
         ),
       ).thenAnswer(
@@ -187,7 +197,7 @@ void main() {
         () => datasource.listCoins(
           wallet: any(named: 'wallet'),
           mnemonic: 'mnemonic',
-          electrumUrl: 'ssl://electrum.example:50002',
+          electrumServers: any(named: 'electrumServers'),
           proxy: '127.0.0.1:9050',
         ),
       ).called(1);
@@ -232,7 +242,7 @@ void main() {
           wallet: any(named: 'wallet'),
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
+          electrumServers: any(named: 'electrumServers'),
           relay: any(named: 'relay'),
           denominationSat: any(named: 'denominationSat'),
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
@@ -273,7 +283,7 @@ void main() {
           wallet: any(named: 'wallet'),
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
+          electrumServers: any(named: 'electrumServers'),
           relay: any(named: 'relay'),
           denominationSat: any(named: 'denominationSat'),
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
@@ -317,7 +327,7 @@ void main() {
           wallet: any(named: 'wallet'),
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
+          electrumServers: any(named: 'electrumServers'),
           inputOutpoint: any(named: 'inputOutpoint'),
           proxy: any(named: 'proxy'),
         ),

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -1,14 +1,20 @@
 import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_datasource.dart';
 import 'package:bb_mobile/features/joinstr/data/joinstr_store.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
-import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_peer_context_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_node_context_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,10 +24,12 @@ class _MockDatasource extends Mock implements JoinstrDatasource {}
 
 class _MockStore extends Mock implements JoinstrStore {}
 
-class _MockResolvePeerContext extends Mock
-    implements ResolveJoinstrPeerContextUsecase {}
+class _MockResolveNodeContext extends Mock
+    implements ResolveJoinstrNodeContextUsecase {}
 
 class _MockResolveProxy extends Mock implements ResolveJoinstrProxyUsecase {}
+
+class _MockGetReceiveAddress extends Mock implements GetReceiveAddressUsecase {}
 
 Wallet _wallet() => Wallet(
   origin: 'origin',
@@ -54,8 +62,9 @@ JoinstrPool _pool({
 void main() {
   late _MockDatasource datasource;
   late _MockStore store;
-  late _MockResolvePeerContext resolvePeerContext;
+  late _MockResolveNodeContext resolveNode;
   late _MockResolveProxy resolveProxy;
+  late _MockGetReceiveAddress getReceiveAddress;
 
   setUpAll(() {
     registerFallbackValue(_wallet());
@@ -76,24 +85,39 @@ void main() {
   setUp(() {
     datasource = _MockDatasource();
     store = _MockStore();
-    resolvePeerContext = _MockResolvePeerContext();
+    resolveNode = _MockResolveNodeContext();
     resolveProxy = _MockResolveProxy();
+    getReceiveAddress = _MockGetReceiveAddress();
 
     when(() => store.getRelay()).thenAnswer((_) async => null);
     when(() => store.appendHistory(any())).thenAnswer((_) async {});
-    when(() => resolveProxy.execute()).thenAnswer((_) async => '127.0.0.1:9050');
-    when(() => store.clearReservedAddress()).thenAnswer((_) async {});
     when(
-      () => resolvePeerContext.execute(wallet: any(named: 'wallet')),
-    ).thenAnswer(
-      (_) async => const JoinstrPeerContext(
+      () => resolveProxy.execute(),
+    ).thenAnswer((_) async => '127.0.0.1:9050');
+    when(() => resolveNode.execute(wallet: any(named: 'wallet'))).thenAnswer(
+      (_) async => const JoinstrNodeContext(
         mnemonic: 'mnemonic',
         electrumUrl: 'ssl://electrum.example:50002',
-        outputAddress: 'tb1qaddress',
         proxy: '127.0.0.1:9050',
       ),
     );
+    when(
+      () => getReceiveAddress.execute(
+        walletId: any(named: 'walletId'),
+        generateNew: any(named: 'generateNew'),
+      ),
+    ).thenAnswer(
+      (_) async => WalletAddress(
+        walletId: 'w',
+        index: 0,
+        address: 'tb1qaddress',
+        createdAt: DateTime(2020),
+        updatedAt: DateTime(2020),
+      ),
+    );
   });
+
+  int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
   group('ListJoinstrPoolsUsecase', () {
     ListJoinstrPoolsUsecase build() => ListJoinstrPoolsUsecase(
@@ -102,56 +126,28 @@ void main() {
       resolveProxyUsecase: resolveProxy,
     );
 
-    int nowSec() => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    void stubPools(List<JoinstrPool> pools) => when(
+      () => datasource.listPools(
+        relay: any(named: 'relay'),
+        back: any(named: 'back'),
+        wait: any(named: 'wait'),
+        proxy: any(named: 'proxy'),
+      ),
+    ).thenAnswer((_) async => pools);
 
-    test('drops expired pools, which can never fill', () async {
-      when(
-        () => datasource.listPools(
-          relay: any(named: 'relay'),
-          back: any(named: 'back'),
-          wait: any(named: 'wait'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).thenAnswer(
-        (_) async => [
-          _pool(denominationSat: 100000, expiresAtUnixSec: nowSec() - 10),
-          _pool(denominationSat: 200000, expiresAtUnixSec: nowSec() + 600),
-        ],
-      );
-
-      final pools = await build().execute();
-      expect(pools.map((p) => p.denominationSat), [200000]);
-    });
-
-    test('sorts joinable pools by denomination', () async {
-      when(
-        () => datasource.listPools(
-          relay: any(named: 'relay'),
-          back: any(named: 'back'),
-          wait: any(named: 'wait'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).thenAnswer(
-        (_) async => [
-          _pool(denominationSat: 500000, expiresAtUnixSec: nowSec() + 600),
-          _pool(denominationSat: 100000, expiresAtUnixSec: nowSec() + 600),
-        ],
-      );
+    test('drops expired pools and sorts by denomination', () async {
+      stubPools([
+        _pool(denominationSat: 500000, expiresAtUnixSec: nowSec() + 600),
+        _pool(denominationSat: 100000, expiresAtUnixSec: nowSec() + 600),
+        _pool(denominationSat: 200000, expiresAtUnixSec: nowSec() - 10),
+      ]);
 
       final pools = await build().execute();
       expect(pools.map((p) => p.denominationSat), [100000, 500000]);
     });
 
     test('uses the stored relay, falling back to the default', () async {
-      when(
-        () => datasource.listPools(
-          relay: any(named: 'relay'),
-          back: any(named: 'back'),
-          wait: any(named: 'wait'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).thenAnswer((_) async => []);
-
+      stubPools([]);
       await build().execute();
       verify(
         () => datasource.listPools(
@@ -161,17 +157,38 @@ void main() {
           proxy: any(named: 'proxy'),
         ),
       ).called(1);
+    });
+  });
 
+  group('ListJoinstrCoinsUsecase', () {
+    ListJoinstrCoinsUsecase build() => ListJoinstrCoinsUsecase(
+      datasource: datasource,
+      resolveNodeContextUsecase: resolveNode,
+    );
+
+    test('resolves node context and returns coins sorted by value', () async {
       when(
-        () => store.getRelay(),
-      ).thenAnswer((_) async => 'wss://relay.example');
-      await build().execute();
-      verify(
-        () => datasource.listPools(
-          relay: 'wss://relay.example',
-          back: any(named: 'back'),
-          wait: any(named: 'wait'),
+        () => datasource.listCoins(
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          electrumUrl: any(named: 'electrumUrl'),
           proxy: any(named: 'proxy'),
+        ),
+      ).thenAnswer(
+        (_) async => const [
+          JoinstrCoin(txid: 'a', vout: 0, valueSat: 100000),
+          JoinstrCoin(txid: 'b', vout: 1, valueSat: 500000),
+        ],
+      );
+
+      final coins = await build().execute(wallet: _wallet());
+      expect(coins.map((c) => c.valueSat), [500000, 100000]);
+      verify(
+        () => datasource.listCoins(
+          wallet: any(named: 'wallet'),
+          mnemonic: 'mnemonic',
+          electrumUrl: 'ssl://electrum.example:50002',
+          proxy: '127.0.0.1:9050',
         ),
       ).called(1);
     });
@@ -201,40 +218,99 @@ void main() {
     });
   });
 
-  group('JoinJoinstrPoolUsecase', () {
-    JoinJoinstrPoolUsecase build() => JoinJoinstrPoolUsecase(
+  group('InitiateJoinstrPoolUsecase', () {
+    InitiateJoinstrPoolUsecase build() => InitiateJoinstrPoolUsecase(
       datasource: datasource,
       store: store,
-      resolvePeerContextUsecase: resolvePeerContext,
+      resolveNodeContextUsecase: resolveNode,
+      getReceiveAddressUsecase: getReceiveAddress,
     );
 
-    test('appends a history entry after the broadcast', () async {
+    test('forwards progress and records history on broadcast', () async {
       when(
-        () => datasource.joinPool(
-          pool: any(named: 'pool'),
+        () => datasource.initiatePool(
           wallet: any(named: 'wallet'),
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
           electrumUrl: any(named: 'electrumUrl'),
+          relay: any(named: 'relay'),
+          denominationSat: any(named: 'denominationSat'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          peers: any(named: 'peers'),
+          maxDuration: any(named: 'maxDuration'),
+          inputOutpoint: any(named: 'inputOutpoint'),
           proxy: any(named: 'proxy'),
         ),
-      ).thenAnswer((_) async => 'txid-abc');
-
-      final txId = await build().execute(
-        wallet: _wallet(),
-        pool: _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.connecting),
+          JoinstrProgress(step: JoinstrRoundStep.done, txId: 'txid-abc'),
+        ]),
       );
 
-      expect(txId, 'txid-abc');
+      final steps = await build()
+          .execute(
+            wallet: _wallet(),
+            denominationSat: 100000,
+            peers: 2,
+            feeRateSatPerVb: 1,
+            inputOutpoint: 'a:0',
+          )
+          .map((p) => p.step)
+          .toList();
+
+      expect(steps, [JoinstrRoundStep.connecting, JoinstrRoundStep.done]);
       final entry =
           verify(() => store.appendHistory(captureAny())).captured.single
               as JoinstrHistoryEntry;
       expect(entry.txId, 'txid-abc');
       expect(entry.amountSat, 100000);
-      expect(entry.relay, 'wss://nos.lol');
     });
 
-    test('does not write history when the round fails', () async {
+    test('does not record history when the round fails', () async {
+      when(
+        () => datasource.initiatePool(
+          wallet: any(named: 'wallet'),
+          mnemonic: any(named: 'mnemonic'),
+          outputAddress: any(named: 'outputAddress'),
+          electrumUrl: any(named: 'electrumUrl'),
+          relay: any(named: 'relay'),
+          denominationSat: any(named: 'denominationSat'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          peers: any(named: 'peers'),
+          maxDuration: any(named: 'maxDuration'),
+          inputOutpoint: any(named: 'inputOutpoint'),
+          proxy: any(named: 'proxy'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.failed, errorMessage: 'boom'),
+        ]),
+      );
+
+      await build()
+          .execute(
+            wallet: _wallet(),
+            denominationSat: 100000,
+            peers: 2,
+            feeRateSatPerVb: 1,
+            inputOutpoint: 'a:0',
+          )
+          .toList();
+
+      verifyNever(() => store.appendHistory(any()));
+    });
+  });
+
+  group('JoinJoinstrPoolUsecase', () {
+    JoinJoinstrPoolUsecase build() => JoinJoinstrPoolUsecase(
+      datasource: datasource,
+      store: store,
+      resolveNodeContextUsecase: resolveNode,
+      getReceiveAddressUsecase: getReceiveAddress,
+    );
+
+    test('forwards progress and records history on broadcast', () async {
       when(
         () => datasource.joinPool(
           pool: any(named: 'pool'),
@@ -242,107 +318,27 @@ void main() {
           mnemonic: any(named: 'mnemonic'),
           outputAddress: any(named: 'outputAddress'),
           electrumUrl: any(named: 'electrumUrl'),
+          inputOutpoint: any(named: 'inputOutpoint'),
           proxy: any(named: 'proxy'),
         ),
-      ).thenThrow(JoinstrException(JoinstrIssue.coinjoinFailed));
-
-      await expectLater(
-        () => build().execute(
-          wallet: _wallet(),
-          pool: _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
-        ),
-        throwsA(isA<JoinstrException>()),
-      );
-      verifyNever(() => store.appendHistory(any()));
-    });
-  });
-
-  group('InitiateJoinstrPoolUsecase', () {
-    InitiateJoinstrPoolUsecase build() => InitiateJoinstrPoolUsecase(
-      datasource: datasource,
-      store: store,
-      resolvePeerContextUsecase: resolvePeerContext,
-    );
-
-    test('uses the stored relay and records history', () async {
-      when(
-        () => store.getRelay(),
-      ).thenAnswer((_) async => 'wss://relay.example');
-      when(
-        () => datasource.initiatePool(
-          wallet: any(named: 'wallet'),
-          mnemonic: any(named: 'mnemonic'),
-          outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
-          relay: any(named: 'relay'),
-          denominationSat: any(named: 'denominationSat'),
-          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
-          peers: any(named: 'peers'),
-          maxDuration: any(named: 'maxDuration'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).thenAnswer((_) async => 'txid-abc');
-
-      await build().execute(
-        wallet: _wallet(),
-        denominationSat: 100000,
-        peers: 2,
-        feeRateSatPerVb: 1,
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.done, txId: 'txid-join'),
+        ]),
       );
 
-      verify(
-        () => datasource.initiatePool(
-          wallet: any(named: 'wallet'),
-          mnemonic: any(named: 'mnemonic'),
-          outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
-          relay: 'wss://relay.example',
-          denominationSat: 100000,
-          feeRateSatPerVb: 1,
-          peers: 2,
-          maxDuration: any(named: 'maxDuration'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).called(1);
+      await build()
+          .execute(
+            wallet: _wallet(),
+            pool: _pool(denominationSat: 100000, expiresAtUnixSec: 1793500000),
+            inputOutpoint: 'a:0',
+          )
+          .toList();
+
       final entry =
           verify(() => store.appendHistory(captureAny())).captured.single
               as JoinstrHistoryEntry;
-      expect(entry.relay, 'wss://relay.example');
-      expect(entry.amountSat, 100000);
-    });
-
-    test('wraps an unexpected error as coinjoinFailed', () async {
-      when(
-        () => datasource.initiatePool(
-          wallet: any(named: 'wallet'),
-          mnemonic: any(named: 'mnemonic'),
-          outputAddress: any(named: 'outputAddress'),
-          electrumUrl: any(named: 'electrumUrl'),
-          relay: any(named: 'relay'),
-          denominationSat: any(named: 'denominationSat'),
-          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
-          peers: any(named: 'peers'),
-          maxDuration: any(named: 'maxDuration'),
-          proxy: any(named: 'proxy'),
-        ),
-      ).thenThrow(StateError('boom'));
-
-      await expectLater(
-        () => build().execute(
-          wallet: _wallet(),
-          denominationSat: 100000,
-          peers: 2,
-          feeRateSatPerVb: 1,
-        ),
-        throwsA(
-          isA<JoinstrException>().having(
-            (e) => e.issue,
-            'issue',
-            JoinstrIssue.coinjoinFailed,
-          ),
-        ),
-      );
-      verifyNever(() => store.appendHistory(any()));
+      expect(entry.txId, 'txid-join');
     });
   });
 }

--- a/test/features/joinstr/domain/joinstr_usecases_test.dart
+++ b/test/features/joinstr/domain/joinstr_usecases_test.dart
@@ -269,7 +269,13 @@ void main() {
           .map((p) => p.step)
           .toList();
 
-      expect(steps, [JoinstrRoundStep.connecting, JoinstrRoundStep.done]);
+      // The usecase yields an initial connecting update carrying the output
+      // address before forwarding the datasource stream.
+      expect(steps, [
+        JoinstrRoundStep.connecting,
+        JoinstrRoundStep.connecting,
+        JoinstrRoundStep.done,
+      ]);
       final entry =
           verify(() => store.appendHistory(captureAny())).captured.single
               as JoinstrHistoryEntry;

--- a/test/features/joinstr/domain/resolve_joinstr_proxy_usecase_test.dart
+++ b/test/features/joinstr/domain/resolve_joinstr_proxy_usecase_test.dart
@@ -1,0 +1,70 @@
+import 'package:bb_mobile/core/tor/data/datasources/tor_datasource.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/resolve_joinstr_proxy_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTor extends Mock implements TorDatasource {}
+
+void main() {
+  late _MockTor tor;
+
+  ResolveJoinstrProxyUsecase build() => ResolveJoinstrProxyUsecase(
+    torDatasource: tor,
+    timeout: const Duration(milliseconds: 300),
+    pollInterval: const Duration(milliseconds: 10),
+  );
+
+  setUp(() => tor = _MockTor());
+
+  test(
+    'waits for a bootstrapping Tor rather than failing immediately',
+    () async {
+      // start() returns while Tor is still bootstrapping; isStarted only flips
+      // true after a few polls. This is the case that used to throw
+      // torUnavailable the instant Create was tapped.
+      var polls = 0;
+      when(() => tor.isStarted).thenAnswer((_) => polls++ >= 3);
+      when(() => tor.start()).thenAnswer((_) async {});
+      when(() => tor.port).thenReturn(9050);
+
+      expect(await build().execute(), '127.0.0.1:9050');
+    },
+  );
+
+  test('does not restart Tor when it is already online', () async {
+    when(() => tor.isStarted).thenReturn(true);
+    when(() => tor.port).thenReturn(9051);
+
+    expect(await build().execute(), '127.0.0.1:9051');
+    verifyNever(() => tor.start());
+  });
+
+  test('throws torUnavailable when Tor never comes online', () async {
+    when(() => tor.isStarted).thenReturn(false);
+    when(() => tor.start()).thenAnswer((_) async {});
+    when(() => tor.port).thenReturn(-1);
+
+    await expectLater(
+      () => build().execute(),
+      throwsA(
+        isA<JoinstrException>().having(
+          (e) => e.issue,
+          'issue',
+          JoinstrIssue.torUnavailable,
+        ),
+      ),
+    );
+  });
+
+  test('recovers from a start() that throws by polling readiness', () async {
+    // A concurrent start may be mid-bootstrap and this start() throws; the
+    // usecase must fall through to the poll instead of surfacing the error.
+    var polls = 0;
+    when(() => tor.isStarted).thenAnswer((_) => polls++ >= 2);
+    when(() => tor.start()).thenThrow(Exception('already starting'));
+    when(() => tor.port).thenReturn(9050);
+
+    expect(await build().execute(), '127.0.0.1:9050');
+  });
+}

--- a/test/features/joinstr/presentation/joinstr_cubit_test.dart
+++ b/test/features/joinstr/presentation/joinstr_cubit_test.dart
@@ -1,0 +1,211 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
+import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetWallets extends Mock implements GetWalletsUsecase {}
+
+class _MockListPools extends Mock implements ListJoinstrPoolsUsecase {}
+
+class _MockJoinPool extends Mock implements JoinJoinstrPoolUsecase {}
+
+class _MockInitiatePool extends Mock implements InitiateJoinstrPoolUsecase {}
+
+Wallet _wallet({
+  String origin = 'w-testnet',
+  Network network = Network.bitcoinTestnet,
+  ScriptType scriptType = ScriptType.bip84,
+  SignerEntity signer = SignerEntity.local,
+}) {
+  return Wallet(
+    origin: origin,
+    network: network,
+    xpubFingerprint: 'ffffffff',
+    masterFingerprint: 'eeeeeeee',
+    scriptType: scriptType,
+    xpub: 'xpub',
+    externalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/0/*)',
+    internalPublicDescriptor: 'wpkh([eeeeeeee/84h/1h/0h]xpub/1/*)',
+    signer: signer,
+    signerDevice: null,
+    balanceSat: BigInt.zero,
+  );
+}
+
+JoinstrPool _pool(int denominationSat) => JoinstrPool(
+  id: 'pool-$denominationSat',
+  rawJson: '{}',
+  denominationSat: denominationSat,
+  peers: 2,
+  expiresAtUnixSec: 1793500000,
+  relay: 'wss://nos.lol',
+  feeRateSatPerVb: 1,
+  publicKey: 'pk',
+);
+
+void main() {
+  late _MockGetWallets getWallets;
+  late _MockListPools listPools;
+  late _MockJoinPool joinPool;
+  late _MockInitiatePool initiatePool;
+
+  JoinstrCubit build() => JoinstrCubit(
+    getWalletsUsecase: getWallets,
+    listJoinstrPoolsUsecase: listPools,
+    joinJoinstrPoolUsecase: joinPool,
+    initiateJoinstrPoolUsecase: initiatePool,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(_wallet());
+    registerFallbackValue(_pool(100000));
+  });
+
+  setUp(() {
+    getWallets = _MockGetWallets();
+    listPools = _MockListPools();
+    joinPool = _MockJoinPool();
+    initiatePool = _MockInitiatePool();
+  });
+
+  group('load', () {
+    test('errors when no local-signer wallet is available', () async {
+      when(
+        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+      ).thenAnswer((_) async => [_wallet(signer: SignerEntity.none)]);
+
+      final cubit = build();
+      await cubit.load();
+
+      expect(cubit.state.status, JoinstrStatus.error);
+      expect(cubit.state.error?.issue, JoinstrIssue.watchOnlyWallet);
+      verifyNever(() => listPools.execute());
+    });
+
+    test('selects a supported testnet wallet over a mainnet one', () async {
+      when(
+        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+      ).thenAnswer(
+        (_) async => [
+          _wallet(origin: 'w-mainnet', network: Network.bitcoinMainnet),
+          _wallet(origin: 'w-testnet', network: Network.bitcoinTestnet),
+        ],
+      );
+      when(() => listPools.execute()).thenAnswer((_) async => []);
+
+      final cubit = build();
+      await cubit.load();
+
+      expect(cubit.state.wallet?.id, 'w-testnet');
+      expect(cubit.state.error, isNull);
+      expect(cubit.state.status, JoinstrStatus.idle);
+    });
+
+    test(
+      'surfaces mainnetNotSupported when only a mainnet wallet exists',
+      () async {
+        when(
+          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+        ).thenAnswer((_) async => [_wallet(network: Network.bitcoinMainnet)]);
+
+        final cubit = build();
+        await cubit.load();
+
+        expect(cubit.state.status, JoinstrStatus.error);
+        expect(cubit.state.error?.issue, JoinstrIssue.mainnetNotSupported);
+      },
+    );
+  });
+
+  group('refreshPools', () {
+    test('moves to idle with the usecase result', () async {
+      when(
+        () => listPools.execute(),
+      ).thenAnswer((_) async => [_pool(100000), _pool(500000)]);
+
+      final cubit = build();
+      await cubit.refreshPools();
+
+      expect(cubit.state.status, JoinstrStatus.idle);
+      expect(cubit.state.pools.map((p) => p.denominationSat), [100000, 500000]);
+    });
+  });
+
+  group('initiatePool validation', () {
+    test('rejects an out-of-range config before calling the usecase', () async {
+      when(
+        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+      ).thenAnswer((_) async => [_wallet()]);
+      when(() => listPools.execute()).thenAnswer((_) async => []);
+
+      final cubit = build();
+      await cubit.load();
+      cubit.peersChanged('1'); // below the 2-peer minimum
+
+      await cubit.initiatePool();
+
+      expect(cubit.state.status, JoinstrStatus.error);
+      expect(cubit.state.error?.issue, JoinstrIssue.invalidPoolConfig);
+      verifyNever(
+        () => initiatePool.execute(
+          wallet: any(named: 'wallet'),
+          denominationSat: any(named: 'denominationSat'),
+          peers: any(named: 'peers'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+        ),
+      );
+    });
+  });
+
+  group('joinPool', () {
+    test('runs then reports the broadcast txid', () async {
+      when(
+        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+      ).thenAnswer((_) async => [_wallet()]);
+      when(() => listPools.execute()).thenAnswer((_) async => []);
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+        ),
+      ).thenAnswer((_) async => 'txid-abc');
+
+      final cubit = build();
+      await cubit.load();
+      await cubit.joinPool(_pool(100000));
+
+      expect(cubit.state.status, JoinstrStatus.done);
+      expect(cubit.state.txId, 'txid-abc');
+    });
+
+    test(
+      'maps a JoinstrException from the usecase to the error state',
+      () async {
+        when(
+          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+        ).thenAnswer((_) async => [_wallet()]);
+        when(() => listPools.execute()).thenAnswer((_) async => []);
+        when(
+          () => joinPool.execute(
+            wallet: any(named: 'wallet'),
+            pool: any(named: 'pool'),
+          ),
+        ).thenThrow(JoinstrException(JoinstrIssue.noEligibleCoin));
+
+        final cubit = build();
+        await cubit.load();
+        await cubit.joinPool(_pool(100000));
+
+        expect(cubit.state.status, JoinstrStatus.error);
+        expect(cubit.state.error?.issue, JoinstrIssue.noEligibleCoin);
+      },
+    );
+  });
+}

--- a/test/features/joinstr/presentation/joinstr_cubit_test.dart
+++ b/test/features/joinstr/presentation/joinstr_cubit_test.dart
@@ -2,15 +2,23 @@ import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_state.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockGetWallets extends Mock implements GetWalletsUsecase {}
+
+class _MockGetSettings extends Mock implements GetJoinstrSettingsUsecase {}
+
+class _MockSaveRelay extends Mock implements SaveJoinstrRelayUsecase {}
 
 class _MockListPools extends Mock implements ListJoinstrPoolsUsecase {}
 
@@ -52,12 +60,16 @@ JoinstrPool _pool(int denominationSat) => JoinstrPool(
 
 void main() {
   late _MockGetWallets getWallets;
+  late _MockGetSettings getSettings;
+  late _MockSaveRelay saveRelay;
   late _MockListPools listPools;
   late _MockJoinPool joinPool;
   late _MockInitiatePool initiatePool;
 
   JoinstrCubit build() => JoinstrCubit(
     getWalletsUsecase: getWallets,
+    getJoinstrSettingsUsecase: getSettings,
+    saveJoinstrRelayUsecase: saveRelay,
     listJoinstrPoolsUsecase: listPools,
     joinJoinstrPoolUsecase: joinPool,
     initiateJoinstrPoolUsecase: initiatePool,
@@ -66,14 +78,31 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_wallet());
     registerFallbackValue(_pool(100000));
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
     getWallets = _MockGetWallets();
+    getSettings = _MockGetSettings();
+    saveRelay = _MockSaveRelay();
     listPools = _MockListPools();
     joinPool = _MockJoinPool();
     initiatePool = _MockInitiatePool();
+
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const JoinstrSettings(relay: 'wss://nos.lol', history: []),
+    );
   });
+
+  Future<JoinstrCubit> loadedCubit() async {
+    when(
+      () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+    ).thenAnswer((_) async => [_wallet()]);
+    when(() => listPools.execute()).thenAnswer((_) async => []);
+    final cubit = build();
+    await cubit.load();
+    return cubit;
+  }
 
   group('load', () {
     test('errors when no local-signer wallet is available', () async {
@@ -122,6 +151,52 @@ void main() {
         expect(cubit.state.error?.issue, JoinstrIssue.mainnetNotSupported);
       },
     );
+
+    test('loads the persisted relay and history', () async {
+      when(() => getSettings.execute()).thenAnswer(
+        (_) async => const JoinstrSettings(
+          relay: 'wss://relay.example',
+          history: [
+            JoinstrHistoryEntry(
+              amountSat: 100000,
+              txId: 'tx-1',
+              relay: 'wss://relay.example',
+              completedAtUnixSec: 1793500000,
+            ),
+          ],
+        ),
+      );
+      when(
+        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+      ).thenAnswer((_) async => [_wallet()]);
+      when(() => listPools.execute()).thenAnswer((_) async => []);
+
+      final cubit = build();
+      await cubit.load();
+
+      expect(cubit.state.relay, 'wss://relay.example');
+      expect(cubit.state.history.single.txId, 'tx-1');
+    });
+
+    test('does not reload while a round is waiting', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+        ),
+      ).thenAnswer((_) async {
+        // Re-entering the screen mid-round must not re-resolve the wallet.
+        await cubit.load();
+        verify(
+          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+        ).called(1);
+        return 'txid-abc';
+      });
+
+      await cubit.joinPool(_pool(100000));
+      expect(cubit.state.rounds.single.txId, 'txid-abc');
+    });
   });
 
   group('refreshPools', () {
@@ -138,15 +213,50 @@ void main() {
     });
   });
 
-  group('initiatePool validation', () {
-    test('rejects an out-of-range config before calling the usecase', () async {
-      when(
-        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-      ).thenAnswer((_) async => [_wallet()]);
+  group('relayChanged', () {
+    test('persists the relay and refreshes pools', () async {
+      when(() => saveRelay.execute(any())).thenAnswer((_) async {});
       when(() => listPools.execute()).thenAnswer((_) async => []);
 
       final cubit = build();
-      await cubit.load();
+      await cubit.relayChanged('wss://relay.example');
+
+      expect(cubit.state.relay, 'wss://relay.example');
+      verify(() => saveRelay.execute('wss://relay.example')).called(1);
+      verify(() => listPools.execute()).called(1);
+    });
+
+    test('surfaces an invalid relay without refreshing', () async {
+      when(
+        () => saveRelay.execute(any()),
+      ).thenThrow(JoinstrException(JoinstrIssue.invalidRelayUrl));
+
+      final cubit = build();
+      await cubit.relayChanged('http://not-a-relay');
+
+      expect(cubit.state.error?.issue, JoinstrIssue.invalidRelayUrl);
+      verifyNever(() => listPools.execute());
+    });
+  });
+
+  group('denominationChanged', () {
+    test('accepts BTC decimal input and rejects everything else', () {
+      final cubit = build();
+
+      cubit.denominationChanged('0.001');
+      expect(cubit.state.denominationBtc, '0.001');
+
+      cubit.denominationChanged('0.001x');
+      expect(cubit.state.denominationBtc, '0.001');
+
+      cubit.denominationChanged('');
+      expect(cubit.state.denominationBtc, '');
+    });
+  });
+
+  group('initiatePool validation', () {
+    test('rejects an out-of-range config before calling the usecase', () async {
+      final cubit = await loadedCubit();
       cubit.peersChanged('1'); // below the 2-peer minimum
 
       await cubit.initiatePool();
@@ -159,17 +269,43 @@ void main() {
           denominationSat: any(named: 'denominationSat'),
           peers: any(named: 'peers'),
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          maxDuration: any(named: 'maxDuration'),
         ),
       );
+    });
+
+    test('converts the BTC input to satoshis for the usecase', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => initiatePool.execute(
+          wallet: any(named: 'wallet'),
+          denominationSat: any(named: 'denominationSat'),
+          peers: any(named: 'peers'),
+          feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          maxDuration: any(named: 'maxDuration'),
+        ),
+      ).thenAnswer((_) async => 'txid-abc');
+
+      cubit.denominationChanged('0.005');
+      await cubit.initiatePool();
+
+      verify(
+        () => initiatePool.execute(
+          wallet: any(named: 'wallet'),
+          denominationSat: 500000,
+          peers: 2,
+          feeRateSatPerVb: 1,
+          maxDuration: any(named: 'maxDuration'),
+        ),
+      ).called(1);
+      expect(cubit.state.rounds.single.status, JoinstrRoundStatus.broadcast);
+      expect(cubit.state.rounds.single.initiated, isTrue);
     });
   });
 
   group('joinPool', () {
-    test('runs then reports the broadcast txid', () async {
-      when(
-        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-      ).thenAnswer((_) async => [_wallet()]);
-      when(() => listPools.execute()).thenAnswer((_) async => []);
+    test('tracks the round to broadcast with its txid', () async {
+      final cubit = await loadedCubit();
       when(
         () => joinPool.execute(
           wallet: any(named: 'wallet'),
@@ -177,35 +313,84 @@ void main() {
         ),
       ).thenAnswer((_) async => 'txid-abc');
 
-      final cubit = build();
-      await cubit.load();
       await cubit.joinPool(_pool(100000));
 
-      expect(cubit.state.status, JoinstrStatus.done);
-      expect(cubit.state.txId, 'txid-abc');
+      final round = cubit.state.rounds.single;
+      expect(round.status, JoinstrRoundStatus.broadcast);
+      expect(round.txId, 'txid-abc');
+      expect(round.initiated, isFalse);
+      expect(round.publicKey, 'pk');
+      expect(cubit.state.isRunning, isFalse);
     });
 
-    test(
-      'maps a JoinstrException from the usecase to the error state',
-      () async {
-        when(
-          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-        ).thenAnswer((_) async => [_wallet()]);
-        when(() => listPools.execute()).thenAnswer((_) async => []);
-        when(
+    test('marks the round failed on a JoinstrException', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+        ),
+      ).thenThrow(JoinstrException(JoinstrIssue.noEligibleCoin));
+
+      await cubit.joinPool(_pool(100000));
+
+      final round = cubit.state.rounds.single;
+      expect(round.status, JoinstrRoundStatus.failed);
+      expect(round.error?.issue, JoinstrIssue.noEligibleCoin);
+      expect(cubit.state.isRunning, isFalse);
+    });
+
+    test('refuses a second round while one is waiting', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+        ),
+      ).thenAnswer((_) async {
+        // While the first round is in flight, a second join and an initiate
+        // must both be no-ops: the same coin must never be offered twice.
+        await cubit.joinPool(_pool(500000));
+        await cubit.initiatePool();
+        verify(
           () => joinPool.execute(
             wallet: any(named: 'wallet'),
             pool: any(named: 'pool'),
           ),
-        ).thenThrow(JoinstrException(JoinstrIssue.noEligibleCoin));
+        ).called(1);
+        return 'txid-abc';
+      });
 
-        final cubit = build();
-        await cubit.load();
-        await cubit.joinPool(_pool(100000));
+      await cubit.joinPool(_pool(100000));
 
-        expect(cubit.state.status, JoinstrStatus.error);
-        expect(cubit.state.error?.issue, JoinstrIssue.noEligibleCoin);
-      },
-    );
+      expect(cubit.state.rounds.single.txId, 'txid-abc');
+    });
+
+    test('reloads history after a broadcast', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+        ),
+      ).thenAnswer((_) async => 'txid-abc');
+      when(() => getSettings.execute()).thenAnswer(
+        (_) async => const JoinstrSettings(
+          relay: 'wss://nos.lol',
+          history: [
+            JoinstrHistoryEntry(
+              amountSat: 100000,
+              txId: 'txid-abc',
+              relay: 'wss://nos.lol',
+              completedAtUnixSec: 1793500000,
+            ),
+          ],
+        ),
+      );
+
+      await cubit.joinPool(_pool(100000));
+
+      expect(cubit.state.history.single.txId, 'txid-abc');
+    });
   });
 }

--- a/test/features/joinstr/presentation/joinstr_cubit_test.dart
+++ b/test/features/joinstr/presentation/joinstr_cubit_test.dart
@@ -2,11 +2,13 @@ import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr.dart';
-import 'package:bb_mobile/features/joinstr/domain/joinstr_history_entry.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_coin.dart';
+import 'package:bb_mobile/features/joinstr/domain/joinstr_progress.dart';
 import 'package:bb_mobile/features/joinstr/domain/joinstr_round.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/get_joinstr_settings_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/initiate_joinstr_pool_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/join_joinstr_pool_usecase.dart';
+import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_coins_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/list_joinstr_pools_usecase.dart';
 import 'package:bb_mobile/features/joinstr/domain/usecases/save_joinstr_relay_usecase.dart';
 import 'package:bb_mobile/features/joinstr/presentation/joinstr_cubit.dart';
@@ -21,6 +23,8 @@ class _MockGetSettings extends Mock implements GetJoinstrSettingsUsecase {}
 class _MockSaveRelay extends Mock implements SaveJoinstrRelayUsecase {}
 
 class _MockListPools extends Mock implements ListJoinstrPoolsUsecase {}
+
+class _MockListCoins extends Mock implements ListJoinstrCoinsUsecase {}
 
 class _MockJoinPool extends Mock implements JoinJoinstrPoolUsecase {}
 
@@ -58,11 +62,14 @@ JoinstrPool _pool(int denominationSat) => JoinstrPool(
   publicKey: 'pk',
 );
 
+const _coin = JoinstrCoin(txid: 'a', vout: 0, valueSat: 100000);
+
 void main() {
   late _MockGetWallets getWallets;
   late _MockGetSettings getSettings;
   late _MockSaveRelay saveRelay;
   late _MockListPools listPools;
+  late _MockListCoins listCoins;
   late _MockJoinPool joinPool;
   late _MockInitiatePool initiatePool;
 
@@ -71,6 +78,7 @@ void main() {
     getJoinstrSettingsUsecase: getSettings,
     saveJoinstrRelayUsecase: saveRelay,
     listJoinstrPoolsUsecase: listPools,
+    listJoinstrCoinsUsecase: listCoins,
     joinJoinstrPoolUsecase: joinPool,
     initiateJoinstrPoolUsecase: initiatePool,
   );
@@ -86,19 +94,23 @@ void main() {
     getSettings = _MockGetSettings();
     saveRelay = _MockSaveRelay();
     listPools = _MockListPools();
+    listCoins = _MockListCoins();
     joinPool = _MockJoinPool();
     initiatePool = _MockInitiatePool();
 
     when(() => getSettings.execute()).thenAnswer(
       (_) async => const JoinstrSettings(relay: 'wss://nos.lol', history: []),
     );
+    when(
+      () => listCoins.execute(wallet: any(named: 'wallet')),
+    ).thenAnswer((_) async => const [_coin]);
+    when(() => listPools.execute()).thenAnswer((_) async => []);
   });
 
   Future<JoinstrCubit> loadedCubit() async {
     when(
       () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
     ).thenAnswer((_) async => [_wallet()]);
-    when(() => listPools.execute()).thenAnswer((_) async => []);
     final cubit = build();
     await cubit.load();
     return cubit;
@@ -115,10 +127,9 @@ void main() {
 
       expect(cubit.state.status, JoinstrStatus.error);
       expect(cubit.state.error?.issue, JoinstrIssue.watchOnlyWallet);
-      verifyNever(() => listPools.execute());
     });
 
-    test('selects a supported testnet wallet over a mainnet one', () async {
+    test('selects a supported testnet wallet and loads coins', () async {
       when(
         () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
       ).thenAnswer(
@@ -127,141 +138,21 @@ void main() {
           _wallet(origin: 'w-testnet', network: Network.bitcoinTestnet),
         ],
       );
-      when(() => listPools.execute()).thenAnswer((_) async => []);
 
       final cubit = build();
       await cubit.load();
 
       expect(cubit.state.wallet?.id, 'w-testnet');
+      expect(cubit.state.coins, [_coin]);
       expect(cubit.state.error, isNull);
-      expect(cubit.state.status, JoinstrStatus.idle);
     });
+  });
 
-    test(
-      'surfaces mainnetNotSupported when only a mainnet wallet exists',
-      () async {
-        when(
-          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-        ).thenAnswer((_) async => [_wallet(network: Network.bitcoinMainnet)]);
-
-        final cubit = build();
-        await cubit.load();
-
-        expect(cubit.state.status, JoinstrStatus.error);
-        expect(cubit.state.error?.issue, JoinstrIssue.mainnetNotSupported);
-      },
-    );
-
-    test('loads the persisted relay and history', () async {
-      when(() => getSettings.execute()).thenAnswer(
-        (_) async => const JoinstrSettings(
-          relay: 'wss://relay.example',
-          history: [
-            JoinstrHistoryEntry(
-              amountSat: 100000,
-              txId: 'tx-1',
-              relay: 'wss://relay.example',
-              completedAtUnixSec: 1793500000,
-            ),
-          ],
-        ),
-      );
-      when(
-        () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-      ).thenAnswer((_) async => [_wallet()]);
-      when(() => listPools.execute()).thenAnswer((_) async => []);
-
-      final cubit = build();
-      await cubit.load();
-
-      expect(cubit.state.relay, 'wss://relay.example');
-      expect(cubit.state.history.single.txId, 'tx-1');
-    });
-
-    test('does not reload while a round is waiting', () async {
+  group('initiatePool', () {
+    test('requires a selected coin', () async {
       final cubit = await loadedCubit();
-      when(
-        () => joinPool.execute(
-          wallet: any(named: 'wallet'),
-          pool: any(named: 'pool'),
-        ),
-      ).thenAnswer((_) async {
-        // Re-entering the screen mid-round must not re-resolve the wallet.
-        await cubit.load();
-        verify(
-          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
-        ).called(1);
-        return 'txid-abc';
-      });
-
-      await cubit.joinPool(_pool(100000));
-      expect(cubit.state.rounds.single.txId, 'txid-abc');
-    });
-  });
-
-  group('refreshPools', () {
-    test('moves to idle with the usecase result', () async {
-      when(
-        () => listPools.execute(),
-      ).thenAnswer((_) async => [_pool(100000), _pool(500000)]);
-
-      final cubit = build();
-      await cubit.refreshPools();
-
-      expect(cubit.state.status, JoinstrStatus.idle);
-      expect(cubit.state.pools.map((p) => p.denominationSat), [100000, 500000]);
-    });
-  });
-
-  group('relayChanged', () {
-    test('persists the relay and refreshes pools', () async {
-      when(() => saveRelay.execute(any())).thenAnswer((_) async {});
-      when(() => listPools.execute()).thenAnswer((_) async => []);
-
-      final cubit = build();
-      await cubit.relayChanged('wss://relay.example');
-
-      expect(cubit.state.relay, 'wss://relay.example');
-      verify(() => saveRelay.execute('wss://relay.example')).called(1);
-      verify(() => listPools.execute()).called(1);
-    });
-
-    test('surfaces an invalid relay without refreshing', () async {
-      when(
-        () => saveRelay.execute(any()),
-      ).thenThrow(JoinstrException(JoinstrIssue.invalidRelayUrl));
-
-      final cubit = build();
-      await cubit.relayChanged('http://not-a-relay');
-
-      expect(cubit.state.error?.issue, JoinstrIssue.invalidRelayUrl);
-      verifyNever(() => listPools.execute());
-    });
-  });
-
-  group('denominationChanged', () {
-    test('accepts BTC decimal input and rejects everything else', () {
-      final cubit = build();
-
-      cubit.denominationChanged('0.001');
-      expect(cubit.state.denominationBtc, '0.001');
-
-      cubit.denominationChanged('0.001x');
-      expect(cubit.state.denominationBtc, '0.001');
-
-      cubit.denominationChanged('');
-      expect(cubit.state.denominationBtc, '');
-    });
-  });
-
-  group('initiatePool validation', () {
-    test('rejects an out-of-range config before calling the usecase', () async {
-      final cubit = await loadedCubit();
-      cubit.peersChanged('1'); // below the 2-peer minimum
-
+      // no coin selected
       await cubit.initiatePool();
-
-      expect(cubit.state.status, JoinstrStatus.error);
       expect(cubit.state.error?.issue, JoinstrIssue.invalidPoolConfig);
       verifyNever(
         () => initiatePool.execute(
@@ -269,12 +160,14 @@ void main() {
           denominationSat: any(named: 'denominationSat'),
           peers: any(named: 'peers'),
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          inputOutpoint: any(named: 'inputOutpoint'),
           maxDuration: any(named: 'maxDuration'),
         ),
       );
     });
 
-    test('converts the BTC input to satoshis for the usecase', () async {
+    test('derives the denomination from the coin and advances the round '
+        'through the progress stream', () async {
       final cubit = await loadedCubit();
       when(
         () => initiatePool.execute(
@@ -282,115 +175,79 @@ void main() {
           denominationSat: any(named: 'denominationSat'),
           peers: any(named: 'peers'),
           feeRateSatPerVb: any(named: 'feeRateSatPerVb'),
+          inputOutpoint: any(named: 'inputOutpoint'),
           maxDuration: any(named: 'maxDuration'),
         ),
-      ).thenAnswer((_) async => 'txid-abc');
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.outputRegistration),
+          JoinstrProgress(step: JoinstrRoundStep.done, txId: 'txid-abc'),
+        ]),
+      );
 
-      cubit.denominationChanged('0.005');
+      cubit.selectCoin(_coin);
       await cubit.initiatePool();
 
+      // denomination = coin value (100000) - surplus (fee 1 -> 500) = 99500
       verify(
         () => initiatePool.execute(
           wallet: any(named: 'wallet'),
-          denominationSat: 500000,
+          denominationSat: 99500,
           peers: 2,
           feeRateSatPerVb: 1,
+          inputOutpoint: 'a:0',
           maxDuration: any(named: 'maxDuration'),
         ),
       ).called(1);
-      expect(cubit.state.rounds.single.status, JoinstrRoundStatus.broadcast);
-      expect(cubit.state.rounds.single.initiated, isTrue);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isBroadcast, isTrue);
+      expect(round.txId, 'txid-abc');
+      expect(round.initiated, isTrue);
     });
   });
 
   group('joinPool', () {
-    test('tracks the round to broadcast with its txid', () async {
+    test('runs the join stream to a broadcast round', () async {
       final cubit = await loadedCubit();
       when(
         () => joinPool.execute(
           wallet: any(named: 'wallet'),
           pool: any(named: 'pool'),
+          inputOutpoint: any(named: 'inputOutpoint'),
         ),
-      ).thenAnswer((_) async => 'txid-abc');
-
-      await cubit.joinPool(_pool(100000));
-
-      final round = cubit.state.rounds.single;
-      expect(round.status, JoinstrRoundStatus.broadcast);
-      expect(round.txId, 'txid-abc');
-      expect(round.initiated, isFalse);
-      expect(round.publicKey, 'pk');
-      expect(cubit.state.isRunning, isFalse);
-    });
-
-    test('marks the round failed on a JoinstrException', () async {
-      final cubit = await loadedCubit();
-      when(
-        () => joinPool.execute(
-          wallet: any(named: 'wallet'),
-          pool: any(named: 'pool'),
-        ),
-      ).thenThrow(JoinstrException(JoinstrIssue.noEligibleCoin));
-
-      await cubit.joinPool(_pool(100000));
-
-      final round = cubit.state.rounds.single;
-      expect(round.status, JoinstrRoundStatus.failed);
-      expect(round.error?.issue, JoinstrIssue.noEligibleCoin);
-      expect(cubit.state.isRunning, isFalse);
-    });
-
-    test('refuses a second round while one is waiting', () async {
-      final cubit = await loadedCubit();
-      when(
-        () => joinPool.execute(
-          wallet: any(named: 'wallet'),
-          pool: any(named: 'pool'),
-        ),
-      ).thenAnswer((_) async {
-        // While the first round is in flight, a second join and an initiate
-        // must both be no-ops: the same coin must never be offered twice.
-        await cubit.joinPool(_pool(500000));
-        await cubit.initiatePool();
-        verify(
-          () => joinPool.execute(
-            wallet: any(named: 'wallet'),
-            pool: any(named: 'pool'),
-          ),
-        ).called(1);
-        return 'txid-abc';
-      });
-
-      await cubit.joinPool(_pool(100000));
-
-      expect(cubit.state.rounds.single.txId, 'txid-abc');
-    });
-
-    test('reloads history after a broadcast', () async {
-      final cubit = await loadedCubit();
-      when(
-        () => joinPool.execute(
-          wallet: any(named: 'wallet'),
-          pool: any(named: 'pool'),
-        ),
-      ).thenAnswer((_) async => 'txid-abc');
-      when(() => getSettings.execute()).thenAnswer(
-        (_) async => const JoinstrSettings(
-          relay: 'wss://nos.lol',
-          history: [
-            JoinstrHistoryEntry(
-              amountSat: 100000,
-              txId: 'txid-abc',
-              relay: 'wss://nos.lol',
-              completedAtUnixSec: 1793500000,
-            ),
-          ],
-        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.done, txId: 'txid-join'),
+        ]),
       );
 
-      await cubit.joinPool(_pool(100000));
+      await cubit.joinPool(_pool(99500), _coin);
 
-      expect(cubit.state.history.single.txId, 'txid-abc');
+      final round = cubit.state.rounds.single;
+      expect(round.isBroadcast, isTrue);
+      expect(round.txId, 'txid-join');
+      expect(round.initiated, isFalse);
+    });
+
+    test('marks the round failed on a failed progress event', () async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+          inputOutpoint: any(named: 'inputOutpoint'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable(const [
+          JoinstrProgress(step: JoinstrRoundStep.failed, errorMessage: 'boom'),
+        ]),
+      );
+
+      await cubit.joinPool(_pool(99500), _coin);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isFailed, isTrue);
     });
   });
 }

--- a/test/features/joinstr/presentation/joinstr_cubit_test.dart
+++ b/test/features/joinstr/presentation/joinstr_cubit_test.dart
@@ -129,6 +129,21 @@ void main() {
       expect(cubit.state.error?.issue, JoinstrIssue.watchOnlyWallet);
     });
 
+    test(
+      'runs once when called concurrently, e.g. from route rebuilds',
+      () async {
+        when(
+          () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
+        ).thenAnswer((_) async => [_wallet()]);
+
+        final cubit = build();
+        await Future.wait([cubit.load(), cubit.load()]);
+
+        verify(() => getSettings.execute()).called(1);
+        verify(() => listPools.execute()).called(1);
+      },
+    );
+
     test('selects a supported testnet wallet and loads coins', () async {
       when(
         () => getWallets.execute(onlyBitcoin: any(named: 'onlyBitcoin')),
@@ -247,6 +262,67 @@ void main() {
       await cubit.joinPool(_pool(99500), _coin);
 
       final round = cubit.state.rounds.single;
+      expect(round.isFailed, isTrue);
+    });
+  });
+
+  group('round lifecycle', () {
+    Future<JoinstrCubit> joinWith(List<JoinstrProgress> updates) async {
+      final cubit = await loadedCubit();
+      when(
+        () => joinPool.execute(
+          wallet: any(named: 'wallet'),
+          pool: any(named: 'pool'),
+          inputOutpoint: any(named: 'inputOutpoint'),
+        ),
+      ).thenAnswer((_) => Stream.fromIterable(updates));
+      await cubit.joinPool(_pool(99500), _coin);
+      return cubit;
+    }
+
+    test('a late failure keeps the step the round had reached', () async {
+      final cubit = await joinWith(const [
+        JoinstrProgress(step: JoinstrRoundStep.posting),
+        JoinstrProgress(step: JoinstrRoundStep.inputRegistration),
+        JoinstrProgress(step: JoinstrRoundStep.failed, errorMessage: 'boom'),
+      ]);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isFailed, isTrue);
+      expect(round.step, JoinstrRoundStep.inputRegistration);
+    });
+
+    test('completion keeps the step the round had reached', () async {
+      final cubit = await joinWith(const [
+        JoinstrProgress(step: JoinstrRoundStep.mined),
+        JoinstrProgress(step: JoinstrRoundStep.done, txId: 'txid-abc'),
+      ]);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isBroadcast, isTrue);
+      expect(round.step, JoinstrRoundStep.mined);
+    });
+
+    test('a stream that ends without a result fails the round instead of '
+        'leaving it waiting and its coin reserved forever', () async {
+      final cubit = await joinWith(const [
+        JoinstrProgress(step: JoinstrRoundStep.outputRegistration),
+      ]);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isWaiting, isFalse);
+      expect(round.isFailed, isTrue);
+      expect(round.step, JoinstrRoundStep.outputRegistration);
+      expect(cubit.state.busyOutpoints, isEmpty);
+    });
+
+    test('done without a txid is a failure, not an empty broadcast', () async {
+      final cubit = await joinWith(const [
+        JoinstrProgress(step: JoinstrRoundStep.done),
+      ]);
+
+      final round = cubit.state.rounds.single;
+      expect(round.isBroadcast, isFalse);
       expect(round.isFailed, isTrue);
     });
   });


### PR DESCRIPTION
This pull request implements a proof of concept for Joinstr, a coinjoin protocol coordinated over Nostr. Peers combine one input each into a single transaction that pays every peer an equal-denomination output back to their own wallet.

Read more: [joinstr.xyz](https://joinstr.xyz/)

Uses the [`joinstr_flutter`](https://github.com/rust-joinstr/joinstr) bindings. Behind superuser settings, testnet only, hot BIP84 wallets only.

TODO:

- [ ] Add screenshots
- [x] Tests
