### PR TITLE
fix(send): resolve stuck sender flow on payjoin fallback (#2246)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -83,6 +83,7 @@ graph TB
     SEND --> NETWORK
     SEND --> PAYJOIN
     SEND --> SWAPS
+    SEND --> TX_HISTORY
     SEND --> UTXO_MGMT
     SEND --> WALLETS
     SETTINGS --> CORE

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -9,7 +9,9 @@ import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies
 import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
@@ -67,6 +69,7 @@ class SendCubit extends Cubit<SendState>
     required this._prepareBitcoinSendUsecase,
     required this._prepareLiquidSendUsecase,
     required this._sendWithPayjoinUsecase,
+    required this._watchPayjoinUsecase,
     required this._getWalletsUsecase,
     required this._getWalletUsecase,
     required this._createSendSwapUsecase,
@@ -117,6 +120,7 @@ class SendCubit extends Cubit<SendState>
   final BroadcastLiquidTransactionUsecase _broadcastLiquidTxUsecase;
   final BroadcastBitcoinTransactionUsecase _broadcastBitcoinTxUsecase;
   final SendWithPayjoinUsecase _sendWithPayjoinUsecase;
+  final WatchPayjoinUsecase _watchPayjoinUsecase;
   final UpdatePaidSendSwapUsecase _updatePaidSendSwapUsecase;
   final GetSwapLimitsUsecase _getSwapLimitsUsecase;
   final DecodeInvoiceUsecase _decodeInvoiceUsecase;
@@ -139,6 +143,7 @@ class SendCubit extends Cubit<SendState>
   StreamSubscription<Swap>? _swapSubscription;
   StreamSubscription<Wallet>? _selectedWalletSyncingSubscription;
   StreamSubscription<WalletTransaction>? _txSubscription;
+  StreamSubscription<Payjoin>? _payjoinSubscription;
 
   /// Monotonic token bumped by [clearBitcoinFeePreviews]. A preview build
   /// captures it before its `await` and re-checks before writing results
@@ -154,6 +159,7 @@ class SendCubit extends Cubit<SendState>
       _swapSubscription?.cancel() ?? Future.value(),
       _selectedWalletSyncingSubscription?.cancel() ?? Future.value(),
       _txSubscription?.cancel() ?? Future.value(),
+      _payjoinSubscription?.cancel() ?? Future.value(),
     ).wait;
     return super.close();
   }
@@ -849,6 +855,7 @@ class SendCubit extends Cubit<SendState>
         exchangeRate: exchangeRate,
         bitcoinUnit: bitcoinUnit,
         inputAmountCurrencyCode: bitcoinUnit.code,
+        payjoinGloballyEnabled: settings.isPayjoinEnabled,
       ),
     );
   }
@@ -942,6 +949,7 @@ class SendCubit extends Cubit<SendState>
   Future<void> onCurrencyChanged(String currencyCode) async {
     double exchangeRate = state.exchangeRate;
     String fiatCurrencyCode = state.fiatCurrencyCode;
+    bool payjoinGloballyEnabled = state.payjoinGloballyEnabled;
 
     if (![BitcoinUnit.btc.code, BitcoinUnit.sats.code].contains(currencyCode)) {
       // If the currency is a fiat currency, retrieve the exchange rate and replace
@@ -958,8 +966,10 @@ class SendCubit extends Cubit<SendState>
         _convertSatsToCurrencyAmountUsecase.execute(),
       ]);
 
-      fiatCurrencyCode = (currencyValues[0] as SettingsEntity).currencyCode;
+      final settings = currencyValues[0] as SettingsEntity;
+      fiatCurrencyCode = settings.currencyCode;
       exchangeRate = currencyValues[1] as double;
+      payjoinGloballyEnabled = settings.isPayjoinEnabled;
     }
 
     emit(
@@ -967,6 +977,7 @@ class SendCubit extends Cubit<SendState>
         inputAmountCurrencyCode: currencyCode,
         fiatCurrencyCode: fiatCurrencyCode,
         exchangeRate: exchangeRate,
+        payjoinGloballyEnabled: payjoinGloballyEnabled,
         amount: '', // Clear the amount when changing the currency
       ),
     );
@@ -1867,11 +1878,8 @@ class SendCubit extends Cubit<SendState>
           state.copyWith(signedLiquidTx: signedPset, signingTransaction: false),
         );
       } else {
-        final paymentRequest = state.paymentRequest;
-        if (state.isToSelf != true &&
-            paymentRequest != null &&
-            paymentRequest is Bip21PaymentRequest &&
-            paymentRequest.pj.isNotEmpty) {
+        if (state.willAttemptPayjoin) {
+          final paymentRequest = state.paymentRequest! as Bip21PaymentRequest;
           final payjoinSender = await _sendWithPayjoinUsecase.execute(
             walletId: state.selectedWallet!.id,
             isTestnet: state.selectedWallet!.network.isTestnet,
@@ -1881,18 +1889,20 @@ class SendCubit extends Cubit<SendState>
             networkFeesSatPerVb: state.selectedFee!.isRelative
                 ? state.selectedFee!.value as double
                 : 1,
-            expireAfterSec: PayjoinConstants.defaultExpireAfterSec,
           );
-          // TODO: Watch the payjoin and transaction to update the txId with the
-          //  payjoin txId if it is completed.
-          final txId = payjoinSender.originalTxId;
+          // Show originalTxId provisionally; the payjoin runs asynchronously
+          //  in the repository (poll → sign → broadcast, or fallback to the
+          //  original on expiry). Watch its stream so the send flow resolves
+          //  to success with the final txid instead of hanging on the
+          //  "coordinating" screen (#2246).
           emit(
             state.copyWith(
-              txId: txId,
+              txId: payjoinSender.originalTxId,
               payjoinSender: payjoinSender,
               signingTransaction: false,
             ),
           );
+          _watchPayjoin(payjoinSender.id);
         } else {
           final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
             psbt: state.unsignedPsbt!,
@@ -1952,19 +1962,15 @@ class SendCubit extends Cubit<SendState>
         );
         emit(state.copyWith(txId: txId));
       } else {
-        final paymentRequest = state.paymentRequest;
-        if (state.isToSelf != true &&
-            paymentRequest != null &&
-            paymentRequest is Bip21PaymentRequest &&
-            paymentRequest.pj.isNotEmpty) {
-          emit(state.copyWith(broadcastingTransaction: false));
-        } else {
-          final txId = await _broadcastBitcoinTxUsecase.execute(
-            isPsbt ? state.signedBitcoinPsbt! : state.signedBitcoinTx!,
-            isPsbt: isPsbt,
-          );
-          emit(state.copyWith(txId: txId));
-        }
+        // Payjoin sends are already broadcast asynchronously by the repository
+        // (and their state.txId is set in signTransaction), so they never
+        // reach here — the guard at the top of this method returns first. Only
+        // plain bitcoin sends broadcast at this point.
+        final txId = await _broadcastBitcoinTxUsecase.execute(
+          isPsbt ? state.signedBitcoinPsbt! : state.signedBitcoinTx!,
+          isPsbt: isPsbt,
+        );
+        emit(state.copyWith(txId: txId));
       }
 
       if (state.lightningSwap != null) {
@@ -2059,11 +2065,17 @@ class SendCubit extends Cubit<SendState>
         emit(state.copyWith(step: SendStep.confirm));
         return;
       }
-      // Start watching the transaction to have the latest status
-      _watchWalletTransactionByTxId(
-        walletId: state.selectedWallet!.id,
-        txId: state.txId!,
-      );
+      // For a payjoin, _watchPayjoin (started in signTransaction) owns
+      // resolving the flow to success — it watches the payjoin session and
+      // sets the final txid. Starting the tx watcher here too would race it
+      // (both emit) and briefly surface the original txid. For all other
+      // sends, watch the broadcast tx for its latest status.
+      if (state.payjoinSender == null) {
+        _watchWalletTransactionByTxId(
+          walletId: state.selectedWallet!.id,
+          txId: state.txId!,
+        );
+      }
     } catch (e) {
       emit(state.copyWith(step: SendStep.confirm));
       log.severe(error: e, trace: StackTrace.current);
@@ -2146,6 +2158,108 @@ class SendCubit extends Cubit<SendState>
         }
       }
     });
+  }
+
+  /// Watches the sender side of an in-flight payjoin and resolves the send
+  /// flow once it terminates. The payjoin negotiation runs asynchronously in
+  /// the repository; without this the UI would sit on the "coordinating"
+  /// screen forever (#2246).
+  ///
+  /// - completed: the receiver responded and the payjoin transaction was
+  ///   broadcast — move to success with the payjoin txid.
+  /// - expired/aborted: the repository fell back to broadcasting the original
+  ///   transaction — move to success with the original txid.
+  void _watchPayjoin(String payjoinId) {
+    _payjoinSubscription?.cancel();
+    // Captured up front: the completion event fires arbitrarily later on a
+    // background poll, so read these off state now rather than closing over
+    // state (which may have moved on) inside the async callback.
+    final walletId = state.selectedWallet?.id;
+    final userLabel = state.label;
+    _payjoinSubscription = _watchPayjoinUsecase
+        .execute(ids: [payjoinId])
+        .where((payjoin) => payjoin is PayjoinSender)
+        .cast<PayjoinSender>()
+        .listen((payjoin) {
+          // The payjoin poll lives in the repository and outlives this cubit;
+          // an event can arrive after the send flow is torn down. Never emit
+          // on a closed cubit (it throws).
+          if (isClosed) return;
+          // logRef, never id: a sender payjoin id is the full BIP21 URI
+          // (address + amount), which must not reach logs.
+          log.info(
+            '[SendCubit] Watched payjoin ${payjoin.logRef} updated: '
+            '${payjoin.status}',
+          );
+          if (payjoin.isCompleted || payjoin.isAborted) {
+            emit(
+              state.copyWith(
+                payjoinSender: payjoin,
+                // Prefer the payjoin txid; fall back to the original tx that
+                //  was broadcast when the negotiation didn't complete.
+                txId: payjoin.txId ?? payjoin.originalTxId,
+                step: SendStep.success,
+              ),
+            );
+            _payjoinSubscription?.cancel();
+            if (walletId != null) {
+              unawaited(
+                _getWalletUsecase.execute(walletId, sync: true).catchError((e) {
+                  log.warning('Failed to sync wallet after payjoin: $e');
+                  return null;
+                }),
+              );
+            }
+            // broadcastTransaction never reaches its own label-store call for
+            //  a payjoin (it early-returns because txId is already set), so
+            //  the user's typed label has to be stored here instead, once the
+            //  final txid is known.
+            // originalTxId is always set for a sender, so this is never null.
+            final finalTxId = payjoin.txId ?? payjoin.originalTxId;
+            if (userLabel.isNotEmpty && walletId != null) {
+              unawaited(
+                _labelsFacade.store(
+                  NewLabel.tx(
+                    transactionId: finalTxId,
+                    label: userLabel,
+                    origin: walletId,
+                  ),
+                ),
+              );
+            }
+          } else if (payjoin.isExpired) {
+            // Terminal without a broadcast: either the session expired and the
+            // original-transaction fallback failed too, or a received proposal
+            // failed to sign/broadcast and the original fallback also failed
+            // (the repository only emits the raw expired-marked entity on one
+            // of these unrecoverable paths). Nothing hit the chain, so surface
+            // a broadcast failure and return to confirm so the user can retry,
+            // instead of hanging on "coordinating".
+            log.warning(
+              '[SendCubit] Payjoin ${payjoin.logRef} expired without broadcast',
+            );
+            _payjoinSubscription?.cancel();
+            // Clear the provisional txId AND payjoinSender so a retry starts
+            //  clean: signTransaction set state.txId = originalTxId up front,
+            //  and broadcastTransaction early-returns while txId != null — so
+            //  leaving them set would permanently short-circuit the retry's
+            //  broadcast. Nulling both lets createTransaction/signTransaction
+            //  re-run the payjoin branch from scratch.
+            emit(
+              state.copyWith(
+                txId: null,
+                payjoinSender: null,
+                step: SendStep.confirm,
+                confirmTransactionException: ConfirmTransactionException(
+                  'Payjoin expired and the transaction could not be broadcast',
+                  isBroadcastFailure: true,
+                ),
+              ),
+            );
+          } else {
+            emit(state.copyWith(payjoinSender: payjoin));
+          }
+        });
   }
 
   void _watchWalletTransactionByTxId({

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -2053,7 +2053,16 @@ class SendCubit extends Cubit<SendState>
         await signTransaction();
         // if (!state.isLightning) {
         if (state.confirmTransactionException == null) {
-          emit(state.copyWith(step: SendStep.sending));
+          // _watchPayjoin (armed inside signTransaction's payjoin branch)
+          //  can resolve the flow to success before this line, if a
+          //  terminal payjoin event arrives in the gap between arming and
+          //  here. Don't clobber an already-resolved success with
+          //  "sending" — that would strand the flow on the sending screen
+          //  despite having actually completed (the exact symptom #2246
+          //  fixes, just a narrower window of it).
+          if (state.step != SendStep.success) {
+            emit(state.copyWith(step: SendStep.sending));
+          }
         } else {
           emit(state.copyWith(step: SendStep.confirm));
           return;
@@ -2167,8 +2176,13 @@ class SendCubit extends Cubit<SendState>
   ///
   /// - completed: the receiver responded and the payjoin transaction was
   ///   broadcast — move to success with the payjoin txid.
-  /// - expired/aborted: the repository fell back to broadcasting the original
-  ///   transaction — move to success with the original txid.
+  /// - aborted: the repository fell back to broadcasting the original
+  ///   transaction (below-minimum decline, failed negotiation, or the
+  ///   counterparty's own fallback observed on-chain) — move to success
+  ///   with the original txid.
+  /// - expired: terminal with nothing broadcast — the original-transaction
+  ///   fallback itself also failed — return to confirm with a
+  ///   broadcast-failure exception so the user can retry.
   void _watchPayjoin(String payjoinId) {
     _payjoinSubscription?.cancel();
     // Captured up front: the completion event fires arbitrarily later on a

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -70,6 +70,10 @@ abstract class SendState with _$SendState {
     Wallet? selectedWallet,
     @Default(false) bool isWalletManuallySelected,
     bool? isToSelf,
+    // Fail-closed default: until getCurrencies()/onCurrencyChanged() have
+    // fetched settings at least once, no payjoin is attempted. Mirrors
+    // SettingsEntity.isPayjoinEnabled.
+    @Default(false) bool payjoinGloballyEnabled,
     @Default('') String amount,
     int? confirmedAmountSat,
     BitcoinUnit? bitcoinUnit,
@@ -168,6 +172,25 @@ abstract class SendState with _$SendState {
 
   /// Whether we have a valid payment request
   bool get hasValidPaymentRequest => paymentRequest != null;
+
+  /// Single source of truth for whether a payjoin will actually be attempted
+  /// for this send — same pattern as [Payjoin.canManuallyBroadcastOriginal],
+  /// which unifies a button's visibility and its action guard. Used BOTH to
+  /// gate `signTransaction`'s payjoin branch and to show the "a payjoin will
+  /// be attempted" indicator on the confirm screen, so the two can never
+  /// disagree.
+  ///
+  /// Gated on [Wallet.signsLocally]: a hardware/remote-signer wallet
+  /// (Ledger/BitBox) never reaches `signTransaction`'s payjoin branch (the
+  /// confirm screen swaps in a device-specific sign button for those
+  /// wallets instead), so without this check the indicator could promise a
+  /// payjoin that structurally can never happen for that wallet class.
+  bool get willAttemptPayjoin =>
+      payjoinGloballyEnabled &&
+      (selectedWallet?.signsLocally ?? false) &&
+      isToSelf != true &&
+      paymentRequest is Bip21PaymentRequest &&
+      (paymentRequest! as Bip21PaymentRequest).pj.isNotEmpty;
 
   String get paymentRequestAddress {
     if (paymentRequest == null) {

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -6,6 +6,7 @@ import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/create_chain_swap_to_external_usecase.dart';
@@ -171,6 +172,7 @@ class SendLocator {
         getSwapLimitsUsecase: locator<GetSwapLimitsUsecase>(),
         watchSwapUsecase: locator<WatchSwapUsecase>(),
         sendWithPayjoinUsecase: locator<SendWithPayjoinUsecase>(),
+        watchPayjoinUsecase: locator<WatchPayjoinUsecase>(),
         watchFinishedWalletSyncsUsecase:
             locator<WatchFinishedWalletSyncsUsecase>(),
         decodeInvoiceUsecase: locator<DecodeInvoiceUsecase>(),

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -22,6 +22,7 @@ import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/core/widgets/tiles/bordered_tappable_tile.dart';
+import 'package:bb_mobile/core/widgets/timers/countdown.dart';
 import 'package:bb_mobile/features/labels/ui/label_entry_bottom_sheet.dart';
 import 'package:bb_mobile/features/bitbox/ui/bitbox_router.dart';
 import 'package:bb_mobile/features/bitbox/ui/screens/bitbox_action_screen.dart';
@@ -989,10 +990,21 @@ class _OnchainTransactionReview extends StatelessWidget {
       (SendCubit cubit) => cubit.state.isToSelf == true,
     );
     final label = context.select((SendCubit cubit) => cubit.state.label);
+    final willAttemptPayjoin = context.select(
+      (SendCubit cubit) => cubit.state.willAttemptPayjoin,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        if (willAttemptPayjoin) ...[
+          InfoCard(
+            description: context.loc.sendPayjoinWillBeAttempted,
+            tagColor: context.appColors.secondary,
+            bgColor: context.appColors.onSecondary,
+          ),
+          const Gap(16),
+        ],
         CommonOnchainSendInfoSection(
           sendWalletLabel: selectedWallet?.displayLabel(context) ?? '',
           receiveWalletLabel: paymentRequestAddress,
@@ -1622,12 +1634,29 @@ class SendSendingScreen extends StatelessWidget {
     final isPayjoin = context.select(
       (SendCubit cubit) => cubit.state.payjoinSender != null,
     );
+    // Same canonical getter the manual-fallback button on the transaction
+    // details screen is gated on (Payjoin.canManuallyBroadcastOriginal) —
+    // reusing it here, rather than a hand-rolled `proposalPsbt == null`
+    // check, means this countdown can never linger past the point where a
+    // proposal has arrived or the session has expired.
+    final showFallbackCountdown = context.select(
+      (SendCubit cubit) =>
+          cubit.state.payjoinSender?.canManuallyBroadcastOriginal ?? false,
+    );
+    final payjoinExpiresAt = context.select(
+      (SendCubit cubit) => cubit.state.payjoinSender?.expiresAt,
+    );
+    // Computed once per build — acceptable, the screen rebuilds on each cubit
+    // emit; deliberately not adding a ticker to the bloc for this.
+    final isImminent =
+        payjoinExpiresAt != null &&
+        payjoinExpiresAt.difference(DateTime.now()) <= const Duration(hours: 1);
 
     return Scaffold(
       appBar: AppBar(
         forceMaterialTransparency: true,
         automaticallyImplyLeading: false,
-        flexibleSpace: const TopBar(title: 'Send'),
+        flexibleSpace: TopBar(title: context.loc.sendTitle),
         actions: [
           CloseButton(
             onPressed: () => context.goNamed(WalletRoute.walletHome.name),
@@ -1694,6 +1723,30 @@ class SendSendingScreen extends StatelessWidget {
                   maxLines: 4,
                   textAlign: TextAlign.center,
                 ),
+                if (showFallbackCountdown &&
+                    payjoinExpiresAt != null &&
+                    isImminent) ...[
+                  const Gap(8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      BBText(
+                        context.loc.sendPayjoinFallbackCountdown,
+                        style: context.font.bodyMedium,
+                        color: context.appColors.secondary,
+                      ),
+                      const Gap(4),
+                      Countdown(
+                        until: payjoinExpiresAt.add(
+                          const Duration(
+                            seconds: PayjoinConstants.directoryPollingInterval,
+                          ),
+                        ),
+                        onTimeout: () {},
+                      ),
+                    ],
+                  ),
+                ],
               ],
             ],
           ),
@@ -1834,11 +1887,28 @@ class SendSucessScreen extends StatelessWidget {
                       context.loc.sendSwapWillTakeTime,
                       style: context.font.labelSmall,
                     ),
-                  ] else
+                  ] else ...[
                     BBText(
                       context.loc.sendSuccessfullySent,
                       style: context.font.bodyLarge,
                     ),
+                    // A payjoin send that completed via the plain-broadcast
+                    // fallback (receiver declined/expired or the payjoin
+                    // negotiation failed). The user explicitly expected a
+                    // payjoin, so say that it didn't happen instead of
+                    // presenting the fallback as indistinguishable from a
+                    // successful payjoin.
+                    if (payjoin != null && payjoin.isAborted) ...[
+                      const Gap(8),
+                      BBText(
+                        context.loc.sendSentWithoutPayjoin,
+                        style: context.font.bodyMedium,
+                        color: context.appColors.secondary,
+                        maxLines: 4,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ],
                   const Gap(8),
                   BBText(
                     amount,
@@ -1890,10 +1960,22 @@ class SendSucessScreen extends StatelessWidget {
                       },
                     );
                   } else if (payjoin != null) {
+                    // Navigate by the on-chain txid, NOT payjoin.id: a
+                    //  sender's id IS the full BIP21 URI (address+amount) and
+                    //  would leak into the router location string. By this
+                    //  point the session is terminal, so txId (real payjoin)
+                    //  or originalTxId (fallback) is always the broadcast tx —
+                    //  and landing on the real transaction is better UX than
+                    //  the session placeholder.
                     context.pushNamed(
-                      TransactionsRoute.payjoinTransactionDetails.name,
-                      pathParameters: {'payjoinId': payjoin.id},
-                      queryParameters: {'returnHome': 'true'},
+                      TransactionsRoute.transactionDetails.name,
+                      pathParameters: {
+                        'txId': payjoin.txId ?? payjoin.originalTxId,
+                      },
+                      queryParameters: {
+                        'walletId': payjoin.walletId,
+                        'returnHome': 'true',
+                      },
                     );
                   }
                 },

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -1,0 +1,496 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/create_chain_swap_to_external_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/decode_invoice_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/get_swap_limits_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/update_send_swap_lockup_fees_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_pset_size_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/create_send_swap_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/select_best_wallet_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_usecase.dart';
+import 'package:bb_mobile/core/utils/payment_request.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
+import 'package:bb_mobile/features/send/presentation/bloc/send_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLabelsFacade extends Mock implements LabelsFacade {}
+
+class _MockSelectBestWalletUsecase extends Mock
+    implements SelectBestWalletUsecase {}
+
+class _MockDetectBitcoinStringUsecase extends Mock
+    implements DetectBitcoinStringUsecase {}
+
+class _MockGetSettingsUsecase extends Mock implements GetSettingsUsecase {}
+
+class _MockConvertSatsToCurrencyAmountUsecase extends Mock
+    implements ConvertSatsToCurrencyAmountUsecase {}
+
+class _MockGetNetworkFeesUsecase extends Mock
+    implements GetNetworkFeesUsecase {}
+
+class _MockGetWalletUtxosUsecase extends Mock
+    implements GetWalletUtxosUsecase {}
+
+class _MockGetAvailableCurrenciesUsecase extends Mock
+    implements GetAvailableCurrenciesUsecase {}
+
+class _MockPrepareBitcoinSendUsecase extends Mock
+    implements PrepareBitcoinSendUsecase {}
+
+class _MockPrepareLiquidSendUsecase extends Mock
+    implements PrepareLiquidSendUsecase {}
+
+class _MockSendWithPayjoinUsecase extends Mock
+    implements SendWithPayjoinUsecase {}
+
+class _MockWatchPayjoinUsecase extends Mock implements WatchPayjoinUsecase {}
+
+class _MockGetWalletsUsecase extends Mock implements GetWalletsUsecase {}
+
+class _MockGetWalletUsecase extends Mock implements GetWalletUsecase {}
+
+class _MockCreateSendSwapUsecase extends Mock
+    implements CreateSendSwapUsecase {}
+
+class _MockUpdatePaidSendSwapUsecase extends Mock
+    implements UpdatePaidSendSwapUsecase {}
+
+class _MockGetSwapLimitsUsecase extends Mock implements GetSwapLimitsUsecase {}
+
+class _MockWatchSwapUsecase extends Mock implements WatchSwapUsecase {}
+
+class _MockWatchFinishedWalletSyncsUsecase extends Mock
+    implements WatchFinishedWalletSyncsUsecase {}
+
+class _MockDecodeInvoiceUsecase extends Mock implements DecodeInvoiceUsecase {}
+
+class _MockSignBitcoinTxUsecase extends Mock implements SignBitcoinTxUsecase {}
+
+class _MockSignLiquidTxUsecase extends Mock implements SignLiquidTxUsecase {}
+
+class _MockBroadcastBitcoinTransactionUsecase extends Mock
+    implements BroadcastBitcoinTransactionUsecase {}
+
+class _MockBroadcastLiquidTransactionUsecase extends Mock
+    implements BroadcastLiquidTransactionUsecase {}
+
+class _MockCalculateLiquidAbsoluteFeesUsecase extends Mock
+    implements CalculateLiquidAbsoluteFeesUsecase {}
+
+class _MockCalculateLiquidPsetSizeUsecase extends Mock
+    implements CalculateLiquidPsetSizeUsecase {}
+
+class _MockCreateChainSwapToExternalUsecase extends Mock
+    implements CreateChainSwapToExternalUsecase {}
+
+class _MockWatchWalletTransactionByTxIdUsecase extends Mock
+    implements WatchWalletTransactionByTxIdUsecase {}
+
+class _MockCalculateBitcoinAbsoluteFeesUsecase extends Mock
+    implements CalculateBitcoinAbsoluteFeesUsecase {}
+
+class _MockUpdateSendSwapLockupFeesUsecase extends Mock
+    implements UpdateSendSwapLockupFeesUsecase {}
+
+class _MockVerifyChainSwapAmountSendUsecase extends Mock
+    implements VerifyChainSwapAmountSendUsecase {}
+
+class _MockPreviewBitcoinFeeUsecase extends Mock
+    implements PreviewBitcoinFeeUsecase {}
+
+class _MockPreviewBitcoinFeePresetsUsecase extends Mock
+    implements PreviewBitcoinFeePresetsUsecase {}
+
+class _FakeNewLabel extends Fake implements NewLabel {}
+
+/// Test seam: [SendCubit]'s payjoin watcher ([_watchPayjoin]) is private and
+/// only started from the tail of the public [SendCubit.signTransaction]. This
+/// subclass exposes [emit] so a test can stage exactly the precondition state
+/// that drives `signTransaction` into its payjoin branch — nothing about the
+/// production class is changed; the tests exercise the real
+/// `signTransaction` → `_watchPayjoin` code path.
+class _TestableSendCubit extends SendCubit {
+  _TestableSendCubit({
+    required super.labelsFacade,
+    required super.bestWalletUsecase,
+    required super.detectBitcoinStringUsecase,
+    required super.getSettingsUsecase,
+    required super.convertSatsToCurrencyAmountUsecase,
+    required super.getNetworkFeesUsecase,
+    required super.getWalletUtxosUsecase,
+    required super.getAvailableCurrenciesUsecase,
+    required super.prepareBitcoinSendUsecase,
+    required super.prepareLiquidSendUsecase,
+    required super.sendWithPayjoinUsecase,
+    required super.watchPayjoinUsecase,
+    required super.getWalletsUsecase,
+    required super.getWalletUsecase,
+    required super.createSendSwapUsecase,
+    required super.updatePaidSendSwapUsecase,
+    required super.getSwapLimitsUsecase,
+    required super.watchSwapUsecase,
+    required super.watchFinishedWalletSyncsUsecase,
+    required super.decodeInvoiceUsecase,
+    required super.signBitcoinTxUsecase,
+    required super.signLiquidTxUsecase,
+    required super.broadcastBitcoinTxUsecase,
+    required super.broadcastLiquidTxUsecase,
+    required super.calculateLiquidAbsoluteFeesUsecase,
+    required super.calculateLiquidPsetSizeUsecase,
+    required super.createChainSwapToExternalUsecase,
+    required super.watchWalletTransactionByTxIdUsecase,
+    required super.calculateBitcoinAbsoluteFeesUsecase,
+    required super.updateSendSwapLockupFeesUsecase,
+    required super.verifyChainSwapAmountSendUsecase,
+    required super.previewBitcoinFeeUsecase,
+    required super.previewBitcoinFeePresetsUsecase,
+  });
+
+  void setStateForTest(SendState state) => emit(state);
+}
+
+Wallet _bitcoinLocalWallet() => Wallet(
+  origin: 'w1',
+  network: Network.bitcoinMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.from(1000000),
+);
+
+Bip21PaymentRequest _payjoinBip21() =>
+    const PaymentRequest.bip21(
+          network: Network.bitcoinMainnet,
+          uri: 'bitcoin:bc1qaddr?amount=0.0005&pj=https://payjo.in',
+          address: 'bc1qaddr',
+          amountSat: 50000,
+          pj: 'https://payjo.in',
+        )
+        as Bip21PaymentRequest;
+
+PayjoinSender _sender({
+  required PayjoinStatus status,
+  String? txId,
+  String originalTxId = 'sender-orig-txid',
+}) =>
+    Payjoin.sender(
+          status: status,
+          uri: 'bitcoin:bc1qaddr?amount=0.0005&pj=https://payjo.in',
+          isTestnet: false,
+          walletId: 'w1',
+          originalPsbt: 'cHNidP8=',
+          originalTxId: originalTxId,
+          amountSat: 50000,
+          createdAt: DateTime(2026),
+          expiresAt: DateTime(2026).add(const Duration(minutes: 1)),
+          txId: txId,
+        )
+        as PayjoinSender;
+
+void main() {
+  late _MockLabelsFacade labelsFacade;
+  late _MockSelectBestWalletUsecase bestWalletUsecase;
+  late _MockDetectBitcoinStringUsecase detectBitcoinStringUsecase;
+  late _MockGetSettingsUsecase getSettingsUsecase;
+  late _MockConvertSatsToCurrencyAmountUsecase convertSatsUsecase;
+  late _MockGetNetworkFeesUsecase getNetworkFeesUsecase;
+  late _MockGetWalletUtxosUsecase getWalletUtxosUsecase;
+  late _MockGetAvailableCurrenciesUsecase getAvailableCurrenciesUsecase;
+  late _MockPrepareBitcoinSendUsecase prepareBitcoinSendUsecase;
+  late _MockPrepareLiquidSendUsecase prepareLiquidSendUsecase;
+  late _MockSendWithPayjoinUsecase sendWithPayjoinUsecase;
+  late _MockWatchPayjoinUsecase watchPayjoinUsecase;
+  late _MockGetWalletsUsecase getWalletsUsecase;
+  late _MockGetWalletUsecase getWalletUsecase;
+  late _MockCreateSendSwapUsecase createSendSwapUsecase;
+  late _MockUpdatePaidSendSwapUsecase updatePaidSendSwapUsecase;
+  late _MockGetSwapLimitsUsecase getSwapLimitsUsecase;
+  late _MockWatchSwapUsecase watchSwapUsecase;
+  late _MockWatchFinishedWalletSyncsUsecase watchFinishedWalletSyncsUsecase;
+  late _MockDecodeInvoiceUsecase decodeInvoiceUsecase;
+  late _MockSignBitcoinTxUsecase signBitcoinTxUsecase;
+  late _MockSignLiquidTxUsecase signLiquidTxUsecase;
+  late _MockBroadcastBitcoinTransactionUsecase broadcastBitcoinTxUsecase;
+  late _MockBroadcastLiquidTransactionUsecase broadcastLiquidTxUsecase;
+  late _MockCalculateLiquidAbsoluteFeesUsecase
+  calculateLiquidAbsoluteFeesUsecase;
+  late _MockCalculateLiquidPsetSizeUsecase calculateLiquidPsetSizeUsecase;
+  late _MockCreateChainSwapToExternalUsecase createChainSwapToExternalUsecase;
+  late _MockWatchWalletTransactionByTxIdUsecase
+  watchWalletTransactionByTxIdUsecase;
+  late _MockCalculateBitcoinAbsoluteFeesUsecase
+  calculateBitcoinAbsoluteFeesUsecase;
+  late _MockUpdateSendSwapLockupFeesUsecase updateSendSwapLockupFeesUsecase;
+  late _MockVerifyChainSwapAmountSendUsecase verifyChainSwapAmountSendUsecase;
+  late _MockPreviewBitcoinFeeUsecase previewBitcoinFeeUsecase;
+  late _MockPreviewBitcoinFeePresetsUsecase previewBitcoinFeePresetsUsecase;
+
+  late StreamController<Payjoin> payjoinEvents;
+
+  _TestableSendCubit buildCubit() => _TestableSendCubit(
+    labelsFacade: labelsFacade,
+    bestWalletUsecase: bestWalletUsecase,
+    detectBitcoinStringUsecase: detectBitcoinStringUsecase,
+    getSettingsUsecase: getSettingsUsecase,
+    convertSatsToCurrencyAmountUsecase: convertSatsUsecase,
+    getNetworkFeesUsecase: getNetworkFeesUsecase,
+    getWalletUtxosUsecase: getWalletUtxosUsecase,
+    getAvailableCurrenciesUsecase: getAvailableCurrenciesUsecase,
+    prepareBitcoinSendUsecase: prepareBitcoinSendUsecase,
+    prepareLiquidSendUsecase: prepareLiquidSendUsecase,
+    sendWithPayjoinUsecase: sendWithPayjoinUsecase,
+    watchPayjoinUsecase: watchPayjoinUsecase,
+    getWalletsUsecase: getWalletsUsecase,
+    getWalletUsecase: getWalletUsecase,
+    createSendSwapUsecase: createSendSwapUsecase,
+    updatePaidSendSwapUsecase: updatePaidSendSwapUsecase,
+    getSwapLimitsUsecase: getSwapLimitsUsecase,
+    watchSwapUsecase: watchSwapUsecase,
+    watchFinishedWalletSyncsUsecase: watchFinishedWalletSyncsUsecase,
+    decodeInvoiceUsecase: decodeInvoiceUsecase,
+    signBitcoinTxUsecase: signBitcoinTxUsecase,
+    signLiquidTxUsecase: signLiquidTxUsecase,
+    broadcastBitcoinTxUsecase: broadcastBitcoinTxUsecase,
+    broadcastLiquidTxUsecase: broadcastLiquidTxUsecase,
+    calculateLiquidAbsoluteFeesUsecase: calculateLiquidAbsoluteFeesUsecase,
+    calculateLiquidPsetSizeUsecase: calculateLiquidPsetSizeUsecase,
+    createChainSwapToExternalUsecase: createChainSwapToExternalUsecase,
+    watchWalletTransactionByTxIdUsecase: watchWalletTransactionByTxIdUsecase,
+    calculateBitcoinAbsoluteFeesUsecase: calculateBitcoinAbsoluteFeesUsecase,
+    updateSendSwapLockupFeesUsecase: updateSendSwapLockupFeesUsecase,
+    verifyChainSwapAmountSendUsecase: verifyChainSwapAmountSendUsecase,
+    previewBitcoinFeeUsecase: previewBitcoinFeeUsecase,
+    previewBitcoinFeePresetsUsecase: previewBitcoinFeePresetsUsecase,
+  );
+
+  /// Precondition state that makes [SendState.willAttemptPayjoin] true and
+  /// gives `signTransaction` everything its bitcoin payjoin branch reads:
+  /// a local-signing bitcoin wallet, a BIP21 request carrying a `pj`
+  /// endpoint, payjoin enabled, not a self-send, an unsigned PSBT, a
+  /// confirmed amount and a relative fee. [label] is the user's typed note.
+  SendState payjoinReadyState({String label = ''}) => SendState(
+    step: SendStep.confirm,
+    sendType: SendType.bitcoin,
+    selectedWallet: _bitcoinLocalWallet(),
+    paymentRequest: _payjoinBip21(),
+    payjoinGloballyEnabled: true,
+    isToSelf: false,
+    unsignedPsbt: 'cHNidP8=',
+    confirmedAmountSat: 50000,
+    label: label,
+    selectedFeeOption: FeeSelection.custom,
+    customFee: NetworkFee.relativeFromSatPerVbyte(2),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(_FakeNewLabel());
+  });
+
+  setUp(() {
+    labelsFacade = _MockLabelsFacade();
+    bestWalletUsecase = _MockSelectBestWalletUsecase();
+    detectBitcoinStringUsecase = _MockDetectBitcoinStringUsecase();
+    getSettingsUsecase = _MockGetSettingsUsecase();
+    convertSatsUsecase = _MockConvertSatsToCurrencyAmountUsecase();
+    getNetworkFeesUsecase = _MockGetNetworkFeesUsecase();
+    getWalletUtxosUsecase = _MockGetWalletUtxosUsecase();
+    getAvailableCurrenciesUsecase = _MockGetAvailableCurrenciesUsecase();
+    prepareBitcoinSendUsecase = _MockPrepareBitcoinSendUsecase();
+    prepareLiquidSendUsecase = _MockPrepareLiquidSendUsecase();
+    sendWithPayjoinUsecase = _MockSendWithPayjoinUsecase();
+    watchPayjoinUsecase = _MockWatchPayjoinUsecase();
+    getWalletsUsecase = _MockGetWalletsUsecase();
+    getWalletUsecase = _MockGetWalletUsecase();
+    createSendSwapUsecase = _MockCreateSendSwapUsecase();
+    updatePaidSendSwapUsecase = _MockUpdatePaidSendSwapUsecase();
+    getSwapLimitsUsecase = _MockGetSwapLimitsUsecase();
+    watchSwapUsecase = _MockWatchSwapUsecase();
+    watchFinishedWalletSyncsUsecase = _MockWatchFinishedWalletSyncsUsecase();
+    decodeInvoiceUsecase = _MockDecodeInvoiceUsecase();
+    signBitcoinTxUsecase = _MockSignBitcoinTxUsecase();
+    signLiquidTxUsecase = _MockSignLiquidTxUsecase();
+    broadcastBitcoinTxUsecase = _MockBroadcastBitcoinTransactionUsecase();
+    broadcastLiquidTxUsecase = _MockBroadcastLiquidTransactionUsecase();
+    calculateLiquidAbsoluteFeesUsecase =
+        _MockCalculateLiquidAbsoluteFeesUsecase();
+    calculateLiquidPsetSizeUsecase = _MockCalculateLiquidPsetSizeUsecase();
+    createChainSwapToExternalUsecase = _MockCreateChainSwapToExternalUsecase();
+    watchWalletTransactionByTxIdUsecase =
+        _MockWatchWalletTransactionByTxIdUsecase();
+    calculateBitcoinAbsoluteFeesUsecase =
+        _MockCalculateBitcoinAbsoluteFeesUsecase();
+    updateSendSwapLockupFeesUsecase = _MockUpdateSendSwapLockupFeesUsecase();
+    verifyChainSwapAmountSendUsecase = _MockVerifyChainSwapAmountSendUsecase();
+    previewBitcoinFeeUsecase = _MockPreviewBitcoinFeeUsecase();
+    previewBitcoinFeePresetsUsecase = _MockPreviewBitcoinFeePresetsUsecase();
+
+    payjoinEvents = StreamController<Payjoin>.broadcast();
+
+    // Benign default stubs for everything the payjoin branch (or its
+    // aftermath) touches.
+    when(
+      () => watchPayjoinUsecase.execute(ids: any(named: 'ids')),
+    ).thenAnswer((_) => payjoinEvents.stream);
+    when(
+      () => getWalletUsecase.execute(any(), sync: any(named: 'sync')),
+    ).thenAnswer((_) async => _bitcoinLocalWallet());
+    when(() => labelsFacade.store(any())).thenAnswer(
+      (_) async => Ok<Label, LabelFailure>(
+        Label(
+          id: 1,
+          type: LabelType.transaction,
+          label: 'note',
+          reference: 'txid',
+        ),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await payjoinEvents.close();
+  });
+
+  /// Drives the real `signTransaction` so `_watchPayjoin` gets armed against
+  /// the mocked [watchPayjoinUsecase] stream, then returns the cubit.
+  Future<_TestableSendCubit> armWatcher(
+    _TestableSendCubit cubit, {
+    String label = '',
+  }) async {
+    when(
+      () => sendWithPayjoinUsecase.execute(
+        walletId: any(named: 'walletId'),
+        isTestnet: any(named: 'isTestnet'),
+        bip21: any(named: 'bip21'),
+        unsignedOriginalPsbt: any(named: 'unsignedOriginalPsbt'),
+        amountSat: any(named: 'amountSat'),
+        networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+      ),
+    ).thenAnswer((_) async => _sender(status: PayjoinStatus.requested));
+
+    cubit.setStateForTest(payjoinReadyState(label: label));
+    await cubit.signTransaction();
+    return cubit;
+  }
+
+  group('SendCubit._watchPayjoin', () {
+    test('a completed PayjoinSender (real payjoin, txId set) resolves the flow '
+        'to success with the payjoin txid, syncs the wallet and stores the '
+        'user label on that final txid', () async {
+      final cubit = await armWatcher(buildCubit(), label: 'coffee');
+      addTearDown(cubit.close);
+
+      // signTransaction set state.txId = originalTxId provisionally.
+      expect(cubit.state.txId, 'sender-orig-txid');
+      expect(cubit.state.step, SendStep.confirm);
+
+      payjoinEvents.add(
+        _sender(status: PayjoinStatus.completed, txId: 'real-payjoin-txid'),
+      );
+      await pumpEventQueue();
+
+      expect(cubit.state.step, SendStep.success);
+      expect(cubit.state.txId, 'real-payjoin-txid');
+      // The wallet is synced (sync: true) once the payjoin resolves.
+      verify(() => getWalletUsecase.execute('w1', sync: true)).called(1);
+      // The typed label is persisted on the FINAL (payjoin) txid.
+      final stored =
+          verify(() => labelsFacade.store(captureAny())).captured.single
+              as NewLabel;
+      expect(stored.reference, 'real-payjoin-txid');
+      expect(stored.label, 'coffee');
+    });
+
+    test('an aborted PayjoinSender (fallback broadcast, txId null) resolves to '
+        'success with the ORIGINAL txid', () async {
+      final cubit = await armWatcher(buildCubit());
+      addTearDown(cubit.close);
+
+      payjoinEvents.add(_sender(status: PayjoinStatus.aborted));
+      await pumpEventQueue();
+
+      expect(cubit.state.step, SendStep.success);
+      expect(cubit.state.txId, 'sender-orig-txid');
+    });
+
+    test('an expired PayjoinSender returns to confirm with a broadcast-failure '
+        'exception AND clears both txId and payjoinSender so a retry starts '
+        'clean (C7 regression pin)', () async {
+      final cubit = await armWatcher(buildCubit());
+      addTearDown(cubit.close);
+
+      // The provisional txId + payjoinSender are set before the event.
+      expect(cubit.state.txId, 'sender-orig-txid');
+      expect(cubit.state.payjoinSender, isNotNull);
+
+      payjoinEvents.add(_sender(status: PayjoinStatus.expired));
+      await pumpEventQueue();
+
+      expect(cubit.state.step, SendStep.confirm);
+      expect(cubit.state.confirmTransactionException, isNotNull);
+      expect(
+        cubit.state.confirmTransactionException!.isBroadcastFailure,
+        isTrue,
+      );
+      // The key C7 clear: both must be nulled so broadcastTransaction's
+      // `txId != null` guard no longer short-circuits the retry.
+      expect(cubit.state.txId, isNull);
+      expect(cubit.state.payjoinSender, isNull);
+    });
+
+    test(
+      'a non-terminal event (requested/proposed) only updates payjoinSender; '
+      'the step stays put (not success, not confirm-with-failure)',
+      () async {
+        final cubit = await armWatcher(buildCubit());
+        addTearDown(cubit.close);
+
+        final stepBefore = cubit.state.step;
+
+        payjoinEvents.add(_sender(status: PayjoinStatus.proposed));
+        await pumpEventQueue();
+
+        expect(cubit.state.payjoinSender, isNotNull);
+        expect(cubit.state.payjoinSender!.status, PayjoinStatus.proposed);
+        expect(cubit.state.step, stepBefore);
+        expect(cubit.state.step, isNot(SendStep.success));
+        expect(cubit.state.confirmTransactionException, isNull);
+      },
+    );
+  });
+}

--- a/test/features/send/presentation/bloc/send_state_test.dart
+++ b/test/features/send/presentation/bloc/send_state_test.dart
@@ -1,6 +1,8 @@
+import 'package:bb_mobile/core/entities/signer_device_entity.dart';
 import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/payment_request.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/send/presentation/bloc/send_state.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -356,4 +358,98 @@ void main() {
       });
     },
   );
+
+  group('SendState.willAttemptPayjoin', () {
+    Bip21PaymentRequest bip21WithPj({String pj = 'https://payjo.in'}) =>
+        PaymentRequest.bip21(
+              network: Network.bitcoinMainnet,
+              uri: 'bitcoin:bc1qtest?pj=$pj',
+              address: 'bc1qtest',
+              pj: pj,
+            )
+            as Bip21PaymentRequest;
+
+    test('false when payjoin is disabled globally, even with a pj= URI', () {
+      final state = SendState(
+        paymentRequest: bip21WithPj(),
+        payjoinGloballyEnabled: false,
+      );
+      expect(state.willAttemptPayjoin, isFalse);
+    });
+
+    test(
+      'false for a self-transfer, even with a pj= URI and the setting on',
+      () {
+        final state = SendState(
+          paymentRequest: bip21WithPj(),
+          payjoinGloballyEnabled: true,
+          isToSelf: true,
+        );
+        expect(state.willAttemptPayjoin, isFalse);
+      },
+    );
+
+    test('false for a BIP21 URI without a pj= parameter', () {
+      final state = SendState(
+        paymentRequest: bip21WithPj(pj: ''),
+        payjoinGloballyEnabled: true,
+      );
+      expect(state.willAttemptPayjoin, isFalse);
+    });
+
+    test('false for a non-BIP21 payment request', () {
+      final state = SendState(
+        paymentRequest: const PaymentRequest.bitcoin(
+          address: 'bc1qtest',
+          isTestnet: false,
+        ),
+        payjoinGloballyEnabled: true,
+      );
+      expect(state.willAttemptPayjoin, isFalse);
+    });
+
+    test('true when enabled globally, not a self-transfer, a locally-signing '
+        'wallet, and the BIP21 URI carries a pj= parameter', () {
+      final state = SendState(
+        selectedWallet: bitcoinWallet(),
+        paymentRequest: bip21WithPj(),
+        payjoinGloballyEnabled: true,
+        isToSelf: false,
+      );
+      expect(state.willAttemptPayjoin, isTrue);
+    });
+
+    test('false when no wallet is selected yet, even if every other condition '
+        'is met — fail-closed default', () {
+      final state = SendState(
+        paymentRequest: bip21WithPj(),
+        payjoinGloballyEnabled: true,
+        isToSelf: false,
+      );
+      expect(state.willAttemptPayjoin, isFalse);
+    });
+
+    test('false for a hardware/remote-signer wallet: the confirm screen\'s '
+        "device-specific sign button never reaches signTransaction's payjoin "
+        'branch, so the indicator must not promise one', () {
+      final state = SendState(
+        selectedWallet: Wallet(
+          origin: 'test-hw-origin',
+          network: Network.bitcoinMainnet,
+          xpubFingerprint: '00000000',
+          scriptType: ScriptType.bip84,
+          xpub: '',
+          externalPublicDescriptor: '',
+          internalPublicDescriptor: '',
+          signer: SignerEntity.remote,
+          signerDevice: SignerDeviceEntity.ledgerNanoX,
+          balanceSat: BigInt.from(100000),
+        ),
+        paymentRequest: bip21WithPj(),
+        payjoinGloballyEnabled: true,
+        isToSelf: false,
+      );
+      expect(state.willAttemptPayjoin, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Fixes the send flow getting stuck when a payjoin proposal fails and the wallet needs to fall back to broadcasting the original transaction. Closes #2246.

Merge order: 4th (parallel with PR4, PR5), after PR2. No dependency on PR4/PR5.
PR2 → PR3 (this)   ‖ PR2 → PR4   ‖ PR2 → PR5
