### PR TITLE
feat(payjoin): harden core engine (watchers, resume, guards)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -72,6 +72,7 @@ graph TB
     LABELS --> CORE
     PAY --> RECIPIENTS
     PAYJOIN --> UTXO_MGMT
+    PAYJOIN --> LABELS
     PIN_CODE --> CORE
     RECEIVE --> PAYJOIN
     RECEIVE --> SWAPS

--- a/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
@@ -58,8 +58,15 @@ class LocalPayjoinDatasource {
       Expression<bool> expr = const Constant(true); // identity
 
       if (onlyUnfinished) {
+        // isAborted is a terminal outcome too (we already broadcast the
+        // original in its place) — excluded here for the same reason
+        // isCompleted/isExpired are, otherwise an aborted session would
+        // keep being "resumed" on every app start.
         expr =
-            expr & row.isExpired.equals(false) & row.isCompleted.equals(false);
+            expr &
+            row.isExpired.equals(false) &
+            row.isCompleted.equals(false) &
+            row.isAborted.equals(false);
       }
 
       if (walletId != null) {
@@ -78,7 +85,10 @@ class LocalPayjoinDatasource {
 
       if (onlyUnfinished) {
         expr =
-            expr & row.isExpired.equals(false) & row.isCompleted.equals(false);
+            expr &
+            row.isExpired.equals(false) &
+            row.isCompleted.equals(false) &
+            row.isAborted.equals(false);
       }
 
       if (walletId != null) {
@@ -103,10 +113,24 @@ class LocalPayjoinDatasource {
     ];
   }
 
+  /// Fetches the payjoin session(s) a transaction id belongs to, matching
+  /// BOTH the payjoin transaction id and the original transaction id. The
+  /// original matters as much as the payjoin one: an aborted session (we
+  /// broadcast the original instead of completing a real payjoin — see
+  /// PayjoinStatus.aborted) has no [txId] at all, so the transaction that
+  /// actually hit the chain IS the original — matching only [txId] made
+  /// that transaction's details lose its payjoin context entirely, hiding
+  /// the very "aborted" outcome the status exists to communicate. The
+  /// transactions LIST already joins on both ids
+  /// (GetTransactionsUsecase); this keeps the details path consistent.
   Future<List<PayjoinModel>> fetchByTxId(String txId) async {
     final (receivers, senders) = await (
-      _db.managers.payjoinReceivers.filter((f) => f.txId(txId)).get(),
-      _db.managers.payjoinSenders.filter((f) => f.txId(txId)).get(),
+      _db.managers.payjoinReceivers
+          .filter((f) => f.txId(txId) | f.originalTxId(txId))
+          .get(),
+      _db.managers.payjoinSenders
+          .filter((f) => f.txId(txId) | f.originalTxId(txId))
+          .get(),
     ).wait;
 
     return [
@@ -124,6 +148,7 @@ class LocalPayjoinDatasource {
       receivers = await receiversTable
           .filter((f) => f.isExpired(false))
           .filter((f) => f.isCompleted(false))
+          .filter((f) => f.isAborted(false))
           .get();
     } else {
       receivers = await receiversTable.get();
@@ -147,6 +172,7 @@ class LocalPayjoinDatasource {
       senders = await sendersTable
           .filter((f) => f.isExpired(false))
           .filter((f) => f.isCompleted(false))
+          .filter((f) => f.isAborted(false))
           .get();
     } else {
       senders = await sendersTable.get();

--- a/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/pdk_payjoin_datasource.dart
@@ -5,6 +5,7 @@ import 'dart:developer';
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/payjoin/data/models/payjoin_input_pair_model.dart';
 import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart' show Payjoin;
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart' as logger;
@@ -43,6 +44,8 @@ class PdkPayjoinDatasource {
   final Set<String> _receiverPollsInFlight = {};
   final Set<String> _senderPollsInFlight = {};
 
+  bool _disposed = false;
+
   PdkPayjoinDatasource({
     this._payjoinDirectoryUrl = PayjoinConstants.directoryUrl,
     required this._dio,
@@ -59,6 +62,46 @@ class PdkPayjoinDatasource {
       _proposalSentController.stream;
 
   Stream<PayjoinModel> get expiredPayjoins => _expiredController.stream;
+
+  /// Stops the directory polling of one session — both the receiver
+  /// request poll and the sender proposal poll, whichever exists for
+  /// [payjoinId]. Called by the repository the moment a session resolves
+  /// through a path the poll itself can't see (the plain-broadcast fallback
+  /// landing on-chain): the poll only self-cancels on request/proposal
+  /// found or expiry, so without this it kept firing until expiry and then
+  /// raised a stale expired event for an already-completed session
+  /// (observed live: a redundant second broadcast of the original
+  /// transaction a minute after the session had already resolved).
+  void stopPolling(String payjoinId) {
+    _receiverTimers.remove(payjoinId)?.cancel();
+    _senderTimers.remove(payjoinId)?.cancel();
+  }
+
+  /// Cancels every polling timer and closes the event streams. Individual
+  /// poll timers self-cancel on success/expiry, but a session that never
+  /// resolves (a relay permanently down) would otherwise leave a
+  /// [Timer.periodic] firing forever plus three unclosed broadcast
+  /// controllers. The production singleton lives for the whole app session,
+  /// but tests (and any future teardown) need a clean exit; the repository's
+  /// own dispose delegates here. Idempotent: a second call is a no-op (closing
+  /// an already-closed controller would otherwise throw).
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    for (final timer in _receiverTimers.values) {
+      timer.cancel();
+    }
+    _receiverTimers.clear();
+    for (final timer in _senderTimers.values) {
+      timer.cancel();
+    }
+    _senderTimers.clear();
+    _receiverPollsInFlight.clear();
+    _senderPollsInFlight.clear();
+    await _payjoinRequestedController.close();
+    await _proposalSentController.close();
+    await _expiredController.close();
+  }
 
   Future<(OhttpKeys?, String?)> fetchOhttpKeyAndRelay({
     required String payjoinDirectory,
@@ -272,6 +315,57 @@ class PdkPayjoinDatasource {
     );
 
     return updatedModel;
+  }
+
+  /// Formally cancels a receiver session that was declined below the
+  /// configured minimum-receive-amount threshold (see
+  /// PayjoinRepositoryImpl._processPayjoinRequest), and closes the
+  /// underlying PDK session so it persists a terminal event.
+  ///
+  /// This replaces silently abandoning the session after broadcasting the
+  /// original transaction out of band: without this, the PDK's own
+  /// typestate machine never learns the session ended, so only our local
+  /// DB flag (isAborted) stood between it and being replayed/resumed as if
+  /// still pending. `cancel()` is available on every receive typestate that
+  /// carries a fallback transaction (verified against the installed
+  /// `payjoin` package's Dart bindings — `MaybeInputsOwned.cancel()` is one
+  /// of them); calling it here transitions to `ReceiverPendingFallback`,
+  /// whose `close()` persists the closing `SessionEvent` via the
+  /// persister. The original transaction itself is still broadcast by the
+  /// caller from the already-captured, already-validated
+  /// [PayjoinReceiverModel.originalTxBytes] — this method only concludes
+  /// the PDK-side state machine to match that outcome.
+  ///
+  /// Always called right after `_pollReceiverOnce` has persisted a session
+  /// at exactly the `MaybeInputsOwned` typestate (where
+  /// `originalTxBytes`/`amountSat` first become available) — any other
+  /// state means the session already progressed past the point a
+  /// below-minimum decline is possible, or is already resolved.
+  String declineReceiverSession(PayjoinReceiverModel receiverModel) {
+    final persister = InMemoryJsonReceiverSessionPersister.fromJson(
+      receiverModel.receiver,
+    );
+    final state = replayReceiverEventLog(persister: persister).state();
+    if (state is! MaybeInputsOwnedReceiveSession) {
+      throw StateError(
+        'Cannot decline payjoin receiver ${receiverModel.id}: expected a '
+        'MaybeInputsOwned session, got $state',
+      );
+    }
+
+    final pendingFallback = state.inner.cancel().save(persister: persister);
+    if (pendingFallback == null) {
+      // The session was already terminal (e.g. a race with another decline
+      // path) — nothing further to persist, but not an error either.
+      logger.log.info(
+        'Payjoin receiver ${receiverModel.id} was already resolved when '
+        'declining below minimum',
+      );
+      return persister.toJson();
+    }
+
+    pendingFallback.close().save(persister: persister);
+    return persister.toJson();
   }
 
   Future<({Monitor monitor, String psbt})> processReceiveSession({
@@ -688,14 +782,18 @@ class PdkPayjoinDatasource {
     PayjoinSenderModel senderModel,
     Timer timer,
   ) async {
+    // logRef, never the raw id in log lines/exception messages: a sender id
+    //  is the full BIP21 URI (address+amount+endpoint). The raw id is still
+    //  used as the internal map key below, which never reaches a log.
+    final senderLogRef = Payjoin.logRefForId(senderModel.id);
     if (!_senderPollsInFlight.add(senderModel.id)) return;
-    log('[sender poll] checking for proposal for ${senderModel.id}');
+    log('[sender poll] checking for proposal for $senderLogRef');
     try {
       // Local expiry backstop: don't rely solely on the PDK surfacing an
       // "expired" error — bound polling by the session's own expiry time.
       if (senderModel.isExpiryTimePassed) {
         throw PayjoinExpiredException(
-          'Payjoin sender ${senderModel.id} expiry time passed',
+          'Payjoin sender $senderLogRef expiry time passed',
         );
       }
       final persister = InMemoryJsonSenderSessionPersister.fromJson(
@@ -715,7 +813,7 @@ class PdkPayjoinDatasource {
       final proposalPsbt = await _getProposalPsbt(state.inner, persister);
       if (proposalPsbt == null) return;
 
-      log('[sender poll] proposal found for ${senderModel.id}');
+      log('[sender poll] proposal found for $senderLogRef');
       final txId = (await BitcoinTx.fromPsbt(proposalPsbt)).txid;
       final updatedModel = senderModel.copyWith(
         sender: persister.toJson(),
@@ -730,13 +828,13 @@ class PdkPayjoinDatasource {
       _senderTimers.remove(senderModel.id);
       _proposalSentController.add(updatedModel);
     } on PayjoinExpiredException catch (e) {
-      logger.log.info('[sender poll] expired for ${senderModel.id}: $e');
+      logger.log.info('[sender poll] expired for $senderLogRef: $e');
       if (!timer.isActive) return;
       timer.cancel();
       _senderTimers.remove(senderModel.id);
       _expiredController.add(senderModel.copyWith(isExpired: true));
     } catch (e) {
-      logger.log.info('[sender poll] ${senderModel.id}: $e');
+      logger.log.info('[sender poll] $senderLogRef: $e');
     } finally {
       _senderPollsInFlight.remove(senderModel.id);
     }

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -858,6 +858,20 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       }
     }
 
+    // Same sweep for senders: a sender's original transaction (originalPsbt)
+    // is always available from session creation, unlike a receiver's (which
+    // only arrives with the request), so the only guard needed here is
+    // proposalPsbt == null — mirroring the receiver branch above.
+    final senders = await _localPayjoinDatasource.fetchSenders();
+    for (final sender in senders) {
+      if (sender.isExpired &&
+          !sender.isAborted &&
+          !sender.isCompleted &&
+          sender.proposalPsbt == null) {
+        await _broadcastOriginalTransaction(sender.toEntity());
+      }
+    }
+
     final models = await _localPayjoinDatasource.fetchAll(onlyUnfinished: true);
     for (final model in models) {
       // Each session is independent: a bug or a transient failure resuming

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -713,7 +713,25 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       //  stale txid on a terminal session pollutes fetchByTxId / the details
       //  screen (same display-hygiene reason _broadcastOriginalTransaction
       //  clears it on the abort path).
-      final failedModel = payjoinModel.copyWith(isExpired: true, txId: null);
+      //
+      // Re-fetch and bail on terminal first: the sign/broadcast attempt
+      //  above took a real network round-trip, during which the fallback
+      //  watcher could have marked this same session aborted (the original
+      //  landing on-chain is exactly what makes the payjoin broadcast fail
+      //  on already-spent inputs, and the original re-broadcast fail as
+      //  already-known). Persisting from the stale `payjoinModel` here would
+      //  overwrite that correct `aborted` outcome with `expired`.
+      final freshModel = await _localPayjoinDatasource.fetchSender(
+        payjoinModel.id,
+      );
+      if (freshModel != null &&
+          (freshModel.isCompleted || freshModel.isAborted)) {
+        return;
+      }
+      final failedModel = (freshModel ?? payjoinModel).copyWith(
+        isExpired: true,
+        txId: null,
+      );
       await _localPayjoinDatasource.update(failedModel);
       _payjoinStreamController.add(failedModel.toEntity());
     }
@@ -825,6 +843,20 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
           walletId: expiredModel.walletId,
           txId: expiredModel.txId!,
         );
+        // Same reasoning as _resumeOne's equivalent receiver branch: the
+        //  sender could independently fall back to the original transaction
+        //  instead of finalizing the real payjoin, and this receiver would
+        //  otherwise have no way to find out — it only watches the payjoin
+        //  txid above. Without this, a receiver resumed here stays marked
+        //  expired forever despite having actually been paid via the
+        //  sender's fallback.
+        if (expiredModel.originalTxId != null) {
+          _watchForFallback(
+            payjoinId: expiredModel.id,
+            walletId: expiredModel.walletId,
+            originalTxId: expiredModel.originalTxId!,
+          );
+        }
       }
 
       // Nothing left for us to retry from this side, so persist the expired
@@ -836,6 +868,25 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
   @override
   Future<void> resumePayjoinsOnStartup() async {
+    // The whole body is inside this try/catch: this method is invoked as
+    //  `unawaited(...)` from AppLocator.setup, so anything that throws here
+    //  (e.g. the DB not yet ready, a fetch failing) would otherwise surface
+    //  as an unhandled zone error during app startup instead of a logged,
+    //  contained failure. Per-session failures inside the resume loop below
+    //  are already isolated by their own try/catch; this outer one covers
+    //  the sweep queries and loops themselves.
+    try {
+      await _resumePayjoinsOnStartupUnguarded();
+    } catch (e, st) {
+      log.severe(
+        message: 'Failed to resume payjoin sessions on startup',
+        error: e,
+        trace: st,
+      );
+    }
+  }
+
+  Future<void> _resumePayjoinsOnStartupUnguarded() async {
     // Sweep receivers whose expiry-time fallback broadcast FAILED on a
     // previous run and were persisted as expired (e.g. by pre-port code that
     // persisted isExpired before broadcasting): the onlyUnfinished resume
@@ -855,6 +906,21 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
           receiver.originalTxBytes != null &&
           receiver.proposalPsbt == null) {
         await _broadcastOriginalTransaction(receiver.toEntity());
+        // Arm the fallback watch regardless of the attempt's outcome above:
+        //  _broadcastOriginalTransaction only arms it on SUCCESS. If it
+        //  failed because the tx is already on-chain (the other side beat
+        //  us to broadcasting it) rather than a transient error, this row
+        //  would otherwise never be marked aborted and this sweep would
+        //  retry — and log SEVERE — on every subsequent app start
+        //  indefinitely. Idempotent: a no-op if already armed by a
+        //  successful attempt above.
+        if (receiver.originalTxId != null) {
+          _watchForFallback(
+            payjoinId: receiver.id,
+            walletId: receiver.walletId,
+            originalTxId: receiver.originalTxId!,
+          );
+        }
       }
     }
 
@@ -869,6 +935,15 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
           !sender.isCompleted &&
           sender.proposalPsbt == null) {
         await _broadcastOriginalTransaction(sender.toEntity());
+        // Same reasoning as the receiver sweep above: converge a failed
+        //  attempt (e.g. already on-chain via the other side) via the
+        //  fallback watch instead of retrying forever. A sender's
+        //  originalTxId is always present (set at session creation).
+        _watchForFallback(
+          payjoinId: sender.id,
+          walletId: sender.walletId,
+          originalTxId: sender.originalTxId,
+        );
       }
     }
 
@@ -993,6 +1068,21 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         payjoin.id,
       );
       if (freshModel == null) throw Exception('Payjoin receiver not found');
+      // Re-check terminal state under the lock: a manual "receive payment
+      //  normally" tap (allowed by canManuallyBroadcastOriginal while
+      //  proposalPsbt == null) or the fallback watcher could have resolved
+      //  this session while we were awaiting getUtxosFrozenByOngoingPayjoins
+      //  above. Without this, an already-aborted/completed/expired row would
+      //  be resurrected to `proposed` by the update below.
+      if (freshModel.isCompleted ||
+          freshModel.isAborted ||
+          freshModel.isExpired) {
+        log.warning(
+          'Skipping payjoin proposal for ${freshModel.toEntity().logRef}: '
+          'session already resolved (${freshModel.status})',
+        );
+        return null;
+      }
 
       final isMineSync = await _bdkWallet.createIsMineChecker(wallet: wallet);
       final signPsbtSync = await _bdkWallet.createPsbtSigner(wallet: wallet);

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -12,6 +12,7 @@ import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/constants.dart' show PayjoinConstants;
@@ -21,7 +22,12 @@ import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasourc
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:meta/meta.dart';
 import 'package:synchronized/synchronized.dart';
 
 class PayjoinRepositoryImpl implements PayjoinRepository {
@@ -32,10 +38,64 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   final BdkWalletDatasource _bdkWallet;
   final BdkBitcoinBlockchainDatasource _blockchain;
   final ElectrumServersPort _serversPort;
+  // Wallet repositories are resolved lazily (via closures, not injected
+  // instances) because this repository is an eager singleton constructed
+  // BEFORE WalletLocator registers them (see core_locator.dart ordering).
+  // They are only ever called well after startup, from broadcast /
+  // proposal / completion handlers.
+  final WalletRepository Function() _walletRepository;
+  final WalletTransactionRepository Function() _walletTransactionRepository;
+  final SettingsRepository _settingsRepository;
+  // Lazy accessor, not a direct LabelsFacade — matches the existing
+  // core/exchange and core/swaps precedent of injecting LabelsFacade
+  // straight into core code that needs to label something (see
+  // LabelExchangeOrdersUsecase, AutoSwapExecutionUsecase). The indirection
+  // here is purely a registration-order workaround, not an architectural
+  // boundary: PayjoinRepositoryImpl is an eager registerSingleton built
+  // during PayjoinLocator.registerRepositories, which runs before
+  // LabelsLocator.registerFacade (see core_locator.dart) — resolving
+  // LabelsFacade eagerly at construction time would throw.
+  final LabelsFacade Function() _labelsFacade;
   // Lock to prevent the same utxo from being used in multiple payjoin proposals
   final Lock _lock;
 
   final StreamController<Payjoin> _payjoinStreamController;
+
+  // Per-session subscriptions watching for a completed payjoin transaction to
+  // appear on-chain, keyed by payjoin id. Kept so each can be cancelled once
+  // its transaction is seen (the underlying watch stream re-emits on every
+  // sync), on expiry, or on teardown. This is the only long-lived
+  // subscription state in this otherwise fire-and-forget singleton, so its
+  // hygiene lives entirely in _watchForBroadcast / _stopWatching / dispose.
+  final Map<String, StreamSubscription<void>> _broadcastWatchers = {};
+
+  // Per-session active-poll timers complementing _broadcastWatchers: each one
+  // periodically forces a sync'd wallet-transaction lookup so completion does
+  // not depend on some unrelated wallet sync happening to run (see
+  // _watchForBroadcast). Keyed by payjoin id, cancelled together with the
+  // passive watcher in _stopWatching / dispose.
+  final Map<String, Timer> _broadcastPollTimers = {};
+
+  // Mirrors _broadcastWatchers/_broadcastPollTimers but for the ORIGINAL
+  // transaction instead of the real payjoin one — the safety net for
+  // "the counterparty fell back independently and we'd otherwise never find
+  // out" (see _watchForFallback). Armed as soon as originalTxId is known
+  // (session creation for a sender, request-received for a receiver) and
+  // runs alongside any later _watchForBroadcast for the same session:
+  // whichever of the two lands on-chain first resolves the session, and
+  // _stopWatching tears down both together.
+  final Map<String, StreamSubscription<void>> _fallbackWatchers = {};
+  final Map<String, Timer> _fallbackPollTimers = {};
+
+  // Datasource stream subscriptions, cancelled on dispose.
+  final List<StreamSubscription<void>> _datasourceSubscriptions = [];
+
+  /// Delay between the automatic original-broadcast fallback retries (see
+  /// [_broadcastOriginalWithRetry]). Mutable only so tests can zero it out to
+  /// avoid real-time waits (and the timer bleed they cause across tests);
+  /// production keeps the 1s default.
+  @visibleForTesting
+  Duration fallbackRetryDelay = const Duration(seconds: 1);
 
   PayjoinRepositoryImpl({
     required this._localPayjoinDatasource,
@@ -45,19 +105,63 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     required BdkWalletDatasource bdkWalletDatasource,
     required BdkBitcoinBlockchainDatasource blockchainDatasource,
     required this._serversPort,
+    required this._walletRepository,
+    required this._walletTransactionRepository,
+    required this._settingsRepository,
+    required this._labelsFacade,
   }) : _seed = seedDatasource,
        _bdkWallet = bdkWalletDatasource,
        _blockchain = blockchainDatasource,
        _lock = Lock(),
        _payjoinStreamController = StreamController<Payjoin>.broadcast() {
     // Listen to payjoin events from the datasource and process them
-    _pdkPayjoinDatasource.requestsForReceivers.listen(_processPayjoinRequest);
-    _pdkPayjoinDatasource.proposalsForSenders.listen(_processPayjoinProposal);
-    _pdkPayjoinDatasource.expiredPayjoins.listen(_processExpiredPayjoin);
+    _datasourceSubscriptions.addAll([
+      _pdkPayjoinDatasource.requestsForReceivers.listen(_processPayjoinRequest),
+      _pdkPayjoinDatasource.proposalsForSenders.listen(_processPayjoinProposal),
+      _pdkPayjoinDatasource.expiredPayjoins.listen(_processExpiredPayjoin),
+    ]);
 
-    // Now that the listeners are set up, we can resume processing of possible
-    //  ongoing payjoins.
-    _resumePayjoins();
+    // Deliberately NOT resuming here: this is an eager singleton constructed
+    //  before WalletLocator / the labels facade register their dependencies
+    //  (see core_locator.dart ordering). A resumed session that reaches
+    //  _watchForBroadcast or the labels facade before those are registered
+    //  would throw inside this unawaited constructor call, silently aborting
+    //  resume for every remaining session. resumePayjoinsOnStartup() is
+    //  called explicitly by AppLocator.setup once every core dependency it
+    //  needs (wallet repositories, settings, the labels facade) is
+    //  registered.
+  }
+
+  /// Releases all long-lived subscriptions and closes the payjoin stream.
+  /// The production singleton lives for the whole app session and is never
+  /// disposed, but tests (and any future teardown) need a clean exit.
+  ///
+  /// Also tears down the datasource so its per-session polling timers and
+  /// event controllers don't outlive this repository — this repository owns
+  /// the datasource's lifecycle (it's the sole subscriber to its streams).
+  Future<void> dispose() async {
+    for (final timer in _broadcastPollTimers.values) {
+      timer.cancel();
+    }
+    _broadcastPollTimers.clear();
+    for (final sub in _broadcastWatchers.values) {
+      await sub.cancel();
+    }
+    _broadcastWatchers.clear();
+    for (final timer in _fallbackPollTimers.values) {
+      timer.cancel();
+    }
+    _fallbackPollTimers.clear();
+    for (final sub in _fallbackWatchers.values) {
+      await sub.cancel();
+    }
+    _fallbackWatchers.clear();
+    for (final sub in _datasourceSubscriptions) {
+      await sub.cancel();
+    }
+    _datasourceSubscriptions.clear();
+    await _pdkPayjoinDatasource.dispose();
+    await _payjoinStreamController.close();
   }
 
   @override
@@ -201,6 +305,16 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     // Store the payjoin sender in the local database
     await _localPayjoinDatasource.storeSender(model);
 
+    // Arm the fallback safety net now: the receiver could decline
+    //  below-minimum (or its own session could expire) and broadcast the
+    //  original transaction well before this sender's own session would
+    //  otherwise notice (see _watchForFallback's doc comment).
+    _watchForFallback(
+      payjoinId: model.id,
+      walletId: model.walletId,
+      originalTxId: model.originalTxId,
+    );
+
     // Return a payjoin entity with send details
     final payjoin = model.toEntity();
 
@@ -209,6 +323,63 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
   @override
   Future<Payjoin?> tryBroadcastOriginalTransaction(Payjoin payjoin) async {
+    // Idempotency/safety guard for MANUAL/external callers only (the
+    // BroadcastOriginalTransactionUsecase invoked from
+    // ReceiveBloc._onPayjoinOriginalTxBroadcasted and
+    // TransactionDetailsCubit.broadcastPayjoinOriginalTx) — re-checked
+    // against the freshest persisted state rather than trusting the
+    // caller's possibly-stale copy, using the SAME canonical
+    // Payjoin.canManuallyBroadcastOriginal getter those buttons' visibility
+    // is gated on, so this can never disagree with what the UI decided to
+    // show. Every one of those UI call sites SHOULD already gate on this
+    // themselves, but this is cheap insurance against a stale UI snapshot
+    // letting a tap through anyway — observed live: a sender's
+    // already-completed-via-fallback session got a second "Send without
+    // payjoin" tap ~10s later, re-broadcasting the same original psbt
+    // (harmless here only because it was byte-for-byte identical to what
+    // already confirmed). Had a REAL payjoin completed instead, this would
+    // have re-broadcast a lower-fee transaction competing for the same
+    // inputs as the already-broadcast payjoin tx — the exact dangerous RBF
+    // race this guard exists to prevent.
+    //
+    // Deliberately NOT applied to this repository's own INTERNAL fallback
+    // calls (_processPayjoinRequest, _processPayjoinProposal,
+    // _processExpiredPayjoin all call _broadcastOriginalTransaction
+    // directly, bypassing this): those run precisely WHILE the freshly
+    // persisted model still has a proposal "in flight" by definition (that
+    // proposal having just failed is why they are falling back at all), so
+    // this guard would otherwise block its own legitimate fallback attempt.
+    final freshModel = payjoin is PayjoinReceiver
+        ? await _localPayjoinDatasource.fetchReceiver(payjoin.id)
+        : await _localPayjoinDatasource.fetchSender(payjoin.id);
+    if (freshModel != null) {
+      final freshEntity = freshModel.toEntity();
+      if (!freshEntity.canManuallyBroadcastOriginal) {
+        log.warning(
+          'tryBroadcastOriginalTransaction ignored for ${payjoin.logRef}: '
+          'already completed or a proposal is in flight',
+        );
+        return freshEntity;
+      }
+    }
+
+    final result = await _broadcastOriginalTransaction(payjoin);
+    // Emit on the stream so OTHER live watchers of this same session (e.g. a
+    //  transaction-details screen open alongside the receive screen) learn of
+    //  the abort without waiting for a reload. Internal callers keep the
+    //  "caller emits" contract and add the result themselves; only this
+    //  public, UI-triggered entry point has no caller downstream to do it.
+    if (result != null) {
+      _payjoinStreamController.add(result);
+    }
+    return result;
+  }
+
+  /// The actual original-transaction broadcast mechanism, shared by the
+  /// public (guarded) [tryBroadcastOriginalTransaction] entry point and this
+  /// repository's own internal fallback call sites, which intentionally
+  /// bypass that guard (see its doc comment for why).
+  Future<Payjoin?> _broadcastOriginalTransaction(Payjoin payjoin) async {
     try {
       final network = ElectrumServerNetwork.fromEnvironment(
         isTestnet: payjoin.isTestnet,
@@ -237,19 +408,76 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         );
         model = await _localPayjoinDatasource.fetchSender(payjoin.id);
       }
+      // logRef, never id/raw txid: a sender payjoin id is the full BIP21
+      // URI and a raw txid identifies the payment on-chain — both off-limits
+      // in logs (user-shareable / pasted into issues).
       log.info(
-        'Original transaction broadcasted: ${payjoin.id} with txId: ${payjoin.originalTxId}',
+        'Original transaction broadcasted for payjoin ${payjoin.logRef}',
       );
-
-      // Update the local database with the completed payjoin
 
       if (model == null) {
         throw Exception('Payjoin not found locally');
       }
-      final completedModel = model.copyWith(isCompleted: true);
-      await _localPayjoinDatasource.update(completedModel);
+      // This is a fallback broadcast, not a real payjoin: mark the session
+      // aborted (not completed) so the true outcome survives in the
+      // transaction history — see PayjoinStatus.aborted.
+      //
+      // txId is explicitly reset: this session is completed by the ORIGINAL
+      // transaction, so any txId persisted earlier refers to a payjoin
+      // transaction that never reached the chain. A sender's txId is set the
+      // moment a proposal is RECEIVED (before signing/broadcasting), so a
+      // proposal that later fails to sign/broadcast would otherwise leave a
+      // stale txId behind — and SendCubit prefers txId over originalTxId for
+      // the success screen and the final tx label, surfacing (and labelling)
+      // a txid that was never broadcast. This clearing is display hygiene,
+      // not status derivation: the status comes from the explicit isAborted
+      // flag (see PayjoinModel.status).
+      final abortedModel = model.copyWith(isAborted: true, txId: null);
+      await _localPayjoinDatasource.update(abortedModel);
+      // Deliberately NOT labelling this transaction "payjoin": every call
+      // site of this method is, by definition, a case where no real payjoin
+      // ever happened — declined below the anti-probing minimum, the
+      // negotiation failed, or the session expired before a proposal was
+      // exchanged. The tx that lands here is byte-for-byte the caller's own
+      // plain, single-party transaction; slapping a "payjoin" label on it
+      // would be misleading. Only _onPayjoinTransactionSeen and _broadcastPsbt
+      // label a transaction — both reachable exclusively once a real proposal
+      // was exchanged.
+      //
+      // Stop watching now that the session is resolved via this path: the
+      //  fallback watch armed at request-received (receiver) or session
+      //  creation (sender) would otherwise keep doing a wallet-transaction
+      //  lookup on every sync for the rest of the app's lifetime. Defensive
+      //  and idempotent — a no-op when no watcher is registered. (Re-armed
+      //  just below to confirm the tx we broadcast actually lands locally.)
+      _stopWatching(payjoin.id);
 
-      return completedModel.toEntity();
+      // Best-effort, non-blocking: get the wallet's balance/tx list to
+      // reflect this broadcast promptly instead of waiting on whatever
+      // unrelated sync happens to run next (the same staleness class of gap
+      // as the receiver's own payjoin-tx watcher — see _watchForBroadcast).
+      _syncWalletAfterBroadcast(abortedModel.walletId);
+
+      // That single sync is not enough on its own: it can be throttled by
+      // the sync coordinator or race the broadcast (observed live: a
+      // receiver's below-minimum fallback stayed invisible in its own
+      // wallet until several manual resyncs). Re-arm the original-tx watch
+      // so its backoff poll keeps forcing DIRECT electrum-backed lookups
+      // (getWalletTransaction(sync: true) bypasses the coordinator) until
+      // the transaction we just broadcast actually lands in the local
+      // wallet database. It tears itself down the moment the tx is seen:
+      // _onOriginalTransactionSeen stops all watchers first and its
+      // terminal guard makes it a pure teardown for this already-persisted
+      // session.
+      if (abortedModel.originalTxId != null) {
+        _watchForFallback(
+          payjoinId: payjoin.id,
+          walletId: abortedModel.walletId,
+          originalTxId: abortedModel.originalTxId!,
+        );
+      }
+
+      return abortedModel.toEntity();
     } catch (e) {
       log.severe(
         message: 'Error broadcasting original transaction',
@@ -261,21 +489,66 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   }
 
   Future<void> _processPayjoinRequest(PayjoinReceiverModel model) async {
-    log.info('Processing payjoin request: ${model.id}');
-    // Update the local database with the new payjoin request
-    await _localPayjoinDatasource.update(model);
-
-    final payjoin = model.toEntity() as PayjoinReceiver;
-
-    // Notify higher layers that a new payjoin request was received
-    _payjoinStreamController.add(payjoin);
-
-    // Now try to process the request
+    // The whole handler is inside this try/catch, including the initial DB
+    // update and stream emit below: a fallible await left outside a try (as
+    // this used to be) can throw straight out of the datasource's
+    // stream .listen() callback as an unhandled async error — with the
+    // directory poll already cancelled by the time this fires, no expiry
+    // event would ever arrive to unstick it either, stranding the session
+    // in "requested" until the app restarts.
     PayjoinReceiver? result;
     try {
-      final wallet = await _loadWallet(model.walletId);
-      final unspentUtxos = await _bdkWallet.getUtxos(wallet: wallet);
-      result = await _proposePayjoin(model, wallet, unspentUtxos);
+      log.info('Processing payjoin request: ${model.id}');
+      await _localPayjoinDatasource.update(model);
+
+      final payjoin = model.toEntity() as PayjoinReceiver;
+
+      // Notify higher layers that a new payjoin request was received
+      _payjoinStreamController.add(payjoin);
+
+      // Arm the fallback safety net now that originalTxId is known: from
+      // here on, EITHER side could end up broadcasting the original
+      // transaction (this receiver declining below-minimum in a moment, a
+      // failed negotiation, or either session's own expiry), and this is
+      // the only way this side finds out if it was the OTHER one that did
+      // it (see _watchForFallback's doc comment). Left running until the
+      // session actually resolves, including through the negotiation
+      // attempted below.
+      if (model.originalTxId != null) {
+        _watchForFallback(
+          payjoinId: model.id,
+          walletId: model.walletId,
+          originalTxId: model.originalTxId!,
+        );
+      }
+
+      // Anti-probing minimum-value policy (BIP78): declining below this
+      // threshold costs the sender nothing extra (they're still paid
+      // normally via the original transaction) while raising the cost of
+      // probing our UTXO set to at least a real payment above the
+      // threshold. See PayjoinConstants.defaultMinAmountSat.
+      final settings = await _settingsRepository.fetch();
+      if (isBelowPayjoinMinimum(
+        amountSat: model.amountSat,
+        minAmountSat: settings.payjoinMinAmountSat,
+      )) {
+        log.warning(
+          'Payjoin request ${model.id} below minimum '
+          '(${settings.payjoinMinAmountSat} sat); declining and '
+          'broadcasting original instead',
+        );
+        final declinedReceiverJson = _pdkPayjoinDatasource
+            .declineReceiverSession(model);
+        final declinedModel = model.copyWith(receiver: declinedReceiverJson);
+        await _localPayjoinDatasource.update(declinedModel);
+        result =
+            (await _broadcastOriginalWithRetry(declinedModel.toEntity()))
+                as PayjoinReceiver?;
+      } else {
+        final wallet = await _loadWallet(model.walletId);
+        final unspentUtxos = await _bdkWallet.getUtxos(wallet: wallet);
+        result = await _proposePayjoin(model, wallet, unspentUtxos);
+      }
     } catch (e) {
       log.severe(
         message: 'Error processing payjoin request',
@@ -283,15 +556,96 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         trace: StackTrace.current,
       );
       result =
-          (await tryBroadcastOriginalTransaction(payjoin)) as PayjoinReceiver?;
+          (await _broadcastOriginalWithRetry(model.toEntity()))
+              as PayjoinReceiver?;
     }
 
     if (result != null) {
       _payjoinStreamController.add(result);
+      // A proposal was sent: from here the sender finalizes and broadcasts
+      // the payjoin transaction. Watch for that txid to land on-chain so we
+      // can mark the receiver session completed and label the transaction.
+      if (result.proposalPsbt != null && result.txId != null) {
+        _watchForBroadcast(
+          payjoinId: result.id,
+          walletId: result.walletId,
+          txId: result.txId!,
+        );
+      }
     }
   }
 
+  /// [_broadcastOriginalTransaction] with a small bounded retry, for the
+  /// automatic fallback paths (below-minimum decline and request-processing
+  /// failure). Those paths run exactly once per request event: the
+  /// directory poll was already cancelled when the request was emitted, so
+  /// no expiry event will fire either — a single transient Electrum blip
+  /// would otherwise leave the session with no further automatic attempt
+  /// this run. If every attempt fails, this logs SEVERE and returns null
+  /// ON PURPOSE without marking the session terminal: it stays unfinished
+  /// in the DB, so the next app start replays it through
+  /// _processPayjoinRequest and retries (the decline path then throws
+  /// StateError on the already-cancelled PDK session, which lands in the
+  /// same catch → broadcast fallback). In the meantime the receive screen's
+  /// manual "receive payment normally" button remains available and
+  /// surfaces its own errors.
+  ///
+  /// Uses [_broadcastOriginalTransaction] directly (not the guarded public
+  /// entry point): this is an internal fallback that runs precisely while
+  /// the persisted model still has a proposal "in flight", which the guard
+  /// would otherwise refuse.
+  Future<Payjoin?> _broadcastOriginalWithRetry(
+    Payjoin payjoin, {
+    int maxAttempts = 3,
+    Duration? delayBetweenAttempts,
+  }) async {
+    final delay = delayBetweenAttempts ?? fallbackRetryDelay;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      final result = await _broadcastOriginalTransaction(payjoin);
+      if (result != null) return result;
+      if (attempt < maxAttempts) {
+        await Future<void>.delayed(delay);
+      }
+    }
+    // Each failed attempt already logged SEVERE (with the underlying error)
+    // inside _broadcastOriginalTransaction — this is the summary line.
+    // logRef, never id: this accepts any Payjoin and a sender id is the full
+    //  BIP21 URI.
+    log.warning(
+      'Failed to broadcast the original transaction after $maxAttempts '
+      'attempts; leaving payjoin ${payjoin.logRef} unfinished so the next app '
+      'start retries',
+    );
+    return null;
+  }
+
+  /// Whether an incoming payjoin request should be declined for being below
+  /// the configured minimum-receive-amount threshold (anti-probing,
+  /// BIP78). `null` (no amount known yet) never counts as below minimum —
+  /// this only gates once the original transaction has actually been
+  /// retrieved and its amount computed (see PdkPayjoinDatasource's receiver
+  /// poll), never blocking on an incomplete read.
+  @visibleForTesting
+  static bool isBelowPayjoinMinimum({
+    required int? amountSat,
+    required int minAmountSat,
+  }) => amountSat != null && amountSat < minAmountSat;
+
   Future<void> _processPayjoinProposal(PayjoinSenderModel payjoinModel) async {
+    // The proposal event carries the datasource's own in-memory copy, which
+    // may have resolved since (e.g. the fallback watcher aborted the session
+    // when the counterparty broadcast the original while this proposal was in
+    // flight). Re-fetch and bail on an already-terminal session — mirroring
+    // _processExpiredPayjoin — so we neither resurrect an aborted row (the
+    // insertOnConflictUpdate below replaces the whole row) nor sign/broadcast
+    // against a session that already resolved another way.
+    final persisted = await _localPayjoinDatasource.fetchSender(
+      payjoinModel.id,
+    );
+    if (persisted != null && (persisted.isCompleted || persisted.isAborted)) {
+      return;
+    }
+
     // Update the local database with the new payjoin proposal
     await _localPayjoinDatasource.update(payjoinModel);
 
@@ -313,74 +667,277 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
             ? Network.bitcoinTestnet
             : Network.bitcoinMainnet,
       );
-      log.info(
-        'Payjoin proposal broadcasted: ${payjoin.id} with txId: ${result.txId}',
-      );
+      // logRef, never id/raw txid: a sender payjoin id is the full BIP21 URI
+      //  and a raw txid identifies the payment on-chain — both off-limits in
+      //  logs.
+      log.info('Payjoin proposal broadcasted for ${payjoin.logRef}');
+      // Label the transaction now that a REAL payjoin actually broadcast
+      // (never a fallback — see _broadcastOriginalTransaction, which marks
+      // aborted sessions aborted, not completed) and the final txid is known.
+      // Deliberately re-derived from [finalizedPsbt] — the bytes actually
+      // broadcast — rather than trusting `result.txId`/the pre-existing
+      // `payjoin.txId`: those are computed from the proposal PSBT before this
+      // signPsbt call above, and finalizing a signature can change the txid
+      // for non-native-segwit inputs (never label a txid that wasn't derived
+      // from the actually-broadcast bytes). The receiver side has the
+      // watch-for-broadcast infra to notice its own completion, but labels
+      // the pre-finalization txid because it never sees the finalized bytes —
+      // an inherent limitation, not a missing feature.
+      final broadcastTxId = (await BitcoinTx.fromPsbt(finalizedPsbt)).txid;
+      await labelCompletedPayjoinSend(broadcastTxId);
     } catch (e) {
       log.severe(
         message: 'Error broadcasting payjoin proposal',
         error: e,
         trace: StackTrace.current,
       );
-      // TODO: Handle this, maybe by sending the original transaction instead
+      // Signing or broadcasting the finalized payjoin transaction failed. By
+      //  this point the sender's poll timer that would otherwise raise an
+      //  expiry is already cancelled (it stopped the moment this proposal
+      //  arrived), so nothing else will ever emit a terminal event for this
+      //  session — fall back to broadcasting the original transaction
+      //  ourselves, mirroring the sender-expiry fallback, so the payment
+      //  still goes through and the send flow doesn't hang forever (#2246).
+      result = await _broadcastOriginalTransaction(payjoin) as PayjoinSender?;
     }
 
     if (result != null) {
       _payjoinStreamController.add(result);
+    } else {
+      // Both the payjoin and the original-transaction fallback failed: mark
+      //  the session terminally failed (modelled as expired, which
+      //  SendCubit._watchPayjoin already surfaces as a broadcast failure)
+      //  instead of leaving the send flow hanging on "coordinating" with no
+      //  event ever arriving again. Clear txId: the pre-existing value is a
+      //  proposal-derived payjoin txid that never reached the chain, and a
+      //  stale txid on a terminal session pollutes fetchByTxId / the details
+      //  screen (same display-hygiene reason _broadcastOriginalTransaction
+      //  clears it on the abort path).
+      final failedModel = payjoinModel.copyWith(isExpired: true, txId: null);
+      await _localPayjoinDatasource.update(failedModel);
+      _payjoinStreamController.add(failedModel.toEntity());
     }
   }
 
   Future<void> _processExpiredPayjoin(PayjoinModel payjoinModel) async {
-    // Update the local database with the expired payjoin
-    await _localPayjoinDatasource.update(payjoinModel);
+    // The expiry event carries the emitter's own in-memory copy of the
+    // session (the PDK poll's model from when polling started, or a resume's
+    // fetch) — not the persisted row, which may have resolved in the
+    // meantime through a path the emitter can't see (the fallback watcher
+    // marking it aborted/completed when a transaction landed on-chain).
+    // Re-fetch and bail on an already-terminal session: without this, an
+    // expiry firing after a fallback completion re-broadcast the original
+    // transaction and re-emitted terminal events for a resolved session
+    // (observed live: a sender's poll expired a minute after
+    // _onOriginalTransactionSeen had already completed the session).
+    final freshModel = payjoinModel is PayjoinReceiverModel
+        ? await _localPayjoinDatasource.fetchReceiver(payjoinModel.id)
+        : await _localPayjoinDatasource.fetchSender(payjoinModel.id);
+    if (freshModel == null || freshModel.isCompleted || freshModel.isAborted) {
+      return;
+    }
 
-    final payjoin = payjoinModel.toEntity();
-
-    _payjoinStreamController.add(payjoin);
+    // Continue with the fresh row (expired-marked, like every caller marks
+    // its own copy), not the event's copy: the branches below decide on
+    // proposalPsbt/originalTxBytes, and the last branch persists the model —
+    // doing either with the stale copy could clobber fields persisted since
+    // the emitter captured it (insertOnConflictUpdate replaces the row).
+    final expiredModel = freshModel.copyWith(isExpired: true);
+    final payjoin = expiredModel.toEntity();
 
     // TODO: Unfreeze the utxo used in the payjoin
 
-    if (payjoin is PayjoinReceiver && payjoin.originalTxBytes != null) {
-      // If the payjoin is a receiver and it has the original transaction bytes
-      //  at expiration, we broadcast the original transaction automatically.
-      await tryBroadcastOriginalTransaction(payjoin);
+    if (payjoin is PayjoinReceiver &&
+        payjoin.originalTxBytes != null &&
+        payjoin.proposalPsbt == null) {
+      // We received the sender's original transaction but never sent a
+      //  proposal before expiring, so broadcast that original automatically —
+      //  the receiver still gets paid, and (per BIP78) doing so imposes the
+      //  mining-fee cost that makes UTXO probing non-free.
+      // Guard on proposalPsbt == null: once a proposal has gone out, the
+      //  sender owns finalizing/broadcasting the payjoin transaction, which
+      //  spends the same inputs. Broadcasting the original here would just
+      //  race our own in-flight payjoin for no benefit.
+      //
+      //  Emit only the terminal outcome — mirroring the sender-expiry
+      //  fallback below — so a receive screen watching this session doesn't
+      //  see an interim "expired" state that suggests the original still
+      //  needs manual broadcasting when it's actually already in flight.
+      //
+      //  Deliberately do NOT call _stopWatching before attempting the
+      //  broadcast: the fallback watch armed in _processPayjoinRequest must
+      //  survive a failed attempt here so it keeps watching for the original
+      //  transaction to land through ANY path — a later resume's retry, or
+      //  the sender broadcasting it independently in the meantime.
+      //  _broadcastOriginalTransaction already stops it on success; leaving
+      //  it running on failure is what fixes a session getting permanently
+      //  stuck otherwise (observed live).
+      //
+      //  Deliberately do NOT persist the raw expired model first:
+      //  _broadcastOriginalTransaction persists isAborted itself on success.
+      //  If the broadcast fails, leaving the row unfinished means the next
+      //  app start's resumePayjoinsOnStartup sees isExpiryTimePassed still
+      //  true and retries the fallback — persisting isExpired here would
+      //  instead permanently exclude it from onlyUnfinished and drop the
+      //  retry.
+      final result = await _broadcastOriginalTransaction(payjoin);
+      _payjoinStreamController.add(result ?? payjoin);
+    } else if (payjoin is PayjoinSender && payjoin.proposalPsbt == null) {
+      // The sender never received a proposal before expiry (the receiver
+      //  didn't respond), so fall back to broadcasting the original
+      //  transaction — the payment must still go through. Guard on
+      //  proposalPsbt == null: once a proposal arrived, _processPayjoinProposal
+      //  owns finalizing/broadcasting the payjoin transaction (same inputs).
+      //
+      //  Emit only the terminal outcome: the aborted result on success (so
+      //  the send flow resolves to success), or the raw expired entity if the
+      //  fallback broadcast itself failed (so listeners see a terminal state
+      //  and don't hang on the "coordinating" screen). We deliberately do NOT
+      //  emit the interim expired entity before the fallback, which would race
+      //  the aborted one on the stream.
+      //
+      //  Same reasoning as the receiver branch above for not persisting the
+      //  expired flag up front, and for NOT calling _stopWatching before
+      //  attempting: the fallback watch armed at session creation must
+      //  survive a failed attempt here.
+      final result = await _broadcastOriginalTransaction(payjoin);
+      _payjoinStreamController.add(result ?? payjoin);
+    } else {
+      // A receiver whose proposal was already sent (proposalPsbt != null)
+      //  lands here. From here the sender owns finalizing/broadcasting the
+      //  payjoin transaction, which can still land on-chain after this
+      //  session's own expiry — deliberately do NOT stop the broadcast
+      //  watcher armed for it (_watchForBroadcast): once the tx is seen,
+      //  _onPayjoinTransactionSeen completes and labels the session even
+      //  though it's presently marked expired. Stopping the watcher here
+      //  would strand the session as permanently expired despite the payment
+      //  actually completing.
+      //
+      //  Beyond hardening: re-arm the broadcast watcher idempotently. For a
+      //  live expiry this is a no-op (the containsKey guard — the watcher
+      //  armed at proposal time is still registered); for a resume-time
+      //  expiry (app was closed) it re-arms the watcher the session lost
+      //  when the app closed, which is exactly the behavior the retention
+      //  above intends.
+      if (expiredModel is PayjoinReceiverModel && expiredModel.txId != null) {
+        _watchForBroadcast(
+          payjoinId: expiredModel.id,
+          walletId: expiredModel.walletId,
+          txId: expiredModel.txId!,
+        );
+      }
+
+      // Nothing left for us to retry from this side, so persist the expired
+      //  marker now (unlike the two fallback branches above).
+      await _localPayjoinDatasource.update(expiredModel);
+      _payjoinStreamController.add(payjoin);
     }
   }
 
-  Future<void> _resumePayjoins() async {
+  @override
+  Future<void> resumePayjoinsOnStartup() async {
+    // Sweep receivers whose expiry-time fallback broadcast FAILED on a
+    // previous run and were persisted as expired (e.g. by pre-port code that
+    // persisted isExpired before broadcasting): the onlyUnfinished resume
+    // below can never see them again while they still hold the sender's
+    // broadcastable original transaction. Without this sweep the sender's
+    // payment would be stranded forever. One attempt per app start per
+    // session: success marks it aborted (ending the retries); a transient
+    // failure — or the tx already being on-chain, which the broadcast
+    // surfaces as an error — retries on the next start. Uses the internal
+    // broadcast (bypassing the manual-call guard): this is an automatic
+    // recovery retry, not a manual action.
+    final receivers = await _localPayjoinDatasource.fetchReceivers();
+    for (final receiver in receivers) {
+      if (receiver.isExpired &&
+          !receiver.isAborted &&
+          !receiver.isCompleted &&
+          receiver.originalTxBytes != null &&
+          receiver.proposalPsbt == null) {
+        await _broadcastOriginalTransaction(receiver.toEntity());
+      }
+    }
+
     final models = await _localPayjoinDatasource.fetchAll(onlyUnfinished: true);
     for (final model in models) {
-      if (model.isExpiryTimePassed) {
-        // A session whose expiry elapsed while the app was closed. Route it
-        //  through the same handler as a live expiry so the receiver's
-        //  original-transaction fallback still fires — otherwise an
-        //  expired-while-closed receiver that already had the sender's
-        //  original tx would silently drop it, leaving the sender's payment
-        //  in limbo (neither payjoin nor fallback ever hits the chain).
-        await _processExpiredPayjoin(model.copyWith(isExpired: true));
-      } else if (model is PayjoinReceiverModel) {
-        if (model.originalTxBytes == null) {
-          // If the original tx bytes are not present, it means the receiver
-          //  needs to listen for a payjoin request from the sender.
-          _pdkPayjoinDatasource.startListeningForRequest(model);
-        } else if (model.proposalPsbt == null) {
-          // If the original tx bytes are present but the proposal psbt is not,
-          //  it means the receiver has already received a payjoin request and
-          //  it should be processed.
-          await _processPayjoinRequest(model);
-        } else {
-          // Todo: listen for the broadcast of the transaction
+      // Each session is independent: a bug or a transient failure resuming
+      //  one (e.g. a missing wallet, a bad persisted event log) must not
+      //  abort the loop and silently leave every other unfinished session
+      //  un-resumed.
+      try {
+        await _resumeOne(model);
+      } catch (e, st) {
+        // logRef, never id: this SEVERE reaches Sentry, and a sender id is
+        // the full BIP21 URI.
+        log.severe(
+          message:
+              'Failed to resume payjoin session ${model.toEntity().logRef}',
+          error: e,
+          trace: st,
+        );
+      }
+    }
+  }
+
+  Future<void> _resumeOne(PayjoinModel model) async {
+    if (model.isExpiryTimePassed) {
+      // A session whose expiry elapsed while the app was closed. Route it
+      //  through the same handler as a live expiry so the receiver's
+      //  original-transaction fallback still fires — otherwise an
+      //  expired-while-closed receiver that already had the sender's
+      //  original tx would silently drop it, leaving the sender's payment
+      //  in limbo (neither payjoin nor fallback ever hits the chain).
+      await _processExpiredPayjoin(model.copyWith(isExpired: true));
+    } else if (model is PayjoinReceiverModel) {
+      if (model.originalTxBytes == null) {
+        // If the original tx bytes are not present, it means the receiver
+        //  needs to listen for a payjoin request from the sender.
+        _pdkPayjoinDatasource.startListeningForRequest(model);
+      } else if (model.proposalPsbt == null) {
+        // If the original tx bytes are present but the proposal psbt is not,
+        //  it means the receiver has already received a payjoin request and
+        //  it should be processed.
+        await _processPayjoinRequest(model);
+      } else if (model.txId != null) {
+        // A proposal was already sent before the app closed. Resume watching
+        //  for the payjoin transaction to appear on-chain so the session can
+        //  be completed and its transaction labelled.
+        _watchForBroadcast(
+          payjoinId: model.id,
+          walletId: model.walletId,
+          txId: model.txId!,
+        );
+        // The sender still owns finalizing/broadcasting the real proposal
+        //  from here, but could instead fall back to the original
+        //  transaction on ITS side without this receiver ever being told —
+        //  resume the same safety net armed when the request first arrived
+        //  (see _watchForFallback's doc comment).
+        if (model.originalTxId != null) {
+          _watchForFallback(
+            payjoinId: model.id,
+            walletId: model.walletId,
+            originalTxId: model.originalTxId!,
+          );
         }
-      } else if (model is PayjoinSenderModel) {
-        if (model.proposalPsbt == null) {
-          // If the proposal psbt is not present, it means the sender needs to
-          //  listen for a payjoin proposal from the receiver.
-          _pdkPayjoinDatasource.startListeningForProposal(model);
-        } else {
-          // If the proposal psbt is present, it means a payjoin proposal was
-          //  already received  and it should be processed.
-          await _processPayjoinProposal(model);
-        }
+      }
+    } else if (model is PayjoinSenderModel) {
+      // Resume the fallback safety net regardless of which branch below is
+      //  taken: originalTxId is always known for a sender (set at creation),
+      //  and the receiver could have broadcast it independently at any point
+      //  while the app was closed (see _watchForFallback's doc comment).
+      _watchForFallback(
+        payjoinId: model.id,
+        walletId: model.walletId,
+        originalTxId: model.originalTxId,
+      );
+      if (model.proposalPsbt == null) {
+        // If the proposal psbt is not present, it means the sender needs to
+        //  listen for a payjoin proposal from the receiver.
+        _pdkPayjoinDatasource.startListeningForProposal(model);
+      } else {
+        // If the proposal psbt is present, it means a payjoin proposal was
+        //  already received  and it should be processed.
+        await _processPayjoinProposal(model);
       }
     }
   }
@@ -468,10 +1025,441 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     if (model == null) {
       throw Exception('Payjoin sender not found');
     }
+    if (model.isAborted) {
+      // The fallback watcher aborted this session (the ORIGINAL transaction
+      //  was seen on-chain) while we were signing/broadcasting the proposal.
+      //  Our payjoin transaction nonetheless made it onto the network and,
+      //  spending the same inputs, will confirm instead of the original — so
+      //  completing (real payjoin) is the correct on-chain outcome and wins
+      //  over the aborted marker (model derivation orders isCompleted first).
+      //  Logged so this genuinely-rare race is visible rather than an
+      //  implicit derivation-order side effect.
+      log.warning(
+        'Payjoin ${model.toEntity().logRef} completed via a real payjoin '
+        'after having been marked aborted (both transactions raced onto the '
+        'network; the payjoin tx wins)',
+      );
+    }
     final completedModel = model.copyWith(isCompleted: true);
     await _localPayjoinDatasource.update(completedModel);
 
+    // Best-effort, non-blocking: see _broadcastOriginalTransaction's call
+    // for why this can't wait on some unrelated sync to run.
+    _syncWalletAfterBroadcast(completedModel.walletId);
+
+    // The session is resolved by the payjoin transaction we just broadcast:
+    // stop the original-tx fallback watch armed at session creation (it
+    // would otherwise keep looking up a transaction that can never land on
+    // every sync for the rest of the app's lifetime) and watch the payjoin
+    // txid instead until it is visible in the local wallet — the single
+    // unawaited sync above can be throttled or race the broadcast (see
+    // _broadcastOriginalTransaction). Self-tearing-down like the fallback
+    // watch: _onPayjoinTransactionSeen stops all watchers first, and its
+    // fetchReceiver returns null for this SENDER session, making it a pure
+    // teardown.
+    _stopWatching(payjoinId);
+    if (completedModel.txId != null) {
+      _watchForBroadcast(
+        payjoinId: payjoinId,
+        walletId: completedModel.walletId,
+        txId: completedModel.txId!,
+      );
+    }
+
     return completedModel.toEntity() as PayjoinSender;
+  }
+
+  /// Delay before the first active broadcast poll of [_watchForBroadcast].
+  /// The sender typically finalizes and broadcasts within seconds of
+  /// receiving the proposal, so the first forced lookup comes quickly.
+  @visibleForTesting
+  static const broadcastPollInitialDelay = Duration(seconds: 5);
+
+  /// Cap for the exponential backoff between active broadcast polls.
+  @visibleForTesting
+  static const broadcastPollMaxDelay = Duration(minutes: 5);
+
+  /// Number of active broadcast polls before giving up on forcing syncs
+  /// ourselves (≈35 minutes with the initial delay doubling up to the cap).
+  /// The passive sync-driven watcher stays armed afterwards, so a very late
+  /// broadcast is still caught by the next organic wallet sync — this bound
+  /// only stops a stranded session from forcing network syncs forever.
+  @visibleForTesting
+  static const broadcastPollMaxAttempts = 12;
+
+  /// Watches for the receiver's payjoin transaction [txId] to appear in
+  /// [walletId], then marks the session completed, labels the transaction,
+  /// and stops watching. Two complementary triggers:
+  ///
+  /// - Passive: a cheap local lookup whenever a sync of this wallet finishes
+  ///   (the stream re-emits on every sync, so the first successful hit
+  ///   cancels the watcher to keep the completion side effect one-shot).
+  /// - Active: a bounded backoff of forced `sync: true` lookups. Without it,
+  ///   completion depended entirely on some unrelated sync happening to run
+  ///   while the session was live — observed live as a receiver stuck on
+  ///   "payjoin in progress" for ~9 minutes after the sender had already
+  ///   broadcast the payjoin transaction, because nothing else synced the
+  ///   wallet in the meantime.
+  ///
+  /// Idempotent: a session already being watched (live path then resume, or
+  /// duplicate resume) is not re-subscribed.
+  void _watchForBroadcast({
+    required String payjoinId,
+    required String walletId,
+    required String txId,
+  }) => _watchForTransaction(
+    payjoinId: payjoinId,
+    walletId: walletId,
+    txId: txId,
+    watchers: _broadcastWatchers,
+    pollTimers: _broadcastPollTimers,
+    onSeen: _onPayjoinTransactionSeen,
+    kind: 'broadcast',
+  );
+
+  /// Watches for the ORIGINAL transaction [originalTxId] to appear in
+  /// [walletId] — the safety net for the plain-broadcast fallback landing
+  /// through a path this device didn't itself observe succeed.
+  ///
+  /// Both a sender and a receiver hold their own copy of the original
+  /// transaction and can each independently decide to broadcast it (a
+  /// receiver declining below the anti-probing minimum, either side's
+  /// session expiring with no proposal exchanged, or a sender's own
+  /// negotiation failing). Whichever side attempts the broadcast persists
+  /// the terminal state itself on success, but there was previously no way
+  /// for the OTHER side to find out — it just kept waiting on its own
+  /// session with no signal that the payment had already landed via the
+  /// other side's fallback. Observed live: a receiver declining
+  /// below-minimum broadcasts the original immediately, while the sender's
+  /// own session sat on "requested" for up to a minute until ITS expiry
+  /// timer independently fired — and if that second, redundant broadcast
+  /// attempt then errored (the tx was already known to the network), the
+  /// sender's session never completed at all.
+  ///
+  /// Armed as soon as `originalTxId` is known — session creation for a
+  /// sender, request-received for a receiver — and left running alongside
+  /// any later [_watchForBroadcast] for the same session: whichever of the
+  /// real payjoin txid or this original txid lands on-chain first resolves
+  /// the session, and [_stopWatching] tears down both together. Mirrors
+  /// [_watchForBroadcast]'s passive+active polling exactly.
+  ///
+  /// Idempotent, same as [_watchForBroadcast].
+  void _watchForFallback({
+    required String payjoinId,
+    required String walletId,
+    required String originalTxId,
+  }) => _watchForTransaction(
+    payjoinId: payjoinId,
+    walletId: walletId,
+    txId: originalTxId,
+    watchers: _fallbackWatchers,
+    pollTimers: _fallbackPollTimers,
+    onSeen: _onOriginalTransactionSeen,
+    kind: 'fallback',
+  );
+
+  /// Shared engine behind [_watchForBroadcast] and [_watchForFallback]. See
+  /// those wrappers for the per-kind rationale; the two registries stay
+  /// separate because both watches can be live for one session at once and
+  /// [_stopWatching] tears them down together.
+  void _watchForTransaction({
+    required String payjoinId,
+    required String walletId,
+    required String txId,
+    required Map<String, StreamSubscription<void>> watchers,
+    required Map<String, Timer> pollTimers,
+    required Future<void> Function(String payjoinId) onSeen,
+    required String kind,
+  }) {
+    if (watchers.containsKey(payjoinId)) return;
+
+    // Best-effort: failing to arm the watch (e.g. a wallet lookup throwing
+    // synchronously) must never take down the proposal/broadcast/resume
+    // handling it was called from — a successful broadcast misreported as
+    // failed would trigger a redundant fallback.
+    try {
+      final subscription = _walletRepository().walletSyncFinishedStream
+          .where((wallet) => wallet.id == walletId)
+          .asyncMap((_) async {
+            try {
+              return await _walletTransactionRepository().getWalletTransaction(
+                txId,
+                walletId: walletId,
+              );
+            } catch (e) {
+              log.warning('Payjoin $kind watch lookup failed: $e');
+              return null;
+            }
+          })
+          .where((tx) => tx != null)
+          .listen((_) {
+            // onSeen (fetch + update + emit) can throw; the future is not
+            //  awaited by the stream, so guard it explicitly or it becomes an
+            //  unhandled zone error.
+            unawaited(
+              onSeen(payjoinId).catchError((Object e) {
+                log.warning('Payjoin $kind completion handler failed: $e');
+              }),
+            );
+          });
+
+      watchers[payjoinId] = subscription;
+
+      _scheduleTransactionPoll(
+        payjoinId: payjoinId,
+        walletId: walletId,
+        txId: txId,
+        watchers: watchers,
+        pollTimers: pollTimers,
+        onSeen: onSeen,
+        kind: kind,
+        attempt: 0,
+      );
+    } catch (e) {
+      // logRefForId: payjoinId is the raw session id, which for a sender IS
+      //  the full BIP21 URI (address+amount) — never log it raw.
+      log.warning(
+        'Failed to arm the $kind watch for '
+        '${Payjoin.logRefForId(payjoinId)}: $e',
+      );
+    }
+  }
+
+  /// Arms the next active poll for [_watchForTransaction]: after an
+  /// exponentially backed-off delay, forces a sync'd wallet-transaction
+  /// lookup and either resolves the session or reschedules itself. The
+  /// `watchers` map is the single source of truth for "still watched": once
+  /// [_stopWatching] removed the session, a pending poll callback becomes a
+  /// no-op.
+  void _scheduleTransactionPoll({
+    required String payjoinId,
+    required String walletId,
+    required String txId,
+    required Map<String, StreamSubscription<void>> watchers,
+    required Map<String, Timer> pollTimers,
+    required Future<void> Function(String payjoinId) onSeen,
+    required String kind,
+    required int attempt,
+  }) {
+    if (attempt >= broadcastPollMaxAttempts) {
+      // The passive sync-driven watcher stays armed; only stop forcing syncs.
+      //  Drop the fired timer from the map so it doesn't falsely advertise an
+      //  active poll (its cancel() is already a no-op).
+      pollTimers.remove(payjoinId);
+      return;
+    }
+
+    var delay = broadcastPollInitialDelay * (1 << attempt.clamp(0, 30));
+    if (delay > broadcastPollMaxDelay) delay = broadcastPollMaxDelay;
+
+    pollTimers[payjoinId] = Timer(delay, () async {
+      if (!watchers.containsKey(payjoinId)) return;
+
+      WalletTransaction? tx;
+      try {
+        tx = await _walletTransactionRepository().getWalletTransaction(
+          txId,
+          walletId: walletId,
+          sync: true,
+        );
+      } catch (e) {
+        log.warning('Payjoin $kind poll failed: $e');
+      }
+
+      // Re-check: the session may have resolved through the passive watcher
+      // (or been torn down) while the sync'd lookup was in flight.
+      if (!watchers.containsKey(payjoinId)) return;
+
+      if (tx != null) {
+        // Guarded: this runs inside a Timer callback, so a throw would be an
+        //  unhandled zone error (same reasoning as the passive watcher).
+        try {
+          await onSeen(payjoinId);
+        } catch (e) {
+          log.warning('Payjoin $kind completion handler failed: $e');
+        }
+      } else {
+        _scheduleTransactionPoll(
+          payjoinId: payjoinId,
+          walletId: walletId,
+          txId: txId,
+          watchers: watchers,
+          pollTimers: pollTimers,
+          onSeen: onSeen,
+          kind: kind,
+          attempt: attempt + 1,
+        );
+      }
+    });
+  }
+
+  Future<void> _onPayjoinTransactionSeen(String payjoinId) async {
+    // Stop first: the watch stream re-emits on every sync, and completion is
+    // a one-shot side effect.
+    _stopWatching(payjoinId);
+
+    final model = await _localPayjoinDatasource.fetchReceiver(payjoinId);
+    if (model == null || model.isCompleted || model.isAborted) return;
+
+    final completedModel = model.copyWith(isCompleted: true);
+    await _localPayjoinDatasource.update(completedModel);
+    if (completedModel.txId != null) {
+      await _labelPayjoinTransaction(
+        txId: completedModel.txId!,
+        walletId: completedModel.walletId,
+      );
+    }
+    _payjoinStreamController.add(completedModel.toEntity());
+    log.info('Payjoin receiver completed on broadcast: $payjoinId');
+  }
+
+  /// The original transaction landed on-chain — regardless of which side
+  /// actually broadcast it (this repository's own attempt, possibly already
+  /// failed, or the counterparty's independent fallback) — so this session
+  /// is resolved via the plain-broadcast fallback (status `aborted`), never
+  /// a real payjoin. `txId` is cleared for the same reason
+  /// [_broadcastOriginalTransaction] clears it. Never labels the transaction
+  /// "payjoin" — this is by definition not a real one.
+  Future<void> _onOriginalTransactionSeen(String payjoinId) async {
+    // Stop first: the watch stream re-emits on every sync, and completion is
+    // a one-shot side effect. Whichever of the real payjoin txid or this
+    // original txid lands first resolves the session, so both watchers are
+    // torn down together.
+    _stopWatching(payjoinId);
+
+    final receiverModel = await _localPayjoinDatasource.fetchReceiver(
+      payjoinId,
+    );
+    final PayjoinModel? model =
+        receiverModel ?? await _localPayjoinDatasource.fetchSender(payjoinId);
+    if (model == null || model.isCompleted || model.isAborted) return;
+
+    final PayjoinModel abortedModel = model is PayjoinReceiverModel
+        ? model.copyWith(isAborted: true, txId: null)
+        : (model as PayjoinSenderModel).copyWith(isAborted: true, txId: null);
+    await _localPayjoinDatasource.update(abortedModel);
+    _syncWalletAfterBroadcast(abortedModel.walletId);
+    final abortedEntity = abortedModel.toEntity();
+    _payjoinStreamController.add(abortedEntity);
+    log.info(
+      'Payjoin ${abortedEntity.logRef} resolved via the original '
+      'transaction observed on-chain (fallback, not necessarily broadcast '
+      'by this device)',
+    );
+  }
+
+  /// Stops every watcher of a session — the real-payjoin broadcast watch
+  /// ([_watchForBroadcast]), the original-transaction fallback watch
+  /// ([_watchForFallback]) AND the PDK directory poll — since the session
+  /// resolving through any one of them means there is nothing left to watch
+  /// for on the others. Stopping the directory poll matters as much as the
+  /// two watchers: a session resolved via the fallback otherwise keeps its
+  /// request/proposal poll firing until expiry, which then raises a stale
+  /// expired event for an already-completed session (see
+  /// [_processExpiredPayjoin]'s guard). Synchronous on purpose:
+  /// `StreamSubscription.cancel()` already guarantees no further events are
+  /// delivered from the moment it is CALLED, so nothing here needs to block
+  /// on its returned future (which only signals resource cleanup) — and
+  /// awaiting it would make completion latency depend on the upstream
+  /// stream's teardown.
+  void _stopWatching(String payjoinId) {
+    _broadcastPollTimers.remove(payjoinId)?.cancel();
+    final broadcastSubscription = _broadcastWatchers.remove(payjoinId);
+    if (broadcastSubscription != null) {
+      unawaited(broadcastSubscription.cancel());
+    }
+    _fallbackPollTimers.remove(payjoinId)?.cancel();
+    final fallbackSubscription = _fallbackWatchers.remove(payjoinId);
+    if (fallbackSubscription != null) {
+      unawaited(fallbackSubscription.cancel());
+    }
+    _pdkPayjoinDatasource.stopPolling(payjoinId);
+  }
+
+  /// Fire-and-forget wallet sync after WE broadcast a transaction (either a
+  /// real payjoin proposal or a plain fallback) — the only two places this
+  /// repository itself puts a new transaction on the network. Not awaited by
+  /// callers: it must never delay resolving the payjoin session (this can
+  /// take a real network round-trip), and a transient failure here (no
+  /// network at that exact moment) shouldn't be treated as the broadcast —
+  /// which already succeeded — having failed. The next organic sync (or the
+  /// receiver's own _watchForBroadcast poll) still catches up eventually.
+  ///
+  /// The call is wrapped in `Future(() => ...)` rather than invoked directly:
+  /// this repository's callers (_broadcastOriginalTransaction, _broadcastPsbt)
+  /// already wrap their whole body in a try/catch for the broadcast itself,
+  /// so a SYNCHRONOUS throw from `_walletRepository()` or `getWallet(...)` (as
+  /// opposed to the future it returns rejecting) would otherwise be caught by
+  /// that outer try/catch and misreported as the broadcast having failed,
+  /// even though it already succeeded.
+  void _syncWalletAfterBroadcast(String walletId) {
+    unawaited(
+      Future(
+        () => _walletRepository().getWallet(walletId, sync: true),
+      ).catchError((Object e) {
+        log.warning('Failed to sync wallet after payjoin broadcast: $e');
+        return null;
+      }),
+    );
+  }
+
+  /// Tags a completed payjoin transaction with the payjoin system label so it
+  /// is recognisable as a payjoin in the transaction list. Best-effort: a
+  /// labelling failure must never fail the (already broadcast) payjoin, so it
+  /// is logged and swallowed. Idempotent — the labels store dedupes on
+  /// (label, reference).
+  Future<void> _labelPayjoinTransaction({
+    required String txId,
+    required String walletId,
+  }) async {
+    try {
+      final result = await _labelsFacade().store(
+        NewLabel.tx(
+          transactionId: txId,
+          label: LabelSystem.payjoin.label,
+          origin: walletId,
+        ),
+      );
+      result.fold(
+        (_) {},
+        (failure) => log.warning(
+          'Failed to label payjoin transaction',
+          error: failure.logMessage,
+        ),
+      );
+    } catch (e) {
+      log.warning('Failed to label payjoin transaction', error: e);
+    }
+  }
+
+  /// Best-effort and idempotent, matching the labelling elsewhere in the
+  /// codebase that touches this same facade from core (see
+  /// LabelExchangeOrdersUsecase, AutoSwapExecutionUsecase): a labelling
+  /// failure is logged and swallowed so it never fails the already-broadcast
+  /// payjoin, and the labels store dedupes on (label, reference) so a
+  /// repeated call for the same txid is harmless.
+  ///
+  /// Not private (and marked [visibleForTesting]) so it can be exercised
+  /// directly: driving it through the full reactive sender pipeline needs a
+  /// real, valid PSBT for BitcoinTx.fromPsbt to parse (FFI-backed — the
+  /// existing payjoin datasource tests document the same offline-fixture
+  /// constraint), which isn't practical to construct in a unit test.
+  @visibleForTesting
+  Future<void> labelCompletedPayjoinSend(String txId) async {
+    try {
+      final result = await _labelsFacade().store(
+        NewLabel.tx(transactionId: txId, label: LabelSystem.payjoin.label),
+      );
+      result.fold(
+        (_) {},
+        (failure) => log.warning(
+          'Failed to label completed payjoin send',
+          error: failure.logMessage,
+        ),
+      );
+    } catch (e) {
+      log.warning('Failed to label completed payjoin send', error: e);
+    }
   }
 }
 

--- a/lib/core/payjoin/domain/repositories/payjoin_repository.dart
+++ b/lib/core/payjoin/domain/repositories/payjoin_repository.dart
@@ -31,4 +31,12 @@ abstract class PayjoinRepository {
     required int expireAfterSec,
   });
   Future<Payjoin?> tryBroadcastOriginalTransaction(Payjoin payjoin);
+
+  /// Resumes polling/watching for every unfinished payjoin session left over
+  /// from a previous app run. A composition-root lifecycle hook: the
+  /// repository is constructed as an eager singleton before every dependency
+  /// it needs (wallet repositories, the labels facade) is registered, so this
+  /// must be called explicitly once every core dependency it needs is
+  /// registered, rather than fired from the constructor — see AppLocator.setup.
+  Future<void> resumePayjoinsOnStartup();
 }

--- a/lib/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart
+++ b/lib/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart
@@ -2,7 +2,6 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
-import 'package:bb_mobile/core/utils/constants.dart';
 
 class ReceiveWithPayjoinUsecase {
   final PayjoinRepository _payjoinRepository;
@@ -27,8 +26,9 @@ class ReceiveWithPayjoinUsecase {
         address: address,
         isTestnet: environment.isTestnet,
         maxFeeRateSatPerVb: BigInt.from(10000),
-        expireAfterSec:
-            expireAfterSec ?? PayjoinConstants.defaultExpireAfterSec,
+        // The user-configured session lifetime (see the payjoin settings
+        // screen) unless the caller explicitly overrides it (e.g. tests).
+        expireAfterSec: expireAfterSec ?? settings.payjoinExpireAfterSec,
       );
 
       return payjoinReceiver;

--- a/lib/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart
+++ b/lib/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart
@@ -1,16 +1,18 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
-import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 
 class SendWithPayjoinUsecase {
   final PayjoinRepository _payjoinRepository;
   final BitcoinWalletRepository _bitcoinWalletRepository;
+  final SettingsRepository _settingsRepository;
 
   const SendWithPayjoinUsecase({
     required this._payjoinRepository,
     required this._bitcoinWalletRepository,
+    required this._settingsRepository,
   });
 
   Future<PayjoinSender> execute({
@@ -28,6 +30,12 @@ class SendWithPayjoinUsecase {
         walletId: walletId,
       );
 
+      // The user-configured session lifetime (payjoin settings screen)
+      // unless the caller explicitly overrides it (e.g. tests) — resolved
+      // here, not by the caller, to mirror ReceiveWithPayjoinUsecase so the
+      // two sides can't silently drift apart.
+      final settings = await _settingsRepository.fetch();
+
       final pjSender = await _payjoinRepository.createPayjoinSender(
         walletId: walletId,
         isTestnet: isTestnet,
@@ -35,8 +43,7 @@ class SendWithPayjoinUsecase {
         originalPsbt: signedOriginalPsbt,
         amountSat: amountSat,
         networkFeesSatPerVb: networkFeesSatPerVb,
-        expireAfterSec:
-            expireAfterSec ?? PayjoinConstants.defaultExpireAfterSec,
+        expireAfterSec: expireAfterSec ?? settings.payjoinExpireAfterSec,
       );
 
       return pjSender;

--- a/lib/core/payjoin/domain/usecases/watch_payjoin_usecase.dart
+++ b/lib/core/payjoin/domain/usecases/watch_payjoin_usecase.dart
@@ -7,12 +7,15 @@ class WatchPayjoinUsecase {
 
   const WatchPayjoinUsecase({required this._payjoinRepository});
 
-  Stream<PayjoinReceiver> execute({List<String>? ids}) {
+  /// Emits every payjoin update (both [PayjoinReceiver] and [PayjoinSender]),
+  /// optionally scoped to [ids]. Consumers that only care about one side
+  /// filter the concrete type themselves — the sender send-flow needs sender
+  /// completion events, which a receiver-only filter here would swallow.
+  Stream<Payjoin> execute({List<String>? ids}) {
     try {
-      return _payjoinRepository.payjoinStream
-          .where((payjoin) => payjoin is PayjoinReceiver)
-          .cast<PayjoinReceiver>()
-          .where((payjoin) => ids == null || ids.contains(payjoin.id));
+      return _payjoinRepository.payjoinStream.where(
+        (payjoin) => ids == null || ids.contains(payjoin.id),
+      );
     } catch (e) {
       throw WatchPayjoinException(e.toString());
     }

--- a/lib/core/payjoin/payjoin_locator.dart
+++ b/lib/core/payjoin/payjoin_locator.dart
@@ -17,6 +17,9 @@ import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 
@@ -39,7 +42,19 @@ class PayjoinLocator {
           BaseOptions(
             connectTimeout: const Duration(seconds: 10),
             sendTimeout: const Duration(seconds: 10),
-            receiveTimeout: const Duration(seconds: 30),
+            // receiveTimeout MUST exceed the payjoin directory's long-poll
+            // hold: payjo.in (payjoin-mailroom) keeps an empty-mailbox poll
+            // open for ~30s before answering 202 Accepted. A timeout at or
+            // below that hold races it and loses every time — each empty
+            // poll aborts just before the 202, is misread as a relay
+            // failure, and cascades through all three relays, so a payjoin
+            // never completes and every send falls back to the original
+            // transaction (a real, previously-shipped bug). 35s = the ~30s
+            // hold + a minimal margin for relay forwarding and OHTTP/TLS
+            // overhead. The session's own expiry (default 24h — see
+            // PayjoinConstants) sits far above this, so the poll budget is
+            // bounded purely by this long-poll-hold floor plus margin.
+            receiveTimeout: const Duration(seconds: 35),
           ),
         ),
       ),
@@ -47,8 +62,10 @@ class PayjoinLocator {
   }
 
   static void registerRepositories(GetIt locator) {
-    // Not a lazy singleton, because it should resume payjoins from the
-    // moment the app starts.
+    // Eager (not lazy) singleton: it subscribes to the datasource's event
+    // streams at construction. Resuming unfinished sessions is deferred to
+    // an explicit resumePayjoinsOnStartup() call from AppLocator.setup (see
+    // that method), once every dependency it needs is registered.
     locator.registerSingleton<PayjoinRepository>(
       PayjoinRepositoryImpl(
         localPayjoinDatasource: locator<LocalPayjoinDatasource>(),
@@ -58,6 +75,19 @@ class PayjoinLocator {
         seedDatasource: locator<SeedDatasource>(),
         blockchainDatasource: locator<BdkBitcoinBlockchainDatasource>(),
         serversPort: locator<ElectrumServersPort>(),
+        // Lazy: WalletLocator registers these AFTER
+        // PayjoinLocator.registerRepositories (see core_locator.dart), and
+        // this repository is an eager registerSingleton. They are only
+        // called from broadcast/completion watchers, well after startup.
+        walletRepository: () => locator<WalletRepository>(),
+        walletTransactionRepository: () =>
+            locator<WalletTransactionRepository>(),
+        settingsRepository: locator<SettingsRepository>(),
+        // Lazy: LabelsLocator.registerFacade runs after
+        // PayjoinLocator.registerRepositories (see core_locator.dart), and
+        // this repository is an eager registerSingleton — see
+        // PayjoinRepositoryImpl's _labelsFacade doc comment.
+        labelsFacade: () => locator<LabelsFacade>(),
       ),
     );
   }
@@ -85,6 +115,7 @@ class PayjoinLocator {
       () => SendWithPayjoinUsecase(
         payjoinRepository: locator<PayjoinRepository>(),
         bitcoinWalletRepository: locator<BitcoinWalletRepository>(),
+        settingsRepository: locator<SettingsRepository>(),
       ),
     );
 

--- a/lib/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart
+++ b/lib/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart
@@ -1,0 +1,32 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+/// Fetches one wallet transaction by txid. With [sync] the lookup first
+/// forces a DIRECT electrum-backed sync of the wallet (the repository's
+/// sync path is not routed through the sync coordinator, so it cannot be
+/// throttled away) — the way to make a transaction that was just broadcast
+/// visible in the local wallet database on demand, instead of waiting for
+/// the next organic sync.
+class GetWalletTransactionUsecase {
+  final WalletTransactionRepository _walletTransactionRepository;
+
+  GetWalletTransactionUsecase({required this._walletTransactionRepository});
+
+  @useResult
+  Future<Result<WalletTransaction?, WalletTransactionLookupFailure>> execute({
+    required String txId,
+    required String walletId,
+    bool sync = false,
+  }) async {
+    try {
+      final transaction = await _walletTransactionRepository
+          .getWalletTransaction(txId, walletId: walletId, sync: sync);
+      return Ok(transaction);
+    } catch (e) {
+      return Err(WalletTransactionLookupFailure(e.toString()));
+    }
+  }
+}

--- a/lib/core/wallet/domain/wallet_failure.dart
+++ b/lib/core/wallet/domain/wallet_failure.dart
@@ -1,0 +1,9 @@
+import 'package:bb_mobile/core/failures/failure.dart';
+
+sealed class WalletFailure extends Failure {
+  const WalletFailure([super.logMessage]);
+}
+
+final class WalletTransactionLookupFailure extends WalletFailure {
+  const WalletTransactionLookupFailure([super.logMessage]);
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -25,6 +25,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_use
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transactions_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
@@ -184,6 +185,11 @@ class WalletLocator {
     locator.registerFactory<GetWalletTransactionsUsecase>(
       () => GetWalletTransactionsUsecase(
         settingsRepository: locator<SettingsRepository>(),
+        walletTransactionRepository: locator<WalletTransactionRepository>(),
+      ),
+    );
+    locator.registerFactory<GetWalletTransactionUsecase>(
+      () => GetWalletTransactionUsecase(
         walletTransactionRepository: locator<WalletTransactionRepository>(),
       ),
     );

--- a/lib/features/receive/presentation/bloc/receive_bloc.dart
+++ b/lib/features/receive/presentation/bloc/receive_bloc.dart
@@ -838,14 +838,18 @@ class ReceiveBloc extends Bloc<ReceiveEvent, ReceiveState> {
   void _watchPayjoin(String payjoinId) {
     // Cancel the previous subscription if it exists
     _payjoinSubscription?.cancel();
-    _payjoinSubscription = _watchPayjoinUsecase.execute(ids: [payjoinId]).listen((
-      updatedPayjoin,
-    ) {
-      log.info(
-        '[ReceiveBloc] Watched payjoin ${updatedPayjoin.id} updated: ${updatedPayjoin.status}',
-      );
-      add(ReceivePayjoinUpdated(updatedPayjoin));
-    });
+    // WatchPayjoinUsecase now emits both receiver and sender sessions; the
+    //  receive flow only deals with the receiver side.
+    _payjoinSubscription = _watchPayjoinUsecase
+        .execute(ids: [payjoinId])
+        .where((payjoin) => payjoin is PayjoinReceiver)
+        .cast<PayjoinReceiver>()
+        .listen((updatedPayjoin) {
+          log.info(
+            '[ReceiveBloc] Watched payjoin ${updatedPayjoin.id} updated: ${updatedPayjoin.status}',
+          );
+          add(ReceivePayjoinUpdated(updatedPayjoin));
+        });
   }
 
   void _watchWalletTransactionToAddress({

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/ark/locator.dart';
 import 'package:bb_mobile/core/core_locator.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/status/status_locator.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/sync/sync_locator.dart';
@@ -64,6 +67,15 @@ class AppLocator {
     CoreLocator.registerUsecases(locator);
     CoreLocator.registerFrameworks(locator);
     CoreLocator.registerFacades(locator);
+
+    // Every dependency PayjoinRepositoryImpl needs (wallet repositories,
+    //  settings, the labels facade) is now guaranteed registered — resume any
+    //  unfinished payjoin sessions left over from a previous run. Not awaited:
+    //  this is background work (relay polling, wallet syncs) that must not
+    //  delay app startup. See resumePayjoinsOnStartup's doc for why this
+    //  can't just run in the repository's constructor.
+    unawaited(locator<PayjoinRepository>().resumePayjoinsOnStartup());
+
     SyncLocator.setup(locator);
 
     // Register feature-specific dependencies

--- a/test/core_test/payjoin/local_payjoin_datasource_test.dart
+++ b/test/core_test/payjoin/local_payjoin_datasource_test.dart
@@ -1,0 +1,95 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late SqliteDatabase db;
+  late LocalPayjoinDatasource datasource;
+
+  setUp(() {
+    db = SqliteDatabase(NativeDatabase.memory());
+    datasource = LocalPayjoinDatasource(db: db);
+  });
+
+  tearDown(() async => db.close());
+
+  final originalTxId = 'a' * 64;
+  final proposalTxId = 'b' * 64;
+
+  PayjoinReceiverModel buildReceiver({
+    String? txId,
+    String? originalTxIdValue,
+    bool isAborted = false,
+  }) =>
+      PayjoinModel.receiver(
+            id: 'r1',
+            address: 'bcrt1qaddress',
+            isTestnet: true,
+            receiver: '[]',
+            walletId: 'w1',
+            pjUri: 'bitcoin:bcrt1qaddress?pj=https://payjo.in/x',
+            maxFeeRateSatPerVb: BigInt.from(10000),
+            createdAt: 1700000000,
+            expireAfterSec: 86400,
+            originalTxBytes: Uint8List.fromList([1, 2, 3]),
+            originalTxId: originalTxIdValue,
+            amountSat: 5000,
+            txId: txId,
+            isAborted: isAborted,
+          )
+          as PayjoinReceiverModel;
+
+  group('fetchByTxId', () {
+    test('finds an aborted session by its ORIGINAL transaction id — the only '
+        'id that exists on-chain for a fallback broadcast (txId is null, no '
+        'proposal was ever broadcast); matching only txId hid the aborted '
+        'outcome from the transaction details entirely', () async {
+      await datasource.storeReceiver(
+        buildReceiver(originalTxIdValue: originalTxId, isAborted: true),
+      );
+
+      final found = await datasource.fetchByTxId(originalTxId);
+
+      expect(found, hasLength(1));
+      expect(found.single.isAborted, isTrue);
+    });
+
+    test('still finds a session by its payjoin transaction id', () async {
+      await datasource.storeReceiver(
+        buildReceiver(txId: proposalTxId, originalTxIdValue: originalTxId),
+      );
+
+      final found = await datasource.fetchByTxId(proposalTxId);
+
+      expect(found, hasLength(1));
+    });
+
+    test('returns nothing for an unrelated transaction id', () async {
+      await datasource.storeReceiver(
+        buildReceiver(txId: proposalTxId, originalTxIdValue: originalTxId),
+      );
+
+      final found = await datasource.fetchByTxId('c' * 64);
+
+      expect(found, isEmpty);
+    });
+  });
+
+  group('fetchAll(onlyUnfinished)', () {
+    test('excludes aborted sessions — they must never be resumed', () async {
+      await datasource.storeReceiver(
+        buildReceiver(originalTxIdValue: originalTxId, isAborted: true),
+      );
+
+      final unfinished = await datasource.fetchAll(onlyUnfinished: true);
+      final all = await datasource.fetchAll();
+
+      expect(unfinished, isEmpty);
+      expect(all, hasLength(1));
+    });
+  });
+}

--- a/test/core_test/payjoin/payjoin_entity_test.dart
+++ b/test/core_test/payjoin/payjoin_entity_test.dart
@@ -1,0 +1,218 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final _defaultOriginalTxBytes = Uint8List.fromList([1, 2, 3]);
+
+PayjoinReceiver _receiver({
+  required PayjoinStatus status,
+  String? txId,
+  String? proposalPsbt,
+  // Defaults to a non-null value: once a request has been received the
+  //  receiver holds the sender's original transaction, which
+  //  canManuallyBroadcastOriginal requires. Pass Uint8List(0)-equivalent
+  //  null via [noOriginalTxBytes] for the `started` (no request yet) case.
+  Uint8List? originalTxBytes,
+  bool noOriginalTxBytes = false,
+}) =>
+    Payjoin.receiver(
+          status: status,
+          id: 'pj1',
+          isTestnet: true,
+          walletId: 'w1',
+          pjUri: 'bitcoin:tb1qtest?pj=https://payjo.in',
+          createdAt: DateTime(2026),
+          expiresAt: DateTime(2026).add(const Duration(minutes: 1)),
+          txId: txId,
+          proposalPsbt: proposalPsbt,
+          originalTxBytes: noOriginalTxBytes
+              ? null
+              : (originalTxBytes ?? _defaultOriginalTxBytes),
+        )
+        as PayjoinReceiver;
+
+PayjoinSender _sender({
+  required PayjoinStatus status,
+  String? txId,
+  String? proposalPsbt,
+}) =>
+    Payjoin.sender(
+          status: status,
+          uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+          isTestnet: true,
+          walletId: 'w1',
+          originalPsbt: 'cHNidP8=',
+          originalTxId: 'orig-txid',
+          amountSat: 50000,
+          createdAt: DateTime(2026),
+          expiresAt: DateTime(2026).add(const Duration(minutes: 1)),
+          txId: txId,
+          proposalPsbt: proposalPsbt,
+        )
+        as PayjoinSender;
+
+void main() {
+  group('Payjoin.isCompleted/isAborted/isExpired/isOngoing', () {
+    Payjoin buildReceiver(PayjoinStatus status) => Payjoin.receiver(
+      status: status,
+      id: 'r1',
+      isTestnet: true,
+      walletId: 'w1',
+      pjUri: 'bitcoin:addr?pj=https://payjo.in/x',
+      createdAt: DateTime(2026),
+      expiresAt: DateTime(2026, 1, 2),
+    );
+
+    test('completed', () {
+      final p = buildReceiver(PayjoinStatus.completed);
+      expect(p.isCompleted, isTrue);
+      expect(p.isAborted, isFalse);
+      expect(p.isExpired, isFalse);
+      expect(p.isOngoing, isFalse);
+    });
+
+    test(
+      'aborted — the payjoin did not happen, WE broadcast the original tx',
+      () {
+        final p = buildReceiver(PayjoinStatus.aborted);
+        expect(p.isCompleted, isFalse);
+        expect(p.isAborted, isTrue);
+        expect(p.isExpired, isFalse);
+        expect(
+          p.isOngoing,
+          isFalse,
+          reason: 'aborted is terminal, exactly like completed/expired',
+        );
+      },
+    );
+
+    test('expired — nothing broadcast by us', () {
+      final p = buildReceiver(PayjoinStatus.expired);
+      expect(p.isCompleted, isFalse);
+      expect(p.isAborted, isFalse);
+      expect(p.isExpired, isTrue);
+      expect(p.isOngoing, isFalse);
+    });
+
+    test('requested/proposed are ongoing', () {
+      expect(buildReceiver(PayjoinStatus.requested).isOngoing, isTrue);
+      expect(buildReceiver(PayjoinStatus.proposed).isOngoing, isTrue);
+    });
+  });
+
+  group('Payjoin.canManuallyBroadcastOriginal', () {
+    test('receiver: true while waiting (request received, no proposal '
+        'sent)', () {
+      expect(
+        _receiver(status: PayjoinStatus.requested).canManuallyBroadcastOriginal,
+        isTrue,
+      );
+    });
+
+    test('receiver: false while still started — no original tx to broadcast '
+        'yet (no request received)', () {
+      expect(
+        _receiver(
+          status: PayjoinStatus.started,
+          noOriginalTxBytes: true,
+        ).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('receiver: false once a proposal is sent — the sender owns it for '
+        'as long as that takes, with no dead-end that would ever need a '
+        'manual retry', () {
+      expect(
+        _receiver(
+          status: PayjoinStatus.proposed,
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        ).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('receiver: false once completed (real payjoin)', () {
+      expect(
+        _receiver(
+          status: PayjoinStatus.completed,
+          txId: 'payjoin-txid',
+        ).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('receiver: false once aborted (fallback already broadcast)', () {
+      expect(
+        _receiver(status: PayjoinStatus.aborted).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('sender: true while waiting (no proposal ever received)', () {
+      expect(
+        _sender(status: PayjoinStatus.requested).canManuallyBroadcastOriginal,
+        isTrue,
+      );
+    });
+
+    test('sender: false while a proposal is being actively processed '
+        '(received, not yet completed or expired)', () {
+      expect(
+        _sender(
+          status: PayjoinStatus.proposed,
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        ).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('sender: false once completed (real payjoin)', () {
+      expect(
+        _sender(
+          status: PayjoinStatus.completed,
+          txId: 'payjoin-txid',
+        ).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('sender: false once aborted (fallback already broadcast)', () {
+      expect(
+        _sender(status: PayjoinStatus.aborted).canManuallyBroadcastOriginal,
+        isFalse,
+      );
+    });
+
+    test('sender: true once its OWN internal fallback also gave up '
+        '(expired, proposalPsbt still set) — no dead-end left, a manual '
+        'retry must still be possible', () {
+      expect(
+        _sender(
+          status: PayjoinStatus.expired,
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        ).canManuallyBroadcastOriginal,
+        isTrue,
+      );
+    });
+  });
+
+  group('Payjoin.logRef', () {
+    test('a receiver id passes through unchanged', () {
+      // A receiver id is already an opaque sha256 prefix of the pjUri, so it
+      // is safe to log verbatim and stays stable across restarts.
+      expect(_receiver(status: PayjoinStatus.requested).logRef, 'pj1');
+    });
+
+    test('a sender logRef is a 16-char lowercase hex hash and never leaks '
+        'the BIP21 uri (which carries the address/amount/endpoint)', () {
+      final sender = _sender(status: PayjoinStatus.requested);
+
+      expect(sender.logRef, matches(RegExp(r'^[0-9a-f]{16}$')));
+      // The raw address must never appear in the log-safe reference.
+      expect(sender.logRef, isNot(contains('tb1qsender')));
+      expect(sender.logRef, isNot(equals(sender.id)));
+    });
+  });
+}

--- a/test/core_test/payjoin/payjoin_model_test.dart
+++ b/test/core_test/payjoin/payjoin_model_test.dart
@@ -1,0 +1,131 @@
+import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PayjoinModel.status derivation', () {
+    PayjoinReceiverModel buildReceiver({
+      bool isCompleted = false,
+      bool isAborted = false,
+      bool isExpired = false,
+      String? proposalPsbt,
+      dynamic originalTxBytes,
+    }) =>
+        PayjoinModel.receiver(
+              id: 'r1',
+              address: 'addr',
+              isTestnet: true,
+              receiver: '[]',
+              walletId: 'w1',
+              pjUri: 'bitcoin:addr?pj=https://payjo.in/x',
+              maxFeeRateSatPerVb: BigInt.from(10000),
+              createdAt: 0,
+              expireAfterSec: 86400,
+              proposalPsbt: proposalPsbt,
+              isCompleted: isCompleted,
+              isAborted: isAborted,
+              isExpired: isExpired,
+            )
+            as PayjoinReceiverModel;
+
+    test('isCompleted takes priority over everything else', () {
+      final model = buildReceiver(
+        isCompleted: true,
+        isAborted: true,
+        isExpired: true,
+      );
+      expect(model.status, PayjoinStatus.completed);
+    });
+
+    test('isAborted takes priority over isExpired', () {
+      final model = buildReceiver(isAborted: true, isExpired: true);
+      expect(model.status, PayjoinStatus.aborted);
+    });
+
+    test('isExpired when neither completed nor aborted', () {
+      final model = buildReceiver(isExpired: true);
+      expect(model.status, PayjoinStatus.expired);
+    });
+
+    test('proposed when a proposal exists and nothing terminal is set', () {
+      final model = buildReceiver(proposalPsbt: 'psbt');
+      expect(model.status, PayjoinStatus.proposed);
+    });
+
+    test('started when nothing has happened yet', () {
+      final model = buildReceiver();
+      expect(model.status, PayjoinStatus.started);
+    });
+  });
+
+  group('PayjoinModel.fromReceiverTable/fromSenderTable round-trip '
+      'isExpired/isCompleted/isAborted (regression: these used to be silently '
+      'dropped on every re-fetch, resetting status to "never resolved")', () {
+    test('fromReceiverTable maps the terminal flags from the row', () {
+      final row = PayjoinReceiverRow(
+        id: 'r1',
+        address: 'addr',
+        isTestnet: true,
+        receiver: '[]',
+        walletId: 'w1',
+        pjUri: 'bitcoin:addr?pj=https://payjo.in/x',
+        maxFeeRateSatPerVb: BigInt.from(10000),
+        createdAt: 0,
+        expireAfterSec: 86400,
+        isExpired: false,
+        isCompleted: true,
+        isAborted: false,
+      );
+
+      final model = PayjoinModel.fromReceiverTable(row);
+
+      expect(model.isCompleted, isTrue);
+      expect(model.status, PayjoinStatus.completed);
+    });
+
+    test('fromReceiverTable maps isAborted from the row', () {
+      final row = PayjoinReceiverRow(
+        id: 'r1',
+        address: 'addr',
+        isTestnet: true,
+        receiver: '[]',
+        walletId: 'w1',
+        pjUri: 'bitcoin:addr?pj=https://payjo.in/x',
+        maxFeeRateSatPerVb: BigInt.from(10000),
+        createdAt: 0,
+        expireAfterSec: 86400,
+        isExpired: false,
+        isCompleted: false,
+        isAborted: true,
+      );
+
+      final model = PayjoinModel.fromReceiverTable(row);
+
+      expect(model.isAborted, isTrue);
+      expect(model.status, PayjoinStatus.aborted);
+    });
+
+    test('fromSenderTable maps the terminal flags from the row', () {
+      final row = PayjoinSenderRow(
+        uri: 'bitcoin:addr?pj=https://payjo.in/x',
+        isTestnet: true,
+        sender: '[]',
+        walletId: 'w1',
+        originalPsbt: 'psbt',
+        originalTxId: 'a' * 64,
+        amountSat: 10000,
+        createdAt: 0,
+        expireAfterSec: 86400,
+        isExpired: false,
+        isCompleted: true,
+        isAborted: false,
+      );
+
+      final model = PayjoinModel.fromSenderTable(row);
+
+      expect(model.isCompleted, isTrue);
+      expect(model.status, PayjoinStatus.completed);
+    });
+  });
+}

--- a/test/core_test/payjoin/payjoin_repository_impl_test.dart
+++ b/test/core_test/payjoin/payjoin_repository_impl_test.dart
@@ -1,0 +1,2004 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart' show SignerEntity;
+import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/datasources/pdk_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
+import 'package:bb_mobile/core/payjoin/data/repository/payjoin_repository_impl.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/core/wallet/wallet_metadata_service.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLocalPayjoinDatasource extends Mock
+    implements LocalPayjoinDatasource {}
+
+class _MockPdkPayjoinDatasource extends Mock implements PdkPayjoinDatasource {}
+
+class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+class _MockBdkWalletDatasource extends Mock implements BdkWalletDatasource {}
+
+class _MockBdkBitcoinBlockchainDatasource extends Mock
+    implements BdkBitcoinBlockchainDatasource {}
+
+class _MockElectrumServersPort extends Mock implements ElectrumServersPort {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+class _MockWalletRepository extends Mock implements WalletRepository {}
+
+class _MockWalletTransactionRepository extends Mock
+    implements WalletTransactionRepository {}
+
+class _MockLabelsFacade extends Mock implements LabelsFacade {}
+
+class _MockLabel extends Mock implements Label {}
+
+class _FakeNewLabel extends Fake implements NewLabel {}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers (adapted from the payjoin-hardening test suite to the
+// work-tree PayjoinModel / Wallet / WalletTransaction constructors).
+// ---------------------------------------------------------------------------
+
+PayjoinReceiverModel _receiverModel({
+  String id = 'pj1',
+  String walletId = 'w1',
+  String? originalTxId = 'orig-txid',
+  String? proposalPsbt,
+  String? txId,
+  int? amountSat,
+  // Defaults to already-elapsed (createdAt: 0) so isExpiryTimePassed is true
+  // by default. Pass a large value to get a not-yet-expired model instead
+  // (e.g. to exercise resume's live-session branches).
+  int expireAfterSec = 300,
+}) {
+  return PayjoinModel.receiver(
+        id: id,
+        address: 'tb1qtest',
+        isTestnet: true,
+        receiver: '[]',
+        walletId: walletId,
+        pjUri: 'bitcoin:tb1qtest?pj=https://payjo.in',
+        maxFeeRateSatPerVb: BigInt.from(10),
+        createdAt: 0,
+        expireAfterSec: expireAfterSec,
+        originalTxBytes: Uint8List.fromList([1, 2, 3]),
+        originalTxId: originalTxId,
+        proposalPsbt: proposalPsbt,
+        txId: txId,
+        amountSat: amountSat,
+      )
+      as PayjoinReceiverModel;
+}
+
+PayjoinSenderModel _senderModel({
+  String uri = 'bitcoin:tb1qsender?pj=https://payjo.in',
+  String walletId = 'w1',
+  String originalTxId = 'sender-orig-txid',
+  String? proposalPsbt,
+}) {
+  return PayjoinModel.sender(
+        uri: uri,
+        isTestnet: true,
+        sender: '[]',
+        walletId: walletId,
+        originalPsbt: 'cHNidP8=',
+        originalTxId: originalTxId,
+        amountSat: 50000,
+        createdAt: 0,
+        expireAfterSec: 300,
+        proposalPsbt: proposalPsbt,
+      )
+      as PayjoinSenderModel;
+}
+
+SettingsEntity _testSettings({int payjoinMinAmountSat = 10000}) =>
+    SettingsEntity(
+      environment: Environment.mainnet,
+      bitcoinUnit: BitcoinUnit.sats,
+      currencyCode: 'USD',
+      payjoinMinAmountSat: payjoinMinAmountSat,
+    );
+
+Wallet _testWallet({String origin = 'w1'}) => Wallet(
+  origin: origin,
+  network: Network.bitcoinMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.zero,
+);
+
+WalletTransaction _testWalletTx({
+  required String txId,
+  required String walletId,
+}) => WalletTransaction(
+  walletId: walletId,
+  network: Network.bitcoinMainnet,
+  direction: WalletTransactionDirection.incoming,
+  status: WalletTransactionStatus.confirmed,
+  txId: txId,
+  amountSat: 50000,
+  feeSat: 500,
+  vsize: 150,
+  inputs: const [],
+  outputs: const [],
+  isRbf: false,
+);
+
+void main() {
+  late _MockLocalPayjoinDatasource localDatasource;
+  late _MockPdkPayjoinDatasource pdkDatasource;
+  late _MockWalletMetadataDatasource walletMetadataDatasource;
+  late _MockSeedDatasource seedDatasource;
+  late _MockBdkWalletDatasource bdkWalletDatasource;
+  late _MockBdkBitcoinBlockchainDatasource blockchainDatasource;
+  late _MockElectrumServersPort serversPort;
+  late _MockSettingsRepository settingsRepository;
+  late _MockWalletRepository walletRepository;
+  late _MockWalletTransactionRepository walletTransactionRepository;
+  late _MockLabelsFacade labelsFacade;
+
+  late StreamController<PayjoinReceiverModel> requestsController;
+  late StreamController<PayjoinSenderModel> proposalsController;
+  late StreamController<PayjoinModel> expiredController;
+
+  setUpAll(() {
+    registerFallbackValue(ElectrumServerNetwork.bitcoinTestnet);
+    registerFallbackValue(_FakeNewLabel());
+    // PayjoinModel is sealed and can't be Fake-implemented from outside its
+    // library — register a real (throwaway) instance instead.
+    registerFallbackValue(_receiverModel());
+    // Fallback for any() matchers against BdkWalletDatasource.signPsbt's
+    // `wallet` param in the real-signing-stack tests.
+    registerFallbackValue(
+      WalletModel.privateBdk(
+            id: 'w1',
+            scriptType: ScriptType.bip84,
+            mnemonic: 'abandon',
+            isTestnet: true,
+          )
+          as PrivateBdkWalletModel,
+    );
+  });
+
+  setUp(() {
+    localDatasource = _MockLocalPayjoinDatasource();
+    pdkDatasource = _MockPdkPayjoinDatasource();
+    walletMetadataDatasource = _MockWalletMetadataDatasource();
+    seedDatasource = _MockSeedDatasource();
+    bdkWalletDatasource = _MockBdkWalletDatasource();
+    blockchainDatasource = _MockBdkBitcoinBlockchainDatasource();
+    serversPort = _MockElectrumServersPort();
+    settingsRepository = _MockSettingsRepository();
+    walletRepository = _MockWalletRepository();
+    walletTransactionRepository = _MockWalletTransactionRepository();
+    labelsFacade = _MockLabelsFacade();
+
+    requestsController = StreamController<PayjoinReceiverModel>.broadcast();
+    proposalsController = StreamController<PayjoinSenderModel>.broadcast();
+    expiredController = StreamController<PayjoinModel>.broadcast();
+
+    when(
+      () => pdkDatasource.requestsForReceivers,
+    ).thenAnswer((_) => requestsController.stream);
+    when(
+      () => pdkDatasource.proposalsForSenders,
+    ).thenAnswer((_) => proposalsController.stream);
+    when(
+      () => pdkDatasource.expiredPayjoins,
+    ).thenAnswer((_) => expiredController.stream);
+    // dispose()/stopPolling are exercised by the repository's own teardown.
+    when(() => pdkDatasource.dispose()).thenAnswer((_) async {});
+    when(() => pdkDatasource.stopPolling(any())).thenReturn(null);
+
+    when(
+      () => localDatasource.fetchAll(
+        onlyUnfinished: any(named: 'onlyUnfinished'),
+      ),
+    ).thenAnswer((_) async => []);
+    // The resume sweep for expired-with-failed-fallback receivers — empty by
+    // default, overridden in the sweep tests. Only runs from
+    // resumePayjoinsOnStartup, never the constructor.
+    when(() => localDatasource.fetchReceivers()).thenAnswer((_) async => []);
+    when(() => localDatasource.update(any())).thenAnswer((_) async {});
+
+    // Passive watchers must never fire spuriously: an empty sync stream and
+    // a not-found transaction lookup keep _watchForFallback/_watchForBroadcast
+    // arming a harmless no-op.
+    when(
+      () => walletRepository.walletSyncFinishedStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => walletRepository.getWallet(any(), sync: any(named: 'sync')),
+    ).thenAnswer((_) async => null);
+    when(
+      () => walletTransactionRepository.getWalletTransaction(
+        any(),
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+      ),
+    ).thenAnswer((_) async => null);
+  });
+
+  tearDown(() async {
+    await requestsController.close();
+    await proposalsController.close();
+    await expiredController.close();
+  });
+
+  PayjoinRepositoryImpl buildRepository() =>
+      PayjoinRepositoryImpl(
+          localPayjoinDatasource: localDatasource,
+          pdkPayjoinDatasource: pdkDatasource,
+          walletMetadataDatasource: walletMetadataDatasource,
+          seedDatasource: seedDatasource,
+          bdkWalletDatasource: bdkWalletDatasource,
+          blockchainDatasource: blockchainDatasource,
+          serversPort: serversPort,
+          walletRepository: () => walletRepository,
+          walletTransactionRepository: () => walletTransactionRepository,
+          settingsRepository: settingsRepository,
+          labelsFacade: () => labelsFacade,
+        )
+        // Zero the fallback-retry delay: with the real 1s delay a permanently
+        //  failing broadcast's later attempts fire (on stale mocks) during
+        //  subsequent tests. No test depends on the delay's duration.
+        ..fallbackRetryDelay = Duration.zero;
+
+  PayjoinReceiverModel buildReceiverModel({
+    required int amountSat,
+    bool isExpired = false,
+  }) =>
+      PayjoinModel.receiver(
+            id: 'r1',
+            address: 'bcrt1qaddress',
+            isTestnet: true,
+            receiver: '[]',
+            walletId: 'w1',
+            pjUri: 'bitcoin:bcrt1qaddress?pj=https://payjo.in/x',
+            maxFeeRateSatPerVb: BigInt.from(10000),
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            expireAfterSec: 86400,
+            originalTxBytes: Uint8List.fromList([1, 2, 3]),
+            originalTxId: 'a' * 64,
+            amountSat: amountSat,
+            isExpired: isExpired,
+          )
+          as PayjoinReceiverModel;
+
+  group('below-minimum decline', () {
+    test(
+      'declines via the PDK cancel path and never proposes a payjoin — '
+      'pinned so an inverted or removed threshold check cannot pass '
+      'silently (the below-minimum-decline test on the branch this was '
+      'adapted from could not fail before this assertion was added)',
+      () async {
+        when(() => settingsRepository.fetch()).thenAnswer(
+          (_) async => const SettingsEntity(
+            environment: Environment.testnet,
+            bitcoinUnit: BitcoinUnit.sats,
+            currencyCode: 'USD',
+            isPayjoinEnabled: true,
+            payjoinMinAmountSat: 100000,
+          ),
+        );
+        when(
+          () => pdkDatasource.declineReceiverSession(any()),
+        ).thenReturn('["cancelled"]');
+        when(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).thenAnswer((_) async {});
+        when(() => localDatasource.fetchReceiver(any())).thenAnswer(
+          (_) async => buildReceiverModel(
+            amountSat: 1000,
+          ).copyWith(receiver: '["cancelled"]'),
+        );
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        // Below the 100,000 sat threshold configured above.
+        requestsController.add(buildReceiverModel(amountSat: 1000));
+        await pumpEventQueue();
+
+        verify(() => pdkDatasource.declineReceiverSession(any())).called(1);
+        verify(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => pdkDatasource.proposePayjoin(
+            receiverModel: any(named: 'receiverModel'),
+            hasOwnedInputs: any(named: 'hasOwnedInputs'),
+            hasReceiverOutput: any(named: 'hasReceiverOutput'),
+            inputPairs: any(named: 'inputPairs'),
+            processPsbt: any(named: 'processPsbt'),
+          ),
+        );
+        // walletMetadataDatasource.fetch is only reached by _loadWallet,
+        // which the propose path (never taken here) calls first — an
+        // indirect but sufficient signal that _proposePayjoin's whole
+        // chain, not just proposePayjoin itself, was skipped.
+        verifyNever(() => walletMetadataDatasource.fetch(any()));
+      },
+    );
+
+    test('a request at or above the minimum is not declined', () async {
+      when(() => settingsRepository.fetch()).thenAnswer(
+        (_) async => const SettingsEntity(
+          environment: Environment.testnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+          isPayjoinEnabled: true,
+          payjoinMinAmountSat: 10000,
+        ),
+      );
+      // Let _proposePayjoin fail fast with a benign error instead of fully
+      // wiring the wallet/UTXO chain — this test only cares that the
+      // decline path (declineReceiverSession) is NOT taken above the
+      // threshold.
+      when(
+        () => walletMetadataDatasource.fetch(any()),
+      ).thenAnswer((_) async => null);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      requestsController.add(buildReceiverModel(amountSat: 10000));
+      await pumpEventQueue();
+
+      verifyNever(() => pdkDatasource.declineReceiverSession(any()));
+      // Positive signal that the PROPOSE path (not just "no decline") was
+      // taken: loading the wallet is its first step.
+      verify(() => walletMetadataDatasource.fetch(any())).called(1);
+    });
+  });
+
+  group('resume sweep for expired receivers with a failed fallback', () {
+    // The sweep now lives inside resumePayjoinsOnStartup (no longer fired
+    // from the constructor), so every test here calls it explicitly.
+    test('an expired-but-not-aborted receiver still holding the original tx '
+        'gets a broadcast attempt at startup and is marked aborted on '
+        'success — otherwise the sender payment is stranded forever '
+        '(excluded from every onlyUnfinished resume)', () async {
+      final stranded = buildReceiverModel(amountSat: 5000, isExpired: true);
+      when(
+        () => localDatasource.fetchReceivers(),
+      ).thenAnswer((_) async => [stranded]);
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => localDatasource.fetchReceiver(any()),
+      ).thenAnswer((_) async => stranded);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.resumePayjoinsOnStartup();
+      await pumpEventQueue();
+
+      verify(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).called(1);
+      final updated = verify(
+        () => localDatasource.update(captureAny()),
+      ).captured;
+      expect(
+        updated.whereType<PayjoinReceiverModel>().any((m) => m.isAborted),
+        isTrue,
+      );
+    });
+
+    test('an already-aborted expired receiver is left alone', () async {
+      final resolved = buildReceiverModel(
+        amountSat: 5000,
+        isExpired: true,
+      ).copyWith(isAborted: true);
+      when(
+        () => localDatasource.fetchReceivers(),
+      ).thenAnswer((_) async => [resolved]);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.resumePayjoinsOnStartup();
+      await pumpEventQueue();
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+    });
+  });
+
+  group('isBelowPayjoinMinimum', () {
+    test('below the threshold', () {
+      expect(
+        PayjoinRepositoryImpl.isBelowPayjoinMinimum(
+          amountSat: 999,
+          minAmountSat: 1000,
+        ),
+        isTrue,
+      );
+    });
+
+    test('at the threshold is not below it', () {
+      expect(
+        PayjoinRepositoryImpl.isBelowPayjoinMinimum(
+          amountSat: 1000,
+          minAmountSat: 1000,
+        ),
+        isFalse,
+      );
+    });
+
+    test('null amount is never below the threshold', () {
+      expect(
+        PayjoinRepositoryImpl.isBelowPayjoinMinimum(
+          amountSat: null,
+          minAmountSat: 1000,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('labelCompletedPayjoinSend', () {
+    // Exercised directly rather than through the full reactive sender
+    // pipeline: that needs a real, valid PSBT for BitcoinTx.fromPsbt to
+    // parse (FFI-backed), which — like the existing payjoin datasource
+    // tests document — isn't practical to construct offline.
+    const txId =
+        'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+    test(
+      'stores a transaction label tagged with the payjoin system label',
+      () async {
+        when(() => labelsFacade.store(any())).thenAnswer(
+          (_) async => Ok(
+            Label(
+              id: 1,
+              type: LabelType.transaction,
+              label: LabelSystem.payjoin.label,
+              reference: txId,
+            ),
+          ),
+        );
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        await repository.labelCompletedPayjoinSend(txId);
+
+        final captured =
+            verify(() => labelsFacade.store(captureAny())).captured.single
+                as NewLabel;
+        expect(captured.type, LabelType.transaction);
+        expect(captured.reference, txId);
+        expect(captured.label, LabelSystem.payjoin.label);
+      },
+    );
+
+    test('swallows a store failure instead of throwing', () async {
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => const Err(LabelUnexpectedFailure('boom')));
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await expectLater(repository.labelCompletedPayjoinSend(txId), completes);
+    });
+
+    test('swallows a thrown exception instead of propagating it', () async {
+      when(() => labelsFacade.store(any())).thenThrow(Exception('boom'));
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await expectLater(repository.labelCompletedPayjoinSend(txId), completes);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ported (and adapted) from payjoin-hardening. DESIGN DIVERGENCE: hardening
+  // derived a fallback completion via `isCompleted`; the work tree has an
+  // explicit `isAborted` flag, so fallback outcomes are asserted via
+  // `isAborted` / `status == PayjoinStatus.aborted`. Real payjoin completion
+  // stays `isCompleted` / `status == completed`.
+  // -------------------------------------------------------------------------
+
+  group('tryBroadcastOriginalTransaction manual-call idempotency guard '
+      '(the public entry point only — internal fallback callers bypass it '
+      'via _broadcastOriginalTransaction)', () {
+    setUp(() {
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('refuses a receiver already completed, and returns its current '
+        'state instead of re-broadcasting (+ isAborted sibling)', () async {
+      final model = _receiverModel(
+        originalTxId: 'orig-txid',
+      ).copyWith(isCompleted: true, txId: null);
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      final result = await repository.tryBroadcastOriginalTransaction(
+        model.toEntity(),
+      );
+
+      expect(result, isNotNull);
+      expect(result!.isCompleted, isTrue);
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+
+      // isAborted sibling: a receiver already resolved via the fallback is
+      // likewise refused.
+      final aborted = _receiverModel(
+        originalTxId: 'orig-txid',
+      ).copyWith(isAborted: true, txId: null);
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => aborted);
+
+      final abortedResult = await repository.tryBroadcastOriginalTransaction(
+        aborted.toEntity(),
+      );
+
+      expect(abortedResult, isNotNull);
+      expect(abortedResult!.isAborted, isTrue);
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+    });
+
+    test('refuses a receiver whose proposal was sent (proposed, not yet '
+        'completed) — the sender owns it for as long as that takes, with '
+        'no dead-end that would ever need a manual retry', () async {
+      final model = _receiverModel(
+        originalTxId: 'orig-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.tryBroadcastOriginalTransaction(model.toEntity());
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+    });
+
+    test('refuses a sender already completed via a real payjoin, and does '
+        'NOT race it with the lower-fee original', () async {
+      final model = _senderModel(
+        originalTxId: 'sender-orig-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      ).copyWith(isCompleted: true, txId: 'real-payjoin-txid');
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      final result = await repository.tryBroadcastOriginalTransaction(
+        model.toEntity(),
+      );
+
+      expect(result, isNotNull);
+      expect((result! as PayjoinSender).txId, 'real-payjoin-txid');
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+    });
+
+    test('refuses a sender whose proposal is still being processed '
+        '(proposalPsbt set, not yet completed or expired)', () async {
+      final model = _senderModel(
+        originalTxId: 'sender-orig-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      await repository.tryBroadcastOriginalTransaction(model.toEntity());
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+    });
+
+    test(
+      'allows a sender manual retry once its OWN internal fallback also '
+      'gave up (isExpired, proposalPsbt still set) — no dead-end left, so '
+      'this must not be permanently blocked; result is terminal (aborted)',
+      () async {
+        when(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).thenAnswer((_) async {});
+        final model = _senderModel(
+          originalTxId: 'sender-orig-txid',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        ).copyWith(isExpired: true);
+        when(
+          () => localDatasource.fetchSender(model.uri),
+        ).thenAnswer((_) async => model);
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        final result = await repository.tryBroadcastOriginalTransaction(
+          model.toEntity(),
+        );
+
+        verify(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).called(1);
+        expect(result, isNotNull);
+        expect(result!.isAborted, isTrue);
+      },
+    );
+
+    test(
+      'allows a receiver or sender manual retry while no proposal has '
+      'ever been received (waiting) — result is terminal (aborted)',
+      () async {
+        when(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).thenAnswer((_) async {});
+        final receiverModel = _receiverModel(originalTxId: 'orig-txid');
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => receiverModel);
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        final result = await repository.tryBroadcastOriginalTransaction(
+          receiverModel.toEntity(),
+        );
+
+        verify(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).called(1);
+        expect(result, isNotNull);
+        expect(result!.isAborted, isTrue);
+      },
+    );
+  });
+
+  group('syncs the wallet after WE broadcast a transaction', () {
+    // Without this, the wallet balance/tx list only picked up a broadcast
+    // this repository itself just made once some unrelated sync happened to
+    // run — the same staleness class of gap _watchForBroadcast's active poll
+    // fixes for the receiver's own detection of the SENDER's broadcast.
+    setUp(() {
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('tryBroadcastOriginalTransaction (receiver fallback) forces a '
+        'synced wallet lookup after a successful broadcast', () async {
+      final model = _receiverModel(walletId: 'w1', originalTxId: 'orig-txid');
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await repository.tryBroadcastOriginalTransaction(model.toEntity());
+      // The sync is deliberately fire-and-forget (unawaited); give its
+      // Future(() => ...) wrapper a tick to run before verifying.
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => walletRepository.getWallet('w1', sync: true)).called(1);
+    });
+
+    test('tryBroadcastOriginalTransaction (sender fallback) forces a synced '
+        'wallet lookup after a successful broadcast', () async {
+      final model = _senderModel(
+        walletId: 'w1',
+        originalTxId: 'sender-orig-txid',
+      );
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await repository.tryBroadcastOriginalTransaction(model.toEntity());
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => walletRepository.getWallet('w1', sync: true)).called(1);
+    });
+
+    test('a sync failure is swallowed and does not affect the already-'
+        'successful broadcast result', () async {
+      when(
+        () => walletRepository.getWallet(any(), sync: any(named: 'sync')),
+      ).thenThrow(Exception('no network'));
+      final model = _receiverModel(walletId: 'w1', originalTxId: 'orig-txid');
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      final result = await repository.tryBroadcastOriginalTransaction(
+        model.toEntity(),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(result, isNotNull);
+      expect(result!.isAborted, isTrue);
+    });
+
+    // SKIP: the _broadcastPsbt real-payjoin sync test. The work tree's
+    // _processPayjoinProposal re-derives the label txid via
+    // BitcoinTx.fromPsbt('signed-psbt'), which throws under FFI in a unit
+    // context and routes into the fallback path — the getWallet(sync: true)
+    // call inside _broadcastPsbt is not cleanly isolatable from the fallback
+    // path's own sync. The two fallback-side sync tests above cover the same
+    // _syncWalletAfterBroadcast machinery.
+  });
+
+  group('_processExpiredPayjoin sender terminal emission (#2246)', () {
+    // These drive the expiredPayjoins stream directly to exercise the
+    // repository's terminal-emission semantics on the send flow.
+    setUp(() {
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('emits only the aborted result (no interim expired) when the '
+        'fallback broadcast succeeds', () async {
+      final model = _senderModel(originalTxId: 'sender-orig-txid');
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      expiredController.add(model.copyWith(isExpired: true));
+      await Future<void>.delayed(Duration.zero);
+
+      // Exactly one terminal event, and it is the fallback (aborted) result —
+      // not the interim expired one that would race the success on the send
+      // flow.
+      expect(emitted, hasLength(1));
+      expect(emitted.single.isAborted, isTrue);
+      await sub.cancel();
+    });
+
+    test('emits the expired entity when the fallback broadcast fails so the '
+        'send flow does not hang', () async {
+      final model = _senderModel(originalTxId: 'sender-orig-txid');
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+      // Make the broadcast fail -> the fallback returns null.
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenThrow(Exception('broadcast failed'));
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      expiredController.add(model.copyWith(isExpired: true));
+      await Future<void>.delayed(Duration.zero);
+
+      // A terminal expired event is still emitted so listeners aren't left
+      // hanging on "coordinating".
+      expect(emitted, hasLength(1));
+      expect(emitted.single.isExpired, isTrue);
+      await sub.cancel();
+    });
+
+    test('bails out when the persisted row already completed — an expiry '
+        'firing after a fallback resolution must not re-broadcast the '
+        'original transaction', () async {
+      // The poll's own stale copy says unfinished, but the row has since
+      // been completed by _onOriginalTransactionSeen (the counterparty's
+      // fallback broadcast landed on-chain).
+      final staleCopy = _senderModel(originalTxId: 'sender-orig-txid');
+      final completedRow = staleCopy.copyWith(isCompleted: true, txId: null);
+      when(
+        () => localDatasource.fetchSender(staleCopy.uri),
+      ).thenAnswer((_) async => completedRow);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      expiredController.add(staleCopy.copyWith(isExpired: true));
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+      verifyNever(() => localDatasource.update(any()));
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+
+    test('bails out when the persisted row is already aborted — the '
+        'isAborted sibling of the completed-bail guard', () async {
+      final staleCopy = _senderModel(originalTxId: 'sender-orig-txid');
+      final abortedRow = staleCopy.copyWith(isAborted: true, txId: null);
+      when(
+        () => localDatasource.fetchSender(staleCopy.uri),
+      ).thenAnswer((_) async => abortedRow);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      expiredController.add(staleCopy.copyWith(isExpired: true));
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+      verifyNever(() => localDatasource.update(any()));
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+
+    test('bails out when the session row no longer exists', () async {
+      final staleCopy = _senderModel(originalTxId: 'sender-orig-txid');
+      when(
+        () => localDatasource.fetchSender(staleCopy.uri),
+      ).thenAnswer((_) async => null);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      expiredController.add(staleCopy.copyWith(isExpired: true));
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+
+    test(
+      'decides on the persisted row, not the stale event copy: a '
+      'proposal persisted since the copy was captured suppresses the '
+      'original-transaction fallback and keeps the proposal intact',
+      () async {
+        final staleCopy = _senderModel(originalTxId: 'sender-orig-txid');
+        final freshRow = staleCopy.copyWith(
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        when(
+          () => localDatasource.fetchSender(staleCopy.uri),
+        ).thenAnswer((_) async => freshRow);
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        final emitted = <Payjoin>[];
+        final sub = repository.payjoinStream.listen(emitted.add);
+
+        expiredController.add(staleCopy.copyWith(isExpired: true));
+        await Future<void>.delayed(Duration.zero);
+
+        // Once a proposal is out the sender owns broadcasting the payjoin
+        // transaction — no original fallback.
+        verifyNever(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        );
+        // The expired marker is persisted on the FRESH row: persisting the
+        // stale copy would clobber the proposal (insertOnConflictUpdate
+        // replaces the whole row).
+        final persisted =
+            verify(() => localDatasource.update(captureAny())).captured.single
+                as PayjoinSenderModel;
+        expect(persisted.proposalPsbt, 'cHNidP9wcm9wb3NhbA==');
+        expect(persisted.isExpired, isTrue);
+        expect(emitted.single.isExpired, isTrue);
+        await sub.cancel();
+      },
+    );
+  });
+
+  group('_processPayjoinProposal terminal emission on broadcast failure '
+      '(#2246)', () {
+    // A received proposal whose signing/broadcast fails must still produce a
+    // terminal event, because by the time a proposal arrives the poll timer
+    // that would otherwise raise an expiry is already cancelled — nothing
+    // else will ever emit for this session again.
+    setUp(() {
+      // _loadWallet throws when metadata is missing — the simplest way to
+      // drive _processPayjoinProposal's catch without mocking a full signing
+      // stack.
+      when(
+        () => walletMetadataDatasource.fetch(any()),
+      ).thenAnswer((_) async => null);
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('falls back to broadcasting the original psbt and completes '
+        '(aborted) when signing/broadcasting the proposal fails', () async {
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      final model = _senderModel(
+        originalTxId: 'sender-orig-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => localDatasource.fetchSender(model.uri),
+      ).thenAnswer((_) async => model);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      proposalsController.add(model);
+      await Future<void>.delayed(Duration.zero);
+
+      // Two events: the raw "proposal received" one, then the fallback's
+      // terminal aborted one (the original transaction still got broadcast,
+      // so the send flow can resolve to success).
+      expect(emitted, hasLength(2));
+      expect(emitted.last.isAborted, isTrue);
+      await sub.cancel();
+    });
+
+    test(
+      'marks the session terminally failed (expired) when both the '
+      'proposal and the original-transaction fallback fail to broadcast',
+      () async {
+        final model = _senderModel(
+          originalTxId: 'sender-orig-txid',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        when(
+          () => localDatasource.fetchSender(model.uri),
+        ).thenAnswer((_) async => model);
+        when(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
+        ).thenThrow(Exception('broadcast failed'));
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        final emitted = <Payjoin>[];
+        final sub = repository.payjoinStream.listen(emitted.add);
+
+        proposalsController.add(model);
+        await Future<void>.delayed(Duration.zero);
+
+        // Terminal failure, not silence: the send flow must never hang forever
+        // waiting for an event that will never arrive.
+        expect(emitted, hasLength(2));
+        expect(emitted.last.isExpired, isTrue);
+        await sub.cancel();
+      },
+    );
+
+    test('bails out when the persisted session already aborted — a proposal '
+        'event arriving after the counterparty fell back must not resurrect '
+        'the row nor sign/broadcast', () async {
+      // The proposal event carries the datasource's stale in-memory copy, but
+      // the persisted row was aborted since (the fallback watcher saw the
+      // original transaction land on-chain).
+      final staleCopy = _senderModel(
+        originalTxId: 'sender-orig-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      final abortedRow = staleCopy.copyWith(isAborted: true, txId: null);
+      when(
+        () => localDatasource.fetchSender(staleCopy.uri),
+      ).thenAnswer((_) async => abortedRow);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+
+      proposalsController.add(staleCopy);
+      await Future<void>.delayed(Duration.zero);
+
+      // No sign/broadcast, no persist, no emission: the session already
+      // resolved another way.
+      verifyNever(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      );
+      verifyNever(() => localDatasource.update(any()));
+      expect(emitted, isEmpty);
+      await sub.cancel();
+    });
+  });
+
+  group('resumePayjoinsOnStartup', () {
+    test(
+      'one session failing to resume does not stop the others from resuming',
+      () async {
+        // Both models are already past expiry by construction (createdAt: 0,
+        //  expireAfterSec: 300), and both have a proposal already sent, so
+        //  _resumeOne routes them straight to _processExpiredPayjoin's
+        //  persist-and-emit else branch (no broadcast attempted).
+        final bad = _receiverModel(
+          id: 'bad',
+          originalTxId: 'bad-orig',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        final ok = _receiverModel(
+          id: 'ok',
+          originalTxId: 'ok-orig',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        when(
+          () => localDatasource.fetchAll(onlyUnfinished: true),
+        ).thenAnswer((_) async => [bad, ok]);
+        // _processExpiredPayjoin re-fetches the persisted row before acting
+        //  (stale-copy guard) — serve each session's own row back.
+        when(
+          () => localDatasource.fetchReceiver('bad'),
+        ).thenAnswer((_) async => bad);
+        when(
+          () => localDatasource.fetchReceiver('ok'),
+        ).thenAnswer((_) async => ok);
+        // "bad"'s persist throws (e.g. a transient DB failure); "ok"'s must
+        //  still go through despite "bad" throwing first in the loop.
+        when(
+          () => localDatasource.update(
+            any(that: predicate<PayjoinModel>((m) => m.id == 'bad')),
+          ),
+        ).thenThrow(Exception('boom'));
+        when(
+          () => localDatasource.update(
+            any(that: predicate<PayjoinModel>((m) => m.id == 'ok')),
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+        final emitted = <Payjoin>[];
+        final sub = repository.payjoinStream.listen(emitted.add);
+
+        await repository.resumePayjoinsOnStartup();
+        await Future<void>.delayed(Duration.zero);
+
+        // "ok" was still resumed and emitted, proving the per-session
+        //  try/catch stopped "bad"'s failure from aborting the whole loop.
+        expect(emitted, hasLength(1));
+        expect(emitted.single.id, 'ok');
+        await sub.cancel();
+      },
+    );
+  });
+
+  group('_watchForBroadcast active polling', () {
+    // The passive watcher only reacts to walletSyncFinishedStream, i.e. to
+    // syncs triggered by something else entirely. The active poll forces
+    // bounded sync'd lookups itself.
+    late StreamController<Wallet> syncController;
+
+    setUp(() {
+      syncController = StreamController<Wallet>.broadcast();
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+
+      // A not-yet-expired proposal-sent receiver session, so resume arms
+      // _watchForBroadcast.
+      final model = _receiverModel(
+        id: 'pj1',
+        walletId: 'w1',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        txId: 'payjoin-txid',
+        expireAfterSec: 9999999999,
+      );
+      when(
+        () => localDatasource.fetchAll(onlyUnfinished: true),
+      ).thenAnswer((_) async => [model]);
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+    });
+
+    tearDown(() => syncController.close());
+
+    test('completes the session via a forced-sync lookup when no wallet sync '
+        'ever happens, then stops polling', () {
+      fakeAsync((async) {
+        var txSeen = false;
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async => txSeen
+              ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
+              : null,
+        );
+
+        final repo = buildRepository();
+        unawaited(repo.resumePayjoinsOnStartup());
+        async.flushMicrotasks();
+
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        // First poll fires after the initial delay; the tx isn't visible yet.
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+        expect(emitted, isEmpty);
+
+        // The sender broadcasts; the next (backed-off) poll finds the tx and
+        // completes the session — no walletSyncFinishedStream event ever
+        // fired in this entire test.
+        txSeen = true;
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay * 2);
+        async.flushMicrotasks();
+
+        expect(emitted, hasLength(1));
+        expect(emitted.single.isCompleted, isTrue);
+        verify(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).called(2);
+
+        // Completion is one-shot: no further forced syncs afterwards.
+        async.elapse(const Duration(hours: 2));
+        verifyNever(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        );
+      });
+    });
+
+    test('gives up active polling after the attempt budget but the passive '
+        'sync-driven watcher still completes a very late broadcast', () {
+      fakeAsync((async) {
+        var txSeen = false;
+        // Active polls never see the tx (it lands hours later).
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer((_) async => null);
+        // Passive (local, non-forced) lookups see it once txSeen flips.
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+          ),
+        ).thenAnswer(
+          (_) async => txSeen
+              ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
+              : null,
+        );
+
+        final repo = buildRepository();
+        unawaited(repo.resumePayjoinsOnStartup());
+        async.flushMicrotasks();
+
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        // Way past the whole active-poll schedule: exactly maxAttempts
+        // forced syncs ran, then the poll chain stopped rescheduling.
+        async.elapse(const Duration(hours: 3));
+        verify(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).called(PayjoinRepositoryImpl.broadcastPollMaxAttempts);
+        expect(emitted, isEmpty);
+
+        // The payjoin tx finally lands and some organic sync of this wallet
+        // finishes: the passive watcher completes the session.
+        txSeen = true;
+        syncController.add(_testWallet(origin: 'w1'));
+        async.flushMicrotasks();
+
+        expect(emitted, hasLength(1));
+        expect(emitted.single.isCompleted, isTrue);
+      });
+    });
+  });
+
+  group('post-broadcast visibility watch (own fallback broadcast)', () {
+    // After WE broadcast the original transaction, the single unawaited
+    // wallet sync can be throttled or race the broadcast. The original-tx
+    // watch re-armed by _broadcastOriginalTransaction must keep forcing
+    // DIRECT sync'd lookups until the tx is visible, then tear itself down
+    // without emitting duplicate events.
+    late StreamController<Wallet> syncController;
+
+    setUp(() {
+      syncController = StreamController<Wallet>.broadcast();
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    tearDown(() => syncController.close());
+
+    test('keeps forcing sync\'d lookups until the broadcast original is '
+        'visible in the wallet, then tears down', () {
+      fakeAsync((async) {
+        var txSeen = false;
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'orig-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async =>
+              txSeen ? _testWalletTx(txId: 'orig-txid', walletId: 'w1') : null,
+        );
+
+        // The row is re-fetched several times along the way (the manual
+        // guard, the broadcast itself, and the visibility watch's completion
+        // handler) — serve back whatever was last persisted so the watch
+        // sees the completed row once the broadcast stored it.
+        var row = _receiverModel(
+          id: 'pj1',
+          walletId: 'w1',
+          originalTxId: 'orig-txid',
+          expireAfterSec: 9999999999,
+        );
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => row);
+        when(() => localDatasource.update(any())).thenAnswer((
+          invocation,
+        ) async {
+          row = invocation.positionalArguments.single as PayjoinReceiverModel;
+        });
+
+        final repo = buildRepository();
+
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        unawaited(repo.tryBroadcastOriginalTransaction(row.toEntity()));
+        async.flushMicrotasks();
+
+        // First poll: the wallet doesn't see the tx yet (throttled sync /
+        // raced broadcast).
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+
+        // The next backed-off poll finds it — no walletSyncFinishedStream
+        // event ever fired in this test, so only the forced lookups can
+        // have made it visible.
+        txSeen = true;
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay * 2);
+        async.flushMicrotasks();
+
+        verify(
+          () => walletTransactionRepository.getWalletTransaction(
+            'orig-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).called(2);
+
+        // The public manual-broadcast entry point emits the aborted result
+        // exactly once (so other open watchers of this session learn of it);
+        // the re-armed visibility watch then resolves as a PURE TEARDOWN —
+        // no SECOND terminal event — because the session is already aborted.
+        expect(emitted, hasLength(1));
+        expect(emitted.single.isAborted, isTrue);
+        async.elapse(const Duration(hours: 2));
+        verifyNever(
+          () => walletTransactionRepository.getWalletTransaction(
+            'orig-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        );
+      });
+    });
+  });
+
+  group('_watchForFallback (the counterparty fell back independently)', () {
+    // Both sides hold their own copy of the original transaction and can
+    // each independently decide to broadcast it. Before this watch existed,
+    // only the side that actually broadcast it persisted the terminal state
+    // — the OTHER side had no way to find out and just kept waiting on its
+    // own session.
+    setUp(() {
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('a sender still waiting for a proposal is resolved (aborted) once '
+        'the original transaction appears in its wallet — the receiver '
+        'broadcast it independently and the sender would otherwise have '
+        'waited out its own full expiry with no signal', () async {
+      final syncController = StreamController<Wallet>.broadcast();
+      addTearDown(syncController.close);
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+
+      // Not yet expired, no proposal received yet: _resumeOne's sender branch
+      // arms _watchForFallback unconditionally.
+      final model = _senderModel(
+        originalTxId: 'sender-orig-txid',
+      ).copyWith(expireAfterSec: 9999999999);
+      when(
+        () => localDatasource.fetchAll(onlyUnfinished: true),
+      ).thenAnswer((_) async => [model]);
+      // _onOriginalTransactionSeen always tries the receiver table first.
+      when(
+        () => localDatasource.fetchReceiver(
+          'bitcoin:tb1qsender?pj=https://payjo.in',
+        ),
+      ).thenAnswer((_) async => null);
+      when(
+        () => localDatasource.fetchSender(
+          'bitcoin:tb1qsender?pj=https://payjo.in',
+        ),
+      ).thenAnswer((_) async => model);
+
+      // The original transaction is now visible in the sender's own wallet —
+      // broadcast by the receiver, not by this device.
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          'sender-orig-txid',
+          walletId: 'w1',
+        ),
+      ).thenAnswer(
+        (_) async => _testWalletTx(txId: 'sender-orig-txid', walletId: 'w1'),
+      );
+
+      final repo = buildRepository();
+      addTearDown(repo.dispose);
+
+      await repo.resumePayjoinsOnStartup();
+
+      final emitted = <Payjoin>[];
+      final sub = repo.payjoinStream.listen(emitted.add);
+
+      syncController.add(_testWallet(origin: 'w1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, hasLength(1));
+      expect(emitted.single.status, PayjoinStatus.aborted);
+      expect(emitted.single.isAborted, isTrue);
+      expect((emitted.single as PayjoinSender).txId, isNull);
+      await sub.cancel();
+    });
+
+    test('idempotent: a session already terminal (isAborted set by whichever '
+        'path got there first) is left untouched, not re-persisted or '
+        're-emitted', () async {
+      final syncController = StreamController<Wallet>.broadcast();
+      addTearDown(syncController.close);
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+
+      final model = _senderModel(
+        originalTxId: 'sender-orig-txid',
+      ).copyWith(expireAfterSec: 9999999999);
+      when(
+        () => localDatasource.fetchAll(onlyUnfinished: true),
+      ).thenAnswer((_) async => [model]);
+      when(
+        () => localDatasource.fetchReceiver(
+          'bitcoin:tb1qsender?pj=https://payjo.in',
+        ),
+      ).thenAnswer((_) async => null);
+      // Already resolved (aborted) by the time the watch fires.
+      final alreadyAborted = model.copyWith(isAborted: true, txId: null);
+      when(
+        () => localDatasource.fetchSender(
+          'bitcoin:tb1qsender?pj=https://payjo.in',
+        ),
+      ).thenAnswer((_) async => alreadyAborted);
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          'sender-orig-txid',
+          walletId: 'w1',
+        ),
+      ).thenAnswer(
+        (_) async => _testWalletTx(txId: 'sender-orig-txid', walletId: 'w1'),
+      );
+
+      final repo = buildRepository();
+      addTearDown(repo.dispose);
+
+      await repo.resumePayjoinsOnStartup();
+
+      final emitted = <Payjoin>[];
+      final sub = repo.payjoinStream.listen(emitted.add);
+
+      syncController.add(_testWallet(origin: 'w1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+      verifyNever(() => localDatasource.update(any()));
+      await sub.cancel();
+    });
+
+    test('a receiver session surviving a failed own-broadcast attempt still '
+        'resolves (aborted) once the original transaction is later observed '
+        'on-chain (the fix: _stopWatching is no longer called before '
+        'attempting the broadcast, so a failed attempt no longer strands the '
+        'session)', () async {
+      final syncController = StreamController<Wallet>.broadcast();
+      addTearDown(syncController.close);
+      when(
+        () => settingsRepository.fetch(),
+      ).thenAnswer((_) async => _testSettings(payjoinMinAmountSat: 10000));
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+
+      final repo = buildRepository();
+      addTearDown(repo.dispose);
+
+      // Below minimum, so _processPayjoinRequest attempts the fallback
+      // broadcast immediately — but the broadcast itself fails.
+      final model = _receiverModel(originalTxId: 'orig-txid', amountSat: 500);
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenThrow(Exception('no network'));
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          'orig-txid',
+          walletId: 'w1',
+        ),
+      ).thenAnswer((_) async => null);
+
+      final emitted = <Payjoin>[];
+      final sub = repo.payjoinStream.listen(emitted.add);
+
+      requestsController.add(model);
+      await Future<void>.delayed(Duration.zero);
+
+      // Own attempt failed: _processPayjoinRequest's below-minimum branch
+      // only emits on success, so just the initial "requested" event is on
+      // the stream — still not resolved.
+      expect(emitted, hasLength(1));
+      expect(emitted.single.isAborted, isFalse);
+
+      // The original transaction eventually lands anyway. The fallback
+      // watch armed at the top of _processPayjoinRequest catches this: it
+      // survived the failed attempt because _stopWatching is no longer
+      // called before attempting the broadcast.
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          'orig-txid',
+          walletId: 'w1',
+        ),
+      ).thenAnswer(
+        (_) async => _testWalletTx(txId: 'orig-txid', walletId: 'w1'),
+      );
+      syncController.add(_testWallet(origin: 'w1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, hasLength(2));
+      expect(emitted.last.status, PayjoinStatus.aborted);
+      await sub.cancel();
+    });
+  });
+
+  group('watcher arming (broadcast + fallback) on the request / resume / '
+      'expired-else paths', () {
+    // These pin that the reactive handlers ARM the broadcast/fallback
+    // watchers on the paths that must keep a live session detectable. Each
+    // proves the watch is live by making its target txid visible through a
+    // FORCED (sync: true) lookup and elapsing the active poll under
+    // fakeAsync — the same technique the sibling '_watchForBroadcast active
+    // polling' / '_watchForFallback' groups use — then asserting the
+    // terminal stream emission the watcher's onSeen handler produces.
+    setUp(() {
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+    });
+
+    test('_processPayjoinRequest arms _watchForBroadcast after a successful '
+        'propose — the receiver session completes once the sender broadcasts '
+        'the payjoin transaction', () {
+      fakeAsync((async) {
+        // A request AT the minimum, so _processPayjoinRequest takes the
+        // propose path (not the below-minimum decline).
+        when(
+          () => settingsRepository.fetch(),
+        ).thenAnswer((_) async => _testSettings(payjoinMinAmountSat: 10000));
+
+        // _loadWallet's dependencies: a decodable-origin metadata row and a
+        // mnemonic seed. The mnemonic is only join()'d into a WalletModel
+        // that getUtxos (mocked) receives — never expanded to a seed here,
+        // so any placeholder words are fine.
+        final origin = WalletMetadataService.encodeOrigin(
+          fingerprint: '00000000',
+          network: Network.bitcoinTestnet,
+          scriptType: ScriptType.bip84,
+        );
+        when(() => walletMetadataDatasource.fetch('w1')).thenAnswer(
+          (_) async => WalletMetadataModel(
+            id: origin,
+            masterFingerprint: '00000000',
+            xpubFingerprint: '00000000',
+            isEncryptedVaultTested: false,
+            isPhysicalBackupTested: false,
+            xpub: '',
+            externalPublicDescriptor: '',
+            internalPublicDescriptor: '',
+            signer: Signer.local,
+            isDefault: false,
+          ),
+        );
+        when(() => seedDatasource.get('00000000')).thenAnswer(
+          (_) async =>
+              const SeedModel.mnemonic(mnemonicWords: ['abandon'])
+                  as MnemonicSeedModel,
+        );
+
+        // One owned bitcoin utxo so _filterAvailableUtxos yields a non-empty
+        // input set and _proposePayjoin doesn't bail with NoInputs.
+        when(
+          () => bdkWalletDatasource.getUtxos(wallet: any(named: 'wallet')),
+        ).thenAnswer(
+          (_) async => [
+            WalletUtxoModel.bitcoin(
+                  txId: 'utxo-txid',
+                  vout: 0,
+                  amountSat: BigInt.from(100000),
+                  scriptPubkey: Uint8List.fromList([0]),
+                  address: 'tb1qtest',
+                  isExternalKeyChain: false,
+                )
+                as BitcoinWalletUtxoModel,
+          ],
+        );
+        when(
+          () => bdkWalletDatasource.createIsMineChecker(
+            wallet: any(named: 'wallet'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              (Uint8List _) => true,
+        );
+        when(
+          () => bdkWalletDatasource.createPsbtSigner(
+            wallet: any(named: 'wallet'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              (String psbt) => psbt,
+        );
+
+        final requestModel = _receiverModel(
+          id: 'pj1',
+          walletId: 'w1',
+          originalTxId: 'orig-txid',
+          amountSat: 10000,
+          expireAfterSec: 9999999999,
+        );
+        // getUtxosFrozenByOngoingPayjoins reads fetchAll(onlyUnfinished) —
+        // kept empty (setUp default) so it never touches FFI BitcoinTx.
+        // _proposePayjoin re-fetches the receiver row before proposing.
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => requestModel);
+        // proposePayjoin (FFI-backed in production) is mocked to return a
+        // proposal-sent model carrying BOTH proposalPsbt and txId — the two
+        // fields _processPayjoinRequest gates the _watchForBroadcast arming
+        // on.
+        when(
+          () => pdkDatasource.proposePayjoin(
+            receiverModel: any(named: 'receiverModel'),
+            hasOwnedInputs: any(named: 'hasOwnedInputs'),
+            hasReceiverOutput: any(named: 'hasReceiverOutput'),
+            inputPairs: any(named: 'inputPairs'),
+            processPsbt: any(named: 'processPsbt'),
+          ),
+        ).thenAnswer(
+          (_) async => requestModel.copyWith(
+            proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+            txId: 'payjoin-txid',
+          ),
+        );
+
+        var txSeen = false;
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async => txSeen
+              ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
+              : null,
+        );
+        // The completion handler re-fetches the receiver row.
+        when(() => localDatasource.fetchReceiver('pj1')).thenAnswer(
+          (_) async => requestModel.copyWith(
+            proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+            txId: 'payjoin-txid',
+          ),
+        );
+
+        final repo = buildRepository();
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        requestsController.add(requestModel);
+        async.flushMicrotasks();
+
+        // The proposal-sent event is on the stream; the broadcast watcher is
+        // now armed. The sender broadcasts; the forced poll finds the tx and
+        // completes the session — no wallet-sync event ever fired.
+        txSeen = true;
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+        async.flushMicrotasks();
+
+        expect(
+          emitted.any((p) => p.isCompleted),
+          isTrue,
+          reason:
+              'the armed _watchForBroadcast should complete the session '
+              'once the payjoin txid becomes visible via a forced sync',
+        );
+      });
+    });
+
+    test('_resumeOne arms BOTH watchers for a receiver with a proposal '
+        'already sent — the broadcast watcher completes the session once the '
+        'payjoin transaction becomes visible', () {
+      fakeAsync((async) {
+        // Not expiry-passed, proposal already sent, txId + originalTxId set:
+        // _resumeOne's `model.txId != null` branch arms _watchForBroadcast
+        // (payjoin-txid) AND _watchForFallback (originalTxId).
+        final model = _receiverModel(
+          id: 'pj1',
+          walletId: 'w1',
+          originalTxId: 'orig-txid',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+          txId: 'payjoin-txid',
+          expireAfterSec: 9999999999,
+        );
+        when(
+          () => localDatasource.fetchAll(onlyUnfinished: true),
+        ).thenAnswer((_) async => [model]);
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => model);
+
+        var txSeen = false;
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async => txSeen
+              ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
+              : null,
+        );
+
+        final repo = buildRepository();
+        unawaited(repo.resumePayjoinsOnStartup());
+        async.flushMicrotasks();
+
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        // The broadcast watcher (armed by resume) fires the moment the
+        // payjoin tx becomes visible via a forced poll.
+        txSeen = true;
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+        async.flushMicrotasks();
+
+        expect(emitted, hasLength(1));
+        expect(emitted.single.isCompleted, isTrue);
+      });
+    });
+
+    test('the expired-else branch re-arms _watchForBroadcast for a resumed, '
+        'expiry-passed receiver whose proposal was already sent — the '
+        'session still completes when the payjoin transaction lands, despite '
+        'having been marked expired', () {
+      fakeAsync((async) {
+        // Expiry-passed (createdAt: 0, small expireAfterSec) with a proposal
+        // already out and a payjoin txId: _resumeOne routes it through
+        // _processExpiredPayjoin, whose else branch persists the expired
+        // marker AND re-arms _watchForBroadcast(txId).
+        final model = _receiverModel(
+          id: 'pj1',
+          walletId: 'w1',
+          originalTxId: 'orig-txid',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+          txId: 'payjoin-txid',
+          expireAfterSec: 1,
+        );
+        when(
+          () => localDatasource.fetchAll(onlyUnfinished: true),
+        ).thenAnswer((_) async => [model]);
+        // _processExpiredPayjoin re-fetches the persisted row (stale-copy
+        // guard); the completion handler re-fetches it too.
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => model);
+
+        var txSeen = false;
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async => txSeen
+              ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
+              : null,
+        );
+
+        final repo = buildRepository();
+        unawaited(repo.resumePayjoinsOnStartup());
+        async.flushMicrotasks();
+
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        // The expired marker was persisted...
+        verify(
+          () => localDatasource.update(
+            any(that: predicate<PayjoinModel>((m) => m.isExpired)),
+          ),
+        ).called(greaterThanOrEqualTo(1));
+
+        // ...but the re-armed broadcast watcher still completes the session
+        // once the payjoin transaction becomes visible.
+        txSeen = true;
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+        async.flushMicrotasks();
+
+        expect(
+          emitted.any((p) => p.isCompleted),
+          isTrue,
+          reason:
+              'the expired-else branch must re-arm _watchForBroadcast so '
+              'a proposal that lands after expiry still completes',
+        );
+      });
+    });
+  });
+
+  group('payjoin labeling on the real completion paths', () {
+    // The payjoin system label must mean "this payment actually got
+    // CoinJoin-style privacy". Only RECEIVER labeling is ported here: the
+    // sender-side path needs FFI BitcoinTx.fromPsbt on a signed psbt, which
+    // isn't practical to construct in a unit test (the work tree keeps its
+    // own labelCompletedPayjoinSend group above for the sender label).
+    test('labels the receiver payjoin tx once it is seen on-chain '
+        '(_onPayjoinTransactionSeen)', () async {
+      final syncController = StreamController<Wallet>.broadcast();
+      addTearDown(syncController.close);
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+      when(
+        () => labelsFacade.store(any()),
+      ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
+
+      final model = _receiverModel(
+        id: 'pj1',
+        walletId: 'w1',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        txId: 'payjoin-txid',
+        expireAfterSec: 9999999999,
+      );
+      when(
+        () => localDatasource.fetchAll(onlyUnfinished: true),
+      ).thenAnswer((_) async => [model]);
+      when(
+        () => localDatasource.fetchReceiver('pj1'),
+      ).thenAnswer((_) async => model);
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          'payjoin-txid',
+          walletId: 'w1',
+        ),
+      ).thenAnswer(
+        (_) async => _testWalletTx(txId: 'payjoin-txid', walletId: 'w1'),
+      );
+
+      final repo = buildRepository();
+      addTearDown(repo.dispose);
+      await repo.resumePayjoinsOnStartup();
+
+      syncController.add(_testWallet(origin: 'w1'));
+      await Future<void>.delayed(Duration.zero);
+
+      final stored =
+          verify(() => labelsFacade.store(captureAny())).captured.single
+              as NewLabel;
+      expect(stored.type, LabelType.transaction);
+      expect(stored.reference, 'payjoin-txid');
+      expect(stored.label, LabelSystem.payjoin.label);
+      expect(stored.origin, 'w1');
+    });
+  });
+}

--- a/test/core_test/payjoin/payjoin_repository_impl_test.dart
+++ b/test/core_test/payjoin/payjoin_repository_impl_test.dart
@@ -227,10 +227,11 @@ void main() {
         onlyUnfinished: any(named: 'onlyUnfinished'),
       ),
     ).thenAnswer((_) async => []);
-    // The resume sweep for expired-with-failed-fallback receivers — empty by
-    // default, overridden in the sweep tests. Only runs from
+    // The resume sweep for expired-with-failed-fallback receivers/senders —
+    // empty by default, overridden in the sweep tests. Only runs from
     // resumePayjoinsOnStartup, never the constructor.
     when(() => localDatasource.fetchReceivers()).thenAnswer((_) async => []);
+    when(() => localDatasource.fetchSenders()).thenAnswer((_) async => []);
     when(() => localDatasource.update(any())).thenAnswer((_) async {});
 
     // Passive watchers must never fire spuriously: an empty sync stream and

--- a/test/core_test/payjoin/pdk_payjoin_datasource_test.dart
+++ b/test/core_test/payjoin/pdk_payjoin_datasource_test.dart
@@ -2,7 +2,10 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/payjoin/data/datasources/pdk_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
+import 'package:bb_mobile/core/utils/constants.dart' show PayjoinConstants;
 import 'package:dio/dio.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:payjoin/payjoin.dart';
@@ -371,6 +374,91 @@ void main() {
       );
 
       expect(result, Uint8List.fromList([4, 5, 6]));
+    });
+  });
+
+  group('PdkPayjoinDatasource.stopPolling', () {
+    // A session whose expiry time is long passed (createdAt: 0): the first
+    // poll tick emits an expired event without any network access, which
+    // makes the poll's liveness observable offline.
+    PayjoinSenderModel expiredSenderModel() =>
+        PayjoinModel.sender(
+              uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+              isTestnet: true,
+              sender: '[]',
+              walletId: 'w1',
+              originalPsbt: 'cHNidP8=',
+              originalTxId: 'orig-txid',
+              amountSat: 50000,
+              createdAt: 0,
+              expireAfterSec: 300,
+            )
+            as PayjoinSenderModel;
+
+    test('control: without stopPolling the poll raises the expiry', () {
+      fakeAsync((async) {
+        final datasource = PdkPayjoinDatasource(dio: Dio());
+        final events = <PayjoinModel>[];
+        final sub = datasource.expiredPayjoins.listen(events.add);
+
+        datasource.startListeningForProposal(expiredSenderModel());
+        async.elapse(
+          const Duration(
+            seconds: PayjoinConstants.directoryPollingInterval + 1,
+          ),
+        );
+
+        expect(events, hasLength(1));
+        sub.cancel();
+        datasource.dispose();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('cancels the session poll so no further event ever fires — the '
+        'repository calls this when a session resolves through a path the '
+        'poll cannot see (fallback landed on-chain)', () {
+      fakeAsync((async) {
+        final datasource = PdkPayjoinDatasource(dio: Dio());
+        final events = <PayjoinModel>[];
+        final sub = datasource.expiredPayjoins.listen(events.add);
+
+        final model = expiredSenderModel();
+        datasource.startListeningForProposal(model);
+        datasource.stopPolling(model.id);
+        async.elapse(
+          const Duration(
+            seconds: PayjoinConstants.directoryPollingInterval * 3,
+          ),
+        );
+
+        expect(events, isEmpty);
+        sub.cancel();
+        datasource.dispose();
+        async.flushMicrotasks();
+      });
+    });
+  });
+
+  group('PdkPayjoinDatasource.dispose', () {
+    test('closes the event streams', () async {
+      final datasource = PdkPayjoinDatasource(dio: Dio());
+
+      await datasource.dispose();
+
+      // A closed broadcast stream completes immediately with no events.
+      await expectLater(datasource.requestsForReceivers, emitsDone);
+      await expectLater(datasource.proposalsForSenders, emitsDone);
+      await expectLater(datasource.expiredPayjoins, emitsDone);
+    });
+
+    test('is idempotent (a second dispose is a no-op)', () async {
+      final datasource = PdkPayjoinDatasource(dio: Dio());
+
+      await datasource.dispose();
+      // Without the _disposed guard this would throw on re-closing a closed
+      // controller.
+      await expectLater(datasource.dispose(), completes);
     });
   });
 }

--- a/test/core_test/payjoin/receive_with_payjoin_usecase_test.dart
+++ b/test/core_test/payjoin/receive_with_payjoin_usecase_test.dart
@@ -1,0 +1,93 @@
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPayjoinRepository extends Mock implements PayjoinRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  setUpAll(() => registerFallbackValue(BigInt.zero));
+
+  late _MockPayjoinRepository payjoinRepository;
+  late _MockSettingsRepository settingsRepository;
+  late ReceiveWithPayjoinUsecase usecase;
+
+  final receiver =
+      Payjoin.receiver(
+            id: 'r1',
+            isTestnet: true,
+            walletId: 'w1',
+            pjUri: 'bitcoin:tb1qtest?pj=https://payjo.in/x',
+            createdAt: DateTime(2026),
+            expiresAt: DateTime(2026, 1, 2),
+          )
+          as PayjoinReceiver;
+
+  setUp(() {
+    payjoinRepository = _MockPayjoinRepository();
+    settingsRepository = _MockSettingsRepository();
+    usecase = ReceiveWithPayjoinUsecase(
+      payjoinRepository: payjoinRepository,
+      settingsRepository: settingsRepository,
+    );
+
+    when(() => settingsRepository.fetch()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.testnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+        isPayjoinEnabled: true,
+        payjoinExpireAfterSec: 3600,
+      ),
+    );
+    when(
+      () => payjoinRepository.createPayjoinReceiver(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        isTestnet: any(named: 'isTestnet'),
+        maxFeeRateSatPerVb: any(named: 'maxFeeRateSatPerVb'),
+        expireAfterSec: any(named: 'expireAfterSec'),
+      ),
+    ).thenAnswer((_) async => receiver);
+  });
+
+  test(
+    'creates the session with the user-configured expiry from settings',
+    () async {
+      await usecase.execute(walletId: 'w1', address: 'tb1qtest');
+
+      verify(
+        () => payjoinRepository.createPayjoinReceiver(
+          walletId: 'w1',
+          address: 'tb1qtest',
+          isTestnet: true,
+          maxFeeRateSatPerVb: any(named: 'maxFeeRateSatPerVb'),
+          expireAfterSec: 3600,
+        ),
+      ).called(1);
+    },
+  );
+
+  test('an explicit expiry override wins over the settings value', () async {
+    await usecase.execute(
+      walletId: 'w1',
+      address: 'tb1qtest',
+      expireAfterSec: 120,
+    );
+
+    verify(
+      () => payjoinRepository.createPayjoinReceiver(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        isTestnet: any(named: 'isTestnet'),
+        maxFeeRateSatPerVb: any(named: 'maxFeeRateSatPerVb'),
+        expireAfterSec: 120,
+      ),
+    ).called(1);
+  });
+}

--- a/test/core_test/payjoin/send_with_payjoin_usecase_test.dart
+++ b/test/core_test/payjoin/send_with_payjoin_usecase_test.dart
@@ -1,0 +1,117 @@
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPayjoinRepository extends Mock implements PayjoinRepository {}
+
+class _MockBitcoinWalletRepository extends Mock
+    implements BitcoinWalletRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late _MockPayjoinRepository payjoinRepository;
+  late _MockBitcoinWalletRepository bitcoinWalletRepository;
+  late _MockSettingsRepository settingsRepository;
+  late SendWithPayjoinUsecase usecase;
+
+  final sender =
+      Payjoin.sender(
+            uri: 'bitcoin:tb1qtest?pj=https://payjo.in/x',
+            isTestnet: true,
+            walletId: 'w1',
+            originalPsbt: 'signed-psbt',
+            originalTxId: 'a' * 64,
+            amountSat: 10000,
+            createdAt: DateTime(2026),
+            expiresAt: DateTime(2026, 1, 2),
+          )
+          as PayjoinSender;
+
+  setUp(() {
+    payjoinRepository = _MockPayjoinRepository();
+    bitcoinWalletRepository = _MockBitcoinWalletRepository();
+    settingsRepository = _MockSettingsRepository();
+    usecase = SendWithPayjoinUsecase(
+      payjoinRepository: payjoinRepository,
+      bitcoinWalletRepository: bitcoinWalletRepository,
+      settingsRepository: settingsRepository,
+    );
+
+    when(() => settingsRepository.fetch()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.testnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+        isPayjoinEnabled: true,
+        payjoinExpireAfterSec: 3600,
+      ),
+    );
+    when(
+      () => bitcoinWalletRepository.signPsbt(
+        any(),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => 'signed-psbt');
+    when(
+      () => payjoinRepository.createPayjoinSender(
+        walletId: any(named: 'walletId'),
+        isTestnet: any(named: 'isTestnet'),
+        bip21: any(named: 'bip21'),
+        originalPsbt: any(named: 'originalPsbt'),
+        amountSat: any(named: 'amountSat'),
+        networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+        expireAfterSec: any(named: 'expireAfterSec'),
+      ),
+    ).thenAnswer((_) async => sender);
+  });
+
+  Future<PayjoinSender> callUsecase({int? expireAfterSec}) => usecase.execute(
+    walletId: 'w1',
+    isTestnet: true,
+    bip21: 'bitcoin:tb1qtest?pj=https://payjo.in/x',
+    unsignedOriginalPsbt: 'unsigned-psbt',
+    amountSat: 10000,
+    networkFeesSatPerVb: 2,
+    expireAfterSec: expireAfterSec,
+  );
+
+  test('creates the session with the user-configured expiry from settings — '
+      'resolved inside the usecase, mirroring the receive side, so callers '
+      'cannot drift', () async {
+    await callUsecase();
+
+    verify(
+      () => payjoinRepository.createPayjoinSender(
+        walletId: 'w1',
+        isTestnet: true,
+        bip21: any(named: 'bip21'),
+        originalPsbt: 'signed-psbt',
+        amountSat: 10000,
+        networkFeesSatPerVb: 2,
+        expireAfterSec: 3600,
+      ),
+    ).called(1);
+  });
+
+  test('an explicit expiry override wins over the settings value', () async {
+    await callUsecase(expireAfterSec: 120);
+
+    verify(
+      () => payjoinRepository.createPayjoinSender(
+        walletId: any(named: 'walletId'),
+        isTestnet: any(named: 'isTestnet'),
+        bip21: any(named: 'bip21'),
+        originalPsbt: any(named: 'originalPsbt'),
+        amountSat: any(named: 'amountSat'),
+        networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+        expireAfterSec: 120,
+      ),
+    ).called(1);
+  });
+}

--- a/test/core_test/payjoin/watch_payjoin_usecase_test.dart
+++ b/test/core_test/payjoin/watch_payjoin_usecase_test.dart
@@ -1,0 +1,66 @@
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPayjoinRepository extends Mock implements PayjoinRepository {}
+
+Payjoin _receiver(String id) => Payjoin.receiver(
+  id: id,
+  isTestnet: true,
+  walletId: 'w1',
+  pjUri: 'bitcoin:tb1q?pj=https://payjo.in',
+  createdAt: DateTime(2020),
+  expiresAt: DateTime(2020, 1, 1, 0, 5),
+);
+
+Payjoin _sender(String uri, {PayjoinStatus status = PayjoinStatus.proposed}) =>
+    Payjoin.sender(
+      status: status,
+      uri: uri,
+      isTestnet: true,
+      walletId: 'w1',
+      originalPsbt: 'cHNidP8=',
+      originalTxId: 'orig-txid',
+      amountSat: 50000,
+      createdAt: DateTime(2020),
+      expiresAt: DateTime(2020, 1, 1, 0, 5),
+    );
+
+void main() {
+  late _MockPayjoinRepository repository;
+  late WatchPayjoinUsecase usecase;
+
+  setUp(() {
+    repository = _MockPayjoinRepository();
+    usecase = WatchPayjoinUsecase(payjoinRepository: repository);
+  });
+
+  test('emits both receiver and sender payjoins (senders are not filtered '
+      'out — #2246)', () async {
+    final receiver = _receiver('r1');
+    final sender = _sender('s1');
+    when(
+      () => repository.payjoinStream,
+    ).thenAnswer((_) => Stream.fromIterable([receiver, sender]));
+
+    final emitted = await usecase.execute().toList();
+
+    // The send flow depends on sender events reaching it; a receiver-only
+    // filter here would swallow them and hang the "coordinating" screen.
+    expect(emitted, [receiver, sender]);
+  });
+
+  test('scopes emissions to the requested ids', () async {
+    final wanted = _sender('wanted');
+    final other = _sender('other');
+    when(
+      () => repository.payjoinStream,
+    ).thenAnswer((_) => Stream.fromIterable([wanted, other]));
+
+    final emitted = await usecase.execute(ids: ['wanted']).toList();
+
+    expect(emitted, [wanted]);
+  });
+}


### PR DESCRIPTION
Hardens the core payjoin engine: watchers, session-resume logic, and guards against invalid states. Models the fallback-to-normal-tx path explicitly via PayjoinStatus.aborted + a DB isAborted flag, instead of deriving it from isCompleted && txId == null. Extends the Payjoin entity with logRef, canManuallyBroadcastOriginal, and isCompleted/isAborted/isExpired getters.

Builds on #2443's typestate API. Addresses part of #2416 (payjoin improvements).

Merge order: 3rd, after PR1. Base of PR3, PR4, PR5 — must merge before all three.
PR1 → PR2 (this) → {PR3, PR4, PR5}
