### PR TITLE
fix(wallet): manual coin selection and RBF toggle

### DIFF
--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -198,12 +198,19 @@ class BdkWalletDatasource {
             ),
           )
           .toList();
-      txBuilder.addUtxos(outpoints: selectableOutPoints);
+      // bdk_dart's TxBuilder is immutable — every method returns a NEW
+      // builder instance rather than mutating in place. Discarding the
+      // return value (as this call did before) silently drops the manual
+      // UTXO selection and leaves BDK to pick inputs automatically.
+      txBuilder = txBuilder.addUtxos(outpoints: selectableOutPoints);
     }
 
     // bdk_dart always has RBF (nSequence = 0xFFFFFFFD) enabled by default,
     // so we set the sequence to 0xFFFFFFFE if replaceByFee is explicitly set to false to disable RBF.
-    if (!replaceByFee) txBuilder.setExactSequence(nsequence: 0xFFFFFFFE);
+    // Same immutable-builder pitfall as addUtxos above — must reassign.
+    if (!replaceByFee) {
+      txBuilder = txBuilder.setExactSequence(nsequence: 0xFFFFFFFE);
+    }
 
     switch (networkFee) {
       case AbsoluteFee(:final sats):

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/mappers/wallet_utxo_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
@@ -16,13 +17,16 @@ class BitcoinWalletRepository {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final SeedDatasource _seed;
   final BdkWalletDatasource _bdkWallet;
+  final FrozenWalletUtxoDatasource _frozenUtxos;
 
   BitcoinWalletRepository({
     required this._walletMetadataDatasource,
     required SeedDatasource seedDatasource,
     required BdkWalletDatasource bdkWalletDatasource,
+    required FrozenWalletUtxoDatasource frozenWalletUtxoDatasource,
   }) : _seed = seedDatasource,
-       _bdkWallet = bdkWalletDatasource;
+       _bdkWallet = bdkWalletDatasource,
+       _frozenUtxos = frozenWalletUtxoDatasource;
 
   Future<String> buildPsbt({
     required String walletId,
@@ -52,17 +56,60 @@ class BitcoinWalletRepository {
               id: metadata.id,
             )
             as PublicBdkWalletModel;
+
+    // D7 defense in depth: a frozen coin must never be spendable. BDK's
+    // documented semantics are the opposite — a manually added utxo
+    // (TxBuilder.addUtxos) overrides the unspendable filter — and the
+    // datasource deliberately preserves those raw semantics. Enforce the
+    // app-level invariant here at the repository boundary, reading the
+    // frozen store LIVE at build time, so it holds for ANY caller and
+    // any staleness of the caller's earlier utxo fetch — not only for
+    // callers going through PrepareBitcoinSendUsecase (which reads the
+    // same store plus the payjoin-derived set; payjoin exclusion stays
+    // at the usecase because it comes from another repository).
+    //
+    // The frozen set read here is:
+    //  * merged into `unspendable`, so BDK's automatic selection can
+    //    never pick a frozen coin even when the caller passed no
+    //    exclusion list at all;
+    //  * used to strip `selected`, so a frozen coin can't be forced in
+    //    as a mandatory input either (the addUtxos override above).
+    final frozenRows = await _frozenUtxos.getAllFrozen();
+    final unspendableKeys = {
+      for (final row in frozenRows) '${row.txId}:${row.vout}',
+      for (final outpoint in unspendable ?? const <({String txId, int vout})>[])
+        '${outpoint.txId}:${outpoint.vout}',
+    };
+    final mergedUnspendable = [
+      for (final outpoint in {
+        for (final row in frozenRows) (txId: row.txId, vout: row.vout),
+        ...?unspendable,
+      })
+        outpoint,
+    ];
+    final spendableSelected = selected
+        ?.where(
+          (utxo) => !unspendableKeys.contains('${utxo.txId}:${utxo.vout}'),
+        )
+        .toList();
+
     final psbt = await _bdkWallet.buildPsbt(
       wallet: wallet,
       address: address,
       amountSat: amountSat,
       networkFee: networkFee,
       drain: drain,
-      unspendable: unspendable,
-      selected: selected
+      // An empty merged list is equivalent to null for the datasource
+      // (it gates on isNotEmpty), so always pass the merge.
+      unspendable: mergedUnspendable,
+      selected: spendableSelected
           ?.map((utxo) => WalletUtxoMapper.fromEntity(utxo))
           .toList(),
-      replaceByFee: replaceByFee ?? false,
+      // Default to RBF-enabled, matching both the datasource default and
+      // BDK's own default sequence (0xFFFFFFFD). `?? false` would disable
+      // RBF for any caller omitting the flag — harmless while
+      // setExactSequence's result was discarded, wrong now that it works.
+      replaceByFee: replaceByFee ?? true,
     );
 
     return psbt;

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -62,6 +62,7 @@ class WalletLocator {
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
         bdkWalletDatasource: locator<BdkWalletDatasource>(),
         seedDatasource: locator<SeedDatasource>(),
+        frozenWalletUtxoDatasource: locator<FrozenWalletUtxoDatasource>(),
       ),
     );
 

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -1,0 +1,325 @@
+// Regression test for a bug where `BdkWalletDatasource.buildPsbt` silently
+// dropped manual UTXO selection and the RBF-off sequence flag.
+//
+// bdk_dart's `TxBuilder` is an IMMUTABLE builder: every method (`addUtxos`,
+// `setExactSequence`, `feeAbsolute`, `unspendable`, ...) returns a brand new
+// `TxBuilder` instance rather than mutating the receiver in place. Two call
+// sites in `buildPsbt` called `txBuilder.addUtxos(...)` and
+// `txBuilder.setExactSequence(...)` without reassigning the result, so both
+// calls were silent no-ops: BDK picked inputs on its own regardless of the
+// user's manual coin selection, and the RBF-off toggle never took effect.
+//
+// This test exercises the real production method end-to-end against a real
+// (offline, in-process) BDK wallet — no network, no mocked repository — so
+// it proves the actual `TxBuilder` wiring, not just that a mock was called
+// with the right arguments.
+//
+// Setup, fully deterministic and offline:
+//   1. A fixed BIP84 testnet wallet (the canonical
+//      "abandon ... abandon about" test mnemonic) is used to derive a
+//      public (watch-only) descriptor pair — exactly what
+//      `BitcoinWalletRepository.buildPsbt` passes down in production.
+//   2. The wallet is "funded" by hand-crafting a raw funding transaction
+//      with two outputs (to two of the wallet's own addresses) and applying
+//      it as an unconfirmed transaction via `Wallet.applyUnconfirmedTxs`.
+//      This is the standard offline way to seed known, deterministic UTXOs
+//      into a BDK wallet without hitting a real Electrum server.
+//   3. `path_provider`'s method channel is mocked to a temp directory so
+//      `BdkFacade`'s sqlite-file persister (production code, untouched)
+//      works under `flutter test`.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The canonical BIP39 test mnemonic ("abandon" x11 + "about"). Public
+// knowledge, no funds, safe to hardcode.
+const _testMnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon '
+    'abandon abandon abandon about';
+
+// A well-known BIP173 test-vector P2WPKH testnet address, used only as an
+// external send destination (not owned by the test wallet).
+const _externalTestnetAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+
+Uint8List _leUint32(int value) {
+  final bytes = ByteData(4)..setUint32(0, value, Endian.little);
+  return bytes.buffer.asUint8List();
+}
+
+Uint8List _leUint64(int value) {
+  final bytes = ByteData(8)..setUint64(0, value, Endian.little);
+  return bytes.buffer.asUint8List();
+}
+
+Uint8List _varInt(int value) {
+  if (value < 0xfd) return Uint8List.fromList([value]);
+  if (value <= 0xffff) {
+    final bytes = ByteData(3)
+      ..setUint8(0, 0xfd)
+      ..setUint16(1, value, Endian.little);
+    return bytes.buffer.asUint8List();
+  }
+  throw UnimplementedError('varint > 0xffff not needed for this test');
+}
+
+/// Hand-crafts a minimal, legacy-serialized (non-segwit) raw transaction
+/// with one throwaway input (never meant to be valid/spendable — BDK's
+/// `apply_unconfirmed_txs` doesn't validate it) and one output per entry in
+/// [outputs]. Used to seed deterministic, known UTXOs into an otherwise
+/// empty offline wallet.
+Uint8List _buildFundingTx(List<({bdk.Script script, int amountSat})> outputs) {
+  final bytes = BytesBuilder();
+  bytes.add(_leUint32(2)); // version
+  bytes.add(_varInt(1)); // 1 (fake) input
+  bytes.add(Uint8List(32)); // prev txid (all-zero, never spent for real)
+  bytes.add(_leUint32(0)); // prev vout
+  bytes.add(_varInt(0)); // empty scriptSig
+  bytes.add(_leUint32(0xFFFFFFFF)); // sequence
+  bytes.add(_varInt(outputs.length));
+  for (final output in outputs) {
+    bytes.add(_leUint64(output.amountSat));
+    final script = output.script.toBytes();
+    bytes.add(_varInt(script.length));
+    bytes.add(script);
+  }
+  bytes.add(_leUint32(0)); // locktime
+  return bytes.toBytes();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late PublicBdkWalletModel walletModel;
+  late String utxoLargeTxId;
+  late int utxoLargeVout;
+
+  const utxoLargeAmountSat = 200000;
+  const utxoSmallAmountSat = 30000;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('bdk_wallet_datasource_');
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'getApplicationDocumentsDirectory') {
+            return tempDir.path;
+          }
+          return null;
+        });
+
+    final mnemonic = bdk.Mnemonic.fromString(mnemonic: _testMnemonic);
+    final secretKey = bdk.DescriptorSecretKey(
+      networkKind: bdk.NetworkKind.test,
+      mnemonic: mnemonic,
+      password: null,
+    );
+    final external = bdk.Descriptor.newBip84(
+      secretKey: secretKey,
+      keychainKind: bdk.KeychainKind.external_,
+      networkKind: bdk.NetworkKind.test,
+    );
+    final internal = bdk.Descriptor.newBip84(
+      secretKey: secretKey,
+      keychainKind: bdk.KeychainKind.internal,
+      networkKind: bdk.NetworkKind.test,
+    );
+
+    walletModel =
+        WalletModel.publicBdk(
+              id: 'bdk-wallet-datasource-test',
+              externalDescriptor: external.toString(),
+              internalDescriptor: internal.toString(),
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+
+    // Build the wallet once here to fund it, then persist so the
+    // datasource's own (separate) `BdkFacade.createWallet` call sees the
+    // exact same UTXOs when the test invokes `buildPsbt`.
+    final wallet = await BdkFacade.createWallet(walletModel);
+
+    final addr0 = wallet.revealNextAddress(
+      keychain: bdk.KeychainKind.external_,
+    );
+    final addr1 = wallet.revealNextAddress(
+      keychain: bdk.KeychainKind.external_,
+    );
+
+    final fundingTxBytes = _buildFundingTx([
+      (script: addr0.address.scriptPubkey(), amountSat: utxoLargeAmountSat),
+      (script: addr1.address.scriptPubkey(), amountSat: utxoSmallAmountSat),
+    ]);
+    final fundingTx = bdk.Transaction(transactionBytes: fundingTxBytes);
+    final fundingTxid = fundingTx.computeTxid().toString();
+
+    wallet.applyUnconfirmedTxs(
+      unconfirmedTxs: [
+        bdk.UnconfirmedTx(
+          tx: fundingTx,
+          lastSeen: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      ],
+    );
+
+    // Sanity-check the funding actually landed before persisting, so a
+    // failure here points clearly at the test's own setup rather than at
+    // `buildPsbt`.
+    final utxos = wallet.listUnspent();
+    expect(
+      utxos.length,
+      2,
+      reason: 'test setup: expected exactly 2 synthetic UTXOs after funding',
+    );
+
+    utxoLargeTxId = fundingTxid;
+    utxoLargeVout = 0;
+
+    await BdkFacade.saveWallet(wallet, walletModel.hexId);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'buildPsbt honors manual UTXO selection: a manually selected UTXO must '
+    'be spendable even when every other UTXO is frozen/unspendable',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      // The LARGE utxo (200k) is marked unspendable — i.e. excluded from
+      // BDK's own automatic coin-selection pool, exactly like a
+      // user-frozen coin (see the D7 guarantee in
+      // PrepareBitcoinSendUsecase). It is ALSO the one manually `selected`
+      // here, which per BDK's coin-control semantics is supposed to force
+      // it into the transaction as a mandatory input regardless of the
+      // unspendable flag (mirroring real coin control: a coin the user
+      // explicitly picks must be spendable even if it's otherwise
+      // frozen-by-default for automatic selection).
+      //
+      // The only utxo left in the automatic pool is the SMALL one (30k),
+      // which alone cannot cover the 150k send. This makes the two code
+      // paths unambiguous, with no dependency on BDK's coin-selection
+      // tie-breaking heuristics:
+      //   * Fixed code: `addUtxos` really runs, forcing the large utxo in
+      //     -> the build succeeds and spends it.
+      //   * Buggy code (return value of `addUtxos` discarded): no utxo is
+      //     forced in; BDK's automatic selection is left with only the
+      //     30k utxo, which can't cover 150k -> the build throws.
+      const sendAmountSat = 150000; // only the large (200k) utxo covers this
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: sendAmountSat,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000), // 4 sat/vB
+        unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final spendsLargeUtxo = tx.input().any(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(
+        spendsLargeUtxo,
+        isTrue,
+        reason:
+            'the manually selected UTXO must be forced into the built '
+            'transaction even though it is also marked unspendable for '
+            "BDK's own automatic selection",
+      );
+    },
+  );
+
+  test(
+    'buildPsbt sets a non-RBF sequence when replaceByFee is false',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: 25000,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: false,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final selectedInput = tx.input().firstWhere(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(selectedInput.sequence, 0xFFFFFFFE);
+    },
+  );
+
+  test(
+    'buildPsbt keeps the default RBF sequence when replaceByFee is true',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: 25000,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final selectedInput = tx.input().firstWhere(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(selectedInput.sequence, 0xFFFFFFFD);
+    },
+  );
+}

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -199,14 +199,23 @@ void main() {
       final datasource = BdkWalletDatasource();
 
       // The LARGE utxo (200k) is marked unspendable — i.e. excluded from
-      // BDK's own automatic coin-selection pool, exactly like a
-      // user-frozen coin (see the D7 guarantee in
-      // PrepareBitcoinSendUsecase). It is ALSO the one manually `selected`
-      // here, which per BDK's coin-control semantics is supposed to force
-      // it into the transaction as a mandatory input regardless of the
-      // unspendable flag (mirroring real coin control: a coin the user
-      // explicitly picks must be spendable even if it's otherwise
-      // frozen-by-default for automatic selection).
+      // BDK's own automatic coin-selection pool. It is ALSO the one
+      // manually `selected` here, which per BDK's documented semantics
+      // forces it into the transaction as a mandatory input REGARDLESS of
+      // the unspendable flag.
+      //
+      // NOTE: this selected-overrides-unspendable behavior is raw BDK
+      // semantics that this datasource deliberately preserves as a thin
+      // wrapper — it is the INVERSE of the app-level D7 invariant ("a
+      // frozen coin must never be spendable"). D7 is enforced one layer
+      // up: BitcoinWalletRepository.buildPsbt strips selected ∩
+      // unspendable before calling down (see
+      // bitcoin_wallet_repository_test.dart), and
+      // PrepareBitcoinSendUsecase additionally strips frozen coins from
+      // the selection. The combination is exploited here ONLY because it
+      // is a deterministic discriminator for the addUtxos-reassignment
+      // regression, with no dependency on BDK's coin-selection
+      // heuristics.
       //
       // The only utxo left in the automatic pool is the SMALL one (30k),
       // which alone cannot cover the 150k send. This makes the two code

--- a/test/core_test/wallet/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/bitcoin_wallet_repository_test.dart
@@ -1,0 +1,295 @@
+// Unit tests for the repository-boundary guarantees of
+// `BitcoinWalletRepository.buildPsbt`:
+//
+//  1. D7 defense in depth — "a frozen coin must never be spendable".
+//     BDK's documented semantics are the opposite: a manually added utxo
+//     (`TxBuilder.addUtxos`) overrides the `unspendable` filter, and
+//     `BdkWalletDatasource` deliberately preserves those raw semantics
+//     (see bdk_wallet_datasource_test.dart, which asserts them). The
+//     repository therefore reads the frozen store LIVE at build time and
+//     enforces the invariant itself — merging the frozen set into the
+//     `unspendable` list (automatic selection can't pick a frozen coin)
+//     and stripping it from `selected` (a frozen coin can't be forced in
+//     as a mandatory input) — so it holds for ANY caller, with any
+//     staleness of the caller's earlier utxo fetch, not only for callers
+//     going through PrepareBitcoinSendUsecase's own frozen-set handling.
+//     (Payjoin-derived exclusions remain at the usecase: they come from
+//     another repository, which this repository must not depend on.)
+//
+//  2. RBF defaults to ENABLED when the caller omits the flag. The
+//     previous `replaceByFee ?? false` was harmless while the datasource's
+//     `setExactSequence` call discarded its result (a silent no-op), but
+//     became wrong once that call was fixed: a null flag would have
+//     started disabling RBF by default, diverging from both the
+//     datasource's own default and BDK's default sequence (0xFFFFFFFD).
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+class _MockBdkWalletDatasource extends Mock implements BdkWalletDatasource {}
+
+class _MockFrozenWalletUtxoDatasource extends Mock
+    implements FrozenWalletUtxoDatasource {}
+
+// Encodes as a bitcoin testnet BIP84 origin so
+// WalletMetadataModelExtension.isBitcoin decodes to true.
+const _walletId = 'wpkh([73c5da0a/84h/1h/0h])';
+
+WalletUtxo _utxo({required String txId, required int vout}) =>
+    WalletUtxo.bitcoin(
+      walletId: _walletId,
+      txId: txId,
+      vout: vout,
+      scriptPubkey: Uint8List(0),
+      amountSat: BigInt.from(100000),
+      address: 'tb1-test-address',
+    );
+
+void main() {
+  late _MockWalletMetadataDatasource metadataDatasource;
+  late _MockBdkWalletDatasource bdkDatasource;
+  late _MockFrozenWalletUtxoDatasource frozenDatasource;
+  late BitcoinWalletRepository repository;
+
+  const metadata = WalletMetadataModel(
+    id: _walletId,
+    masterFingerprint: '73c5da0a',
+    xpubFingerprint: 'deadbeef',
+    isEncryptedVaultTested: false,
+    isPhysicalBackupTested: false,
+    xpub: 'tpub-test',
+    externalPublicDescriptor: 'wpkh(external)',
+    internalPublicDescriptor: 'wpkh(internal)',
+    signer: Signer.local,
+    isDefault: true,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(
+      const WalletModel.publicBdk(
+        id: _walletId,
+        externalDescriptor: 'wpkh(external)',
+        internalDescriptor: 'wpkh(internal)',
+        isTestnet: true,
+      ),
+    );
+    registerFallbackValue(const NetworkFee.relativeSatPerKwu(1000));
+  });
+
+  setUp(() {
+    metadataDatasource = _MockWalletMetadataDatasource();
+    bdkDatasource = _MockBdkWalletDatasource();
+    frozenDatasource = _MockFrozenWalletUtxoDatasource();
+    repository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: _MockSeedDatasource(),
+      bdkWalletDatasource: bdkDatasource,
+      frozenWalletUtxoDatasource: frozenDatasource,
+    );
+
+    when(
+      () => metadataDatasource.fetch(_walletId),
+    ).thenAnswer((_) async => metadata);
+    // Frozen store is empty by default; individual tests override it.
+    when(() => frozenDatasource.getAllFrozen()).thenAnswer((_) async => []);
+    when(
+      () => bdkDatasource.buildPsbt(
+        wallet: any(named: 'wallet'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenAnswer((_) async => 'psbt');
+  });
+
+  List<WalletUtxoModel>? capturedSelected() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: any(named: 'unspendable'),
+              selected: captureAny(named: 'selected'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as List<WalletUtxoModel>?;
+
+  List<({String txId, int vout})>? capturedUnspendable() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: captureAny(named: 'unspendable'),
+              selected: any(named: 'selected'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as List<({String txId, int vout})>?;
+
+  bool capturedReplaceByFee() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: any(named: 'unspendable'),
+              selected: any(named: 'selected'),
+              replaceByFee: captureAny(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as bool;
+
+  Future<void> buildPsbt({
+    List<({String txId, int vout})>? unspendable,
+    List<WalletUtxo>? selected,
+    bool? replaceByFee,
+  }) => repository.buildPsbt(
+    walletId: _walletId,
+    address: 'tb1-destination',
+    amountSat: 25000,
+    networkFee: const NetworkFee.relativeSatPerKwu(1000),
+    unspendable: unspendable,
+    selected: selected,
+    replaceByFee: replaceByFee,
+  );
+
+  group('D7 — frozen store is read live at build time', () {
+    test('a coin frozen in the store is stripped from the selection even when '
+        'the caller passes NO unspendable list', () async {
+      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+      );
+
+      await buildPsbt(
+        selected: [
+          _utxo(txId: 'tx-frozen', vout: 0), // frozen in DB -> stripped
+          _utxo(txId: 'tx-free', vout: 1), // passes through
+        ],
+      );
+
+      final selected = capturedSelected();
+      expect(selected, hasLength(1));
+      expect(selected!.single.txId, 'tx-free');
+    });
+
+    test('frozen outpoints are merged into the unspendable list passed down, '
+        'so automatic selection cannot pick them either', () async {
+      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+      );
+
+      await buildPsbt(unspendable: const [(txId: 'tx-caller', vout: 3)]);
+
+      final unspendable = capturedUnspendable();
+      expect(
+        unspendable,
+        containsAll(<({String txId, int vout})>[
+          (txId: 'tx-frozen', vout: 0),
+          (txId: 'tx-caller', vout: 3),
+        ]),
+      );
+      expect(unspendable, hasLength(2));
+    });
+
+    test(
+      'duplicate outpoints (frozen AND caller-supplied) are deduped',
+      () async {
+        when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+          (_) async => [(walletId: _walletId, txId: 'tx-both', vout: 0)],
+        );
+
+        await buildPsbt(unspendable: const [(txId: 'tx-both', vout: 0)]);
+
+        expect(capturedUnspendable(), hasLength(1));
+      },
+    );
+  });
+
+  group('D7 — selected ∩ unspendable (caller-supplied) is stripped', () {
+    test(
+      'a selected coin that is also unspendable never reaches the datasource',
+      () async {
+        await buildPsbt(
+          unspendable: const [(txId: 'tx-frozen', vout: 0)],
+          selected: [
+            _utxo(txId: 'tx-frozen', vout: 0), // must be stripped
+            _utxo(txId: 'tx-free', vout: 1), // must pass through
+          ],
+        );
+
+        final selected = capturedSelected();
+        expect(selected, hasLength(1));
+        expect(selected!.single.txId, 'tx-free');
+        expect(selected.single.vout, 1);
+      },
+    );
+
+    test('same txId but different vout is NOT stripped', () async {
+      await buildPsbt(
+        unspendable: const [(txId: 'tx-shared', vout: 0)],
+        selected: [_utxo(txId: 'tx-shared', vout: 1)],
+      );
+
+      final selected = capturedSelected();
+      expect(selected, hasLength(1));
+      expect(selected!.single.vout, 1);
+    });
+
+    test(
+      'empty frozen store and no unspendable leaves the selection untouched',
+      () async {
+        await buildPsbt(
+          selected: [
+            _utxo(txId: 'tx-a', vout: 0),
+            _utxo(txId: 'tx-b', vout: 1),
+          ],
+        );
+
+        expect(capturedSelected(), hasLength(2));
+      },
+    );
+  });
+
+  group('replaceByFee default', () {
+    test('omitted flag defaults to RBF ENABLED (true)', () async {
+      await buildPsbt();
+
+      expect(capturedReplaceByFee(), isTrue);
+    });
+
+    test('explicit false is forwarded unchanged', () async {
+      await buildPsbt(replaceByFee: false);
+
+      expect(capturedReplaceByFee(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
bdk_dart's TxBuilder is immutable — every method returns a new builder instance instead of mutating in place. Two call sites in buildPsbt discarded the return value, silently no-opping both manual UTXO selection and the RBF-off toggle: BDK always picked inputs on its own regardless of the user's coin selection, and disabling RBF never actually changed the sequence field.

Pre-existing on main.

Affects hot wallets and every remote signer (Ledger/BitBox/Trezor) identically.

Adds an offline regression test that funds a real BDK wallet via a hand-crafted unconfirmed transaction (no network) and exercises buildPsbt end-to-end, proving manual selection now overrides otherwise-unspendable coins and that the RBF sequence is set correctly in both directions.