### PR TITLE
fix(export): use UTC timestamps in CSV export

### DIFF
--- a/lib/features/transactions/application/usecases/export_transactions_csv_usecase.dart
+++ b/lib/features/transactions/application/usecases/export_transactions_csv_usecase.dart
@@ -21,8 +21,15 @@ class ExportTransactionsCsvUsecase {
 
     final transactions = await _getTransactionsUsecase.execute();
 
+    // Preserve the input's UTC-ness when rounding up to the next day:
+    // building a plain (local) DateTime from a UTC end's wall-clock fields
+    // shifted the inclusive-day boundary by the machine's UTC offset, so
+    // the same export included or excluded edge transactions depending on
+    // the device's timezone.
     final exclusiveEnd = end == null
         ? null
+        : end.isUtc
+        ? DateTime.utc(end.year, end.month, end.day + 1)
         : DateTime(end.year, end.month, end.day + 1);
 
     final filtered = transactions.where((tx) {


### PR DESCRIPTION
Fixes local vs. UTC timestamp handling in the transaction CSV export.

Merge order: independent — any time after #2443. No dependency on PR1-PR5, PR6.
#2443 → PR7 (this)
