### PR TITLE
feat(transactions): display payjoin status and land on broadcast tx

### DIFF
--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -51,6 +51,69 @@ sealed class Transaction with _$Transaction {
       isOngoingPayjoin && payjoin is PayjoinReceiver;
   bool get isOngoingPayjoinSender =>
       isOngoingPayjoin && payjoin is PayjoinSender;
+
+  /// The payjoin status to DISPLAY, derived from what actually happened
+  /// on-chain rather than from the session row alone. The session's
+  /// persisted status can lag reality: completion/abort detection runs on
+  /// background polls in the payjoin repository, so right after a payment
+  /// lands the row may still say requested/proposed while the broadcast
+  /// transaction is already visible in the wallet. When the wallet
+  /// transaction is present, its txid is authoritative:
+  /// - it IS the payjoin transaction → the negotiation completed;
+  /// - it IS the original transaction → the payjoin was aborted and the
+  ///   payment fell back to a plain broadcast.
+  /// Falls back to the session status when there is no wallet transaction
+  /// (nothing broadcast yet, or not synced in) — and null when this
+  /// transaction has no payjoin at all.
+  PayjoinStatus? get displayPayjoinStatus {
+    final pj = payjoin;
+    if (pj == null) return null;
+    final walletTxId = walletTransaction?.txId;
+    if (walletTxId != null) {
+      if (walletTxId == pj.txId) return PayjoinStatus.completed;
+      if (walletTxId == pj.originalTxId && !pj.isCompleted) {
+        return PayjoinStatus.aborted;
+      }
+    }
+    return pj.status;
+  }
+
+  /// The mining fee (sats) deducted from a completed payjoin receive,
+  /// paying for the input the receiver contributed to the transaction
+  /// (BIP78). `null` unless this is a payjoin actually reflected in a
+  /// broadcast transaction, on the receive side, with a positive gap
+  /// between the amount the sender negotiated ([Payjoin.amountSat]) and the
+  /// amount the wallet actually sees ([WalletTransaction.amountSat]).
+  ///
+  /// The applicability check deliberately mirrors the existing "is this
+  /// payjoin done" display heuristic used elsewhere
+  /// (transaction_details_table.dart's status row: isCompleted ||
+  /// (proposed && the broadcast tx IS the proposal)) rather than a strict
+  /// `isCompleted` check: without the receiver-side watch-for-broadcast
+  /// this branch doesn't add, a receiver session may never reach
+  /// `completed` even once its real payjoin transaction has landed in the
+  /// wallet — a strict check would never show this row for a receiver at
+  /// all. The proposed case additionally requires the wallet transaction's
+  /// txid to match the session's proposal txid: sessions are also joined
+  /// to their ORIGINAL transaction (see LocalPayjoinDatasource.fetchByTxId),
+  /// and an original that landed on-chain is a plain fallback — no input
+  /// was contributed, so no fee-contribution row must appear for it.
+  int? get payjoinFeeContributionSat {
+    final p = payjoin;
+    final wt = walletTransaction;
+    if (p is! PayjoinReceiver || wt == null) return null;
+    final isRealPayjoinBroadcast =
+        p.isCompleted ||
+        (p.status == PayjoinStatus.proposed &&
+            p.txId != null &&
+            p.txId == wt.txId);
+    if (!isRealPayjoinBroadcast) return null;
+    final expectedAmountSat = p.amountSat;
+    if (expectedAmountSat == null) return null;
+    final gap = expectedAmountSat - wt.amountSat;
+    return gap > 0 ? gap : null;
+  }
+
   bool get isOrder => order != null;
   bool get isBuyOrder => order is BuyOrder;
   bool get isSellOrder => order is SellOrder;

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
@@ -29,6 +30,7 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   TransactionDetailsCubit({
     required this._getWalletUsecase,
     required this._getTransactionsByTxIdUsecase,
+    required this._getWalletTransactionUsecase,
     required this._watchWalletTransactionByTxIdUsecase,
     required this._getSwapUsecase,
     required this._getPayjoinByIdUsecase,
@@ -42,6 +44,7 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
 
   final GetWalletUsecase _getWalletUsecase;
   final GetTransactionsByTxIdUsecase _getTransactionsByTxIdUsecase;
+  final GetWalletTransactionUsecase _getWalletTransactionUsecase;
   final WatchWalletTransactionByTxIdUsecase
   _watchWalletTransactionByTxIdUsecase;
   final GetSwapUsecase _getSwapUsecase;
@@ -60,6 +63,11 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   StreamSubscription? _payjoinTxSubscription;
   StreamSubscription? _payjoinOriginalTxSubscription;
 
+  // The payjoin id _payjoinSubscription is currently listening to on the
+  // by-wallet-tx path, so reloads triggered by its own events don't
+  // needlessly cancel and re-create the same subscription.
+  String? _watchedPayjoinId;
+
   @override
   Future<void> close() async {
     await Future.wait([
@@ -73,7 +81,10 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   }
 
   Future<void> initByWalletTxId(String txId, {required String walletId}) async {
-    // Start monitoring the wallet transaction for updates.
+    // Start monitoring the wallet transaction for updates. Cancel any
+    // previous watcher first: this is also reached from the by-payjoin-id
+    // path once the broadcast transaction becomes visible.
+    await _walletTransactionSubscription?.cancel();
     _walletTransactionSubscription = _watchWalletTransactionByTxIdUsecase
         .execute(txId: txId, walletId: walletId)
         .listen((_) => _loadDetailsByWalletTxId(txId, walletId: walletId));
@@ -133,11 +144,67 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
           swapClaimedAmountSat: await _counterpartAmountForSwap(swap),
         ),
       );
+
+      // If this transaction belongs to a payjoin session, keep the details
+      // live on payjoin events too — not just on wallet syncs. The session's
+      // terminal transitions (fallback broadcast, completion on broadcast)
+      // happen in the payjoin repository long after this screen was opened,
+      // and without this the screen only refreshed on the next wallet sync
+      // (observed live: a stale "Send without payjoin" button lingering for
+      // ~a minute after the fallback had already broadcast the original).
+      final payjoin = transaction.payjoin;
+      if (payjoin != null) {
+        _watchPayjoinForWalletTx(
+          payjoinId: payjoin.id,
+          txId: txId,
+          walletId: walletId,
+        );
+      }
     } on TransactionNotFoundError catch (e) {
       emit(state.copyWith(notFoundError: e));
     } catch (e) {
       emit(state.copyWith(err: e));
     }
+  }
+
+  /// Reloads the by-wallet-tx details whenever the given payjoin session
+  /// emits an update. Payjoin state lives in the local database, so the
+  /// reload is instant — the manual-broadcast button and the payjoin status
+  /// row react the moment the repository resolves the session instead of
+  /// waiting for a wallet sync to trigger the transaction watcher.
+  ///
+  /// On a terminal event (aborted/completed/expired) a targeted sync of this
+  /// wallet is also fired when the broadcast transaction isn't visible as a
+  /// wallet transaction yet, so the screen swaps from payjoin-only data to
+  /// the real transaction promptly instead of at the next scheduled sync.
+  void _watchPayjoinForWalletTx({
+    required String payjoinId,
+    required String txId,
+    required String walletId,
+  }) {
+    if (_watchedPayjoinId == payjoinId) return;
+    _watchedPayjoinId = payjoinId;
+    unawaited(_payjoinSubscription?.cancel());
+    _payjoinSubscription = _watchPayjoinUsecase
+        .execute(ids: [payjoinId])
+        .listen((payjoin) async {
+          // The payjoin repository's timers outlive this cubit; an event can
+          // arrive after close() (see ReceiveBloc/SendCubit's identical guard).
+          if (isClosed) return;
+          await _loadDetailsByWalletTxId(txId, walletId: walletId);
+          if (isClosed) return;
+          if (!payjoin.isOngoing &&
+              state.transaction?.walletTransaction == null) {
+            unawaited(
+              _getWalletUsecase.execute(walletId, sync: true).catchError((
+                Object e,
+              ) {
+                log.warning('Failed to sync wallet after payjoin event: $e');
+                return null;
+              }),
+            );
+          }
+        });
   }
 
   /// The exact amount returned on the recovered chain swap's *counterpart* leg —
@@ -248,6 +315,11 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   }
 
   Future<void> initByPayjoinId(String payjoinId) async {
+    // Cancel any prior subscription (a re-entry, or one armed by the
+    //  by-wallet-tx path) before replacing it — otherwise the old listener
+    //  leaks and keeps firing duplicate _loadDetailsByPayjoinId runs.
+    _watchedPayjoinId = null;
+    await _payjoinSubscription?.cancel();
     _payjoinSubscription = _watchPayjoinUsecase
         .execute(ids: [payjoinId])
         .listen((_) => _loadDetailsByPayjoinId(payjoinId));
@@ -260,12 +332,53 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
     try {
       final payjoin = await _getPayjoinByIdUsecase.execute(payjoinId);
 
+      // The broadcast transaction (the payjoin one, or the original on a
+      // fallback) is usually already in the local wallet database by the
+      // time this screen opens — the repository fires a targeted sync right
+      // after any broadcast. Resolve it NOW instead of waiting for the next
+      // organic sync to trigger the watchers below: without this the screen
+      // sat on payjoin-session-only data (a stale "requested"/"proposed"
+      // status and no transaction) even though the payment was already
+      // on-chain (observed live on both sides of a fallback).
+      var broadcastTxId = await _broadcastTxIdForPayjoin(payjoin);
+      if (broadcastTxId == null && !payjoin.isOngoing) {
+        // Resolved session whose broadcast isn't visible locally yet (the
+        // user tapped "view details" within seconds of the broadcast, before
+        // any sync pulled it in). Force a DIRECT sync'd lookup — the
+        // repository's per-transaction sync path is not routed through the
+        // sync coordinator, so it can't be throttled away — and wait for it,
+        // so the user lands straight on the transaction view instead of a
+        // payjoin-session placeholder that swaps out moments later
+        // (observed live on the receiver side of an aborted payjoin).
+        broadcastTxId = await _syncBroadcastTxForPayjoin(payjoin);
+      }
+      if (broadcastTxId != null) {
+        // Reset so _loadDetailsByWalletTxId re-arms its own payjoin watcher
+        // after this by-payjoin-id one is cancelled. Also cancel the two
+        // per-txid watchers a previous pass may have armed — otherwise they
+        // keep watching the same txid as _walletTransactionSubscription and
+        // double-reload once it lands.
+        _watchedPayjoinId = null;
+        await _payjoinSubscription?.cancel();
+        await _payjoinTxSubscription?.cancel();
+        await _payjoinOriginalTxSubscription?.cancel();
+        await initByWalletTxId(broadcastTxId, walletId: payjoin.walletId);
+        return;
+      }
+
       if (payjoin.txId != null) {
         // Listen for the payjoin transaction to be broadcasted.
         await _payjoinTxSubscription?.cancel();
         _payjoinTxSubscription = _watchWalletTransactionByTxIdUsecase
             .execute(txId: payjoin.txId!, walletId: payjoin.walletId)
             .listen((_) async {
+              // An event can arrive around close() (the usecase stream and the
+              //  repo's watchers outlive this cubit); never emit on a closed
+              //  cubit (_loadDetailsByWalletTxId emits).
+              if (isClosed) return;
+              // Reset so _loadDetailsByWalletTxId re-arms its own payjoin
+              // watcher after this by-payjoin-id one is cancelled.
+              _watchedPayjoinId = null;
               await _payjoinSubscription?.cancel();
               await _loadDetailsByWalletTxId(
                 payjoin.txId!,
@@ -279,6 +392,9 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
         _payjoinOriginalTxSubscription = _watchWalletTransactionByTxIdUsecase
             .execute(txId: payjoin.originalTxId!, walletId: payjoin.walletId)
             .listen((_) async {
+              // See the txId watcher above.
+              if (isClosed) return;
+              _watchedPayjoinId = null;
               await _payjoinSubscription?.cancel();
               await _loadDetailsByWalletTxId(
                 payjoin.originalTxId!,
@@ -294,9 +410,73 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
           wallet: wallet,
         ),
       );
+
+      // The session is resolved but its broadcast transaction isn't visible
+      // in the local wallet database yet — fire a targeted sync so the
+      // watchers armed above swap this screen to the real transaction
+      // promptly instead of at the next scheduled sync (same gap
+      // _watchPayjoinForWalletTx closes on the by-wallet-tx path).
+      if (!payjoin.isOngoing) {
+        unawaited(
+          _getWalletUsecase.execute(payjoin.walletId, sync: true).catchError((
+            Object e,
+          ) {
+            log.warning('Failed to sync wallet for resolved payjoin: $e');
+            return null;
+          }),
+        );
+      }
     } catch (e) {
       emit(state.copyWith(err: e));
     }
+  }
+
+  /// The txid of this payjoin session's transaction that actually reached
+  /// the chain AND is already visible as a wallet transaction locally — the
+  /// payjoin transaction when the negotiation completed, or the original
+  /// transaction when the session fell back to a plain broadcast. Null while
+  /// neither is visible yet (session still ongoing, or the wallet hasn't
+  /// synced the broadcast in).
+  Future<String?> _broadcastTxIdForPayjoin(Payjoin payjoin) async {
+    for (final txId in [payjoin.txId, payjoin.originalTxId]) {
+      if (txId == null) continue;
+      try {
+        final transactions = await _getTransactionsByTxIdUsecase.execute(txId);
+        final isVisibleInWallet = transactions.any(
+          (tx) =>
+              tx.walletId == payjoin.walletId && tx.walletTransaction != null,
+        );
+        if (isVisibleInWallet) return txId;
+      } catch (_) {
+        // Nothing found for this txid — try the next candidate.
+      }
+    }
+    return null;
+  }
+
+  /// Same candidates as [_broadcastTxIdForPayjoin], but each lookup forces a
+  /// direct electrum-backed sync first, pulling a just-broadcast transaction
+  /// into the local wallet database on demand. Bounded by one sync per
+  /// candidate; best-effort — a failed lookup just means the watchers armed
+  /// by the caller resolve it later.
+  Future<String?> _syncBroadcastTxForPayjoin(Payjoin payjoin) async {
+    for (final txId in [payjoin.txId, payjoin.originalTxId]) {
+      if (txId == null) continue;
+      final result = await _getWalletTransactionUsecase.execute(
+        txId: txId,
+        walletId: payjoin.walletId,
+        sync: true,
+      );
+      switch (result) {
+        case Ok(:final value):
+          if (value != null) return txId;
+        case Err(:final failure):
+          log.warning(
+            'Forced lookup of payjoin broadcast tx failed: ${failure.logMessage}',
+          );
+      }
+    }
+    return null;
   }
 
   Future<void> initByOrderId(String orderId) async {
@@ -372,6 +552,17 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
     try {
       final payjoin = state.payjoin;
       if (payjoin == null) return;
+      // Backstop using the SAME canonical Payjoin.canManuallyBroadcastOriginal
+      // getter TransactionDetailsScreen's button visibility is gated on (see
+      // its doc comment for the exact semantics): a manual rebroadcast here
+      // would otherwise either be a no-op or, worse, race/replace an
+      // already-broadcast real payjoin transaction that spends the same
+      // inputs at a different fee. Deriving both the button's visibility and
+      // this action from the one getter means they can't drift out of sync —
+      // this is the backstop against a stale snapshot letting a tap through
+      // anyway, observed live (a second "Send without payjoin" tap
+      // re-broadcast an already-completed session's original transaction).
+      if (!payjoin.canManuallyBroadcastOriginal) return;
       emit(state.copyWith(isBroadcastingPayjoinOriginalTx: true, err: null));
       final updatedPayjoin = await _broadcastOriginalTransactionUsecase.execute(
         payjoin,

--- a/lib/features/transactions/transactions_locator.dart
+++ b/lib/features/transactions/transactions_locator.dart
@@ -12,6 +12,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/process_swap_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_started_wallet_syncs_usecase.dart';
@@ -109,6 +110,7 @@ class TransactionsLocator {
       () => TransactionDetailsCubit(
         getWalletUsecase: locator<GetWalletUsecase>(),
         getTransactionsByTxIdUsecase: locator<GetTransactionsByTxIdUsecase>(),
+        getWalletTransactionUsecase: locator<GetWalletTransactionUsecase>(),
         watchWalletTransactionByTxIdUsecase:
             locator<WatchWalletTransactionByTxIdUsecase>(),
         getSwapUsecase: locator<GetSwapUsecase>(),

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
-import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/logger.dart' show log;
@@ -48,9 +47,15 @@ class TransactionDetailsScreen extends StatelessWidget {
     final wallet = context.select(
       (TransactionDetailsCubit bloc) => bloc.state.wallet,
     );
-    final isPayjoinCompleted = context.select(
+    // The single source of truth this button's visibility must agree with —
+    // see Payjoin.canManuallyBroadcastOriginal's doc comment. Deriving both
+    // from the same getter as the cubit's own guard means the button can
+    // never be shown for a session where tapping it would just silently
+    // no-op (observed live before this was unified: a stale-looking button
+    // let a tap through that re-broadcast an already-completed session).
+    final canManuallyBroadcastOriginal = context.select(
       (TransactionDetailsCubit bloc) =>
-          bloc.state.payjoin?.status == PayjoinStatus.completed,
+          bloc.state.payjoin?.canManuallyBroadcastOriginal ?? false,
     );
     final isBroadcastingPayjoinOriginalTx = context.select(
       (TransactionDetailsCubit bloc) =>
@@ -172,7 +177,7 @@ class TransactionDetailsScreen extends StatelessWidget {
                 ],
                 const Gap(16),
                 if (tx?.isOngoingPayjoinSender == true &&
-                    !isPayjoinCompleted) ...[
+                    canManuallyBroadcastOriginal) ...[
                   const SenderBroadcastPayjoinOriginalTxButton(),
                   const Gap(24),
                 ],

--- a/lib/features/transactions/ui/widgets/transaction_details_status_label.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_status_label.dart
@@ -18,8 +18,13 @@ class TransactionDetailsStatusLabel extends StatelessWidget {
     final swap = transaction?.swap;
     final order = transaction?.order;
     final isOrder = transaction?.isOrder;
+    // Display status, not the raw session status: derived from the broadcast
+    // transaction when it is already visible, so a stale session row
+    // (completion detection lagging on a background poll) can't surface
+    // "requested"/"proposed" for a payment that's already on-chain.
     final payjoinStatus = context.select(
-      (TransactionDetailsCubit bloc) => bloc.state.payjoin?.status,
+      (TransactionDetailsCubit bloc) =>
+          bloc.state.transaction?.displayPayjoinStatus,
     );
 
     return BBText(
@@ -47,6 +52,8 @@ class TransactionDetailsStatusLabel extends StatelessWidget {
           ? order.orderType.value
           : payjoinStatus == PayjoinStatus.completed
           ? context.loc.transactionStatusPayjoinCompleted
+          : payjoinStatus == PayjoinStatus.aborted
+          ? context.loc.transactionStatusPayjoinAborted
           : payjoinStatus == PayjoinStatus.requested
           ? context.loc.transactionStatusPayjoinRequested
           : transaction?.isIncoming == true

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -1004,14 +1004,23 @@ class TransactionDetailsTable extends StatelessWidget {
         if (payjoin != null) ...[
           DetailsTableItem(
             label: context.loc.transactionDetailLabelPayjoinStatus,
-            displayValue:
-                payjoin.isCompleted ||
-                    (payjoin.status == PayjoinStatus.proposed &&
-                        walletTransaction != null)
-                ? context.loc.transactionDetailLabelPayjoinCompleted
-                : payjoin.isExpired
-                ? context.loc.transactionDetailLabelPayjoinExpired
-                : payjoin.status.name,
+            // Display status, derived from the broadcast transaction when it
+            // is visible (see Transaction.displayPayjoinStatus): a stale
+            // session row can't surface a raw "requested"/"proposed" for a
+            // payment already on-chain. The exhaustive switch makes a new
+            // PayjoinStatus a compile error rather than a leaked enum name.
+            displayValue: switch (transaction!.displayPayjoinStatus!) {
+              PayjoinStatus.completed =>
+                context.loc.transactionDetailLabelPayjoinCompleted,
+              PayjoinStatus.aborted =>
+                context.loc.transactionDetailLabelPayjoinAborted,
+              PayjoinStatus.expired =>
+                context.loc.transactionDetailLabelPayjoinExpired,
+              PayjoinStatus.started ||
+              PayjoinStatus.requested ||
+              PayjoinStatus.proposed =>
+                context.loc.transactionDetailLabelPayjoinInProgress,
+            },
           ),
           DetailsTableItem(
             label: context.loc.transactionDetailLabelPayjoinCreationTime,
@@ -1019,6 +1028,26 @@ class TransactionDetailsTable extends StatelessWidget {
               'MMM d, y, h:mm a',
             ).format(payjoin.createdAt),
           ),
+          if (transaction.payjoinFeeContributionSat != null)
+            DetailsTableItem(
+              label: context.loc.transactionDetailLabelPayjoinFeeContribution,
+              displayValue: bitcoinUnit == BitcoinUnit.sats
+                  ? FormatAmount.sats(
+                      transaction.payjoinFeeContributionSat!,
+                    ).toUpperCase()
+                  : FormatAmount.btc(
+                      ConvertAmount.satsToBtc(
+                        transaction.payjoinFeeContributionSat!,
+                      ),
+                    ).toUpperCase(),
+              expandableChild: BBText(
+                context.loc.transactionPayjoinFeeContributionExplanation,
+                style: context.font.bodySmall?.copyWith(
+                  color: context.appColors.secondary,
+                ),
+                maxLines: 5,
+              ),
+            ),
         ],
       ],
     );

--- a/test/features/transactions/domain/entities/transaction_test.dart
+++ b/test/features/transactions/domain/entities/transaction_test.dart
@@ -1,0 +1,279 @@
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+WalletTransaction _walletTx({
+  required String txId,
+  WalletTransactionDirection direction = WalletTransactionDirection.outgoing,
+  int amountSat = 50000,
+}) => WalletTransaction(
+  walletId: 'w1',
+  network: Network.bitcoinMainnet,
+  direction: direction,
+  status: WalletTransactionStatus.pending,
+  txId: txId,
+  amountSat: amountSat,
+  feeSat: 500,
+  vsize: 150,
+  inputs: const [],
+  outputs: const [],
+  isRbf: false,
+);
+
+Payjoin _senderPayjoin({
+  PayjoinStatus status = PayjoinStatus.requested,
+  String originalTxId = 'orig-txid',
+  String? txId,
+}) => Payjoin.sender(
+  status: status,
+  uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+  isTestnet: false,
+  walletId: 'w1',
+  originalPsbt: 'cHNidP8=',
+  originalTxId: originalTxId,
+  amountSat: 50000,
+  createdAt: DateTime(2026),
+  expiresAt: DateTime(2026, 1, 1, 0, 5),
+  txId: txId,
+);
+
+void main() {
+  group('Transaction.displayPayjoinStatus', () {
+    test('is null when the transaction has no payjoin', () {
+      expect(const Transaction().displayPayjoinStatus, isNull);
+      expect(
+        Transaction(
+          walletTransaction: _walletTx(txId: 'any'),
+        ).displayPayjoinStatus,
+        isNull,
+      );
+    });
+
+    test('passes the session status through while nothing is broadcast', () {
+      for (final status in [
+        PayjoinStatus.requested,
+        PayjoinStatus.proposed,
+        PayjoinStatus.completed,
+        PayjoinStatus.aborted,
+        PayjoinStatus.expired,
+      ]) {
+        expect(
+          Transaction(
+            payjoin: _senderPayjoin(status: status),
+          ).displayPayjoinStatus,
+          status,
+        );
+      }
+    });
+
+    test('derives completed from the wallet transaction being the payjoin '
+        'transaction, even while the session row still lags on '
+        'proposed', () {
+      final transaction = Transaction(
+        walletTransaction: _walletTx(txId: 'payjoin-txid'),
+        payjoin: _senderPayjoin(
+          status: PayjoinStatus.proposed,
+          txId: 'payjoin-txid',
+        ),
+      );
+
+      expect(transaction.displayPayjoinStatus, PayjoinStatus.completed);
+    });
+
+    test('derives aborted (fallback) from the wallet transaction being the '
+        'ORIGINAL transaction, even while the session row still lags on '
+        'requested', () {
+      final transaction = Transaction(
+        walletTransaction: _walletTx(txId: 'orig-txid'),
+        payjoin: _senderPayjoin(status: PayjoinStatus.requested),
+      );
+
+      expect(transaction.displayPayjoinStatus, PayjoinStatus.aborted);
+    });
+
+    test('never downgrades a real payjoin completion to fallback', () {
+      // Degenerate ordering safety: a session already marked completed keeps
+      // that status regardless of which transaction this record was paired
+      // with.
+      final transaction = Transaction(
+        walletTransaction: _walletTx(txId: 'orig-txid'),
+        payjoin: _senderPayjoin(
+          status: PayjoinStatus.completed,
+          txId: 'payjoin-txid',
+        ),
+      );
+
+      expect(transaction.displayPayjoinStatus, PayjoinStatus.completed);
+    });
+
+    test('keeps the session status when the wallet transaction matches '
+        'neither txid', () {
+      final transaction = Transaction(
+        walletTransaction: _walletTx(txId: 'unrelated-txid'),
+        payjoin: _senderPayjoin(status: PayjoinStatus.proposed),
+      );
+
+      expect(transaction.displayPayjoinStatus, PayjoinStatus.proposed);
+    });
+  });
+
+  group('Transaction.payjoinFeeContributionSat', () {
+    WalletTransaction buildWalletTransaction(int amountSat) =>
+        WalletTransaction(
+          walletId: 'w1',
+          network: Network.bitcoinMainnet,
+          direction: WalletTransactionDirection.incoming,
+          status: WalletTransactionStatus.confirmed,
+          txId: 'a' * 64,
+          amountSat: amountSat,
+          feeSat: 200,
+          vsize: 250,
+          inputs: const [],
+          outputs: const [],
+          isRbf: false,
+        );
+
+    Payjoin buildReceiver({
+      required int amountSat,
+      required PayjoinStatus status,
+      String? txId,
+    }) => Payjoin.receiver(
+      status: status,
+      id: 'r1',
+      isTestnet: false,
+      walletId: 'w1',
+      pjUri: 'bitcoin:addr?pj=https://payjo.in/x',
+      createdAt: DateTime(2026),
+      expiresAt: DateTime(2026, 1, 2),
+      amountSat: amountSat,
+      txId: txId,
+    );
+
+    test('derives the gap between the negotiated amount and the wallet-visible '
+        'amount for a completed receiver payjoin', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(948),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.completed,
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, 54);
+    });
+
+    test('also applies while merely proposed when the broadcast tx IS the '
+        'proposal (txid match) — mirrors the existing status-display '
+        'heuristic, since a receiver session may never reach `completed` '
+        'without watch-for-broadcast', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(948),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.proposed,
+          txId: 'a' * 64, // same as the wallet transaction's txId
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, 54);
+    });
+
+    test('null while proposed when the broadcast tx is NOT the proposal (e.g. '
+        'the original transaction, joined to the session by originalTxId): a '
+        'fallback contributed no input, so no fee-contribution row', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(948),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.proposed,
+          txId: 'b' * 64, // proposal txid differs from the broadcast tx
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+
+    test('null when there is no gap (amounts match)', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(1002),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.completed,
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+
+    test('null when the wallet actually received more (a negative gap)', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(1100),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.completed,
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+
+    test('null for a sender payjoin (receive-side only)', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(948),
+        payjoin: Payjoin.sender(
+          status: PayjoinStatus.completed,
+          uri: 'bitcoin:addr?pj=https://payjo.in/x',
+          isTestnet: false,
+          walletId: 'w1',
+          originalPsbt: 'psbt',
+          originalTxId: 'a' * 64,
+          amountSat: 1002,
+          createdAt: DateTime(2026),
+          expiresAt: DateTime(2026, 1, 2),
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+
+    test('null when the session never resolved (still just requested)', () {
+      final transaction = Transaction(
+        walletTransaction: buildWalletTransaction(948),
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.requested,
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+
+    test(
+      'null for an aborted session (a plain broadcast, not a real payjoin)',
+      () {
+        final transaction = Transaction(
+          walletTransaction: buildWalletTransaction(948),
+          payjoin: buildReceiver(
+            amountSat: 1002,
+            status: PayjoinStatus.aborted,
+          ),
+        );
+
+        expect(transaction.payjoinFeeContributionSat, isNull);
+      },
+    );
+
+    test('null without a broadcast transaction yet', () {
+      final transaction = Transaction(
+        payjoin: buildReceiver(
+          amountSat: 1002,
+          status: PayjoinStatus.completed,
+        ),
+      );
+
+      expect(transaction.payjoinFeeContributionSat, isNull);
+    });
+  });
+}

--- a/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
@@ -1,0 +1,577 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/entities/signer_entity.dart' show SignerEntity;
+import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/broadcast_original_transaction_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/get_payjoin_by_id_usecase.dart';
+import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/get_swap_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/process_swap_usecase.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/transactions/application/usecases/get_transactions_by_tx_id_usecase.dart';
+import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
+import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetWalletUsecase extends Mock implements GetWalletUsecase {}
+
+class _MockGetTransactionsByTxIdUsecase extends Mock
+    implements GetTransactionsByTxIdUsecase {}
+
+class _MockGetWalletTransactionUsecase extends Mock
+    implements GetWalletTransactionUsecase {}
+
+class _MockWatchWalletTransactionByTxIdUsecase extends Mock
+    implements WatchWalletTransactionByTxIdUsecase {}
+
+class _MockGetSwapUsecase extends Mock implements GetSwapUsecase {}
+
+class _MockGetPayjoinByIdUsecase extends Mock
+    implements GetPayjoinByIdUsecase {}
+
+class _MockGetOrderUsecase extends Mock implements GetOrderUsecase {}
+
+class _MockWatchSwapUsecase extends Mock implements WatchSwapUsecase {}
+
+class _MockWatchPayjoinUsecase extends Mock implements WatchPayjoinUsecase {}
+
+class _MockLabelsFacade extends Mock implements LabelsFacade {}
+
+class _MockBroadcastOriginalTransactionUsecase extends Mock
+    implements BroadcastOriginalTransactionUsecase {}
+
+class _MockProcessSwapUsecase extends Mock implements ProcessSwapUsecase {}
+
+Wallet _testWallet({String origin = 'w1'}) => Wallet(
+  origin: origin,
+  network: Network.bitcoinMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.zero,
+);
+
+WalletTransaction _walletTx({required String txId, String walletId = 'w1'}) =>
+    WalletTransaction(
+      walletId: walletId,
+      network: Network.bitcoinMainnet,
+      direction: WalletTransactionDirection.outgoing,
+      status: WalletTransactionStatus.pending,
+      txId: txId,
+      amountSat: 50000,
+      feeSat: 500,
+      vsize: 150,
+      inputs: const [],
+      outputs: const [],
+      isRbf: false,
+    );
+
+PayjoinSender _sender({
+  required PayjoinStatus status,
+  String? txId,
+  String? proposalPsbt,
+}) =>
+    Payjoin.sender(
+          status: status,
+          uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+          isTestnet: true,
+          walletId: 'w1',
+          originalPsbt: 'cHNidP8=',
+          originalTxId: 'sender-orig-txid',
+          amountSat: 50000,
+          createdAt: DateTime(2026),
+          expiresAt: DateTime(2026).add(const Duration(minutes: 1)),
+          txId: txId,
+          proposalPsbt: proposalPsbt,
+        )
+        as PayjoinSender;
+
+void main() {
+  late _MockGetWalletUsecase getWallet;
+  late _MockGetTransactionsByTxIdUsecase getTransactionsByTxId;
+  late _MockGetWalletTransactionUsecase getWalletTransaction;
+  late _MockGetPayjoinByIdUsecase getPayjoinById;
+  late _MockWatchPayjoinUsecase watchPayjoin;
+  late _MockWatchWalletTransactionByTxIdUsecase watchWalletTransactionByTxId;
+  late _MockBroadcastOriginalTransactionUsecase broadcastOriginalTransaction;
+
+  TransactionDetailsCubit buildCubit() => TransactionDetailsCubit(
+    getWalletUsecase: getWallet,
+    getTransactionsByTxIdUsecase: getTransactionsByTxId,
+    getWalletTransactionUsecase: getWalletTransaction,
+    watchWalletTransactionByTxIdUsecase: watchWalletTransactionByTxId,
+    getSwapUsecase: _MockGetSwapUsecase(),
+    getPayjoinByIdUsecase: getPayjoinById,
+    getOrderUsecase: _MockGetOrderUsecase(),
+    watchSwapUsecase: _MockWatchSwapUsecase(),
+    watchPayjoinUsecase: watchPayjoin,
+    labelsFacade: _MockLabelsFacade(),
+    broadcastOriginalTransactionUsecase: broadcastOriginalTransaction,
+    processSwapUsecase: _MockProcessSwapUsecase(),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(_sender(status: PayjoinStatus.requested));
+  });
+
+  setUp(() {
+    getWallet = _MockGetWalletUsecase();
+    getTransactionsByTxId = _MockGetTransactionsByTxIdUsecase();
+    getWalletTransaction = _MockGetWalletTransactionUsecase();
+    getPayjoinById = _MockGetPayjoinByIdUsecase();
+    watchPayjoin = _MockWatchPayjoinUsecase();
+    watchWalletTransactionByTxId = _MockWatchWalletTransactionByTxIdUsecase();
+    broadcastOriginalTransaction = _MockBroadcastOriginalTransactionUsecase();
+
+    when(
+      () => getWallet.execute(any(), sync: any(named: 'sync')),
+    ).thenAnswer((_) async => _testWallet());
+    // By default the forced sync'd lookup finds nothing — individual tests
+    // override it to simulate the broadcast becoming visible on demand. The
+    // usecase returns a Result now, so the "nothing" case is Ok(null).
+    when(
+      () => getWalletTransaction.execute(
+        txId: any(named: 'txId'),
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+      ),
+    ).thenAnswer(
+      (_) async =>
+          const Ok<WalletTransaction?, WalletTransactionLookupFailure>(null),
+    );
+    when(
+      () => watchPayjoin.execute(ids: any(named: 'ids')),
+    ).thenAnswer((_) => const Stream.empty());
+    // _loadDetailsByPayjoinId always arms a watcher for both payjoin.txId
+    // (when set) and payjoin.originalTxId (always set on our fixtures) —
+    // an unstubbed call here throws synchronously (mocktail returns null,
+    // and .listen() on null throws), silently short-circuiting
+    // _loadDetailsByPayjoinId's try/catch before state.transaction is ever
+    // populated, which would make every guard test a false positive (the
+    // guard never actually runs because state.payjoin stayed null).
+    when(
+      () => watchWalletTransactionByTxId.execute(
+        txId: any(named: 'txId'),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) => const Stream.empty());
+  });
+
+  group('TransactionDetailsCubit.broadcastPayjoinOriginalTx guard', () {
+    test(
+      'does NOT broadcast once the session already completed via a real '
+      'payjoin: re-broadcasting the lower-fee original would race an '
+      'already-broadcast payjoin transaction spending the same inputs',
+      () async {
+        final payjoin = _sender(
+          status: PayjoinStatus.completed,
+          txId: 'real-payjoin-txid',
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        when(
+          () => getPayjoinById.execute(payjoin.uri),
+        ).thenAnswer((_) async => payjoin);
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.initByPayjoinId(payjoin.uri);
+
+        await cubit.broadcastPayjoinOriginalTx();
+
+        verifyNever(() => broadcastOriginalTransaction.execute(any()));
+        expect(cubit.state.isBroadcastingPayjoinOriginalTx, isFalse);
+      },
+    );
+
+    test('does NOT broadcast once already completed via the plain-'
+        'broadcast fallback (PayjoinStatus.aborted — same isCompleted as a '
+        'real payjoin, nothing left to do)', () async {
+      final payjoin = _sender(status: PayjoinStatus.aborted);
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      await cubit.broadcastPayjoinOriginalTx();
+
+      verifyNever(() => broadcastOriginalTransaction.execute(any()));
+    });
+
+    test('does NOT broadcast while a proposal is still being actively '
+        'processed (received, not yet completed or expired)', () async {
+      final payjoin = _sender(
+        status: PayjoinStatus.proposed,
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      await cubit.broadcastPayjoinOriginalTx();
+
+      verifyNever(() => broadcastOriginalTransaction.execute(any()));
+    });
+
+    test('broadcasts while waiting for a proposal (the legitimate manual '
+        'fallback)', () async {
+      final payjoin = _sender(status: PayjoinStatus.requested);
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+      final completed = _sender(status: PayjoinStatus.aborted);
+      when(
+        () => broadcastOriginalTransaction.execute(any()),
+      ).thenAnswer((_) async => completed);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      await cubit.broadcastPayjoinOriginalTx();
+
+      verify(() => broadcastOriginalTransaction.execute(payjoin)).called(1);
+      expect(cubit.state.payjoin, completed);
+    });
+
+    test('allows a manual retry once the repository\'s own internal '
+        'fallback also gave up (expired, proposalPsbt still set)', () async {
+      final payjoin = _sender(
+        status: PayjoinStatus.expired,
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+      final completed = _sender(status: PayjoinStatus.aborted);
+      when(
+        () => broadcastOriginalTransaction.execute(any()),
+      ).thenAnswer((_) async => completed);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      await cubit.broadcastPayjoinOriginalTx();
+
+      verify(() => broadcastOriginalTransaction.execute(payjoin)).called(1);
+    });
+  });
+
+  group('TransactionDetailsCubit.initByPayjoinId broadcast resolution', () {
+    test(
+      'resolves straight to the wallet transaction when the broadcast is '
+      'already visible locally — the screen must show the pending bitcoin '
+      'transaction, not payjoin-session-only data (observed live: a '
+      'fallback-completed send showing a stale "requested" session)',
+      () async {
+        // Session row still lagging on requested, but the ORIGINAL
+        // transaction (the fallback broadcast) is already in the wallet.
+        final payjoin = _sender(status: PayjoinStatus.requested);
+        when(
+          () => getPayjoinById.execute(payjoin.uri),
+        ).thenAnswer((_) async => payjoin);
+        when(
+          () => getTransactionsByTxId.execute('sender-orig-txid'),
+        ).thenAnswer(
+          (_) async => [
+            Transaction(
+              walletTransaction: _walletTx(txId: 'sender-orig-txid'),
+              payjoin: payjoin,
+            ),
+          ],
+        );
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.initByPayjoinId(payjoin.uri);
+
+        expect(cubit.state.transaction?.walletTransaction, isNotNull);
+        expect(
+          cubit.state.transaction?.walletTransaction?.txId,
+          'sender-orig-txid',
+        );
+        // And the displayed payjoin status derives "aborted" (fallback)
+        // from the original transaction being the one on-chain, despite
+        // the stale session row.
+        expect(
+          cubit.state.transaction?.displayPayjoinStatus,
+          PayjoinStatus.aborted,
+        );
+      },
+    );
+
+    test('prefers the payjoin transaction over the original when the session '
+        'completed for real', () async {
+      final payjoin = _sender(
+        status: PayjoinStatus.completed,
+        txId: 'real-payjoin-txid',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+      );
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+      when(() => getTransactionsByTxId.execute('real-payjoin-txid')).thenAnswer(
+        (_) async => [
+          Transaction(
+            walletTransaction: _walletTx(txId: 'real-payjoin-txid'),
+            payjoin: payjoin,
+          ),
+        ],
+      );
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      expect(
+        cubit.state.transaction?.walletTransaction?.txId,
+        'real-payjoin-txid',
+      );
+      expect(
+        cubit.state.transaction?.displayPayjoinStatus,
+        PayjoinStatus.completed,
+      );
+    });
+
+    test('stays on payjoin-session data while nothing is broadcast, without '
+        'firing a targeted sync for a still-ongoing session', () async {
+      final payjoin = _sender(status: PayjoinStatus.requested);
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+      // Nothing visible in any wallet for either txid.
+      when(
+        () => getTransactionsByTxId.execute(any()),
+      ).thenAnswer((_) async => [Transaction(payjoin: payjoin)]);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      expect(cubit.state.transaction?.walletTransaction, isNull);
+      expect(cubit.state.payjoin, payjoin);
+      verifyNever(() => getWallet.execute(any(), sync: true));
+    });
+
+    test('waits for a forced sync\'d lookup and lands DIRECTLY on the wallet '
+        'transaction when the broadcast was not visible locally yet — no '
+        'payjoin-session placeholder that swaps out moments later '
+        '(observed live on the receiver side of an aborted payjoin)', () async {
+      final payjoin = _sender(status: PayjoinStatus.aborted);
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+
+      // Invisible locally until the forced sync'd lookup pulls it in.
+      var visible = false;
+      when(() => getTransactionsByTxId.execute('sender-orig-txid')).thenAnswer(
+        (_) async => [
+          if (visible)
+            Transaction(
+              walletTransaction: _walletTx(txId: 'sender-orig-txid'),
+              payjoin: payjoin,
+            )
+          else
+            Transaction(payjoin: payjoin),
+        ],
+      );
+      when(
+        () => getWalletTransaction.execute(
+          txId: 'sender-orig-txid',
+          walletId: 'w1',
+          sync: true,
+        ),
+      ).thenAnswer((_) async {
+        visible = true;
+        return Ok<WalletTransaction?, WalletTransactionLookupFailure>(
+          _walletTx(txId: 'sender-orig-txid'),
+        );
+      });
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+
+      expect(
+        cubit.state.transaction?.walletTransaction?.txId,
+        'sender-orig-txid',
+      );
+      expect(
+        cubit.state.transaction?.displayPayjoinStatus,
+        PayjoinStatus.aborted,
+      );
+    });
+
+    test(
+      'does not force a sync\'d lookup for a still-ongoing session',
+      () async {
+        final payjoin = _sender(status: PayjoinStatus.requested);
+        when(
+          () => getPayjoinById.execute(payjoin.uri),
+        ).thenAnswer((_) async => payjoin);
+        when(
+          () => getTransactionsByTxId.execute(any()),
+        ).thenAnswer((_) async => [Transaction(payjoin: payjoin)]);
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.initByPayjoinId(payjoin.uri);
+
+        verifyNever(
+          () => getWalletTransaction.execute(
+            txId: any(named: 'txId'),
+            walletId: any(named: 'walletId'),
+            sync: any(named: 'sync'),
+          ),
+        );
+      },
+    );
+
+    test('fires a targeted wallet sync when the session is resolved but its '
+        'broadcast transaction is not visible locally yet', () async {
+      final payjoin = _sender(status: PayjoinStatus.aborted);
+      when(
+        () => getPayjoinById.execute(payjoin.uri),
+      ).thenAnswer((_) async => payjoin);
+      when(
+        () => getTransactionsByTxId.execute(any()),
+      ).thenAnswer((_) async => [Transaction(payjoin: payjoin)]);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByPayjoinId(payjoin.uri);
+      await pumpEventQueue();
+
+      expect(cubit.state.transaction?.walletTransaction, isNull);
+      verify(() => getWallet.execute('w1', sync: true)).called(1);
+    });
+  });
+
+  group('TransactionDetailsCubit payjoin reactivity on the by-tx-id path', () {
+    test(
+      'a payjoin event reloads the details immediately — the manual-broadcast '
+      'guard flips the moment the repository resolves the session, without '
+      'waiting for a wallet sync (observed live: a stale "Send without '
+      'payjoin" button lingering after the fallback had already broadcast)',
+      () async {
+        final ongoing = _sender(status: PayjoinStatus.requested);
+        final completedViaFallback = _sender(status: PayjoinStatus.aborted);
+        final payjoinEvents = StreamController<Payjoin>.broadcast();
+        addTearDown(payjoinEvents.close);
+
+        var loadCount = 0;
+        when(() => getTransactionsByTxId.execute(any())).thenAnswer(
+          (_) async => [
+            Transaction(
+              payjoin: loadCount++ == 0 ? ongoing : completedViaFallback,
+            ),
+          ],
+        );
+        when(
+          () => watchPayjoin.execute(ids: [ongoing.id]),
+        ).thenAnswer((_) => payjoinEvents.stream);
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.initByWalletTxId('sender-orig-txid', walletId: 'w1');
+
+        expect(cubit.state.payjoin?.canManuallyBroadcastOriginal, isTrue);
+
+        payjoinEvents.add(completedViaFallback);
+        await pumpEventQueue();
+
+        // Work-tree divergence from payjoin-hardening: a fallback completion
+        // is an explicit `aborted` status here (not `isCompleted`), per the
+        // Payjoin entity's status semantics. Either way it is terminal, and
+        // the manual-broadcast guard flips shut.
+        expect(cubit.state.payjoin?.isAborted, isTrue);
+        expect(cubit.state.payjoin?.isOngoing, isFalse);
+        expect(cubit.state.payjoin?.canManuallyBroadcastOriginal, isFalse);
+      },
+    );
+
+    test('a TERMINAL payjoin event with no wallet transaction on screen yet '
+        'fires a targeted sync of the wallet, so the broadcast transaction '
+        'shows up promptly instead of at the next scheduled sync', () async {
+      final ongoing = _sender(status: PayjoinStatus.requested);
+      final completedViaFallback = _sender(status: PayjoinStatus.aborted);
+      final payjoinEvents = StreamController<Payjoin>.broadcast();
+      addTearDown(payjoinEvents.close);
+
+      var loadCount = 0;
+      when(() => getTransactionsByTxId.execute(any())).thenAnswer(
+        (_) async => [
+          Transaction(
+            payjoin: loadCount++ == 0 ? ongoing : completedViaFallback,
+          ),
+        ],
+      );
+      when(
+        () => watchPayjoin.execute(ids: [ongoing.id]),
+      ).thenAnswer((_) => payjoinEvents.stream);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByWalletTxId('sender-orig-txid', walletId: 'w1');
+
+      payjoinEvents.add(completedViaFallback);
+      await pumpEventQueue();
+
+      verify(() => getWallet.execute('w1', sync: true)).called(1);
+    });
+
+    test(
+      'a NON-terminal payjoin event does not fire the targeted sync',
+      () async {
+        final ongoing = _sender(status: PayjoinStatus.requested);
+        final proposed = _sender(
+          status: PayjoinStatus.proposed,
+          proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        );
+        final payjoinEvents = StreamController<Payjoin>.broadcast();
+        addTearDown(payjoinEvents.close);
+
+        var loadCount = 0;
+        when(() => getTransactionsByTxId.execute(any())).thenAnswer(
+          (_) async => [
+            Transaction(payjoin: loadCount++ == 0 ? ongoing : proposed),
+          ],
+        );
+        when(
+          () => watchPayjoin.execute(ids: [ongoing.id]),
+        ).thenAnswer((_) => payjoinEvents.stream);
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.initByWalletTxId('sender-orig-txid', walletId: 'w1');
+
+        payjoinEvents.add(proposed);
+        await pumpEventQueue();
+
+        expect(cubit.state.payjoin?.status, PayjoinStatus.proposed);
+        verifyNever(() => getWallet.execute(any(), sync: true));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Adds displayPayjoinStatus on the Transaction entity to correctly reflect completed/aborted/expired states in transaction history, replacing the misleading "proposed" label. Navigates directly to the freshly-broadcast transaction after send.

Closes #947 (Better Payjoin Status). Addresses part of #2416 (payjoin improvements — items 1 and 3 on tx confirmation/timer display are not covered, flagged as follow-up).

Merge order: 4th (parallel with PR3, PR4), after PR2. No dependency on PR3/PR4.
PR2 → PR5 (this)   ‖ PR2 → PR3   ‖ PR2 → PR4
