### PR TITLE
feat(consolidation): Liquid UTXO consolidation with decoy outputs

### DIFF
--- a/integration_test/coins_test.dart
+++ b/integration_test/coins_test.dart
@@ -4,12 +4,11 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
-import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart'
-    show NoSpendableUtxoException;
 import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';

--- a/lib/core/swaps/domain/usecases/auto_swap_execution_usecase.dart
+++ b/lib/core/swaps/domain/usecases/auto_swap_execution_usecase.dart
@@ -6,8 +6,12 @@ import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
 import 'package:bb_mobile/core/swaps/domain/ports/blockchain_port.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 
@@ -15,6 +19,8 @@ class AutoSwapExecutionUsecase {
   final BoltzSwapRepository _repository;
   final WalletRepository _walletRepository;
   final LiquidWalletRepository _liquidWalletRepository;
+  final WalletUtxoRepository _walletUtxoRepository;
+  final WalletAddressRepository _walletAddressRepository;
   final BlockchainPort _blockchainPort;
   final WalletTransactionRepository _walletTxRepository;
   final LabelsFacade _labelsFacade;
@@ -23,6 +29,8 @@ class AutoSwapExecutionUsecase {
     required this._repository,
     required this._walletRepository,
     required this._liquidWalletRepository,
+    required this._walletUtxoRepository,
+    required this._walletAddressRepository,
     required this._blockchainPort,
     required this._walletTxRepository,
     required this._labelsFacade,
@@ -130,10 +138,44 @@ class AutoSwapExecutionUsecase {
     );
 
     log.fine('Building PSET...');
-    final pset = await _liquidWalletRepository.buildPset(
+    // Built via buildCustomTx (an explicit UTXO list), not buildPset (LWK's
+    // own coin selection, which is known to add every L-BTC UTXO regardless
+    // of amount — see PrepareLiquidSendUsecase) — this is a background,
+    // unattended payment, so a frozen UTXO (e.g. a consolidation decoy,
+    // which must never be re-spent) must never be able to slip in here
+    // either, same as an ordinary user-initiated send.
+    final confirmed = await _liquidWalletRepository.getConfirmedLbtcOutpoints(
       walletId: defaultLiquidWallet.id,
-      address: swap.paymentAddress,
-      amountSat: swap.paymentAmount,
+    );
+    final frozen = (await _walletUtxoRepository.getAllFrozenOutpoints())
+        .toSet();
+    final usable = confirmed.where((o) => !frozen.contains(o)).toList();
+
+    if (usable.isEmpty) {
+      throw NoSpendableUtxoException(
+        'Wallet ${defaultLiquidWallet.id} has no spendable (confirmed, '
+        'unfrozen) L-BTC UTXOs',
+      );
+    }
+    if (_liquidWalletRepository.exceedsLiquidInputLimit(usable.length)) {
+      throw LiquidInputLimitExceededException(
+        'Wallet ${defaultLiquidWallet.id} exceeds the Liquid confidential-tx '
+        'input limit',
+      );
+    }
+
+    final changeAddress = await _walletAddressRepository
+        .generateNewReceiveAddress(walletId: defaultLiquidWallet.id);
+    final pset = await _liquidWalletRepository.buildCustomTx(
+      walletId: defaultLiquidWallet.id,
+      utxos: usable,
+      outputs: [
+        LiquidTxOutput(
+          address: swap.paymentAddress,
+          satoshi: swap.paymentAmount,
+        ),
+      ],
+      drainToAddress: changeAddress.address,
       // 0.1 sat/vByte = 25 sat/kwu — Liquid's network minrelayfee default.
       feeRate: const RelativeFee(25),
     );

--- a/lib/core/swaps/swaps_locator.dart
+++ b/lib/core/swaps/swaps_locator.dart
@@ -34,6 +34,7 @@ import 'package:bb_mobile/core/swaps/interface_adapters/blockchain_adapter.dart'
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';

--- a/lib/core/swaps/swaps_locator.dart
+++ b/lib/core/swaps/swaps_locator.dart
@@ -36,6 +36,7 @@ import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:get_it/get_it.dart';
 
@@ -240,6 +241,8 @@ class SwapsLocator {
         ),
         walletRepository: locator<WalletRepository>(),
         liquidWalletRepository: locator<LiquidWalletRepository>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+        walletAddressRepository: locator<WalletAddressRepository>(),
         blockchainPort: locator<BlockchainPort>(),
         walletTxRepository: locator<WalletTransactionRepository>(),
         labelsFacade: locator<LabelsFacade>(),

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_transaction_model.dart'
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -824,10 +825,6 @@ class FailedToSignPsbtException extends BullException {
 
 class UnsupportedBdkNetworkException extends BullException {
   UnsupportedBdkNetworkException(super.message);
-}
-
-class NoSpendableUtxoException extends BullException {
-  NoSpendableUtxoException(super.message);
 }
 
 /// Confirmation count for an output confirmed at [height], given the current

--- a/lib/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart
+++ b/lib/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart
@@ -1,0 +1,63 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists, per Liquid wallet, the highest receive-address index this app
+/// has ever handed out to the UI — independent of LWK's own sync state.
+///
+/// LWK's "last unused address" is derived purely from what the wallet has
+/// synced as used; two receive requests issued before an intervening sync
+/// would otherwise return the identical address (there's no LWK-side
+/// reservation mechanism, unlike BDK's persisted, sync-independent
+/// reveal-index — see `BdkWalletDatasource.getNewAddress` /
+/// `BdkFacade.saveWallet`). This datasource is that missing reservation for
+/// Liquid, so the same class of address reuse can't happen there either.
+class LiquidReceiveAddressIndexDatasource {
+  static String _key(String walletId) =>
+      'liquid_last_receive_address_index_$walletId';
+
+  // Per-wallet async mutex: each call for a given walletId waits for the
+  // previous one (for that same wallet) to finish before reading, so a
+  // concurrent reservation race can't have two callers read the same
+  // "current" value before either writes back. Different wallets never
+  // block each other.
+  final Map<String, Future<void>> _locks = {};
+
+  /// The persisted index, or null if nothing has ever been reserved for
+  /// this wallet yet.
+  Future<int?> read(String walletId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_key(walletId));
+  }
+
+  /// Atomically reserves and persists a new "last issued" index for
+  /// [walletId]: `max(persisted, atLeast) + 1`. [atLeast] should be LWK's
+  /// own sync-derived next-unused index, so a wallet restored on a new
+  /// device (where the local persisted counter starts at 0) still advances
+  /// correctly. Concurrent calls for the same wallet are serialized, so
+  /// each one is guaranteed a distinct reserved index.
+  Future<int> reserveNext(String walletId, {required int atLeast}) {
+    final previous = _locks[walletId] ?? Future.value();
+    final chained = previous.then((_) async {
+      final prefs = await SharedPreferences.getInstance();
+      final current = prefs.getInt(_key(walletId)) ?? 0;
+      final next = (current > atLeast ? current : atLeast) + 1;
+      await prefs.setInt(_key(walletId), next);
+      return next;
+    });
+    // Release the lock once this reservation settles, whatever the outcome,
+    // so a failure here can't deadlock every later call for this wallet.
+    _locks[walletId] = chained.then((_) {}, onError: (_) {});
+    return chained;
+  }
+
+  /// Self-heals the persisted index up to [atLeast] without reserving a new
+  /// one — used when the address actually returned to the UI (after any
+  /// system-label skip-forward) ended up higher than what's currently
+  /// persisted, so the next reservation still starts from the right place.
+  Future<void> ensureAtLeast(String walletId, int atLeast) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_key(walletId)) ?? 0;
+    if (atLeast > current) {
+      await prefs.setInt(_key(walletId), atLeast);
+    }
+  }
+}

--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -504,34 +504,6 @@ class LwkWalletDatasource {
     }
   }
 
-  /// Number of confidential-tx inputs above which a Liquid transaction can no
-  /// longer be built (the true protocol maximum is 256).
-  static const int maxLiquidTxInputs = 256;
-
-  /// Number of L-BTC UTXOs in the wallet — the count that matters for the
-  /// 256-input limit (asset-filtered, mirroring lwk's `utxoStatus`). Drives
-  /// consolidation detection.
-  Future<int> getLbtcUtxoCount({required WalletModel wallet}) async {
-    try {
-      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
-      final utxos = await lwkWallet.utxos();
-      final network = wallet.isTestnet
-          ? Network.liquidTestnet
-          : Network.liquidMainnet;
-      final lbtcAssetId = _lBtcAssetId(network);
-      final lbtcCount = utxos
-          .where((u) => u.unblinded.asset == lbtcAssetId)
-          .length;
-      return lbtcCount;
-    } catch (e) {
-      if (e is lwk.LwkError) {
-        throw e.msg;
-      } else {
-        rethrow;
-      }
-    }
-  }
-
   Future<bool> _exceedsLiquidInputLimit(WalletModel wallet) async {
     try {
       return await getLbtcUtxoCount(wallet: wallet) > maxLiquidTxInputs;

--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -12,6 +12,8 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_transaction_model.dart'
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:flutter/material.dart';
 import 'package:bull_sdk/lwk.dart' as lwk;
@@ -72,9 +74,19 @@ class LwkWalletDatasource {
     }
   }
 
+  /// [stopAtIndex]: scan the descriptor at least up to this derivation
+  /// index, instead of stopping at LWK's default 20-consecutive-unused gap
+  /// limit. Must be passed whenever the app has handed out addresses beyond
+  /// what LWK has ever seen as used (see
+  /// `LiquidReceiveAddressIndexDatasource`): e.g. a consolidation reserves
+  /// 2 fresh addresses per batch without syncing in between, so a multi-batch
+  /// run can leave funded addresses further out than a default gap-limit
+  /// scan will ever look — making those UTXOs (and the balance they carry)
+  /// invisible to the wallet until a deep-enough scan runs.
   Future<void> sync({
     required WalletModel wallet,
     required ElectrumConnection electrumServer,
+    int? stopAtIndex,
   }) {
     // TODO: if needed, add these debugPrint to a filterable logger.debug
     // TODO: to avoid spamming the terminal with recurring prints
@@ -88,6 +100,7 @@ class LwkWalletDatasource {
         await lwkWallet.sync_(
           electrumUrl: electrumServer.url,
           validateDomain: electrumServer.validateDomain,
+          stopAtIndex: stopAtIndex,
         );
         //debugPrint('[Sync] Sync completed for wallet: ${wallet.id}');
       } catch (e) {
@@ -377,26 +390,104 @@ class LwkWalletDatasource {
     }
   }
 
-  Future<String> buildPset({
-    required String address,
-    required RelativeFee feeRate,
-    int? amountSat,
-    bool drain = false,
+  /// Number of confidential-tx inputs above which a Liquid transaction can no
+  /// longer be built (the true protocol maximum is 256).
+  static const int maxLiquidTxInputs = 256;
+
+  /// Number of L-BTC UTXOs in the wallet — the count that matters for the
+  /// 256-input limit (asset-filtered, mirroring lwk's `utxoStatus`). Drives
+  /// consolidation detection.
+  Future<int> getLbtcUtxoCount({required WalletModel wallet}) async {
+    try {
+      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
+      final utxos = await lwkWallet.utxos();
+      final network = wallet.isTestnet
+          ? Network.liquidTestnet
+          : Network.liquidMainnet;
+      final lbtcAssetId = _lBtcAssetId(network);
+      final lbtcCount = utxos
+          .where((u) => u.unblinded.asset == lbtcAssetId)
+          .length;
+      return lbtcCount;
+    } catch (e) {
+      if (e is lwk.LwkError) {
+        throw e.msg;
+      } else {
+        rethrow;
+      }
+    }
+  }
+
+  /// Confirmed L-BTC UTXOs — the candidates for consolidation batching.
+  /// Asset+height filtered directly against the live LWK UTXO set (mirrors
+  /// the filter the old `Wallet.consolidate()` RPC used to apply internally).
+  ///
+  /// Distinct from [getLbtcUtxoCount], which counts ALL L-BTC UTXOs
+  /// (confirmed or not) for the send-blocking input-limit check — consolidate
+  /// candidates must be confirmed, but a pending send still has to account
+  /// for every UTXO it could end up spending.
+  Future<List<WalletUtxoModel>> getConfirmedLbtcUtxos({
     required WalletModel wallet,
   }) async {
     try {
       final lwkWallet = await LwkFacade.createPublicWallet(wallet);
-      // LWK accepts sat/kvByte as a double. Our RelativeFee stores sat/kwu,
-      // and 1 sat/kwu = 4 sat/kvByte, so the conversion is exact integer
-      // arithmetic promoted to double — no precision loss at the SDK boundary.
-      final pset = await lwkWallet.buildLbtcTx(
-        sats: BigInt.from(amountSat ?? 0),
-        outAddress: address,
+      final utxos = await lwkWallet.utxos();
+      final network = wallet.isTestnet
+          ? Network.liquidTestnet
+          : Network.liquidMainnet;
+      final lbtcAssetId = _lBtcAssetId(network);
+      return utxos
+          .where((u) => u.unblinded.asset == lbtcAssetId && u.height != null)
+          .map(
+            (u) => WalletUtxoModel.liquid(
+              txId: u.outpoint.txid,
+              vout: u.outpoint.vout,
+              amountSat: u.unblinded.value,
+              scriptPubkey: u.scriptPubkey,
+              standardAddress: u.address.standard,
+              confidentialAddress: u.address.confidential,
+              confirmations: 1,
+            ),
+          )
+          .toList();
+    } catch (e) {
+      if (e is lwk.LwkError) {
+        throw e.msg;
+      } else {
+        rethrow;
+      }
+    }
+  }
+
+  /// Build a PSET spending exactly [utxos], paying [outputs], with any
+  /// leftover L-BTC value (after outputs + fee) swept to [drainToAddress] if
+  /// set. General-purpose builder for custom output shapes — e.g. a
+  /// consolidation batch's drain output plus a decoy output.
+  Future<String> buildCustomTx({
+    required WalletModel wallet,
+    required List<Outpoint> utxos,
+    required List<LiquidTxOutput> outputs,
+    String? drainToAddress,
+    required RelativeFee feeRate,
+  }) async {
+    try {
+      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
+      final pset = await lwkWallet.buildCustomTx(
+        utxos: utxos
+            .map((o) => lwk.OutPoint(txid: o.txId, vout: o.vout))
+            .toList(),
+        outputs: outputs
+            .map(
+              (o) => lwk.TxOutputSpec(
+                address: o.address,
+                satoshi: BigInt.from(o.satoshi),
+                assetId: o.assetId,
+              ),
+            )
+            .toList(),
+        drainTo: drainToAddress,
         feeRate: feeRate.satPerKvbyte,
-        drain: drain,
       );
-      final decoded = await lwkWallet.decodeTx(pset: pset);
-      log.info(decoded.absoluteFees.toString());
       return pset;
     } catch (e) {
       if (e is lwk.LwkError) {
@@ -487,6 +578,37 @@ class LwkWalletDatasource {
     }
   }
 
+  /// The output index (vout) of the first output in [pset] with a plaintext
+  /// value of exactly [satoshi] — used to identify a known-amount output
+  /// (e.g. a decoy) after building a custom tx, without assuming output
+  /// ordering. A PSET (unlike a finalized tx) still carries the plaintext
+  /// amount for outputs this wallet itself constructed, so no unblinding is
+  /// needed. Returns null if no output matches.
+  int? findOutputIndexByAmount({required String pset, required int satoshi}) {
+    try {
+      final decoded = lwk.PartiallySignedElementsTransaction.fromString(
+        psetString: pset,
+      );
+      final outputs = decoded.getOutputs();
+      final target = BigInt.from(satoshi);
+      for (var i = 0; i < outputs.length; i++) {
+        final output = outputs[i];
+        // Exclude the fee output (empty scriptPubkey) so an implausibly
+        // small fee can never be mistaken for the decoy.
+        if (output.amount == target && output.scriptPubkey.isNotEmpty) {
+          return i;
+        }
+      }
+      return null;
+    } catch (e) {
+      if (e is lwk.LwkError) {
+        throw e.msg;
+      } else {
+        rethrow;
+      }
+    }
+  }
+
   Future<String> signPset(
     String pset, {
     required PrivateLwkWalletModel wallet,
@@ -515,6 +637,16 @@ class LwkWalletDatasource {
       final decoded = await lwk.getSizeAndAbsoluteFees(pset: pset);
       debugPrint(decoded.absoluteFees.toString());
       // final decoded = await lwkWallet.decodeTx(pset: pset);
+      if (decoded.absoluteFees.isEmpty) {
+        // Should never happen for a well-formed single-asset (L-BTC) PSET —
+        // surfaced as a clear, specific message instead of an opaque
+        // `StateError: No element` from `.first`, so a caller's failure
+        // banner/log actually says what went wrong.
+        throw Exception(
+          'PSET decoded with no fee entries for any asset (absoluteFees was '
+          'empty)',
+        );
+      }
       return (
         decoded.discountedVsize.toInt(),
         decoded.absoluteFees.first.value,

--- a/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
@@ -5,6 +5,9 @@ import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dar
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 
 class LiquidWalletRepository {
   final WalletMetadataDatasource _walletMetadataDatasource;
@@ -18,42 +21,112 @@ class LiquidWalletRepository {
   }) : _seed = seedDatasource,
        _lwkWallet = lwkWalletDatasource;
 
-  Future<String> buildPset({
-    required String walletId,
-    required String address,
-    int? amountSat,
-    required RelativeFee feeRate,
-    bool? drain,
-  }) async {
-    final metadata = await _walletMetadataDatasource.fetch(walletId);
+  Future<(int, int)> getPsetSizeAndAbsoluteFees({required String pset}) async {
+    final (size, fees) = await _lwkWallet.decodeAbsoluteFeesFromPset(pset);
+    return (size, fees);
+  }
 
+  /// The output index (vout) of the first output in [pset] with a plaintext
+  /// value of exactly [satoshi], or null if none matches. Pure PSET decoding
+  /// — not wallet-specific, so no metadata lookup is needed.
+  int? findOutputIndexByAmount({required String pset, required int satoshi}) {
+    return _lwkWallet.findOutputIndexByAmount(pset: pset, satoshi: satoshi);
+  }
+
+  /// Whether spending [utxoCount] confirmed L-BTC UTXOs in a single
+  /// transaction would exceed the confidential-tx input limit — exposed
+  /// here so a caller building via [buildCustomTx] (which has no built-in
+  /// pre-check, since it takes an explicit UTXO list instead of letting LWK
+  /// choose) can enforce it without needing to import the datasource itself
+  /// just to read its constant.
+  bool exceedsLiquidInputLimit(int utxoCount) =>
+      utxoCount > LwkWalletDatasource.maxLiquidTxInputs;
+
+  Future<int> getLbtcUtxoCount({required String walletId}) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
     if (metadata == null) {
       throw Exception('Wallet metadata not found for walletId: $walletId');
     }
-
     if (!metadata.isLiquid) {
       throw Exception('Wallet $walletId is not a Liquid wallet');
     }
-
     final wallet = WalletModel.publicLwk(
       combinedCtDescriptor: metadata.externalPublicDescriptor,
       isTestnet: metadata.isTestnet,
       id: metadata.id,
     );
-    final pset = await _lwkWallet.buildPset(
-      wallet: wallet,
-      address: address,
-      amountSat: amountSat,
-      feeRate: feeRate,
-      drain: drain ?? false,
-    );
-
-    return pset;
+    return _lwkWallet.getLbtcUtxoCount(wallet: wallet);
   }
 
-  Future<(int, int)> getPsetSizeAndAbsoluteFees({required String pset}) async {
-    final (size, fees) = await _lwkWallet.decodeAbsoluteFeesFromPset(pset);
-    return (size, fees);
+  /// Outpoints of the wallet's confirmed L-BTC UTXOs — the candidates for
+  /// consolidation batching.
+  Future<List<Outpoint>> getConfirmedLbtcOutpoints({
+    required String walletId,
+  }) async {
+    final utxos = await _confirmedLbtcUtxos(walletId);
+    return utxos.map((u) => (txId: u.txId, vout: u.vout)).toList();
+  }
+
+  /// Same candidates as [getConfirmedLbtcOutpoints], but with each UTXO's
+  /// amount — for a caller that needs to distribute UTXOs across multiple
+  /// batches *by value*, not just chunk them by position (a batch made up
+  /// entirely of dust UTXOs can't even cover its own fee).
+  Future<List<OutpointAmount>> getConfirmedLbtcOutpointAmounts({
+    required String walletId,
+  }) async {
+    final utxos = await _confirmedLbtcUtxos(walletId);
+    return utxos
+        .map(
+          (u) => (txId: u.txId, vout: u.vout, amountSat: u.amountSat.toInt()),
+        )
+        .toList();
+  }
+
+  Future<List<WalletUtxoModel>> _confirmedLbtcUtxos(String walletId) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+    if (metadata == null) {
+      throw Exception('Wallet metadata not found for walletId: $walletId');
+    }
+    if (!metadata.isLiquid) {
+      throw Exception('Wallet $walletId is not a Liquid wallet');
+    }
+    final wallet = WalletModel.publicLwk(
+      combinedCtDescriptor: metadata.externalPublicDescriptor,
+      isTestnet: metadata.isTestnet,
+      id: metadata.id,
+    );
+    return _lwkWallet.getConfirmedLbtcUtxos(wallet: wallet);
+  }
+
+  /// Build a PSET spending exactly [utxos], paying [outputs], with any
+  /// leftover L-BTC value (after outputs + fee) swept to [drainToAddress] if
+  /// set.
+  Future<String> buildCustomTx({
+    required String walletId,
+    required List<Outpoint> utxos,
+    required List<LiquidTxOutput> outputs,
+    String? drainToAddress,
+    required RelativeFee feeRate,
+  }) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+    if (metadata == null) {
+      throw Exception('Wallet metadata not found for walletId: $walletId');
+    }
+    if (!metadata.isLiquid) {
+      throw Exception('Wallet $walletId is not a Liquid wallet');
+    }
+    final wallet = WalletModel.publicLwk(
+      combinedCtDescriptor: metadata.externalPublicDescriptor,
+      isTestnet: metadata.isTestnet,
+      id: metadata.id,
+    );
+    return _lwkWallet.buildCustomTx(
+      wallet: wallet,
+      utxos: utxos,
+      outputs: outputs,
+      drainToAddress: drainToAddress,
+      feeRate: feeRate,
+    );
   }
 
   Future<int> getLbtcUtxoCount({required String walletId}) async {

--- a/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
@@ -129,22 +129,6 @@ class LiquidWalletRepository {
     );
   }
 
-  Future<int> getLbtcUtxoCount({required String walletId}) async {
-    final metadata = await _walletMetadataDatasource.fetch(walletId);
-    if (metadata == null) {
-      throw Exception('Wallet metadata not found for walletId: $walletId');
-    }
-    if (!metadata.isLiquid) {
-      throw Exception('Wallet $walletId is not a Liquid wallet');
-    }
-    final wallet = WalletModel.publicLwk(
-      combinedCtDescriptor: metadata.externalPublicDescriptor,
-      isTestnet: metadata.isTestnet,
-      id: metadata.id,
-    );
-    return _lwkWallet.getLbtcUtxoCount(wallet: wallet);
-  }
-
   Future<List<String>> consolidate({
     required String walletId,
     required RelativeFee feeRate,

--- a/lib/core/wallet/data/repositories/wallet_address_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_address_repository.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/mappers/wallet_address_mapper.dart';
@@ -14,15 +15,19 @@ class WalletAddressRepository {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final BdkWalletDatasource _bdkWallet;
   final LwkWalletDatasource _lwkWallet;
+  final LiquidReceiveAddressIndexDatasource _liquidReceiveIndex;
   final LabelsFacade _labelsFacade;
 
   WalletAddressRepository({
     required this._walletMetadataDatasource,
     required BdkWalletDatasource bdkWalletDatasource,
     required LwkWalletDatasource lwkWalletDatasource,
+    required LiquidReceiveAddressIndexDatasource
+    liquidReceiveAddressIndexDatasource,
     required this._labelsFacade,
   }) : _bdkWallet = bdkWalletDatasource,
-       _lwkWallet = lwkWalletDatasource;
+       _lwkWallet = lwkWalletDatasource,
+       _liquidReceiveIndex = liquidReceiveAddressIndexDatasource;
 
   Future<WalletAddress> getLastRevealedReceiveAddress({
     required String walletId,
@@ -44,11 +49,26 @@ class WalletAddressRepository {
       index = addressInfo.index;
       address = addressInfo.address;
     } else {
-      final ({String confidential, int index, String standard}) addressInfo =
+      // LWK's own "last unused" is purely sync-derived — self-heal against
+      // whichever locally persisted index is higher (e.g. a restored
+      // wallet's sync hasn't caught up yet, or a prior session already
+      // handed out a higher index this app's sync doesn't reflect yet).
+      final ({String confidential, int index, String standard}) syncDerived =
           await _lwkWallet.getLastUnusedAddress(wallet: walletModel);
+      final persistedIndex =
+          await _liquidReceiveIndex.read(walletId) ?? syncDerived.index;
 
-      index = addressInfo.index;
-      address = addressInfo.confidential;
+      if (persistedIndex > syncDerived.index) {
+        final addressInfo = await _lwkWallet.getAddressByIndex(
+          persistedIndex,
+          wallet: walletModel,
+        );
+        index = persistedIndex;
+        address = addressInfo.confidential;
+      } else {
+        index = syncDerived.index;
+        address = syncDerived.confidential;
+      }
     }
 
     var labels = await _labelsFacade.fetchByReference(address);
@@ -68,6 +88,10 @@ class WalletAddressRepository {
         address = addressInfo.confidential;
       }
       labels = await _labelsFacade.fetchByReference(address);
+    }
+
+    if (walletModel is! PublicBdkWalletModel) {
+      await _liquidReceiveIndex.ensureAtLeast(walletId, index);
     }
 
     final walletAddressModel = WalletAddressModel(
@@ -110,9 +134,15 @@ class WalletAddressRepository {
         wallet: walletModel,
       );
 
-      // Generate a new address with the next index.
+      // Atomically reserve a fresh index — never the same one twice, even
+      // if this is called again before a sync updates LWK's own view of
+      // what's "last unused".
+      final reservedIndex = await _liquidReceiveIndex.reserveNext(
+        walletId,
+        atLeast: lastUnusedAddressInfo.index,
+      );
       final addressInfo = await _lwkWallet.getAddressByIndex(
-        lastUnusedAddressInfo.index + 1,
+        reservedIndex,
         wallet: walletModel,
       );
 
@@ -137,6 +167,10 @@ class WalletAddressRepository {
         address = addressInfo.confidential;
       }
       labels = await _labelsFacade.fetchByReference(address);
+    }
+
+    if (walletModel is! PublicBdkWalletModel) {
+      await _liquidReceiveIndex.ensureAtLeast(walletId, index);
     }
 
     final walletAddressModel = WalletAddressModel(

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -10,6 +10,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/balance_model.dart';
@@ -25,6 +26,7 @@ class WalletRepository {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final BdkWalletDatasource _bdkWallet;
   final LwkWalletDatasource _lwkWallet;
+  final LiquidReceiveAddressIndexDatasource _liquidReceiveIndex;
   final ElectrumServersPort _serversPort;
 
   final _electrumSyncResultController =
@@ -34,9 +36,12 @@ class WalletRepository {
     required this._walletMetadataDatasource,
     required BdkWalletDatasource bdkWalletDatasource,
     required LwkWalletDatasource lwkWalletDatasource,
+    required LiquidReceiveAddressIndexDatasource
+    liquidReceiveAddressIndexDatasource,
     required this._serversPort,
   }) : _bdkWallet = bdkWalletDatasource,
-       _lwkWallet = lwkWalletDatasource {
+       _lwkWallet = lwkWalletDatasource,
+       _liquidReceiveIndex = liquidReceiveAddressIndexDatasource {
     // Keep track of the last sync time in the wallet metadata
     _walletSyncFinishedStream.listen(_updateWalletSyncTime);
     // Start auto syncing wallets
@@ -492,12 +497,20 @@ class WalletRepository {
       isLiquid: isLiquid,
     );
 
+    final stopAtIndex = isLiquid
+        ? await _liquidReceiveIndex.read(wallet.id)
+        : null;
+
     try {
       await _serversPort.runWithFallback<void>(
         network: network,
         operation: (connection) async {
           if (isLiquid) {
-            await _lwkWallet.sync(wallet: wallet, electrumServer: connection);
+            await _lwkWallet.sync(
+              wallet: wallet,
+              electrumServer: connection,
+              stopAtIndex: stopAtIndex,
+            );
           } else {
             await _bdkWallet.sync(wallet: wallet, electrumServer: connection);
           }

--- a/lib/core/wallet/domain/entities/liquid_tx_output.dart
+++ b/lib/core/wallet/domain/entities/liquid_tx_output.dart
@@ -1,0 +1,17 @@
+/// An explicit Liquid transaction output — an address, an amount, and
+/// (optionally) which asset. `null` [assetId] means the policy asset (L-BTC).
+///
+/// Lives in `domain/` so repository contracts speak it instead of the raw SDK
+/// wire type (the boundary rule) — mirrors `lwk`'s `TxOutputSpec`, converted
+/// to/from it only inside `data/`.
+class LiquidTxOutput {
+  final String address;
+  final int satoshi;
+  final String? assetId;
+
+  const LiquidTxOutput({
+    required this.address,
+    required this.satoshi,
+    this.assetId,
+  });
+}

--- a/lib/core/wallet/domain/entities/outpoint.dart
+++ b/lib/core/wallet/domain/entities/outpoint.dart
@@ -4,3 +4,9 @@
 /// Lives in `domain/` so repository contracts and use-cases speak it without
 /// depending on any `data/` layer (the boundary rule).
 typedef Outpoint = ({String txId, int vout});
+
+/// An [Outpoint] plus its L-BTC value — for callers that need to reason
+/// about *which* UTXOs to group together, not just which ones exist (e.g.
+/// consolidation batching by value, so a batch is never accidentally made up
+/// entirely of dust that can't even cover its own fee).
+typedef OutpointAmount = ({String txId, int vout, int amountSat});

--- a/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -2,11 +2,11 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 
 class PrepareBitcoinSendUsecase {
   final PayjoinRepository _payjoin;

--- a/lib/core/wallet/domain/wallet_build_tx_exceptions.dart
+++ b/lib/core/wallet/domain/wallet_build_tx_exceptions.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+
+/// No unspent, spendable UTXO exists to build a transaction from.
+class NoSpendableUtxoException extends BullException {
+  NoSpendableUtxoException(super.message);
+}
+
+/// A build failed because the wallet's confirmed L-BTC UTXO count exceeds
+/// the Liquid confidential-tx input limit. Callers map this to their own
+/// feature's typed exception/failure; never rethrow this type past the
+/// use-case layer.
+class LiquidInputLimitExceededException extends BullException {
+  LiquidInputLimitExceededException(super.message);
+}
+
+/// Raised when the Liquid wallet holds more confirmed L-BTC UTXOs than a
+/// single confidential transaction can spend; the wallet needs consolidating
+/// before this send/swap can be built. Lives here (not inside `send`'s
+/// domain) so any feature building a Liquid send/swap can catch it without
+/// reaching into another feature's internals (AGENTS.md rule #1).
+class ConsolidationRequiredException extends BullException {
+  ConsolidationRequiredException(super.message);
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart'
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
@@ -56,6 +57,10 @@ class WalletLocator {
     locator.registerLazySingleton<FrozenWalletUtxoDatasource>(
       () => FrozenWalletUtxoDatasource(db: locator<SqliteDatabase>()),
     );
+
+    locator.registerLazySingleton<LiquidReceiveAddressIndexDatasource>(
+      () => LiquidReceiveAddressIndexDatasource(),
+    );
   }
 
   static void registerRepositories(GetIt locator) {
@@ -80,6 +85,8 @@ class WalletLocator {
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
         bdkWalletDatasource: locator<BdkWalletDatasource>(),
         lwkWalletDatasource: locator<LwkWalletDatasource>(),
+        liquidReceiveAddressIndexDatasource:
+            locator<LiquidReceiveAddressIndexDatasource>(),
         serversPort: locator<ElectrumServersPort>(),
       ),
     );
@@ -99,6 +106,8 @@ class WalletLocator {
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
         bdkWalletDatasource: locator<BdkWalletDatasource>(),
         lwkWalletDatasource: locator<LwkWalletDatasource>(),
+        liquidReceiveAddressIndexDatasource:
+            locator<LiquidReceiveAddressIndexDatasource>(),
         labelsFacade: locator<LabelsFacade>(),
       ),
     );

--- a/lib/core/widgets/cards/consolidation_required_card.dart
+++ b/lib/core/widgets/cards/consolidation_required_card.dart
@@ -3,22 +3,49 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
-class ConsolidationRequiredCard extends StatelessWidget {
+class ConsolidationRequiredCard extends StatefulWidget {
   const ConsolidationRequiredCard({
     super.key,
-    this.onTap,
     required this.title,
+    this.onTap,
     this.body,
   });
 
-  final VoidCallback? onTap;
+  final Future<void> Function()? onTap;
   final String title;
   final String? body;
 
   @override
+  State<ConsolidationRequiredCard> createState() =>
+      _ConsolidationRequiredCardState();
+}
+
+class _ConsolidationRequiredCardState extends State<ConsolidationRequiredCard> {
+  bool _navigating = false;
+
+  Future<void> _handleTap(Future<void> Function() onTap) async {
+    setState(() => _navigating = true);
+    try {
+      await onTap();
+    } catch (e, st) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: e,
+          stack: st,
+          library: 'ConsolidationRequiredCard',
+          context: ErrorDescription('while handling the card tap'),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _navigating = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final onTap = widget.onTap;
     return InkWell(
-      onTap: onTap,
+      onTap: onTap == null || _navigating ? null : () => _handleTap(onTap),
       child: Container(
         padding: const EdgeInsets.all(14),
         decoration: BoxDecoration(
@@ -38,14 +65,14 @@ class ConsolidationRequiredCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   BBText(
-                    title,
+                    widget.title,
                     style: context.font.bodyMedium,
                     color: context.appColors.onSurface,
                   ),
-                  if (body != null) ...[
+                  if (widget.body != null) ...[
                     const Gap(2),
                     BBText(
-                      body!,
+                      widget.body!,
                       style: context.font.bodyMedium,
                       color: context.appColors.secondary,
                       maxLines: 4,

--- a/lib/features/consolidation/consolidation_locator.dart
+++ b/lib/features/consolidation/consolidation_locator.dart
@@ -1,18 +1,34 @@
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_banner_cubit.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_cubit.dart';
+import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
 import 'package:get_it/get_it.dart';
 
 class ConsolidationLocator {
   static void setup(GetIt locator) {
+    locator.registerLazySingleton<CheckLiquidConsolidationUsecase>(
+      () => CheckLiquidConsolidationUsecase(
+        liquidWalletRepository: locator<LiquidWalletRepository>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+      ),
+    );
+
     locator.registerFactory<ConsolidateLiquidWalletUsecase>(
       () => ConsolidateLiquidWalletUsecase(
         liquidWalletRepository: locator<LiquidWalletRepository>(),
         broadcastLiquidTransactionUsecase:
             locator<BroadcastLiquidTransactionUsecase>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+        walletAddressRepository: locator<WalletAddressRepository>(),
+        getWalletUsecase: locator<GetWalletUsecase>(),
+        syncWalletUsecase: locator<SyncWalletUsecase>(),
       ),
     );
 
@@ -23,6 +39,8 @@ class ConsolidationLocator {
             locator<ConsolidateLiquidWalletUsecase>(),
         checkLiquidConsolidationUsecase:
             locator<CheckLiquidConsolidationUsecase>(),
+        getWalletUsecase: locator<GetWalletUsecase>(),
+        syncWalletUsecase: locator<SyncWalletUsecase>(),
       ),
     );
 
@@ -31,6 +49,13 @@ class ConsolidationLocator {
         checkLiquidConsolidationUsecase:
             locator<CheckLiquidConsolidationUsecase>(),
         walletId: walletId,
+      ),
+    );
+
+    locator.registerFactory<ConsolidationFacade>(
+      () => ConsolidationFacade(
+        checkLiquidConsolidationUsecase:
+            locator<CheckLiquidConsolidationUsecase>(),
       ),
     );
   }

--- a/lib/features/consolidation/domain/consolidation_config.dart
+++ b/lib/features/consolidation/domain/consolidation_config.dart
@@ -20,4 +20,11 @@ class ConsolidationConfig {
   /// Max inputs per consolidation transaction. Uniform in 230–250 (never above
   /// the 250 safety cap).
   static final int maximumInputs = 230 + _rng.nextInt(21);
+
+  /// Amount (in sats) of the decoy output added to each consolidation batch
+  /// alongside the real drained output, so the transaction looks like an
+  /// ordinary 2-output payment rather than an obvious many-in/one-out
+  /// self-transfer. Liquid's confidential amounts mean this value is never
+  /// visible on-chain to anyone but the wallet itself.
+  static const int decoySats = 1;
 }

--- a/lib/features/consolidation/domain/consolidation_failure.dart
+++ b/lib/features/consolidation/domain/consolidation_failure.dart
@@ -1,0 +1,57 @@
+import 'package:bb_mobile/core/failures/failure.dart';
+
+sealed class ConsolidationFailure extends Failure {
+  const ConsolidationFailure([super.logMessage]);
+}
+
+/// A Liquid send/swap build was blocked because the wallet holds more
+/// confirmed L-BTC UTXOs than a single confidential transaction can spend.
+/// Consolidate before retrying.
+final class ConsolidationRequiredFailure extends ConsolidationFailure {
+  const ConsolidationRequiredFailure([super.logMessage]);
+}
+
+/// The wallet's L-BTC UTXO count could not be read.
+final class ConsolidationCountUnavailableFailure extends ConsolidationFailure {
+  const ConsolidationCountUnavailableFailure([super.logMessage]);
+}
+
+/// Building the unsigned consolidation PSET(s) failed.
+final class ConsolidationBuildFailure extends ConsolidationFailure {
+  const ConsolidationBuildFailure([super.logMessage]);
+}
+
+/// Signing one of the consolidation PSETs failed. [succeededTxids] holds the
+/// txids of any earlier batches that already broadcast successfully before
+/// this one failed to sign — a retry must not resend those.
+final class ConsolidationSignFailure extends ConsolidationFailure {
+  const ConsolidationSignFailure(this.succeededTxids, [super.logMessage]);
+
+  final List<String> succeededTxids;
+}
+
+/// Broadcasting one of the consolidation transactions failed, after it was
+/// signed. [succeededTxids] holds the txids of any earlier batches that
+/// already broadcast successfully before this one failed — a retry must not
+/// resend those.
+final class ConsolidationBroadcastFailure extends ConsolidationFailure {
+  const ConsolidationBroadcastFailure(this.succeededTxids, [super.logMessage]);
+
+  final List<String> succeededTxids;
+}
+
+/// Anything not otherwise modeled.
+final class ConsolidationUnexpectedFailure extends ConsolidationFailure {
+  const ConsolidationUnexpectedFailure([super.logMessage]);
+}
+
+/// Refreshing the wallet's local UTXO view failed while retrying after a
+/// previous failure — surfaced instead of silently attempting to rebuild
+/// against a possibly-stale view (which could re-offer an outpoint an
+/// earlier, partially-successful broadcast round already spent; the build
+/// itself would succeed, since it has no way to know that, and only fail
+/// later, confusingly, when signing/broadcasting rejects it as a
+/// double-spend). No batch was built or broadcast this round.
+final class ConsolidationSyncFailure extends ConsolidationFailure {
+  const ConsolidationSyncFailure([super.logMessage]);
+}

--- a/lib/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart
+++ b/lib/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart
@@ -1,0 +1,55 @@
+import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+
+/// UTXO count above which a Liquid wallet should be consolidated. Kept a bit
+/// below the ~256 hard confidential-tx input limit so we warn the user before
+/// a spend actually fails.
+const int kLiquidConsolidationThreshold = 250;
+
+/// The wallet's confirmed, unfrozen L-BTC UTXO count (or null if it couldn't
+/// be read) plus whether that count is over the consolidation threshold —
+/// bundled together so callers needing either value (or both) still only
+/// ever call the one `execute()` entry point, matching the codebase-wide
+/// use-case convention of a single public entry method.
+typedef LiquidConsolidationStatus = ({int? utxoCount, bool isRequired});
+
+class CheckLiquidConsolidationUsecase {
+  final LiquidWalletRepository _repository;
+  final WalletUtxoRepository _utxoRepository;
+
+  CheckLiquidConsolidationUsecase({
+    required LiquidWalletRepository liquidWalletRepository,
+    required WalletUtxoRepository walletUtxoRepository,
+  }) : _repository = liquidWalletRepository,
+       _utxoRepository = walletUtxoRepository;
+
+  /// [LiquidConsolidationStatus.utxoCount] matches
+  /// [ConsolidateLiquidWalletUsecase]'s own filtering exactly (confirmed,
+  /// unfrozen), so the banner and the consolidation screen always agree on
+  /// what "needs consolidating" means — a frozen UTXO doesn't count here
+  /// either. [LiquidConsolidationStatus.isRequired] is that count compared
+  /// against [kLiquidConsolidationThreshold].
+  Future<LiquidConsolidationStatus> execute({required String walletId}) async {
+    final utxoCount = await _confirmedUnfrozenUtxoCount(walletId: walletId);
+    return (
+      utxoCount: utxoCount,
+      isRequired:
+          utxoCount != null && utxoCount > kLiquidConsolidationThreshold,
+    );
+  }
+
+  Future<int?> _confirmedUnfrozenUtxoCount({required String walletId}) async {
+    try {
+      final confirmedOutpoints = await _repository.getConfirmedLbtcOutpoints(
+        walletId: walletId,
+      );
+      final frozenOutpoints = (await _utxoRepository.getAllFrozenOutpoints())
+          .toSet();
+      return confirmedOutpoints
+          .where((o) => !frozenOutpoints.contains(o))
+          .length;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart
+++ b/lib/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart
@@ -1,42 +1,87 @@
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
-import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
 import 'package:bb_mobile/features/consolidation/domain/consolidation_config.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+import 'package:meta/meta.dart';
+
+/// One consolidation batch: the unsigned PSET (draining a group of UTXOs to
+/// one real output, plus a small decoy output) and which output index within
+/// it is the decoy — needed to freeze the right UTXO once it's broadcast.
+class ConsolidationBatch {
+  final String pset;
+  final int decoyVout;
+
+  const ConsolidationBatch({required this.pset, required this.decoyVout});
+}
 
 /// Result of building (but not yet broadcasting) a consolidation: the unsigned
-/// PSETs plus the total network fee summed across them, for the confirm screen.
+/// batches plus the total network fee summed across them, for the confirm
+/// screen.
 class ConsolidationPreview {
-  const ConsolidationPreview({
-    required this.unsignedPsets,
-    required this.totalFeeSat,
-  });
-
-  final List<String> unsignedPsets;
+  final List<ConsolidationBatch> batches;
   final int totalFeeSat;
+
+  /// How many UTXOs are actually being consolidated (confirmed, unfrozen —
+  /// the same filtered candidate list batching was computed from). This is
+  /// the "outputs before" number the confirm screen shows; it's carried
+  /// alongside the batches themselves rather than recomputed separately, so
+  /// the two numbers can never disagree — a frozen UTXO isn't just excluded
+  /// from being spent, it doesn't count as "there" at all for this screen.
+  final int utxoCount;
+
+  const ConsolidationPreview({
+    required this.batches,
+    required this.totalFeeSat,
+    required this.utxoCount,
+  });
 
   /// One consolidated output per transaction, so this is also the resulting
   /// UTXO count.
-  int get transactionCount => unsignedPsets.length;
+  int get transactionCount => batches.length;
 }
 
-/// Orchestrates a Liquid consolidation as a set of self-transactions:
-/// `consolidate` (build) → `signPset` (each) → broadcast (each, via the same
-/// [BroadcastLiquidTransactionUsecase] a normal send uses).
+/// Result of signing and broadcasting a [ConsolidationPreview]'s batches.
+class ConsolidationBroadcastResult {
+  final List<String> txids;
+
+  /// How many decoy outputs failed to freeze (best-effort bookkeeping, not a
+  /// fund-safety issue — the broadcasts still succeeded). Non-zero means the
+  /// user may want to freeze them manually via the Coins screen.
+  final int unfrozenDecoyCount;
+
+  const ConsolidationBroadcastResult({
+    required this.txids,
+    required this.unfrozenDecoyCount,
+  });
+}
+
+/// Orchestrates a Liquid consolidation as a set of self-transactions, each
+/// with two outputs: the real drained output, and a small decoy output (so
+/// the tx isn't an obvious many-in/one-out self-transfer signature).
 ///
-/// [prepare] builds the PSETs and totals the fee for the confirm screen;
-/// [broadcast] signs and broadcasts them. Thresholds/batch size come from the
-/// per-boot [ConsolidationConfig] to avoid fingerprinting.
+/// `consolidate` (build, via `buildCustomTx`) → `signPset` (each) →
+/// broadcast (each, via the same [BroadcastLiquidTransactionUsecase] a normal
+/// send uses) → freeze the decoy (best-effort).
 ///
-/// KNOWN LIMITATION (accepted for now — see
-/// [LiquidWalletRepository.consolidate]'s doc comment): repeated calls to
-/// [prepare] in quick succession (before a sync completes) can produce
-/// batches that reuse a drain address, since address selection happens
-/// natively and isn't backed by a persisted, app-level reservation. Not a
-/// fund-safety issue — only an address-reuse/privacy one.
+/// [prepare] builds the batches and totals the fee for the confirm screen;
+/// [broadcast] signs, broadcasts, and freezes the decoys. Thresholds/batch
+/// size/decoy amount come from the per-boot [ConsolidationConfig] to avoid
+/// fingerprinting.
 class ConsolidateLiquidWalletUsecase {
   final LiquidWalletRepository _repository;
   final BroadcastLiquidTransactionUsecase _broadcast;
+  final WalletUtxoRepository _utxoRepository;
+  final WalletAddressRepository _addressRepository;
+  final GetWalletUsecase _getWallet;
+  final SyncWalletUsecase _sync;
 
   // Liquid network minrelayfee default (0.1 sat/vByte = 25 sat/kwu); the
   // consolidation self-transfer doesn't need to be fast.
@@ -46,65 +91,228 @@ class ConsolidateLiquidWalletUsecase {
     required LiquidWalletRepository liquidWalletRepository,
     required BroadcastLiquidTransactionUsecase
     broadcastLiquidTransactionUsecase,
+    required WalletUtxoRepository walletUtxoRepository,
+    required WalletAddressRepository walletAddressRepository,
+    required GetWalletUsecase getWalletUsecase,
+    required SyncWalletUsecase syncWalletUsecase,
   }) : _repository = liquidWalletRepository,
-       _broadcast = broadcastLiquidTransactionUsecase;
+       _broadcast = broadcastLiquidTransactionUsecase,
+       _utxoRepository = walletUtxoRepository,
+       _addressRepository = walletAddressRepository,
+       _getWallet = getWalletUsecase,
+       _sync = syncWalletUsecase;
 
-  Future<ConsolidationPreview> prepare({required String walletId}) async {
+  /// Number of batches and UTXOs-per-batch so that no batch exceeds
+  /// [maxInputs] and batches are as evenly sized as possible. Mirrors the
+  /// math the old `lwk` `consolidate()` RPC used to do on the Rust side —
+  /// batching now happens here so each batch can carry a decoy output.
+  ///
+  /// Deliberately `n = ceil(total / maxInputs)`, not the literal
+  /// `round(total / maxInputs)` from the original design discussion:
+  /// round-half-up can produce a batch that *exceeds* [maxInputs] (e.g.
+  /// 300 UTXOs / 250 max rounds to a single 300-input batch, over the safety
+  /// cap), whereas ceiling never does. `@visibleForTesting` since this pure
+  /// math is worth exercising directly at a realistic scale (hundreds of
+  /// UTXOs) without needing to fake that many outpoints through [prepare].
+  @visibleForTesting
+  static (int, int) batchSizes(int total, int maxInputs) {
+    final n = (total + maxInputs - 1) ~/ maxInputs;
+    final perBatch = (total + n - 1) ~/ n;
+    return (n, perBatch);
+  }
+
+  @visibleForTesting
+  static List<List<OutpointAmount>> distributeByValue(
+    List<OutpointAmount> candidates,
+    int n,
+  ) {
+    final sorted = [...candidates]
+      ..sort((a, b) => b.amountSat.compareTo(a.amountSat));
+    final buckets = List.generate(n, (_) => <OutpointAmount>[]);
+    for (var i = 0; i < sorted.length; i++) {
+      buckets[i % n].add(sorted[i]);
+    }
+    return buckets;
+  }
+
+  @useResult
+  Future<Result<ConsolidationPreview, ConsolidationFailure>> prepare({
+    required String walletId,
+  }) async {
+    // LiquidWalletRepository still throws (rule #11's staged-migration
+    // exception: "the feature use-case when wrapping a shared core repo that
+    // still throws" is the try/catch boundary) — core/wallet itself isn't
+    // being converted to Result/Failure in this PR, only this new feature is.
     try {
-      final psets = await _repository.consolidate(
+      final confirmedUtxos = await _repository.getConfirmedLbtcOutpointAmounts(
         walletId: walletId,
-        feeRate: _feeRate,
-        highUtxoThreshold: ConsolidationConfig.highUtxoThreshold,
-        maximumInputs: ConsolidationConfig.maximumInputs,
       );
+      // A frozen UTXO doesn't exist for consolidation purposes — it's
+      // excluded from both the "outputs before" count and the batches
+      // themselves, not just from being spent (e.g. a previous
+      // consolidation's own decoy outputs, already frozen, must never be
+      // pulled back into a later consolidation).
+      final frozenOutpoints = (await _utxoRepository.getAllFrozenOutpoints())
+          .toSet();
+      final usableUtxos = confirmedUtxos
+          .where((u) => !frozenOutpoints.contains((txId: u.txId, vout: u.vout)))
+          .toList();
+
+      if (usableUtxos.length <= ConsolidationConfig.highUtxoThreshold) {
+        return Ok(
+          ConsolidationPreview(
+            batches: const [],
+            totalFeeSat: 0,
+            utxoCount: usableUtxos.length,
+          ),
+        );
+      }
+
+      final (n, _) = batchSizes(
+        usableUtxos.length,
+        ConsolidationConfig.maximumInputs,
+      );
+      // Distributed by value (not chunked by position) so no batch ends up
+      // made entirely of dust that can't cover its own decoy + fee — see
+      // distributeByValue's doc comment for the incident this fixes.
+      final valueBalancedBatches = distributeByValue(usableUtxos, n);
+
+      final batches = <ConsolidationBatch>[];
       var totalFeeSat = 0;
-      for (final pset in psets) {
+      for (var i = 0; i < n; i++) {
+        final chunk = valueBalancedBatches[i]
+            .map((u) => (txId: u.txId, vout: u.vout))
+            .toList();
+        if (chunk.isEmpty) continue;
+
+        // Reserved through WalletAddressRepository (not a raw
+        // getLastUnusedAddressIndex/getAddressByIndex pair) so two batches —
+        // or a consolidation running close in time to any other
+        // address-generating event — can never be handed the same address.
+        // LWK's own "last unused" is purely sync-derived and doesn't
+        // advance until a sync completes, so calling it twice in a row
+        // (once per batch here, or once here and once elsewhere) can return
+        // the same index both times; the reservation datasource is the one
+        // thing that actually prevents that collision.
+        final mainAddress = await _addressRepository.generateNewReceiveAddress(
+          walletId: walletId,
+        );
+        final decoyAddress = await _addressRepository.generateNewReceiveAddress(
+          walletId: walletId,
+        );
+
+        final pset = await _repository.buildCustomTx(
+          walletId: walletId,
+          utxos: chunk,
+          outputs: [
+            LiquidTxOutput(
+              address: decoyAddress.address,
+              satoshi: ConsolidationConfig.decoySats,
+            ),
+          ],
+          drainToAddress: mainAddress.address,
+          feeRate: _feeRate,
+        );
+
+        final decoyVout = _repository.findOutputIndexByAmount(
+          pset: pset,
+          satoshi: ConsolidationConfig.decoySats,
+        );
+        if (decoyVout == null) {
+          return Err(
+            ConsolidationBuildFailure(
+              'Could not locate the decoy output in batch ${i + 1}/$n',
+            ),
+          );
+        }
+
         final (_, feeSat) = await _repository.getPsetSizeAndAbsoluteFees(
           pset: pset,
         );
         totalFeeSat += feeSat;
+
+        batches.add(ConsolidationBatch(pset: pset, decoyVout: decoyVout));
       }
-      return ConsolidationPreview(
-        unsignedPsets: psets,
-        totalFeeSat: totalFeeSat,
+
+      return Ok(
+        ConsolidationPreview(
+          batches: batches,
+          totalFeeSat: totalFeeSat,
+          utxoCount: usableUtxos.length,
+        ),
       );
     } catch (e) {
-      throw ConsolidationException(e.toString());
+      return Err(ConsolidationBuildFailure(e.toString()));
     }
   }
 
-  /// Sign and broadcast the previously-built PSETs, returning the txids.
-  ///
-  /// If a PSET partway through the list fails to sign or broadcast, the
-  /// txids of whatever already succeeded are carried on the thrown
-  /// [ConsolidationException.succeededTxids] rather than discarded — the
-  /// caller (see [ConsolidationCubit]) uses this to avoid resubmitting an
-  /// already-broadcast (and so already-spent) PSET on retry.
-  Future<List<String>> broadcast({
+  /// Sign, broadcast, and (best-effort) freeze the decoy of each batch.
+  @useResult
+  Future<Result<ConsolidationBroadcastResult, ConsolidationFailure>> broadcast({
     required String walletId,
-    required List<String> unsignedPsets,
+    required List<ConsolidationBatch> batches,
   }) async {
     final txids = <String>[];
-    try {
-      for (final pset in unsignedPsets) {
-        final signed = await _repository.signPset(
-          pset: pset,
+    var unfrozenDecoyCount = 0;
+    for (final batch in batches) {
+      final String signed;
+      try {
+        signed = await _repository.signPset(
+          pset: batch.pset,
           walletId: walletId,
         );
-        txids.add(await _broadcast.execute(signed));
+      } catch (e) {
+        // txids collected so far already broadcast — a retry must not
+        // resend them (see ConsolidationSignFailure.succeededTxids). Sync
+        // now if any did, same reasoning as the full-success path below.
+        if (txids.isNotEmpty) await _syncPastThisRound(walletId);
+        return Err(
+          ConsolidationSignFailure(List.unmodifiable(txids), e.toString()),
+        );
       }
-      return txids;
-    } catch (e) {
-      throw ConsolidationException(e.toString(), List.unmodifiable(txids));
+      final String txid;
+      try {
+        txid = await _broadcast.execute(signed);
+      } catch (e) {
+        if (txids.isNotEmpty) await _syncPastThisRound(walletId);
+        return Err(
+          ConsolidationBroadcastFailure(List.unmodifiable(txids), e.toString()),
+        );
+      }
+      txids.add(txid);
+
+      // Best-effort: freezing the decoy is bookkeeping, not fund safety — a
+      // failure here doesn't undo the successful broadcast, but the caller
+      // surfaces unfrozenDecoyCount so the user knows to freeze it manually.
+      try {
+        await _utxoRepository.freezeUtxos(
+          walletId: walletId,
+          outpoints: [(txId: txid, vout: batch.decoyVout)],
+        );
+      } catch (_) {
+        unfrozenDecoyCount++;
+      }
+    }
+
+    if (txids.isNotEmpty) {
+      await _syncPastThisRound(walletId);
+    }
+    return Ok(
+      ConsolidationBroadcastResult(
+        txids: txids,
+        unfrozenDecoyCount: unfrozenDecoyCount,
+      ),
+    );
+  }
+
+  Future<void> _syncPastThisRound(String walletId) async {
+    try {
+      final wallet = await _getWallet.execute(walletId);
+      if (wallet != null) await _sync.execute(wallet);
+    } catch (_) {
+      // Best-effort: a failure here just means the next sync's default
+      // gap-limit scan may lag one round behind — not fatal, but worth
+      // being aware nothing else currently backstops it.
     }
   }
-}
-
-class ConsolidationException extends BullException {
-  /// Txids that already broadcast successfully before this failure occurred
-  /// (empty if the failure happened before anything broadcast, e.g. during
-  /// [ConsolidateLiquidWalletUsecase.prepare]).
-  final List<String> succeededTxids;
-
-  ConsolidationException(super.message, [this.succeededTxids = const []]);
 }

--- a/lib/features/consolidation/presentation/consolidation_banner_cubit.dart
+++ b/lib/features/consolidation/presentation/consolidation_banner_cubit.dart
@@ -1,11 +1,6 @@
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-/// Whether [ConsolidationBanner] should show for one wallet — the seam
-/// between that widget and [CheckLiquidConsolidationUsecase], so the widget
-/// never resolves/calls the use-case itself (ui → presentation → usecase,
-/// AGENTS.md rule #2). One instance per banner (per wallet), created via
-/// `locator<ConsolidationBannerCubit>(param1: walletId)`.
 class ConsolidationBannerCubit extends Cubit<bool> {
   final CheckLiquidConsolidationUsecase _check;
 
@@ -17,12 +12,10 @@ class ConsolidationBannerCubit extends Cubit<bool> {
   }) : _check = checkLiquidConsolidationUsecase,
        super(false);
 
-  /// Best-effort: this drives a non-critical banner, so a failed read just
-  /// keeps the last known value rather than surfacing an error.
   Future<void> reload() async {
     try {
-      final required = await _check.execute(walletId: _walletId);
-      if (!isClosed) emit(required);
+      final status = await _check.execute(walletId: _walletId);
+      if (!isClosed) emit(status.isRequired);
     } catch (_) {
       // Keep the last known value.
     }

--- a/lib/features/consolidation/presentation/consolidation_cubit.dart
+++ b/lib/features/consolidation/presentation/consolidation_cubit.dart
@@ -1,84 +1,127 @@
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-/// Presentation layer for the consolidation screen. Loads the UTXO count and a
-/// fee preview, then drives the review → broadcasting → success/failed flow.
-/// No business decisions live here — it delegates to
-/// [ConsolidateLiquidWalletUsecase].
 class ConsolidationCubit extends Cubit<ConsolidationState> {
   final ConsolidateLiquidWalletUsecase _consolidate;
   final CheckLiquidConsolidationUsecase _check;
+  final GetWalletUsecase _getWallet;
+  final SyncWalletUsecase _sync;
 
   ConsolidationCubit({
     required String walletId,
     required ConsolidateLiquidWalletUsecase consolidateLiquidWalletUsecase,
     required CheckLiquidConsolidationUsecase checkLiquidConsolidationUsecase,
+    required GetWalletUsecase getWalletUsecase,
+    required SyncWalletUsecase syncWalletUsecase,
   }) : _consolidate = consolidateLiquidWalletUsecase,
        _check = checkLiquidConsolidationUsecase,
+       _getWallet = getWalletUsecase,
+       _sync = syncWalletUsecase,
        super(ConsolidationState(walletId: walletId));
 
   Future<void> load() async {
-    // L-BTC UTXO count (asset-accurate) for the "outputs before" display.
-    final utxoCount = await _check.count(walletId: state.walletId);
-    if (!isClosed && utxoCount != null) {
-      emit(state.copyWith(utxoCount: utxoCount));
-    }
-    // Build the PSETs up front so the real network fee can be shown before
-    // the user confirms.
     try {
-      final preview = await _consolidate.prepare(walletId: state.walletId);
-      if (!isClosed) emit(state.copyWith(preview: preview));
-    } catch (e) {
-      // Leave the preview/fee unavailable (shown as "—"), but still log the
-      // cause — previously this was silently discarded, making a real build
-      // failure indistinguishable from "still loading" with no way to
-      // diagnose why the fee never appeared.
-      log.warning('Consolidation prepare failed: $e');
+      final wallet = await _getWallet.execute(state.walletId);
+      if (!isClosed && wallet != null) {
+        emit(state.copyWith(balanceSat: wallet.balanceSat.toInt()));
+      }
+    } catch (_) {
+      // Best-effort: the balance row just stays at 0.
+    }
+
+    // L-BTC UTXO count (asset-accurate) for the "outputs before" display.
+    final status = await _check.execute(walletId: state.walletId);
+    if (!isClosed && status.utxoCount != null) {
+      emit(state.copyWith(utxoCount: status.utxoCount!));
+    }
+
+    final previewResult = await _consolidate.prepare(walletId: state.walletId);
+    if (!isClosed) {
+      switch (previewResult) {
+        case Ok(:final value):
+          emit(state.copyWith(preview: value, utxoCount: value.utxoCount));
+        case Err(:final failure):
+          log.warning('Consolidation prepare failed: ${failure.logMessage}');
+          emit(
+            state.copyWith(
+              status: ConsolidationStatus.failed,
+              failure: failure,
+            ),
+          );
+      }
     }
   }
 
   Future<void> consolidate() async {
-    // Re-entrancy guard: a second call (e.g. a fast double-tap landing before
-    // the UI's own `disabled` rebuild takes effect) must be a no-op rather
-    // than running the whole build→sign→broadcast pipeline concurrently a
-    // second time against the same, still-unbroadcast PSETs.
     if (state.status == ConsolidationStatus.broadcasting) return;
 
     emit(state.copyWith(status: ConsolidationStatus.broadcasting));
-    try {
-      // consolidate (build) → sign → broadcast. batchBroadcast loops the same
-      // broadcastLiquidTransaction usecase a normal send uses.
-      final preview =
-          state.preview ?? await _consolidate.prepare(walletId: state.walletId);
-      await _consolidate.broadcast(
+
+    var preview = state.preview;
+    if (preview == null) {
+      try {
+        final wallet = await _getWallet.execute(state.walletId);
+        if (wallet != null) await _sync.execute(wallet);
+      } catch (e) {
+        log.warning('Consolidation pre-retry sync failed: $e');
+        if (!isClosed) {
+          emit(
+            state.copyWith(
+              status: ConsolidationStatus.failed,
+              failure: ConsolidationSyncFailure(e.toString()),
+            ),
+          );
+        }
+        return;
+      }
+
+      final previewResult = await _consolidate.prepare(
         walletId: state.walletId,
-        unsignedPsets: preview.unsignedPsets,
       );
-      if (!isClosed) {
-        emit(state.copyWith(status: ConsolidationStatus.success));
+      switch (previewResult) {
+        case Ok(:final value):
+          preview = value;
+        case Err(:final failure):
+          if (!isClosed) {
+            emit(
+              state.copyWith(
+                status: ConsolidationStatus.failed,
+                failure: failure,
+              ),
+            );
+          }
+          return;
       }
-    } catch (e) {
-      // No funds are ever double-spent (an already-broadcast PSET's inputs
-      // are already spent, so the network simply rejects a resubmission),
-      // but a stale `preview` left in state would still repeatedly retry
-      // the very same (partially already-spent) PSET list on every tap —
-      // never reaching whichever batches never got a chance to broadcast,
-      // and never surfacing that some of them actually did succeed. Clear
-      // it so the next attempt always calls `prepare()` again, rebuilding
-      // fresh PSETs.
-      final succeededTxids = e is ConsolidationException
-          ? e.succeededTxids
-          : const <String>[];
-      log.warning(
-        'Consolidation broadcast failed: $e '
-        '(${succeededTxids.length} batch(es) already succeeded)',
-      );
-      if (!isClosed) {
-        emit(state.copyWith(status: ConsolidationStatus.failed, preview: null));
-      }
+    }
+
+    final broadcastResult = await _consolidate.broadcast(
+      walletId: state.walletId,
+      batches: preview.batches,
+    );
+    if (isClosed) return;
+    switch (broadcastResult) {
+      case Ok(:final value):
+        emit(
+          state.copyWith(
+            status: ConsolidationStatus.success,
+            unfrozenDecoyCount: value.unfrozenDecoyCount,
+          ),
+        );
+      case Err(:final failure):
+        emit(
+          state.copyWith(
+            status: ConsolidationStatus.failed,
+            failure: failure,
+            preview: null,
+          ),
+        );
     }
   }
 }

--- a/lib/features/consolidation/presentation/consolidation_failure_l10n.dart
+++ b/lib/features/consolidation/presentation/consolidation_failure_l10n.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+import 'package:flutter/widgets.dart';
+
+extension ConsolidationFailureL10n on ConsolidationFailure {
+  String toTranslated(BuildContext context) => switch (this) {
+    ConsolidationRequiredFailure() => context.loc.consolidationRequiredTitle,
+    ConsolidationCountUnavailableFailure() =>
+      context.loc.oopsSomethingWentWrong,
+    ConsolidationBuildFailure() => context.loc.consolidationFailedBody,
+    // Some batches already broadcast before this one failed — say so rather
+    // than the generic "no transaction was broadcast" message, which would
+    // be factually wrong here.
+    ConsolidationSignFailure(:final succeededTxids)
+        when succeededTxids.isNotEmpty =>
+      context.loc.consolidationPartialFailureBody(succeededTxids.length),
+    ConsolidationSignFailure() => context.loc.consolidationFailedBody,
+    ConsolidationBroadcastFailure(:final succeededTxids)
+        when succeededTxids.isNotEmpty =>
+      context.loc.consolidationPartialFailureBody(succeededTxids.length),
+    ConsolidationBroadcastFailure() => context.loc.consolidationFailedBody,
+    ConsolidationUnexpectedFailure() => context.loc.oopsSomethingWentWrong,
+    ConsolidationSyncFailure() => context.loc.consolidationSyncRetryFailedBody,
+  };
+}

--- a/lib/features/consolidation/presentation/consolidation_state.dart
+++ b/lib/features/consolidation/presentation/consolidation_state.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/features/consolidation/domain/consolidation_config.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
 import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -13,17 +14,24 @@ abstract class ConsolidationState with _$ConsolidationState {
   const factory ConsolidationState({
     required String walletId,
     @Default(ConsolidationStatus.idle) ConsolidationStatus status,
+    // Wallet balance for the header/amount row; fetched via GetWalletUsecase
+    // (core), not the `wallet` feature's WalletBloc — see ConsolidationCubit.
+    @Default(0) int balanceSat,
     // Confirmed L-BTC UTXO count (outputs "before"); null until loaded.
     int? utxoCount,
-    // Built PSETs + total fee; null until `prepare` succeeds (needs lwk
-    // `consolidate`, so null — fee shows "—" — until the SDK is bumped).
+    // Built batches + total fee; null until `prepare` succeeds.
     ConsolidationPreview? preview,
+    ConsolidationFailure? failure,
+    // Set after a successful broadcast if one or more decoy outputs failed
+    // to freeze (bookkeeping, not a fund-safety issue — see
+    // ConsolidateLiquidWalletUsecase.broadcast).
+    @Default(0) int unfrozenDecoyCount,
   }) = _ConsolidationState;
 
   const ConsolidationState._();
 
-  /// Whether a non-empty preview (built PSETs) is available.
-  bool get _hasPreview => preview != null && preview!.unsignedPsets.isNotEmpty;
+  /// Whether a non-empty preview (built batches) is available.
+  bool get _hasPreview => preview != null && preview!.batches.isNotEmpty;
 
   /// Total network fee across all consolidation transactions, or null if not
   /// yet known (no PSETs built).

--- a/lib/features/consolidation/public/consolidation_facade.dart
+++ b/lib/features/consolidation/public/consolidation_facade.dart
@@ -1,16 +1,19 @@
+export 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+export 'package:bb_mobile/features/consolidation/presentation/consolidation_failure_l10n.dart';
 export 'package:bb_mobile/features/consolidation/ui/consolidation_router.dart';
 export 'package:bb_mobile/features/consolidation/ui/widgets/consolidation_banner.dart';
 
-/// Public contract of the `consolidation` feature. Other features must never
-/// import `consolidation`'s `domain/`, `data/`, or `ui/` internals directly —
-/// this facade (plus its `export`ed types/widgets) is the only surface.
-///
-/// This feature's actual "is consolidation required" check
-/// ([CheckLiquidConsolidationUsecase]) lives in `core/wallet/domain/`, not
-/// inside this feature, so it's already legitimately importable by any
-/// feature directly (as shared core infrastructure) — it doesn't need to be
-/// re-exported here. What this facade narrows is the feature-owned surface:
-/// the route and the banner widgets consumers navigate to / render.
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
+
 class ConsolidationFacade {
-  const ConsolidationFacade();
+  final CheckLiquidConsolidationUsecase _check;
+
+  ConsolidationFacade({
+    required CheckLiquidConsolidationUsecase checkLiquidConsolidationUsecase,
+  }) : _check = checkLiquidConsolidationUsecase;
+
+  Future<bool> isConsolidationRequired({required String walletId}) async {
+    final status = await _check.execute(walletId: walletId);
+    return status.isRequired;
+  }
 }

--- a/lib/features/consolidation/ui/consolidation_router.dart
+++ b/lib/features/consolidation/ui/consolidation_router.dart
@@ -1,6 +1,5 @@
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_cubit.dart';
 import 'package:bb_mobile/features/consolidation/ui/screens/consolidation_screen.dart';
-import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -17,14 +16,6 @@ class ConsolidationRouter {
   static final route = GoRoute(
     name: ConsolidationRoute.consolidation.name,
     path: ConsolidationRoute.consolidation.path,
-    redirect: (context, state) {
-      // Deep-link / refresh with no wallet id → fall back to home rather than
-      // force-unwrap-crash.
-      if (state.pathParameters['walletId'] == null) {
-        return WalletRoute.walletHome.path;
-      }
-      return null;
-    },
     builder: (context, state) {
       final walletId = state.pathParameters['walletId']!;
       return BlocProvider(

--- a/lib/features/consolidation/ui/screens/consolidation_screen.dart
+++ b/lib/features/consolidation/ui/screens/consolidation_screen.dart
@@ -7,19 +7,13 @@ import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_cubit.dart';
+import 'package:bb_mobile/features/consolidation/presentation/consolidation_failure_l10n.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_state.dart';
-import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 
-/// Confirmation + progress screen for consolidating a Liquid wallet. Styled to
-/// match the Send confirm screen (top bar, header, info rows, primary button).
-///
-/// Consolidation is a set of self-transactions (many outputs → a few), so it
-/// broadcasts through the same Liquid pipeline as a normal send: review →
-/// broadcasting → success (or the failure banner). All logic lives in
-/// [ConsolidationCubit].
 class ConsolidationScreen extends StatelessWidget {
   const ConsolidationScreen({super.key});
 
@@ -65,7 +59,7 @@ class _Body extends StatelessWidget {
       case ConsolidationStatus.broadcasting:
         return const _BroadcastingView();
       case ConsolidationStatus.success:
-        return const _SuccessView();
+        return _SuccessView(unfrozenDecoyCount: state.unfrozenDecoyCount);
       case ConsolidationStatus.idle:
       case ConsolidationStatus.failed:
         return _ReviewView(state: state);
@@ -80,15 +74,7 @@ class _ReviewView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final wallet = context.select((WalletBloc bloc) {
-      try {
-        return bloc.state.wallets.firstWhere((w) => w.id == state.walletId);
-      } catch (_) {
-        return null;
-      }
-    });
-
-    final balanceSat = wallet?.balanceSat.toInt() ?? 0;
+    final balanceSat = state.balanceSat;
     final before = state.utxoCount;
     final after = state.transactionCount;
     final feeSat = state.feeSat;
@@ -104,7 +90,9 @@ class _ReviewView extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: ConsolidationRequiredCard(
                 title: context.loc.consolidationFailedTitle,
-                body: context.loc.consolidationFailedBody,
+                body:
+                    state.failure?.toTranslated(context) ??
+                    context.loc.consolidationFailedBody,
               ),
             ),
             const Gap(24),
@@ -173,6 +161,7 @@ class _ReviewView extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: BBButton.big(
               label: context.loc.consolidationScreenTitle,
+              disabled: state.status == ConsolidationStatus.broadcasting,
               onPressed: () => context.read<ConsolidationCubit>().consolidate(),
               bgColor: context.appColors.secondary,
               textColor: context.appColors.onSecondary,
@@ -194,7 +183,6 @@ class _ReviewView extends StatelessWidget {
       Container(height: 1, color: context.appColors.secondaryFixedDim);
 }
 
-/// Label/value row matching the Send confirm screen's `InfoRow`.
 class _InfoRow extends StatelessWidget {
   const _InfoRow({required this.title, required this.details});
 
@@ -279,7 +267,9 @@ class _BroadcastingView extends StatelessWidget {
 }
 
 class _SuccessView extends StatelessWidget {
-  const _SuccessView();
+  const _SuccessView({required this.unfrozenDecoyCount});
+
+  final int unfrozenDecoyCount;
 
   @override
   Widget build(BuildContext context) {
@@ -303,10 +293,22 @@ class _SuccessView extends StatelessWidget {
               textAlign: TextAlign.center,
               maxLines: 4,
             ),
+            if (unfrozenDecoyCount > 0) ...[
+              const Gap(16),
+              BBText(
+                context.loc.consolidationUnfrozenDecoyWarning(
+                  unfrozenDecoyCount,
+                ),
+                style: context.font.bodySmall,
+                color: context.appColors.error,
+                textAlign: TextAlign.center,
+                maxLines: 4,
+              ),
+            ],
             const Gap(24),
             BBButton.big(
               label: context.loc.consolidationDone,
-              onPressed: () => Navigator.of(context).maybePop(),
+              onPressed: () => context.go('/wallet'),
               bgColor: context.appColors.secondary,
               textColor: context.appColors.onSecondary,
             ),

--- a/lib/features/consolidation/ui/widgets/consolidation_banner.dart
+++ b/lib/features/consolidation/ui/widgets/consolidation_banner.dart
@@ -3,87 +3,97 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/widgets/cards/consolidation_required_card.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_banner_cubit.dart';
 import 'package:bb_mobile/features/consolidation/ui/consolidation_router.dart';
-import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
-class ConsolidationBanner extends StatelessWidget {
+class ConsolidationBanner extends StatefulWidget {
   const ConsolidationBanner({
     super.key,
     required this.wallet,
     this.showWalletName = false,
+    this.isRefreshing = false,
   });
 
   final Wallet wallet;
   final bool showWalletName;
 
+  final bool isRefreshing;
   @override
-  Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) =>
-          locator<ConsolidationBannerCubit>(param1: wallet.id)..reload(),
-      child: _ConsolidationBannerView(
-        wallet: wallet,
-        showWalletName: showWalletName,
-      ),
-    );
-  }
+  State<ConsolidationBanner> createState() => _ConsolidationBannerState();
 }
 
-class _ConsolidationBannerView extends StatelessWidget {
-  const _ConsolidationBannerView({
-    required this.wallet,
-    required this.showWalletName,
-  });
+class _ConsolidationBannerState extends State<ConsolidationBanner> {
+  late final ConsolidationBannerCubit _cubit;
 
-  final Wallet wallet;
-  final bool showWalletName;
+  @override
+  void initState() {
+    super.initState();
+    _cubit = locator<ConsolidationBannerCubit>(param1: widget.wallet.id)
+      ..reload();
+  }
+
+  @override
+  void didUpdateWidget(covariant ConsolidationBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isRefreshing && !widget.isRefreshing) {
+      _cubit.reload();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cubit.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<WalletBloc, WalletState>(
-      // Re-check after a sync finishes (a received tx may push it over).
-      listenWhen: (prev, curr) => prev.isRefreshing && !curr.isRefreshing,
-      listener: (context, _) =>
-          context.read<ConsolidationBannerCubit>().reload(),
-      child: BlocBuilder<ConsolidationBannerCubit, bool>(
-        builder: (context, required) {
-          if (!required) return const SizedBox.shrink();
-          return Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-            child: ConsolidationRequiredCard(
-              title: showWalletName
-                  ? context.loc.consolidationRequiredTitleNamed(
-                      wallet.displayLabel(context),
-                    )
-                  : context.loc.consolidationRequiredTitle,
-              onTap: () => context.pushNamed(
-                ConsolidationRoute.consolidation.name,
-                pathParameters: {'walletId': wallet.id},
-              ),
+    return BlocBuilder<ConsolidationBannerCubit, bool>(
+      bloc: _cubit,
+      builder: (context, required) {
+        if (!required) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          child: ConsolidationRequiredCard(
+            title: widget.showWalletName
+                ? context.loc.consolidationRequiredTitleNamed(
+                    widget.wallet.displayLabel(context),
+                  )
+                : context.loc.consolidationRequiredTitle,
+            onTap: () => context.pushNamed(
+              ConsolidationRoute.consolidation.name,
+              pathParameters: {'walletId': widget.wallet.id},
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }
 
 class HomeConsolidationBanner extends StatelessWidget {
-  const HomeConsolidationBanner({super.key});
+  const HomeConsolidationBanner({
+    super.key,
+    required this.liquidWallets,
+    this.isRefreshing = false,
+  });
+
+  final List<Wallet> liquidWallets;
+  final bool isRefreshing;
 
   @override
   Widget build(BuildContext context) {
-    final liquidWallets = context.select<WalletBloc, List<Wallet>>(
-      (bloc) => bloc.state.wallets.where((w) => w.isLiquid).toList(),
-    );
     if (liquidWallets.isEmpty) return const SizedBox.shrink();
     return Column(
       children: [
         for (final wallet in liquidWallets)
-          ConsolidationBanner(wallet: wallet, showWalletName: true),
+          ConsolidationBanner(
+            wallet: wallet,
+            showWalletName: true,
+            isRefreshing: isRefreshing,
+          ),
       ],
     );
   }

--- a/lib/features/send/domain/usecases/check_liquid_consolidation_required_usecase.dart
+++ b/lib/features/send/domain/usecases/check_liquid_consolidation_required_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
+
+class CheckLiquidConsolidationRequiredUsecase {
+  final ConsolidationFacade _facade;
+
+  CheckLiquidConsolidationRequiredUsecase({
+    required ConsolidationFacade consolidationFacade,
+  }) : _facade = consolidationFacade;
+
+  Future<bool> execute({required String walletId}) {
+    return _facade.isConsolidationRequired(walletId: walletId);
+  }
+}

--- a/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
@@ -1,13 +1,22 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
-import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 
 class PrepareLiquidSendUsecase {
   final LiquidWalletRepository _liquidWalletRepository;
+  final WalletUtxoRepository _walletUtxoRepository;
+  final WalletAddressRepository _walletAddressRepository;
 
-  PrepareLiquidSendUsecase({required this._liquidWalletRepository});
+  PrepareLiquidSendUsecase({
+    required this._liquidWalletRepository,
+    required this._walletUtxoRepository,
+    required this._walletAddressRepository,
+  });
 
   Future<String> execute({
     required String walletId,
@@ -21,14 +30,52 @@ class PrepareLiquidSendUsecase {
         throw Exception('Amount cannot be empty if drain is not true');
       }
 
-      final psbt = await _liquidWalletRepository.buildPset(
+      // Built via buildCustomTx (an explicit UTXO list) rather than the
+      // LWK-coin-selecting buildPset, specifically so a frozen UTXO (e.g. a
+      // consolidation decoy, which must never be re-spent — see the
+      // consolidation feature) is never even offered to the builder, not
+      // just excluded from the UI's own bookkeeping.
+      final confirmed = await _liquidWalletRepository.getConfirmedLbtcOutpoints(
         walletId: walletId,
-        address: address,
-        amountSat: drain ? null : amountSat,
-        feeRate: feeRate,
-        drain: drain,
       );
-      return psbt;
+      final frozen = (await _walletUtxoRepository.getAllFrozenOutpoints())
+          .toSet();
+      final usable = confirmed.where((o) => !frozen.contains(o)).toList();
+
+      if (usable.isEmpty) {
+        throw NoSpendableUtxoException(
+          'Wallet $walletId has no spendable (confirmed, unfrozen) L-BTC '
+          'UTXOs',
+        );
+      }
+      if (_liquidWalletRepository.exceedsLiquidInputLimit(usable.length)) {
+        throw ConsolidationRequiredException(
+          'Wallet $walletId exceeds the Liquid confidential-tx input limit',
+        );
+      }
+
+      // Drain (send-all): everything in the usable set goes to the
+      // recipient, no change back to self. Normal send: pay the recipient,
+      // sweep the rest to a freshly reserved address of our own — reserved
+      // through WalletAddressRepository (not a raw index lookup) so this
+      // doesn't race the receive flow's own address reservation.
+      final outputs = drain
+          ? const <LiquidTxOutput>[]
+          : [LiquidTxOutput(address: address, satoshi: amountSat!)];
+      final drainToAddress = drain
+          ? address
+          : (await _walletAddressRepository.generateNewReceiveAddress(
+              walletId: walletId,
+            )).address;
+
+      final pset = await _liquidWalletRepository.buildCustomTx(
+        walletId: walletId,
+        utxos: usable,
+        outputs: outputs,
+        drainToAddress: drainToAddress,
+        feeRate: feeRate,
+      );
+      return pset;
     } on NoSpendableUtxoException {
       rethrow;
     } on ConsolidationRequiredException {

--- a/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
@@ -2,7 +2,6 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -14,7 +14,6 @@ import 'package:bb_mobile/core/payjoin/domain/usecases/send_with_payjoin_usecase
 import 'package:bb_mobile/core/payjoin/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/create_chain_swap_to_external_usecase.dart';
@@ -36,10 +35,12 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.d
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:bb_mobile/core/widgets/fees/fee_modal_controller.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_pset_size_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/check_liquid_consolidation_required_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/create_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
@@ -93,7 +94,7 @@ class SendCubit extends Cubit<SendState>
     required this._verifyChainSwapAmountSendUsecase,
     required this._previewBitcoinFeeUsecase,
     required this._previewBitcoinFeePresetsUsecase,
-    required this._checkLiquidConsolidationUsecase,
+    required this._checkLiquidConsolidationRequiredUsecase,
   }) : super(const SendState());
 
   /// Distinct user-defined labels for the suggestion chips in the label
@@ -142,7 +143,8 @@ class SendCubit extends Cubit<SendState>
   final VerifyChainSwapAmountSendUsecase _verifyChainSwapAmountSendUsecase;
   final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
-  final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
+  final CheckLiquidConsolidationRequiredUsecase
+  _checkLiquidConsolidationRequiredUsecase;
 
   StreamSubscription<Swap>? _swapSubscription;
   StreamSubscription<Wallet>? _selectedWalletSyncingSubscription;
@@ -1176,14 +1178,15 @@ class SendCubit extends Cubit<SendState>
       // Proactively flag consolidation for Liquid wallets whose UTXO count is
       // over the threshold, so the card shows before a build is attempted. The
       // ConsolidationRequiredException remains the backstop on the build path.
-      // Routed through CheckLiquidConsolidationUsecase (the same check the
+      // Routed through CheckLiquidConsolidationRequiredUsecase (which wraps
+      // ConsolidationFacade.isConsolidationRequired, the same check the
       // consolidation banner uses) rather than re-deriving the comparison
       // here from a possibly-differently-filtered UTXO list, so this and the
       // banner can never disagree about whether the wallet needs
       // consolidating.
       final consolidationRequired =
           (state.selectedWallet?.isLiquid ?? false) &&
-          await _checkLiquidConsolidationUsecase.execute(
+          await _checkLiquidConsolidationRequiredUsecase.execute(
             walletId: state.selectedWallet!.id,
           );
       emit(

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -22,15 +22,16 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repositor
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_pset_size_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/check_liquid_consolidation_required_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/create_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
@@ -147,6 +148,11 @@ class SendLocator {
         walletRepository: locator<WalletRepository>(),
       ),
     );
+    locator.registerFactory<CheckLiquidConsolidationRequiredUsecase>(
+      () => CheckLiquidConsolidationRequiredUsecase(
+        consolidationFacade: locator<ConsolidationFacade>(),
+      ),
+    );
   }
 
   static void registerBlocs(GetIt locator) {
@@ -197,8 +203,8 @@ class SendLocator {
         previewBitcoinFeeUsecase: locator<PreviewBitcoinFeeUsecase>(),
         previewBitcoinFeePresetsUsecase:
             locator<PreviewBitcoinFeePresetsUsecase>(),
-        checkLiquidConsolidationUsecase:
-            locator<CheckLiquidConsolidationUsecase>(),
+        checkLiquidConsolidationRequiredUsecase:
+            locator<CheckLiquidConsolidationRequiredUsecase>(),
       ),
     );
   }

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -18,6 +18,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
@@ -63,6 +64,8 @@ class SendLocator {
     locator.registerFactory<PrepareLiquidSendUsecase>(
       () => PrepareLiquidSendUsecase(
         liquidWalletRepository: locator<LiquidWalletRepository>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+        walletAddressRepository: locator<WalletAddressRepository>(),
       ),
     );
     locator.registerFactory<SignLiquidTxUsecase>(

--- a/lib/features/swap/domain/check_liquid_consolidation_required_usecase.dart
+++ b/lib/features/swap/domain/check_liquid_consolidation_required_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
+
+class CheckLiquidConsolidationRequiredUsecase {
+  final ConsolidationFacade _facade;
+
+  CheckLiquidConsolidationRequiredUsecase({
+    required ConsolidationFacade consolidationFacade,
+  }) : _facade = consolidationFacade;
+
+  Future<bool> execute({required String walletId}) {
+    return _facade.isConsolidationRequired(walletId: walletId);
+  }
+}

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -4,7 +4,6 @@ import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_tran
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
@@ -29,8 +28,10 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:bb_mobile/core/widgets/fees/fee_modal_controller.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/swap/domain/check_liquid_consolidation_required_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
@@ -76,7 +77,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     required this._convertSatsToCurrencyAmountUsecase,
     required this._previewBitcoinFeeUsecase,
     required this._previewBitcoinFeePresetsUsecase,
-    required this._checkLiquidConsolidationUsecase,
+    required this._checkLiquidConsolidationRequiredUsecase,
   }) : super(const TransferState()) {
     on<TransferStarted>(_onStarted);
     on<TransferWalletsChanged>(_onWalletsChanged);
@@ -125,7 +126,8 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
   final ConvertSatsToCurrencyAmountUsecase _convertSatsToCurrencyAmountUsecase;
   final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
-  final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
+  final CheckLiquidConsolidationRequiredUsecase
+  _checkLiquidConsolidationRequiredUsecase;
 
   /// Bumped by [_clearBitcoinFeePreviews]; a preview build captures it
   /// before its `await` and re-checks before writing back, so an
@@ -310,14 +312,17 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     // Proactively flag consolidation when the source is a Liquid wallet with
     // too many UTXOs, so the card shows before the swap build is attempted.
     // The ConsolidationRequiredException remains the backstop on the build.
-    // Routed through CheckLiquidConsolidationUsecase (the same check the
+    // Routed through CheckLiquidConsolidationRequiredUsecase (which wraps
+    // ConsolidationFacade.isConsolidationRequired, the same check the
     // consolidation banner and `send` use) rather than re-deriving the
     // comparison here from this bloc's own UTXO read, so all three surfaces
     // can never disagree about whether the wallet needs consolidating.
     if (newFromWallet.isLiquid) {
       try {
-        final consolidationRequired = await _checkLiquidConsolidationUsecase
-            .execute(walletId: newFromWallet.id);
+        final consolidationRequired =
+            await _checkLiquidConsolidationRequiredUsecase.execute(
+              walletId: newFromWallet.id,
+            );
         emit(state.copyWith(consolidationRequired: consolidationRequired));
       } catch (_) {
         // Best-effort: leave the flag as-is on a read failure.

--- a/lib/features/swap/swap_locator.dart
+++ b/lib/features/swap/swap_locator.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
@@ -51,6 +52,8 @@ class SwapLocator {
     locator.registerFactory<PrepareLiquidSendUsecase>(
       () => PrepareLiquidSendUsecase(
         liquidWalletRepository: locator<LiquidWalletRepository>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+        walletAddressRepository: locator<WalletAddressRepository>(),
       ),
     );
     locator.registerFactory<SignLiquidTxUsecase>(

--- a/lib/features/swap/swap_locator.dart
+++ b/lib/features/swap/swap_locator.dart
@@ -18,14 +18,15 @@ import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
+import 'package:bb_mobile/features/swap/domain/check_liquid_consolidation_required_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
@@ -114,6 +115,11 @@ class SwapLocator {
         ),
       ),
     );
+    locator.registerFactory<CheckLiquidConsolidationRequiredUsecase>(
+      () => CheckLiquidConsolidationRequiredUsecase(
+        consolidationFacade: locator<ConsolidationFacade>(),
+      ),
+    );
   }
 
   static void registerBlocs(GetIt locator) {
@@ -152,8 +158,8 @@ class SwapLocator {
         previewBitcoinFeeUsecase: locator<PreviewBitcoinFeeUsecase>(),
         previewBitcoinFeePresetsUsecase:
             locator<PreviewBitcoinFeePresetsUsecase>(),
-        checkLiquidConsolidationUsecase:
-            locator<CheckLiquidConsolidationUsecase>(),
+        checkLiquidConsolidationRequiredUsecase:
+            locator<CheckLiquidConsolidationRequiredUsecase>(),
       ),
     );
   }

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -226,14 +226,14 @@ class SwapPageState extends State<SwapPage> {
                           padding: const EdgeInsets.only(bottom: 12),
                           child: ConsolidationRequiredCard(
                             title: context.loc.consolidationRequiredTitle,
-                            onTap: () {
+                            onTap: () async {
                               final walletId = context
                                   .read<TransferBloc>()
                                   .state
                                   .fromWallet
                                   ?.id;
                               if (walletId != null) {
-                                context.pushNamed(
+                                await context.pushNamed(
                                   ConsolidationRoute.consolidation.name,
                                   pathParameters: {'walletId': walletId},
                                 );

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -40,6 +40,9 @@ class WalletDetailScreen extends StatelessWidget {
       }
     });
     final walletName = wallet != null ? wallet.displayLabel(context) : '';
+    final isRefreshing = context.select(
+      (WalletBloc bloc) => bloc.state.isRefreshing,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -75,7 +78,10 @@ class WalletDetailScreen extends StatelessWidget {
                   ),
                   if (wallet.isLiquid)
                     SliverToBoxAdapter(
-                      child: ConsolidationBanner(wallet: wallet),
+                      child: ConsolidationBanner(
+                        wallet: wallet,
+                        isRefreshing: isRefreshing,
+                      ),
                     ),
                   if (wallet.isBitcoin) ...[
                     const SliverToBoxAdapter(child: Gap(8)),

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -142,6 +142,19 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                 const SliverToBoxAdapter(child: AutoSwapFeeWarning()),
                 const SliverToBoxAdapter(child: HomeConsolidationBanner()),
                 SliverToBoxAdapter(
+                  child: BlocBuilder<WalletBloc, WalletState>(
+                    buildWhen: (previous, current) =>
+                        previous.wallets != current.wallets ||
+                        previous.isRefreshing != current.isRefreshing,
+                    builder: (context, state) => HomeConsolidationBanner(
+                      liquidWallets: state.wallets
+                          .where((w) => w.isLiquid)
+                          .toList(),
+                      isRefreshing: state.isRefreshing,
+                    ),
+                  ),
+                ),
+                SliverToBoxAdapter(
                   child: WalletCards(
                     onTap: (w) {
                       context.pushNamed(

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -67,7 +67,9 @@
   "@swapRestoreActionable": {
     "description": "Header count of restorable swaps with locked, unresolved funds",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "swapRestoreNoSwaps": "No swaps found to restore",
@@ -15008,5 +15010,35 @@
   "receivePayjoinBelowMinimumAmount": "Payjoin is off for this amount — it is below your Payjoin minimum. Request a larger amount to enable it.",
   "@receivePayjoinBelowMinimumAmount": {
     "description": "Hint on the receive screen when payjoin is enabled but the requested amount is below the anti-probing minimum, so the QR does not advertise a payjoin endpoint."
+  },
+  "receivePayjoinNoUtxos": "Receive funds first to enable it.\nUTXOs are required to use payjoin.",
+  "@receivePayjoinNoUtxos": {
+    "description": "Snackbar shown when user tries to enable payjoin on a wallet without any UTXOs"
+  },
+  "receivePayjoinActivated": "Payjoin activated",
+  "@receivePayjoinActivated": {
+    "description": "Message indicating that payjoin is activated for the receive transaction"
+  },
+  "consolidationPartialFailureBody": "{count, plural, =1{1 transaction was} other{{count} transactions were}} already broadcast before this failed. Your funds are safe. Try again to consolidate the rest.",
+  "@consolidationPartialFailureBody": {
+    "description": "Body of the error banner when some but not all consolidation transactions broadcast before a later one failed",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "consolidationUnfrozenDecoyWarning": "{count, plural, =1{1 decoy output} other{{count} decoy outputs}} could not be frozen automatically — you can freeze it manually from the Coins screen.",
+  "@consolidationUnfrozenDecoyWarning": {
+    "description": "Warning shown on the consolidation success screen when one or more decoy outputs failed to auto-freeze",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "consolidationSyncRetryFailedBody": "Couldn't refresh your wallet's data before retrying. Please check your connection and try again.",
+  "@consolidationSyncRetryFailedBody": {
+    "description": "Shown when consolidation retries after a previous failure, but refreshing the wallet's local data first fails (so nothing was built or broadcast this round)."
   }
 }

--- a/test/core_test/swaps/auto_swap_execution_usecase_test.dart
+++ b/test/core_test/swaps/auto_swap_execution_usecase_test.dart
@@ -1,0 +1,317 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
+import 'package:bb_mobile/core/swaps/domain/entity/auto_swap.dart';
+import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
+import 'package:bb_mobile/core/swaps/domain/ports/blockchain_port.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/swaps/domain/usecases/auto_swap_execution_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockBoltzSwapRepository extends Mock implements BoltzSwapRepository {}
+
+class _MockWalletRepository extends Mock implements WalletRepository {}
+
+class _MockLiquidWalletRepository extends Mock
+    implements LiquidWalletRepository {}
+
+class _MockWalletUtxoRepository extends Mock implements WalletUtxoRepository {}
+
+class _MockWalletAddressRepository extends Mock
+    implements WalletAddressRepository {}
+
+class _MockBlockchainPort extends Mock implements BlockchainPort {}
+
+class _MockWalletTransactionRepository extends Mock
+    implements WalletTransactionRepository {}
+
+class _MockLabelsFacade extends Mock implements LabelsFacade {}
+
+void main() {
+  late _MockBoltzSwapRepository boltz;
+  late _MockWalletRepository walletRepo;
+  late _MockLiquidWalletRepository liquidRepo;
+  late _MockWalletUtxoRepository utxoRepo;
+  late _MockWalletAddressRepository addressRepo;
+  late _MockBlockchainPort blockchainPort;
+  late _MockWalletTransactionRepository walletTxRepo;
+  late _MockLabelsFacade labelsFacade;
+  late AutoSwapExecutionUsecase usecase;
+
+  const liquidWalletId = 'liquid-wallet-1';
+  const bitcoinWalletId = 'bitcoin-wallet-1';
+  const changeAddress = 'lq1qqchange...';
+
+  Wallet buildWallet({
+    required String origin,
+    required bool isLiquid,
+    required BigInt balanceSat,
+  }) => Wallet(
+    origin: origin,
+    network: isLiquid ? Network.liquidMainnet : Network.bitcoinMainnet,
+    isDefault: true,
+    xpubFingerprint: 'fingerprint',
+    scriptType: ScriptType.bip84,
+    xpub: 'xpub',
+    externalPublicDescriptor: 'external-descriptor',
+    internalPublicDescriptor: 'internal-descriptor',
+    signer: SignerEntity.local,
+    signerDevice: null,
+    balanceSat: balanceSat,
+  );
+
+  final liquidWallet = buildWallet(
+    origin: liquidWalletId,
+    isLiquid: true,
+    balanceSat: BigInt.from(3000000),
+  );
+  final bitcoinWallet = buildWallet(
+    origin: bitcoinWalletId,
+    isLiquid: false,
+    balanceSat: BigInt.zero,
+  );
+
+  final chainSwap = ChainSwap(
+    id: 'swap-1',
+    keyIndex: 0,
+    type: SwapType.liquidToBitcoin,
+    status: SwapStatus.pending,
+    environment: Environment.mainnet,
+    creationTime: DateTime(2026),
+    sendWalletId: liquidWalletId,
+    paymentAddress: 'ex1qswaplockup...',
+    paymentAmount: 2000000,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const <LiquidTxOutput>[]);
+    registerFallbackValue(const RelativeFee(25));
+    registerFallbackValue(const AutoSwap());
+    registerFallbackValue(
+      NewLabel.tx(transactionId: 'fallback', label: 'fallback'),
+    );
+  });
+
+  setUp(() {
+    boltz = _MockBoltzSwapRepository();
+    walletRepo = _MockWalletRepository();
+    liquidRepo = _MockLiquidWalletRepository();
+    utxoRepo = _MockWalletUtxoRepository();
+    addressRepo = _MockWalletAddressRepository();
+    blockchainPort = _MockBlockchainPort();
+    walletTxRepo = _MockWalletTransactionRepository();
+    labelsFacade = _MockLabelsFacade();
+    usecase = AutoSwapExecutionUsecase(
+      repository: boltz,
+      walletRepository: walletRepo,
+      liquidWalletRepository: liquidRepo,
+      walletUtxoRepository: utxoRepo,
+      walletAddressRepository: addressRepo,
+      blockchainPort: blockchainPort,
+      walletTxRepository: walletTxRepo,
+      labelsFacade: labelsFacade,
+    );
+
+    when(() => boltz.getAutoSwapParams()).thenAnswer(
+      (_) async => const AutoSwap(
+        enabled: true,
+        showWarning: false,
+        recipientWalletId: bitcoinWalletId,
+        triggerBalanceSats: 2000000,
+        balanceThresholdSats: 1000000,
+      ),
+    );
+    when(
+      () => walletRepo.getWallets(environment: any(named: 'environment')),
+    ).thenAnswer((_) async => [liquidWallet, bitcoinWallet]);
+    when(() => boltz.getSwapLimitsAndFees(SwapType.liquidToBitcoin)).thenAnswer(
+      (_) async =>
+          (const SwapLimits(min: 1000, max: 10000000), const SwapFees()),
+    );
+    when(
+      () => boltz.createLiquidToBitcoinSwap(
+        sendWalletId: any(named: 'sendWalletId'),
+        amountSat: any(named: 'amountSat'),
+        btcElectrumUrl: any(named: 'btcElectrumUrl'),
+        lbtcElectrumUrl: any(named: 'lbtcElectrumUrl'),
+        receiveWalletId: any(named: 'receiveWalletId'),
+      ),
+    ).thenAnswer((_) async => chainSwap);
+    when(
+      () => liquidRepo.getConfirmedLbtcOutpoints(
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+    when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+    when(() => liquidRepo.exceedsLiquidInputLimit(any())).thenReturn(false);
+    when(
+      () => addressRepo.generateNewReceiveAddress(
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer(
+      (_) async => WalletAddress(
+        walletId: liquidWalletId,
+        index: 1,
+        address: changeAddress,
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      ),
+    );
+    when(
+      () => liquidRepo.buildCustomTx(
+        walletId: any(named: 'walletId'),
+        utxos: any(named: 'utxos'),
+        outputs: any(named: 'outputs'),
+        drainToAddress: any(named: 'drainToAddress'),
+        feeRate: any(named: 'feeRate'),
+      ),
+    ).thenAnswer((_) async => 'unsigned-pset');
+    when(
+      () => liquidRepo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+    ).thenAnswer((_) async => (200, 50));
+    when(
+      () => liquidRepo.signPset(
+        pset: any(named: 'pset'),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => 'signed-pset');
+    when(
+      () => blockchainPort.broadcastLiquidTransaction(
+        signedPset: any(named: 'signedPset'),
+        isTestnet: any(named: 'isTestnet'),
+      ),
+    ).thenAnswer((_) async => 'txid-123');
+    when(
+      () => boltz.updatePaidSendSwap(
+        swapId: any(named: 'swapId'),
+        txid: any(named: 'txid'),
+        absoluteFees: any(named: 'absoluteFees'),
+      ),
+    ).thenAnswer((_) async {});
+    when(() => boltz.updateAutoSwapParams(any())).thenAnswer((_) async {});
+    when(() => labelsFacade.store(any())).thenAnswer(
+      (_) async =>
+          Ok(Label.tx(id: 1, transactionId: 'txid-123', label: 'Auto-Swap')),
+    );
+    when(
+      () => walletTxRepo.getWalletTransaction(
+        any(),
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+      ),
+    ).thenAnswer((_) async => null);
+  });
+
+  group('frozen-UTXO enforcement: an auto-swap lockup payment is a background, '
+      'unattended send — a frozen UTXO (e.g. a consolidation decoy) must '
+      'never be able to slip into it either', () {
+    test(
+      'excludes frozen outpoints from the utxos passed to buildCustomTx',
+      () async {
+        when(
+          () => liquidRepo.getConfirmedLbtcOutpoints(
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            (txId: 'tx0', vout: 0),
+            (txId: 'tx1', vout: 0),
+            (txId: 'tx2', vout: 0),
+          ],
+        );
+        when(
+          () => utxoRepo.getAllFrozenOutpoints(),
+        ).thenAnswer((_) async => [(txId: 'tx1', vout: 0)]);
+
+        await usecase.execute(feeBlock: false);
+
+        final captured = verify(
+          () => liquidRepo.buildCustomTx(
+            walletId: liquidWalletId,
+            utxos: captureAny(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).captured;
+        final utxos = captured.single as List;
+        expect(utxos, [(txId: 'tx0', vout: 0), (txId: 'tx2', vout: 0)]);
+      },
+    );
+
+    test('throws NoSpendableUtxoException when every confirmed UTXO is '
+        'frozen, never reaching buildCustomTx', () async {
+      when(
+        () => liquidRepo.getConfirmedLbtcOutpoints(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+      when(
+        () => utxoRepo.getAllFrozenOutpoints(),
+      ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+
+      await expectLater(
+        usecase.execute(feeBlock: false),
+        throwsA(isA<NoSpendableUtxoException>()),
+      );
+      verifyNever(
+        () => liquidRepo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      );
+    });
+
+    test('throws LiquidInputLimitExceededException when the usable count '
+        'exceeds the input limit', () async {
+      when(
+        () => liquidRepo.getConfirmedLbtcOutpoints(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer(
+        (_) async => List.generate(300, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      when(() => liquidRepo.exceedsLiquidInputLimit(300)).thenReturn(true);
+
+      await expectLater(
+        usecase.execute(feeBlock: false),
+        throwsA(isA<LiquidInputLimitExceededException>()),
+      );
+    });
+  });
+
+  test('the swap lockup output and reserved change address are exactly what '
+      'gets passed to buildCustomTx', () async {
+    await usecase.execute(feeBlock: false);
+
+    final captured = verify(
+      () => liquidRepo.buildCustomTx(
+        walletId: liquidWalletId,
+        utxos: any(named: 'utxos'),
+        outputs: captureAny(named: 'outputs'),
+        drainToAddress: captureAny(named: 'drainToAddress'),
+        feeRate: any(named: 'feeRate'),
+      ),
+    ).captured;
+    final outputs = captured[0] as List<LiquidTxOutput>;
+    expect(outputs, hasLength(1));
+    expect(outputs.single.address, chainSwap.paymentAddress);
+    expect(outputs.single.satoshi, chainSwap.paymentAmount);
+    expect(captured[1], changeAddress);
+  });
+}

--- a/test/core_test/wallet/liquid_receive_address_index_datasource_test.dart
+++ b/test/core_test/wallet/liquid_receive_address_index_datasource_test.dart
@@ -1,0 +1,87 @@
+import 'package:bb_mobile/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late LiquidReceiveAddressIndexDatasource datasource;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    datasource = LiquidReceiveAddressIndexDatasource();
+  });
+
+  group('read', () {
+    test('returns null when nothing has ever been reserved', () async {
+      expect(await datasource.read('wallet-1'), isNull);
+    });
+  });
+
+  group('reserveNext', () {
+    test('starts at atLeast + 1 on a fresh wallet', () async {
+      final index = await datasource.reserveNext('wallet-1', atLeast: 5);
+
+      expect(index, 6);
+      expect(await datasource.read('wallet-1'), 6);
+    });
+
+    test('advances past the previously persisted index', () async {
+      await datasource.reserveNext('wallet-1', atLeast: 5); // -> 6
+
+      final second = await datasource.reserveNext('wallet-1', atLeast: 0);
+
+      expect(second, 7); // max(persisted=6, atLeast=0) + 1
+    });
+
+    test('self-heals to atLeast when it exceeds the persisted index', () async {
+      await datasource.reserveNext('wallet-1', atLeast: 2); // -> 3
+
+      // Simulates LWK's sync catching up past what was locally persisted
+      // (e.g. a wallet restored on a new device).
+      final next = await datasource.reserveNext('wallet-1', atLeast: 100);
+
+      expect(next, 101);
+    });
+
+    test(
+      'two concurrent reservations for the same wallet never collide',
+      () async {
+        // This is the exact race the datasource exists to close: without
+        // serialization, both calls could read the same "current" value
+        // before either writes back, returning the same index twice.
+        final results = await Future.wait([
+          datasource.reserveNext('wallet-1', atLeast: 0),
+          datasource.reserveNext('wallet-1', atLeast: 0),
+        ]);
+
+        expect(results.toSet(), hasLength(2)); // no duplicate
+        expect(results..sort(), [1, 2]);
+      },
+    );
+
+    test('different wallets reserve independently', () async {
+      final walletA = await datasource.reserveNext('wallet-a', atLeast: 0);
+      final walletB = await datasource.reserveNext('wallet-b', atLeast: 0);
+
+      expect(walletA, 1);
+      expect(walletB, 1); // not affected by wallet-a's reservation
+    });
+  });
+
+  group('ensureAtLeast', () {
+    test('bumps the persisted index up when behind', () async {
+      await datasource.reserveNext('wallet-1', atLeast: 0); // -> 1
+
+      await datasource.ensureAtLeast('wallet-1', 10);
+
+      expect(await datasource.read('wallet-1'), 10);
+    });
+
+    test('never moves the persisted index backwards', () async {
+      await datasource.reserveNext('wallet-1', atLeast: 10); // -> 11
+
+      await datasource.ensureAtLeast('wallet-1', 3);
+
+      expect(await datasource.read('wallet-1'), 11);
+    });
+  });
+}

--- a/test/core_test/wallet/wallet_repository_sync_test.dart
+++ b/test/core_test/wallet/wallet_repository_sync_test.dart
@@ -1,0 +1,197 @@
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/liquid_receive_address_index_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockBdkWalletDatasource extends Mock implements BdkWalletDatasource {}
+
+class _MockLwkWalletDatasource extends Mock implements LwkWalletDatasource {}
+
+class _MockLiquidReceiveAddressIndexDatasource extends Mock
+    implements LiquidReceiveAddressIndexDatasource {}
+
+class _MockElectrumServersPort extends Mock implements ElectrumServersPort {}
+
+/// The gap-limit regression: LWK's default sync only scans 20 consecutive
+/// unused addresses past its own last-known-used index, but the app can hand
+/// out addresses further out (receive, send change, consolidation
+/// drain/decoy, auto-swap change) without necessarily syncing in between.
+/// The fix under test: every Liquid sync passes the reservation counter's
+/// persisted index as `stopAtIndex` (when known), so the scan reaches at
+/// least as far as every address the app has handed out.
+///
+/// Deliberately no blanket minimum here (tried, reverted — it made every
+/// wallet open noticeably slower, since a `stopAtIndex` is scanned
+/// unconditionally regardless of whether anything's actually there). The
+/// real fix for the gap forming in the first place is
+/// `ConsolidateLiquidWalletUsecase` syncing with this same counter right
+/// after every consolidation round — see its own tests.
+void main() {
+  late _MockWalletMetadataDatasource metadataDatasource;
+  late _MockBdkWalletDatasource bdkWallet;
+  late _MockLwkWalletDatasource lwkWallet;
+  late _MockLiquidReceiveAddressIndexDatasource liquidReceiveIndex;
+  late _MockElectrumServersPort serversPort;
+  late WalletRepository repository;
+
+  const connection = ElectrumConnection(
+    url: 'ssl://electrum.example:50002',
+    retry: 1,
+    timeout: 5,
+    stopGap: 20,
+    validateDomain: true,
+    isCustom: false,
+  );
+
+  // Origins follow the app's `[fingerprint/script'h/coin'h/account'h]`
+  // format (see WalletMetadataService.decodeOrigin) — 1776h = Liquid
+  // mainnet, 0h = Bitcoin mainnet.
+  Wallet buildWallet({required bool isLiquid}) => Wallet(
+    origin: isLiquid ? '[73c5da0a/84h/1776h/0h]' : '[73c5da0a/84h/0h/0h]',
+    network: isLiquid ? Network.liquidMainnet : Network.bitcoinMainnet,
+    xpubFingerprint: 'fingerprint',
+    scriptType: ScriptType.bip84,
+    xpub: 'xpub',
+    externalPublicDescriptor: 'external-descriptor',
+    internalPublicDescriptor: 'internal-descriptor',
+    signer: SignerEntity.local,
+    signerDevice: null,
+    balanceSat: BigInt.zero,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(
+      const WalletModel.publicLwk(
+        id: 'fallback',
+        combinedCtDescriptor: 'descriptor',
+        isTestnet: false,
+      ),
+    );
+    registerFallbackValue(connection);
+    registerFallbackValue(
+      ElectrumServerNetwork.fromEnvironment(isTestnet: false, isLiquid: true),
+    );
+  });
+
+  setUp(() {
+    metadataDatasource = _MockWalletMetadataDatasource();
+    bdkWallet = _MockBdkWalletDatasource();
+    lwkWallet = _MockLwkWalletDatasource();
+    liquidReceiveIndex = _MockLiquidReceiveAddressIndexDatasource();
+    serversPort = _MockElectrumServersPort();
+
+    // The repository's constructor subscribes to both datasources' sync
+    // streams for last-sync-time bookkeeping.
+    when(
+      () => bdkWallet.walletSyncStartedStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => bdkWallet.walletSyncFinishedStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => lwkWallet.walletSyncStartedStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => lwkWallet.walletSyncFinishedStream,
+    ).thenAnswer((_) => const Stream.empty());
+
+    // runWithFallback: invoke the operation once with the fake connection,
+    // exactly like the real adapter would on a healthy first server.
+    when(
+      () => serversPort.runWithFallback<void>(
+        network: any(named: 'network'),
+        operation: any(named: 'operation'),
+        isTransient: any(named: 'isTransient'),
+      ),
+    ).thenAnswer((invocation) async {
+      final operation =
+          invocation.namedArguments[#operation]
+              as Future<void> Function(ElectrumConnection);
+      await operation(connection);
+    });
+
+    when(
+      () => lwkWallet.sync(
+        wallet: any(named: 'wallet'),
+        electrumServer: any(named: 'electrumServer'),
+        stopAtIndex: any(named: 'stopAtIndex'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => bdkWallet.sync(
+        wallet: any(named: 'wallet'),
+        electrumServer: any(named: 'electrumServer'),
+      ),
+    ).thenAnswer((_) async {});
+
+    repository = WalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      bdkWalletDatasource: bdkWallet,
+      lwkWalletDatasource: lwkWallet,
+      liquidReceiveAddressIndexDatasource: liquidReceiveIndex,
+      serversPort: serversPort,
+    );
+  });
+
+  test('a Liquid sync passes the reservation counter\'s persisted index as '
+      'stopAtIndex', () async {
+    when(
+      () => liquidReceiveIndex.read('[73c5da0a/84h/1776h/0h]'),
+    ).thenAnswer((_) async => 45);
+
+    await repository.sync(buildWallet(isLiquid: true));
+
+    verify(
+      () => lwkWallet.sync(
+        wallet: any(named: 'wallet'),
+        electrumServer: connection,
+        stopAtIndex: 45,
+      ),
+    ).called(1);
+  });
+
+  test(
+    'a wallet with no reservation history syncs with a null stopAtIndex — '
+    'LWK\'s own default gap-limit behavior, not an unconditional deep scan '
+    'that would slow down every wallet open regardless of actual usage',
+    () async {
+      when(
+        () => liquidReceiveIndex.read('[73c5da0a/84h/1776h/0h]'),
+      ).thenAnswer((_) async => null);
+
+      await repository.sync(buildWallet(isLiquid: true));
+
+      verify(
+        () => lwkWallet.sync(
+          wallet: any(named: 'wallet'),
+          electrumServer: connection,
+          stopAtIndex: null,
+        ),
+      ).called(1);
+    },
+  );
+
+  test('a Bitcoin sync never touches the Liquid reservation counter', () async {
+    await repository.sync(buildWallet(isLiquid: false));
+
+    verifyNever(() => liquidReceiveIndex.read(any()));
+    verify(
+      () => bdkWallet.sync(
+        wallet: any(named: 'wallet'),
+        electrumServer: connection,
+      ),
+    ).called(1);
+  });
+}

--- a/test/core_test/widgets/cards/consolidation_required_card_test.dart
+++ b/test/core_test/widgets/cards/consolidation_required_card_test.dart
@@ -1,74 +1,133 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/cards/consolidation_required_card.dart';
-import 'package:bb_mobile/generated/l10n/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// The card's tap guard must be scoped to the navigation, not one-shot:
+/// tapping pushes the consolidation route ON TOP of the current screen, so
+/// this card's State stays alive underneath and a permanent flag would leave
+/// the card dead after the user pops back (the reported bug: tap → visit
+/// consolidation → return → tapping again did nothing).
 void main() {
   Future<void> pumpCard(
     WidgetTester tester, {
-    required String title,
-    String? body,
-    VoidCallback? onTap,
+    required Future<void> Function()? onTap,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: AppTheme.themeData(AppThemeType.light),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: ConsolidationRequiredCard(
-            title: title,
-            body: body,
-            onTap: onTap,
-          ),
+          body: ConsolidationRequiredCard(title: 'Consolidate', onTap: onTap),
         ),
       ),
     );
   }
 
-  testWidgets('renders the given title', (tester) async {
-    await pumpCard(tester, title: 'Consolidate the wallet');
+  testWidgets('tap fires onTap', (tester) async {
+    var taps = 0;
+    await pumpCard(tester, onTap: () async => taps++);
 
-    expect(find.text('Consolidate the wallet'), findsOneWidget);
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pumpAndSettle();
+
+    expect(taps, 1);
   });
 
-  testWidgets('renders the body when provided', (tester) async {
+  testWidgets(
+    'a second tap while the navigation is still open (Future pending) is '
+    'ignored — the double-tap guard',
+    (tester) async {
+      var taps = 0;
+      // Completer stands in for context.pushNamed's Future: it only
+      // completes when the pushed route is popped.
+      final navigation = Completer<void>();
+      await pumpCard(
+        tester,
+        onTap: () {
+          taps++;
+          return navigation.future;
+        },
+      );
+
+      await tester.tap(find.byType(ConsolidationRequiredCard));
+      await tester.pump();
+      await tester.tap(find.byType(ConsolidationRequiredCard));
+      await tester.pump();
+
+      expect(taps, 1); // second tap swallowed while navigating
+
+      navigation.complete(); // let the test end cleanly
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets('the card re-enables itself once the navigation Future completes '
+      '(user popped back) — tap, return, tap again works', (tester) async {
+    var taps = 0;
+    var navigation = Completer<void>();
     await pumpCard(
       tester,
-      title: 'Consolidate the wallet',
-      body: 'Something went wrong',
+      onTap: () {
+        taps++;
+        return navigation.future;
+      },
     );
 
-    expect(find.text('Something went wrong'), findsOneWidget);
+    // First tap: navigates.
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pump();
+    expect(taps, 1);
+
+    // User pops back: the navigation Future completes.
+    navigation.complete();
+    await tester.pumpAndSettle();
+
+    // Second tap must work again — this is the reported bug's regression
+    // test (the old one-shot flag stayed set forever).
+    navigation = Completer<void>();
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pump();
+    expect(taps, 2);
+
+    navigation.complete();
+    await tester.pumpAndSettle();
   });
 
-  testWidgets('renders no body text when body is null', (tester) async {
-    await pumpCard(tester, title: 'Consolidate the wallet');
-
-    expect(find.text('Something went wrong'), findsNothing);
-  });
-
-  testWidgets('invokes onTap when tapped', (tester) async {
-    var tapped = false;
+  testWidgets('the guard re-enables even when the navigation Future throws', (
+    tester,
+  ) async {
+    var taps = 0;
+    var shouldThrow = true;
     await pumpCard(
       tester,
-      title: 'Consolidate the wallet',
-      onTap: () => tapped = true,
+      onTap: () async {
+        taps++;
+        if (shouldThrow) throw Exception('router error');
+      },
     );
 
-    await tester.tap(find.byType(InkWell));
-    await tester.pump();
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pumpAndSettle();
+    expect(taps, 1);
+    // The error is reported through FlutterError (not silently swallowed,
+    // not an unhandled async error)...
+    expect(tester.takeException(), isA<Exception>());
 
-    expect(tapped, isTrue);
+    // ...and must not leave the guard stuck: the next tap works.
+    shouldThrow = false;
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pumpAndSettle();
+    expect(taps, 2);
   });
 
-  testWidgets('does nothing when tapped with no onTap given', (tester) async {
-    await pumpCard(tester, title: 'Consolidate the wallet');
+  testWidgets('null onTap renders an inert card', (tester) async {
+    await pumpCard(tester, onTap: null);
 
-    await tester.tap(find.byType(InkWell));
-    await tester.pump();
-    // No exception thrown, no state to assert — this just proves a null
-    // onTap doesn't crash the widget.
+    await tester.tap(find.byType(ConsolidationRequiredCard));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Consolidate'), findsOneWidget); // still renders fine
   });
 }

--- a/test/features/consolidation/domain/usecases/check_liquid_consolidation_usecase_test.dart
+++ b/test/features/consolidation/domain/usecases/check_liquid_consolidation_usecase_test.dart
@@ -1,0 +1,93 @@
+import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLiquidWalletRepository extends Mock
+    implements LiquidWalletRepository {}
+
+class _MockWalletUtxoRepository extends Mock implements WalletUtxoRepository {}
+
+void main() {
+  late _MockLiquidWalletRepository repo;
+  late _MockWalletUtxoRepository utxoRepo;
+  late CheckLiquidConsolidationUsecase usecase;
+
+  const walletId = 'wallet-1';
+
+  setUp(() {
+    repo = _MockLiquidWalletRepository();
+    utxoRepo = _MockWalletUtxoRepository();
+    usecase = CheckLiquidConsolidationUsecase(
+      liquidWalletRepository: repo,
+      walletUtxoRepository: utxoRepo,
+    );
+  });
+
+  group('execute — utxoCount', () {
+    test('excludes frozen outpoints from the confirmed count', () async {
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenAnswer(
+        (_) async => [
+          (txId: 'a', vout: 0),
+          (txId: 'b', vout: 0),
+          (txId: 'c', vout: 0),
+        ],
+      );
+      when(
+        () => utxoRepo.getAllFrozenOutpoints(),
+      ).thenAnswer((_) async => [(txId: 'b', vout: 0)]);
+
+      final status = await usecase.execute(walletId: walletId);
+
+      expect(status.utxoCount, 2);
+    });
+
+    test('is null if the underlying call fails', () async {
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenThrow(Exception('boom'));
+
+      final status = await usecase.execute(walletId: walletId);
+
+      expect(status.utxoCount, isNull);
+      expect(status.isRequired, isFalse);
+    });
+  });
+
+  group('execute — isRequired', () {
+    test('is true once the unfrozen count exceeds the threshold', () async {
+      final total = kLiquidConsolidationThreshold + 1;
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenAnswer(
+        (_) async => List.generate(total, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+
+      final status = await usecase.execute(walletId: walletId);
+
+      expect(status.isRequired, isTrue);
+    });
+
+    test('is false when enough of the confirmed UTXOs are frozen to drop at '
+        'or below the threshold', () async {
+      final total = kLiquidConsolidationThreshold + 1;
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenAnswer(
+        (_) async => List.generate(total, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer(
+        (_) async => List.generate(total - 1, (i) => (txId: 'tx$i', vout: 0)),
+      );
+
+      final status = await usecase.execute(walletId: walletId);
+
+      // total - (total-1) frozen = 1 unfrozen, not > threshold.
+      expect(status.isRequired, isFalse);
+    });
+  });
+}

--- a/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_batch_sizes_test.dart
+++ b/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_batch_sizes_test.dart
@@ -1,0 +1,104 @@
+import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises [ConsolidateLiquidWalletUsecase.batchSizes] directly, at the
+/// realistic UTXO counts (hundreds, approaching/exceeding the 256 confidential
+/// -tx input limit) the underlying GitHub issue is actually about — the
+/// wallet-level `prepare()`/`broadcast()` tests use tiny fixtures (a handful
+/// of outpoints) because they're driven by the TEMP=2 test config, so this
+/// file is where the batching *math* itself is proven correct at scale,
+/// independent of whatever `ConsolidationConfig` happens to be set to.
+void main() {
+  group('batchSizes', () {
+    test('the issue\'s own worked example: 1126 UTXOs / 250 max inputs -> 5 '
+        'batches of 226, 226, 226, 226, 222 (never exceeding 250)', () {
+      final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(
+        1126,
+        250,
+      );
+
+      expect(n, 5);
+      expect(perBatch, 226);
+      // Simulate the actual skip/take split prepare() does, to confirm
+      // every batch is non-empty and within the cap, and all batches
+      // together account for every UTXO exactly once.
+      final sizes = List.generate(n, (i) {
+        final start = i * perBatch;
+        final end = (start + perBatch).clamp(0, 1126);
+        return end - start;
+      });
+      expect(sizes, [226, 226, 226, 226, 222]);
+      expect(sizes.reduce((a, b) => a + b), 1126);
+      expect(sizes.every((s) => s <= 250), isTrue);
+    });
+
+    test('a wallet just over the 256-input crash limit (300 UTXOs / 250 max) '
+        'never produces an over-cap batch — the deliberate ceiling-vs-round '
+        'divergence: round-half-up would give a single 300-input batch here, '
+        'violating the cap; ceiling correctly splits into two', () {
+      final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(300, 250);
+
+      expect(n, 2);
+      expect(perBatch, 150);
+      expect(perBatch, lessThanOrEqualTo(250));
+    });
+
+    test('an exact multiple never over-allocates a trailing empty batch', () {
+      final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(500, 250);
+
+      expect(n, 2);
+      expect(perBatch, 250);
+    });
+
+    test('one UTXO over a single batch\'s capacity still needs 2 batches', () {
+      final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(251, 250);
+
+      expect(n, 2);
+      expect(perBatch, lessThanOrEqualTo(250));
+      // 251 split across 2 batches as evenly as possible: 126 + 125.
+      expect(perBatch, 126);
+    });
+
+    test('a UTXO count exactly at the cap needs only 1 batch', () {
+      final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(250, 250);
+
+      expect(n, 1);
+      expect(perBatch, 250);
+    });
+
+    test(
+      'no batch ever exceeds maxInputs across a range of realistic sizes',
+      () {
+        const maxInputs = 250;
+        for (final total in [
+          1,
+          2,
+          249,
+          250,
+          251,
+          256,
+          500,
+          1000,
+          1126,
+          10000,
+        ]) {
+          final (n, perBatch) = ConsolidateLiquidWalletUsecase.batchSizes(
+            total,
+            maxInputs,
+          );
+          expect(
+            perBatch,
+            lessThanOrEqualTo(maxInputs),
+            reason:
+                'total=$total produced a perBatch of $perBatch > $maxInputs',
+          );
+          expect(
+            n * perBatch,
+            greaterThanOrEqualTo(total),
+            reason: 'total=$total: $n batches of $perBatch cannot cover it',
+          );
+        }
+      },
+    );
+  });
+}

--- a/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_distribute_by_value_test.dart
+++ b/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_distribute_by_value_test.dart
@@ -1,0 +1,108 @@
+import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises [ConsolidateLiquidWalletUsecase.distributeByValue] directly —
+/// the fix for the incident where several 1-sat leftover decoy UTXOs (no
+/// longer frozen) landed together in one batch under the old sequential
+/// chunking, producing a batch whose total value couldn't cover its own
+/// decoy output + fee (`InsufficientFunds`).
+void main() {
+  group('distributeByValue', () {
+    test('never puts all the dust in one bucket when a large UTXO exists', () {
+      final candidates = [
+        (txId: 'large', vout: 0, amountSat: 1000000),
+        ...List.generate(8, (i) => (txId: 'dust$i', vout: 0, amountSat: 1)),
+      ];
+
+      final buckets = ConsolidateLiquidWalletUsecase.distributeByValue(
+        candidates,
+        2,
+      );
+
+      expect(buckets, hasLength(2));
+      final bucketHasLarge = buckets
+          .map((b) => b.any((u) => u.txId == 'large'))
+          .toList();
+      expect(bucketHasLarge.where((has) => has).length, 1);
+      for (final bucket in buckets) {
+        expect(
+          bucket.any((u) => u.txId.startsWith('dust')),
+          isTrue,
+          reason: 'every bucket should get some dust too',
+        );
+      }
+    });
+
+    test('every candidate appears in exactly one bucket — none dropped, '
+        'none duplicated', () {
+      final candidates = List.generate(
+        21,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: i * 100),
+      );
+
+      final buckets = ConsolidateLiquidWalletUsecase.distributeByValue(
+        candidates,
+        3,
+      );
+
+      final all = buckets.expand((b) => b).toList();
+      expect(all.length, 21);
+      expect(
+        all.map((u) => u.txId).toSet(),
+        candidates.map((u) => u.txId).toSet(),
+      );
+    });
+
+    test('bucket sizes never differ by more than 1 (round-robin dealing '
+        'preserves the same balance batchSizes already guarantees)', () {
+      final candidates = List.generate(
+        10,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: 100),
+      );
+
+      final buckets = ConsolidateLiquidWalletUsecase.distributeByValue(
+        candidates,
+        3,
+      );
+
+      final sizes = buckets.map((b) => b.length).toList();
+      expect(
+        sizes.reduce((a, b) => a > b ? a : b) -
+            sizes.reduce((a, b) => a < b ? a : b),
+        lessThanOrEqualTo(1),
+      );
+    });
+
+    test('a single bucket just gets everything, still sorted by nothing '
+        'in particular (n=1 is the "no split needed" case)', () {
+      final candidates = List.generate(
+        4,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: i),
+      );
+
+      final buckets = ConsolidateLiquidWalletUsecase.distributeByValue(
+        candidates,
+        1,
+      );
+
+      expect(buckets, hasLength(1));
+      expect(buckets.single, hasLength(4));
+    });
+
+    test('with uniform amounts, dealing degenerates to a simple round-robin '
+        '(order-only), which is harmless when value-balance is moot', () {
+      final candidates = List.generate(
+        6,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: 500),
+      );
+
+      final buckets = ConsolidateLiquidWalletUsecase.distributeByValue(
+        candidates,
+        2,
+      );
+
+      expect(buckets[0], hasLength(3));
+      expect(buckets[1], hasLength(3));
+    });
+  });
+}

--- a/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_test.dart
+++ b/test/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase_test.dart
@@ -1,6 +1,17 @@
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_config.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
 import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -11,96 +22,535 @@ class _MockLiquidWalletRepository extends Mock
 class _MockBroadcastLiquidTransactionUsecase extends Mock
     implements BroadcastLiquidTransactionUsecase {}
 
+class _MockWalletUtxoRepository extends Mock implements WalletUtxoRepository {}
+
+class _MockWalletAddressRepository extends Mock
+    implements WalletAddressRepository {}
+
+class _MockGetWalletUsecase extends Mock implements GetWalletUsecase {}
+
+class _MockSyncWalletUsecase extends Mock implements SyncWalletUsecase {}
+
 void main() {
   late _MockLiquidWalletRepository repo;
   late _MockBroadcastLiquidTransactionUsecase broadcast;
+  late _MockWalletUtxoRepository utxoRepo;
+  late _MockWalletAddressRepository addressRepo;
+  late _MockGetWalletUsecase getWallet;
+  late _MockSyncWalletUsecase sync;
   late ConsolidateLiquidWalletUsecase usecase;
 
   const walletId = 'wallet-1';
 
+  // ConsolidationConfig's thresholds are randomized per app boot (see its
+  // doc comment); tests reference the live values directly rather than
+  // hardcoding numbers, so they keep passing whatever the jittered range
+  // resolves to in this process.
+  final threshold = ConsolidationConfig.highUtxoThreshold;
+  final maxInputs = ConsolidationConfig.maximumInputs;
+
   setUpAll(() {
     registerFallbackValue(const RelativeFee(25));
+    registerFallbackValue(
+      Wallet(
+        origin: 'fallback',
+        network: Network.liquidMainnet,
+        xpubFingerprint: 'fingerprint',
+        scriptType: ScriptType.bip84,
+        xpub: 'xpub',
+        externalPublicDescriptor: 'external-descriptor',
+        internalPublicDescriptor: 'internal-descriptor',
+        signer: SignerEntity.local,
+        signerDevice: null,
+        balanceSat: BigInt.zero,
+      ),
+    );
   });
 
   setUp(() {
     repo = _MockLiquidWalletRepository();
     broadcast = _MockBroadcastLiquidTransactionUsecase();
+    utxoRepo = _MockWalletUtxoRepository();
+    addressRepo = _MockWalletAddressRepository();
+    getWallet = _MockGetWalletUsecase();
+    sync = _MockSyncWalletUsecase();
     usecase = ConsolidateLiquidWalletUsecase(
       liquidWalletRepository: repo,
       broadcastLiquidTransactionUsecase: broadcast,
+      walletUtxoRepository: utxoRepo,
+      walletAddressRepository: addressRepo,
+      getWalletUsecase: getWallet,
+      syncWalletUsecase: sync,
     );
+    // Best-effort sync-after-broadcast: default to a no-op success so tests
+    // that don't care about it don't need their own stub.
+    when(() => getWallet.execute(any())).thenThrow(Exception('no wallet'));
+
+    // ConsolidationConfig's current (TEMP test) values: highUtxoThreshold=8,
+    // maximumInputs=8, decoySats=1 — every scenario below is designed against
+    // those, matching how the usecase itself references them directly (no DI
+    // seam exists for thresholds today).
+    //
+    // Every call reserves a fresh, distinct address (never the same one
+    // twice) — mirroring WalletAddressRepository's real collision-safe
+    // reservation behavior, so a test that captures addresses across
+    // batches can assert they're actually all different.
+    var addressCounter = 0;
+    when(
+      () => addressRepo.generateNewReceiveAddress(
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async {
+      final index = addressCounter++;
+      return WalletAddress(
+        walletId: walletId,
+        index: index,
+        address: 'conf-$index',
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+    });
+    // No frozen UTXOs by default — individual tests override this to
+    // exercise the exclusion behavior.
+    when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
   });
 
   group('prepare', () {
-    test('builds a preview with the total fee summed across every PSET '
-        'returned by the repository, at or below the 256-input safety cap '
-        'this issue is about — a wallet over the threshold produces PSETs, '
-        'not a crash', () async {
+    test(
+      'just above the threshold triggers consolidation into a single '
+      'batch (threshold+1 confirmed UTXOs is comfortably under '
+      'maximumInputs, so ceil((threshold+1)/maximumInputs) is always 1)',
+      () async {
+        final total = threshold + 1;
+        final outpoints = List.generate(
+          total,
+          (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+        );
+        when(
+          () => repo.getConfirmedLbtcOutpointAmounts(
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer((_) async => outpoints);
+        when(
+          () => repo.buildCustomTx(
+            walletId: any(named: 'walletId'),
+            utxos: any(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).thenAnswer((_) async => 'pset');
+        when(
+          () => repo.findOutputIndexByAmount(
+            pset: any(named: 'pset'),
+            satoshi: any(named: 'satoshi'),
+          ),
+        ).thenReturn(0);
+        when(
+          () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+        ).thenAnswer((_) async => (200, 50));
+
+        final result = await usecase.prepare(walletId: walletId);
+
+        final preview = (result as Ok).value as ConsolidationPreview;
+        expect(preview.utxoCount, total);
+        expect(preview.batches, hasLength(1));
+        expect(preview.transactionCount, 1);
+        expect(preview.totalFeeSat, 50);
+
+        final captured = verify(
+          () => repo.buildCustomTx(
+            walletId: walletId,
+            utxos: captureAny(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).captured;
+        expect(captured.single, hasLength(total)); // all UTXOs, one batch
+      },
+    );
+
+    test('returns an empty preview when at or below the threshold', () async {
       when(
-        () => repo.consolidate(
+        () => repo.getConfirmedLbtcOutpointAmounts(
           walletId: any(named: 'walletId'),
-          feeRate: any(named: 'feeRate'),
-          highUtxoThreshold: any(named: 'highUtxoThreshold'),
-          maximumInputs: any(named: 'maximumInputs'),
         ),
-      ).thenAnswer((_) async => ['pset-1', 'pset-2']);
-      when(
-        () => repo.getPsetSizeAndAbsoluteFees(pset: 'pset-1'),
-      ).thenAnswer((_) async => (200, 50));
-      when(
-        () => repo.getPsetSizeAndAbsoluteFees(pset: 'pset-2'),
-      ).thenAnswer((_) async => (210, 60));
+      ).thenAnswer((_) async => [(txId: 'a', vout: 0, amountSat: 1000)]);
 
-      final preview = await usecase.prepare(walletId: walletId);
+      final result = await usecase.prepare(walletId: walletId);
 
-      expect(preview.unsignedPsets, ['pset-1', 'pset-2']);
-      expect(preview.totalFeeSat, 110);
-      expect(preview.transactionCount, 2);
-    });
-
-    test('a wallet at or below the threshold returns an empty preview (no '
-        'regression case: normal, small wallets are untouched)', () async {
-      when(
-        () => repo.consolidate(
-          walletId: any(named: 'walletId'),
-          feeRate: any(named: 'feeRate'),
-          highUtxoThreshold: any(named: 'highUtxoThreshold'),
-          maximumInputs: any(named: 'maximumInputs'),
-        ),
-      ).thenAnswer((_) async => []);
-
-      final preview = await usecase.prepare(walletId: walletId);
-
-      expect(preview.unsignedPsets, isEmpty);
+      expect(result, isA<Ok<ConsolidationPreview, ConsolidationFailure>>());
+      final preview = (result as Ok).value as ConsolidationPreview;
+      expect(preview.batches, isEmpty);
       expect(preview.totalFeeSat, 0);
-      expect(preview.transactionCount, 0);
+      expect(preview.utxoCount, 1);
       verifyNever(
-        () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
-      );
-    });
-
-    test('wraps any repository failure in a ConsolidationException — the '
-        'user-friendly-error acceptance criterion', () async {
-      when(
-        () => repo.consolidate(
+        () => repo.buildCustomTx(
           walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
           feeRate: any(named: 'feeRate'),
-          highUtxoThreshold: any(named: 'highUtxoThreshold'),
-          maximumInputs: any(named: 'maximumInputs'),
         ),
-      ).thenThrow(Exception('lwk build failed'));
-
-      await expectLater(
-        () => usecase.prepare(walletId: walletId),
-        throwsA(isA<ConsolidationException>()),
       );
     });
+
+    test(
+      'splits UTXOs into evenly-sized batches, each with a decoy + drain output',
+      () async {
+        // maximumInputs+1 UTXOs forces exactly ceil((maxInputs+1)/maxInputs)
+        // = 2 batches, comfortably over highUtxoThreshold so batching
+        // actually triggers. Same amount on every UTXO (value-balancing
+        // isn't what this test is about — see the dedicated
+        // distributeByValue tests below).
+        final total = maxInputs + 1;
+        final outpoints = List.generate(
+          total,
+          (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+        );
+        when(
+          () => repo.getConfirmedLbtcOutpointAmounts(
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer((_) async => outpoints);
+        when(
+          () => repo.buildCustomTx(
+            walletId: any(named: 'walletId'),
+            utxos: any(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).thenAnswer((_) async => 'pset');
+        when(
+          () => repo.findOutputIndexByAmount(
+            pset: any(named: 'pset'),
+            satoshi: any(named: 'satoshi'),
+          ),
+        ).thenReturn(0);
+        when(
+          () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+        ).thenAnswer((_) async => (200, 50));
+
+        final result = await usecase.prepare(walletId: walletId);
+
+        final preview = (result as Ok).value as ConsolidationPreview;
+        expect(preview.batches, hasLength(2));
+        expect(preview.transactionCount, 2);
+        expect(preview.totalFeeSat, 100); // 50 per batch * 2 batches
+        expect(preview.utxoCount, total);
+        for (final batch in preview.batches) {
+          expect(batch.pset, 'pset');
+          expect(batch.decoyVout, 0);
+        }
+
+        final captured = verify(
+          () => repo.buildCustomTx(
+            walletId: any(named: 'walletId'),
+            utxos: captureAny(named: 'utxos'),
+            outputs: captureAny(named: 'outputs'),
+            drainToAddress: captureAny(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).captured;
+        final firstBatchUtxos = captured[0] as List;
+        final secondBatchUtxos = captured[3] as List;
+        // Batches together account for every UTXO, sized within 1 of each
+        // other (round-robin dealing), and disjoint (no UTXO reused).
+        expect(firstBatchUtxos.length + secondBatchUtxos.length, total);
+        expect(
+          (firstBatchUtxos.length - secondBatchUtxos.length).abs() <= 1,
+          isTrue,
+        );
+        expect(
+          firstBatchUtxos.toSet().intersection(secondBatchUtxos.toSet()),
+          isEmpty,
+        );
+        final firstOutputs = captured[1] as List<LiquidTxOutput>;
+        expect(firstOutputs.single.satoshi, 1); // decoySats
+      },
+    );
+
+    test('every batch reserves its own distinct main/decoy address via '
+        'WalletAddressRepository — never a raw index lookup, and never the '
+        'same address handed out twice, even across batches in the same '
+        'prepare() call (the address-reuse bug this fix closes: two batches '
+        'sharing an address means two of a user\'s future receives could '
+        'collide at that same address)', () async {
+      final outpoints = List.generate(
+        maxInputs + 1,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+      );
+      when(
+        () => repo.getConfirmedLbtcOutpointAmounts(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => outpoints);
+      when(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).thenAnswer((_) async => 'pset');
+      when(
+        () => repo.findOutputIndexByAmount(
+          pset: any(named: 'pset'),
+          satoshi: any(named: 'satoshi'),
+        ),
+      ).thenReturn(0);
+      when(
+        () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+      ).thenAnswer((_) async => (200, 50));
+
+      final result = await usecase.prepare(walletId: walletId);
+      expect(result, isA<Ok<ConsolidationPreview, ConsolidationFailure>>());
+
+      // 2 batches * (1 drain + 1 decoy) = 4 reservations, all distinct.
+      verify(
+        () => addressRepo.generateNewReceiveAddress(walletId: walletId),
+      ).called(4);
+
+      final captured = verify(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: captureAny(named: 'outputs'),
+          drainToAddress: captureAny(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).captured;
+      final drainAddresses = [captured[1] as String, captured[3] as String];
+      final decoyAddresses = [
+        (captured[0] as List<LiquidTxOutput>).single.address,
+        (captured[2] as List<LiquidTxOutput>).single.address,
+      ];
+      final allAddresses = [...drainAddresses, ...decoyAddresses];
+      expect(allAddresses.toSet(), hasLength(4)); // no duplicates anywhere
+    });
+
+    test('a larger UTXO set (well beyond a single batch) still produces '
+        'disjoint, correctly-sized batches that account for every UTXO '
+        'exactly once — a scale check independent of the batchSizes-only '
+        'test', () async {
+      final total = maxInputs * 3 + 7;
+      final outpoints = List.generate(
+        total,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+      );
+      when(
+        () => repo.getConfirmedLbtcOutpointAmounts(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => outpoints);
+      when(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).thenAnswer((_) async => 'pset');
+      when(
+        () => repo.findOutputIndexByAmount(
+          pset: any(named: 'pset'),
+          satoshi: any(named: 'satoshi'),
+        ),
+      ).thenReturn(0);
+      when(
+        () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+      ).thenAnswer((_) async => (200, 50));
+
+      final result = await usecase.prepare(walletId: walletId);
+
+      final preview = (result as Ok).value as ConsolidationPreview;
+      expect(preview.utxoCount, total);
+      expect(preview.batches, isNotEmpty);
+
+      final captured = verify(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: captureAny(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).captured;
+      final allBatchedUtxos = captured.cast<List>().expand((u) => u).toSet();
+      // Every confirmed outpoint appears in exactly one batch — none
+      // dropped, none duplicated across batches.
+      expect(
+        allBatchedUtxos,
+        outpoints.map((u) => (txId: u.txId, vout: u.vout)).toSet(),
+      );
+      final totalBatched = captured.cast<List>().fold<int>(
+        0,
+        (sum, u) => sum + u.length,
+      );
+      expect(totalBatched, total);
+    });
+
+    test('excludes frozen UTXOs — they count as not existing, for both the '
+        'threshold check and the batches', () async {
+      // 10 confirmed outpoints, 9 of them already frozen (e.g. a previous
+      // consolidation's own decoy outputs) — only 1 usable, comfortably at
+      // or below the threshold (which is always >= 100), so no batches
+      // should be built at all.
+      final outpoints = List.generate(
+        10,
+        (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+      );
+      when(
+        () => repo.getConfirmedLbtcOutpointAmounts(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => outpoints);
+      when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer(
+        (_) async => List.generate(9, (i) => (txId: 'tx$i', vout: 0)),
+      );
+
+      final result = await usecase.prepare(walletId: walletId);
+
+      final preview = (result as Ok).value as ConsolidationPreview;
+      expect(preview.utxoCount, 1); // 10 confirmed - 9 frozen = 1 usable
+      expect(preview.batches, isEmpty);
+      verifyNever(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      );
+    });
+
+    test('distributes UTXOs across batches by value, not by position — no '
+        'batch ends up made entirely of dust that could fail with '
+        'InsufficientFunds trying to pay for its own decoy + fee (the '
+        'reported incident: several 1-sat leftover decoy UTXOs, no longer '
+        'frozen, landed together in one batch when chunking was purely '
+        'sequential)', () async {
+      // 1 large UTXO + (maxInputs+50) dust (1-sat) UTXOs, comfortably over
+      // the threshold and forcing exactly 2 batches (total <= 2*maxInputs).
+      // Sequential chunking would put the single large UTXO in the FIRST
+      // batch and leave the SECOND batch as pure 1-sat dust; value-balanced
+      // dealing must instead put the large UTXO in one batch and spread
+      // dust evenly, so both batches have real value.
+      final dustCount = maxInputs + 50;
+      final outpoints = [
+        (txId: 'large', vout: 0, amountSat: 1000000),
+        ...List.generate(
+          dustCount,
+          (i) => (txId: 'dust$i', vout: 0, amountSat: 1),
+        ),
+      ];
+      when(
+        () => repo.getConfirmedLbtcOutpointAmounts(
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => outpoints);
+      when(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).thenAnswer((_) async => 'pset');
+      when(
+        () => repo.findOutputIndexByAmount(
+          pset: any(named: 'pset'),
+          satoshi: any(named: 'satoshi'),
+        ),
+      ).thenReturn(0);
+      when(
+        () => repo.getPsetSizeAndAbsoluteFees(pset: any(named: 'pset')),
+      ).thenAnswer((_) async => (200, 50));
+
+      final result = await usecase.prepare(walletId: walletId);
+      expect(result, isA<Ok<ConsolidationPreview, ConsolidationFailure>>());
+
+      final captured = verify(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: captureAny(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).captured;
+      final batchContainsLarge = captured
+          .cast<List<({String txId, int vout})>>()
+          .map((batch) => batch.any((o) => o.txId == 'large'))
+          .toList();
+      // The large UTXO is in exactly one batch (obviously), but the
+      // *other* batch must not be 100% dust — i.e. every batch has at
+      // least one dust UTXO too, proving the deal actually mixed them
+      // rather than grouping all dust together in whichever batch
+      // didn't get the large one.
+      expect(batchContainsLarge.where((has) => has).length, 1);
+      for (final batch in captured.cast<List<({String txId, int vout})>>()) {
+        expect(
+          batch.any((o) => o.txId.startsWith('dust')),
+          isTrue,
+          reason:
+              'every batch should contain at least some dust too, '
+              'not have it all dumped in one place',
+        );
+      }
+    });
+
+    test(
+      'fails the batch if the decoy output cannot be located in the built PSET',
+      () async {
+        when(
+          () => repo.getConfirmedLbtcOutpointAmounts(
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer(
+          (_) async => List.generate(
+            threshold + 1,
+            (i) => (txId: 'tx$i', vout: 0, amountSat: 1000),
+          ),
+        );
+        when(
+          () => repo.buildCustomTx(
+            walletId: any(named: 'walletId'),
+            utxos: any(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: any(named: 'feeRate'),
+          ),
+        ).thenAnswer((_) async => 'pset');
+        when(
+          () => repo.findOutputIndexByAmount(
+            pset: any(named: 'pset'),
+            satoshi: any(named: 'satoshi'),
+          ),
+        ).thenReturn(null);
+
+        final result = await usecase.prepare(walletId: walletId);
+
+        expect(result, isA<Err<ConsolidationPreview, ConsolidationFailure>>());
+        expect((result as Err).failure, isA<ConsolidationBuildFailure>());
+      },
+    );
   });
 
   group('broadcast', () {
+    final batches = [
+      const ConsolidationBatch(pset: 'pset-1', decoyVout: 0),
+      const ConsolidationBatch(pset: 'pset-2', decoyVout: 1),
+    ];
+
     test(
-      'signs and broadcasts every PSET in order, returning the txids — '
-      'the consolidation-transaction-succeeds acceptance criterion',
+      'signs, broadcasts, and freezes each decoy — reporting 0 unfrozen on full success',
       () async {
         when(
           () => repo.signPset(
@@ -115,92 +565,248 @@ void main() {
           final signed = invocation.positionalArguments.first as String;
           return 'txid-$signed';
         });
+        when(
+          () => utxoRepo.freezeUtxos(
+            walletId: any(named: 'walletId'),
+            outpoints: any(named: 'outpoints'),
+          ),
+        ).thenAnswer((_) async {});
 
-        final txids = await usecase.broadcast(
+        final result = await usecase.broadcast(
           walletId: walletId,
-          unsignedPsets: ['pset-1', 'pset-2'],
+          batches: batches,
         );
 
-        expect(txids, ['txid-signed-pset-1', 'txid-signed-pset-2']);
+        expect(
+          result,
+          isA<Ok<ConsolidationBroadcastResult, ConsolidationFailure>>(),
+        );
+        final value = (result as Ok).value as ConsolidationBroadcastResult;
+        expect(value.txids, hasLength(2));
+        expect(value.unfrozenDecoyCount, 0);
         verify(
-          () => repo.signPset(pset: 'pset-1', walletId: walletId),
+          () => utxoRepo.freezeUtxos(
+            walletId: walletId,
+            outpoints: [(txId: 'txid-signed-pset-1', vout: 0)],
+          ),
         ).called(1);
         verify(
-          () => repo.signPset(pset: 'pset-2', walletId: walletId),
+          () => utxoRepo.freezeUtxos(
+            walletId: walletId,
+            outpoints: [(txId: 'txid-signed-pset-2', vout: 1)],
+          ),
         ).called(1);
       },
     );
 
-    test('wraps a signing failure in a ConsolidationException with an empty '
-        'succeededTxids when it happens on the very first PSET', () async {
+    test(
+      'still succeeds (funds moved) but reports unfrozenDecoyCount when a freeze call fails',
+      () async {
+        when(
+          () => repo.signPset(
+            pset: any(named: 'pset'),
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer((_) async => 'signed');
+        when(() => broadcast.execute(any())).thenAnswer((_) async => 'txid');
+        when(
+          () => utxoRepo.freezeUtxos(
+            walletId: any(named: 'walletId'),
+            outpoints: any(named: 'outpoints'),
+          ),
+        ).thenThrow(Exception('db locked'));
+
+        final result = await usecase.broadcast(
+          walletId: walletId,
+          batches: batches,
+        );
+
+        final value = (result as Ok).value as ConsolidationBroadcastResult;
+        expect(value.txids, hasLength(2));
+        expect(value.unfrozenDecoyCount, 2);
+      },
+    );
+
+    test(
+      'a broadcast failure keeps the already-succeeded txids for the caller to see',
+      () async {
+        when(
+          () => repo.signPset(
+            pset: any(named: 'pset'),
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer((invocation) async {
+          final pset = invocation.namedArguments[#pset] as String;
+          return 'signed-$pset';
+        });
+        when(() => broadcast.execute(any())).thenAnswer((invocation) async {
+          final signed = invocation.positionalArguments.first as String;
+          if (signed == 'signed-pset-1') return 'first-txid';
+          throw Exception('node unreachable');
+        });
+        when(
+          () => utxoRepo.freezeUtxos(
+            walletId: any(named: 'walletId'),
+            outpoints: any(named: 'outpoints'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final result = await usecase.broadcast(
+          walletId: walletId,
+          batches: batches,
+        );
+
+        expect(
+          result,
+          isA<Err<ConsolidationBroadcastResult, ConsolidationFailure>>(),
+        );
+        final failure = (result as Err).failure;
+        expect(failure, isA<ConsolidationBroadcastFailure>());
+        expect((failure as ConsolidationBroadcastFailure).succeededTxids, [
+          'first-txid',
+        ]);
+      },
+    );
+
+    Wallet buildWallet() => Wallet(
+      origin: walletId,
+      network: Network.liquidMainnet,
+      xpubFingerprint: 'fingerprint',
+      scriptType: ScriptType.bip84,
+      xpub: 'xpub',
+      externalPublicDescriptor: 'external-descriptor',
+      internalPublicDescriptor: 'internal-descriptor',
+      signer: SignerEntity.local,
+      signerDevice: null,
+      balanceSat: BigInt.zero,
+    );
+
+    test(
+      'syncs the wallet once broadcasting finishes — keeps LWK\'s own '
+      '"last used address" bookkeeping caught up with every address this '
+      'round just handed out, so a later sync\'s default gap-limit scan '
+      'doesn\'t drift further behind after every consolidation round (the '
+      'root cause of a wallet balance disappearing after several rounds)',
+      () async {
+        when(
+          () => repo.signPset(
+            pset: any(named: 'pset'),
+            walletId: any(named: 'walletId'),
+          ),
+        ).thenAnswer((_) async => 'signed');
+        when(() => broadcast.execute(any())).thenAnswer((_) async => 'txid');
+        when(
+          () => utxoRepo.freezeUtxos(
+            walletId: any(named: 'walletId'),
+            outpoints: any(named: 'outpoints'),
+          ),
+        ).thenAnswer((_) async {});
+        final wallet = buildWallet();
+        when(() => getWallet.execute(walletId)).thenAnswer((_) async => wallet);
+        when(() => sync.execute(wallet)).thenAnswer((_) async {});
+
+        final result = await usecase.broadcast(
+          walletId: walletId,
+          batches: batches,
+        );
+        expect(
+          result,
+          isA<Ok<ConsolidationBroadcastResult, ConsolidationFailure>>(),
+        );
+
+        verify(() => getWallet.execute(walletId)).called(1);
+        verify(() => sync.execute(wallet)).called(1);
+      },
+    );
+
+    test('does not attempt a sync if nothing broadcast at all (the very first '
+        'batch failed to sign)', () async {
       when(
         () => repo.signPset(
           pset: any(named: 'pset'),
           walletId: any(named: 'walletId'),
         ),
-      ).thenThrow(Exception('signing failed'));
+      ).thenThrow(Exception('sign failed'));
 
-      await expectLater(
-        () => usecase.broadcast(walletId: walletId, unsignedPsets: ['pset-1']),
-        throwsA(isA<ConsolidationException>()),
+      final result = await usecase.broadcast(
+        walletId: walletId,
+        batches: batches,
       );
-      verifyNever(() => broadcast.execute(any()));
+      expect(
+        result,
+        isA<Err<ConsolidationBroadcastResult, ConsolidationFailure>>(),
+      );
+
+      verifyNever(() => getWallet.execute(any()));
+      verifyNever(() => sync.execute(any()));
     });
 
-    test('wraps a broadcast failure in a ConsolidationException with an empty '
-        'succeededTxids when it happens on the very first PSET', () async {
+    test('still syncs whatever DID broadcast even when a later batch fails to '
+        'sign — so those funds are immediately discoverable, not stuck '
+        'behind a stale gap-limit scan until some other sync happens to '
+        'cover them', () async {
+      when(
+        () => repo.signPset(
+          pset: 'pset-1',
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenAnswer((_) async => 'signed-1');
+      when(
+        () => repo.signPset(
+          pset: 'pset-2',
+          walletId: any(named: 'walletId'),
+        ),
+      ).thenThrow(Exception('sign failed'));
+      when(() => broadcast.execute(any())).thenAnswer((_) async => 'txid');
+      when(
+        () => utxoRepo.freezeUtxos(
+          walletId: any(named: 'walletId'),
+          outpoints: any(named: 'outpoints'),
+        ),
+      ).thenAnswer((_) async {});
+      final wallet = buildWallet();
+      when(() => getWallet.execute(walletId)).thenAnswer((_) async => wallet);
+      when(() => sync.execute(wallet)).thenAnswer((_) async {});
+
+      final result = await usecase.broadcast(
+        walletId: walletId,
+        batches: batches,
+      );
+
+      expect(
+        result,
+        isA<Err<ConsolidationBroadcastResult, ConsolidationFailure>>(),
+      );
+      verify(() => sync.execute(wallet)).called(1);
+    });
+
+    test('a failed sync is swallowed (best-effort) — never turns a '
+        'successful broadcast into a reported failure', () async {
       when(
         () => repo.signPset(
           pset: any(named: 'pset'),
           walletId: any(named: 'walletId'),
         ),
       ).thenAnswer((_) async => 'signed');
+      when(() => broadcast.execute(any())).thenAnswer((_) async => 'txid');
       when(
-        () => broadcast.execute(any()),
-      ).thenThrow(Exception('broadcast rejected'));
+        () => utxoRepo.freezeUtxos(
+          walletId: any(named: 'walletId'),
+          outpoints: any(named: 'outpoints'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => getWallet.execute(walletId),
+      ).thenThrow(Exception('network down'));
 
-      await expectLater(
-        () => usecase.broadcast(walletId: walletId, unsignedPsets: ['pset-1']),
-        throwsA(isA<ConsolidationException>()),
+      final result = await usecase.broadcast(
+        walletId: walletId,
+        batches: batches,
       );
-    });
 
-    test('a failure partway through carries the already-broadcast txids on '
-        'the thrown exception, rather than discarding them — this is what '
-        'lets a retry (see ConsolidationCubit) know not to resubmit an '
-        'already-spent batch', () async {
-      when(
-        () => repo.signPset(
-          pset: any(named: 'pset'),
-          walletId: any(named: 'walletId'),
-        ),
-      ).thenAnswer((invocation) async {
-        final pset = invocation.namedArguments[#pset] as String;
-        return 'signed-$pset';
-      });
-      when(() => broadcast.execute(any())).thenAnswer((invocation) async {
-        final signed = invocation.positionalArguments.first as String;
-        if (signed == 'signed-pset-2') {
-          throw Exception('node unreachable');
-        }
-        return 'txid-$signed';
-      });
-
-      try {
-        await usecase.broadcast(
-          walletId: walletId,
-          unsignedPsets: ['pset-1', 'pset-2', 'pset-3'],
-        );
-        fail('expected a ConsolidationException');
-      } on ConsolidationException catch (e) {
-        expect(e.succeededTxids, ['txid-signed-pset-1']);
-      }
-      // pset-3 was never attempted — the loop stops at the first failure.
-      verifyNever(
-        () => repo.signPset(
-          pset: 'pset-3',
-          walletId: any(named: 'walletId'),
-        ),
+      expect(
+        result,
+        isA<Ok<ConsolidationBroadcastResult, ConsolidationFailure>>(),
       );
     });
   });

--- a/test/features/consolidation/presentation/consolidation_banner_cubit_test.dart
+++ b/test/features/consolidation/presentation/consolidation_banner_cubit_test.dart
@@ -1,4 +1,4 @@
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_banner_cubit.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,19 +8,21 @@ class _MockCheckLiquidConsolidationUsecase extends Mock
 
 void main() {
   late _MockCheckLiquidConsolidationUsecase check;
-  late ConsolidationBannerCubit cubit;
 
   const walletId = 'wallet-1';
 
+  ConsolidationBannerCubit buildCubit() => ConsolidationBannerCubit(
+    checkLiquidConsolidationUsecase: check,
+    walletId: walletId,
+  );
+
   setUp(() {
     check = _MockCheckLiquidConsolidationUsecase();
-    cubit = ConsolidationBannerCubit(
-      checkLiquidConsolidationUsecase: check,
-      walletId: walletId,
-    );
   });
 
   test('starts false before reload is ever called', () {
+    final cubit = buildCubit();
+
     expect(cubit.state, isFalse);
   });
 
@@ -28,8 +30,9 @@ void main() {
     'emits true when the use-case reports consolidation is required',
     () async {
       when(
-        () => check.execute(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => true);
+        () => check.execute(walletId: walletId),
+      ).thenAnswer((_) async => (utxoCount: 300, isRequired: true));
+      final cubit = buildCubit();
 
       await cubit.reload();
 
@@ -39,8 +42,9 @@ void main() {
 
   test('emits false when consolidation is not required', () async {
     when(
-      () => check.execute(walletId: any(named: 'walletId')),
-    ).thenAnswer((_) async => false);
+      () => check.execute(walletId: walletId),
+    ).thenAnswer((_) async => (utxoCount: 3, isRequired: false));
+    final cubit = buildCubit();
 
     await cubit.reload();
 
@@ -51,29 +55,32 @@ void main() {
     'keeps the last known value (best-effort) when the use-case throws',
     () async {
       when(
-        () => check.execute(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => true);
+        () => check.execute(walletId: walletId),
+      ).thenAnswer((_) async => (utxoCount: 300, isRequired: true));
+      final cubit = buildCubit();
       await cubit.reload();
       expect(cubit.state, isTrue);
 
       when(
-        () => check.execute(walletId: any(named: 'walletId')),
-      ).thenThrow(Exception('read failed'));
+        () => check.execute(walletId: walletId),
+      ).thenThrow(Exception('network down'));
+
       await cubit.reload();
 
-      expect(cubit.state, isTrue);
+      expect(cubit.state, isTrue); // unchanged, not reset to false
     },
   );
 
   test('does not emit after being closed', () async {
     when(
-      () => check.execute(walletId: any(named: 'walletId')),
-    ).thenAnswer((_) async => true);
-
+      () => check.execute(walletId: walletId),
+    ).thenAnswer((_) async => (utxoCount: 300, isRequired: true));
+    final cubit = buildCubit();
     await cubit.close();
+
     await cubit.reload();
 
     expect(cubit.isClosed, isTrue);
-    expect(cubit.state, isFalse);
+    expect(cubit.state, isFalse); // never emitted after close
   });
 }

--- a/test/features/consolidation/presentation/consolidation_cubit_test.dart
+++ b/test/features/consolidation/presentation/consolidation_cubit_test.dart
@@ -1,4 +1,10 @@
-import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+import 'package:bb_mobile/features/consolidation/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/features/consolidation/domain/usecases/consolidate_liquid_wallet_usecase.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_cubit.dart';
 import 'package:bb_mobile/features/consolidation/presentation/consolidation_state.dart';
@@ -11,223 +17,231 @@ class _MockConsolidateLiquidWalletUsecase extends Mock
 class _MockCheckLiquidConsolidationUsecase extends Mock
     implements CheckLiquidConsolidationUsecase {}
 
+class _MockGetWalletUsecase extends Mock implements GetWalletUsecase {}
+
+class _MockSyncWalletUsecase extends Mock implements SyncWalletUsecase {}
+
 void main() {
   late _MockConsolidateLiquidWalletUsecase consolidate;
   late _MockCheckLiquidConsolidationUsecase check;
+  late _MockGetWalletUsecase getWallet;
+  late _MockSyncWalletUsecase sync;
   late ConsolidationCubit cubit;
 
   const walletId = 'wallet-1';
 
+  Wallet buildWallet() => Wallet(
+    origin: walletId,
+    network: Network.liquidMainnet,
+    xpubFingerprint: 'fingerprint',
+    scriptType: ScriptType.bip84,
+    xpub: 'xpub',
+    externalPublicDescriptor: 'external-descriptor',
+    internalPublicDescriptor: 'internal-descriptor',
+    signer: SignerEntity.local,
+    signerDevice: null,
+    balanceSat: BigInt.zero,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(buildWallet());
+  });
+
   setUp(() {
     consolidate = _MockConsolidateLiquidWalletUsecase();
     check = _MockCheckLiquidConsolidationUsecase();
+    getWallet = _MockGetWalletUsecase();
+    sync = _MockSyncWalletUsecase();
     cubit = ConsolidationCubit(
       walletId: walletId,
       consolidateLiquidWalletUsecase: consolidate,
       checkLiquidConsolidationUsecase: check,
+      getWalletUsecase: getWallet,
+      syncWalletUsecase: sync,
     );
+
+    when(() => getWallet.execute(any())).thenThrow(Exception('no wallet'));
+    when(
+      () => check.execute(walletId: any(named: 'walletId')),
+    ).thenAnswer((_) async => (utxoCount: 9, isRequired: true));
   });
 
-  group('load()', () {
-    test('populates utxoCount and the preview on success', () async {
-      when(
-        () => check.count(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => 9);
-      const preview = ConsolidationPreview(
-        unsignedPsets: ['pset-1'],
-        totalFeeSat: 50,
-      );
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-
-      await cubit.load();
-
-      expect(cubit.state.utxoCount, 9);
-      expect(cubit.state.preview, preview);
-      expect(cubit.state.feeSat, 50);
-      expect(cubit.state.status, ConsolidationStatus.idle);
-    });
-
-    test('a prepare() failure leaves the preview/fee unavailable (shown as '
-        '"—") without throwing past load() — the fix closes the previous '
-        'silent-discard so the failure is at least logged, not just '
-        'invisible', () async {
-      when(
-        () => check.count(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => 9);
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenThrow(Exception('consolidate build failed'));
-
-      await cubit.load();
-
-      expect(cubit.state.preview, isNull);
-      expect(cubit.state.feeSat, isNull);
-      expect(cubit.state.utxoCount, 9);
-      expect(cubit.state.status, ConsolidationStatus.idle);
-    });
-
-    test('a count() failure (returns null) leaves utxoCount unset', () async {
-      when(
-        () => check.count(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => null);
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer(
-        (_) async =>
-            const ConsolidationPreview(unsignedPsets: [], totalFeeSat: 0),
-      );
-
-      await cubit.load();
-
-      expect(cubit.state.utxoCount, isNull);
-    });
-  });
-
-  group('consolidate()', () {
-    test('builds (if no preview cached), signs, and broadcasts — ending in '
-        'success', () async {
-      const preview = ConsolidationPreview(
-        unsignedPsets: ['pset-1', 'pset-2'],
-        totalFeeSat: 100,
-      );
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-      when(
-        () => consolidate.broadcast(
-          walletId: any(named: 'walletId'),
-          unsignedPsets: any(named: 'unsignedPsets'),
-        ),
-      ).thenAnswer((_) async => ['txid-1', 'txid-2']);
-
-      await cubit.consolidate();
-
-      expect(cubit.state.status, ConsolidationStatus.success);
-      verify(() => consolidate.prepare(walletId: walletId)).called(1);
-      verify(
-        () => consolidate.broadcast(
-          walletId: walletId,
-          unsignedPsets: preview.unsignedPsets,
-        ),
-      ).called(1);
-    });
-
-    test('reuses an already-loaded preview instead of rebuilding it', () async {
-      when(
-        () => check.count(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => 9);
-      const preview = ConsolidationPreview(
-        unsignedPsets: ['pset-1'],
-        totalFeeSat: 50,
-      );
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-      await cubit.load();
-      clearInteractions(consolidate);
-
-      when(
-        () => consolidate.broadcast(
-          walletId: any(named: 'walletId'),
-          unsignedPsets: any(named: 'unsignedPsets'),
-        ),
-      ).thenAnswer((_) async => ['txid-1']);
-
-      await cubit.consolidate();
-
-      expect(cubit.state.status, ConsolidationStatus.success);
-      verifyNever(() => consolidate.prepare(walletId: any(named: 'walletId')));
-    });
-
-    test(
-      'a build/broadcast failure sets status to failed — the '
-      'user-friendly-error acceptance criterion, and the previously '
-      'silent catch now at least logs the cause (see ConsolidationCubit)',
-      () async {
+  group(
+    'load() — the fee-fetch regression: a prepare() failure must be visible, '
+    'not silently discarded (previously the fee/batch rows would sit at "—" '
+    'forever with no error shown, no matter what the underlying cause was)',
+    () {
+      test('a successful prepare() populates the preview normally', () async {
         when(
           () => consolidate.prepare(walletId: any(named: 'walletId')),
-        ).thenThrow(Exception('lwk build failed'));
+        ).thenAnswer(
+          (_) async => const Ok(
+            ConsolidationPreview(batches: [], totalFeeSat: 0, utxoCount: 9),
+          ),
+        );
+
+        await cubit.load();
+
+        expect(cubit.state.status, ConsolidationStatus.idle);
+        expect(cubit.state.failure, isNull);
+        expect(cubit.state.utxoCount, 9);
+      });
+
+      test(
+        'a prepare() failure sets status to failed and stores the failure — '
+        'instead of leaving the state looking identical to "still loading"',
+        () async {
+          const failure = ConsolidationBuildFailure('buildCustomTx exploded');
+          when(
+            () => consolidate.prepare(walletId: any(named: 'walletId')),
+          ).thenAnswer((_) async => const Err(failure));
+
+          await cubit.load();
+
+          expect(cubit.state.status, ConsolidationStatus.failed);
+          expect(cubit.state.failure, failure);
+          // The fee row has nothing to show — confirmed via feeSat, not
+          // just "preview is null", since that's the actual UI-visible
+          // symptom the bug produced.
+          expect(cubit.state.feeSat, isNull);
+        },
+      );
+    },
+  );
+
+  group(
+    'consolidate() — forces a real sync before rebuilding when no preview is '
+    'in hand (the M2 fix: closes the race where a previous broadcast '
+    'round\'s own best-effort sync failed silently, leaving a rebuild to '
+    'read a stale view that could still list an already-spent outpoint as '
+    'confirmed)',
+    () {
+      test(
+        'an existing preview (already populated by a successful load()) '
+        'skips the sync and prepare entirely, going straight to broadcast',
+        () async {
+          const preview = ConsolidationPreview(
+            batches: [ConsolidationBatch(pset: 'pset-1', decoyVout: 0)],
+            totalFeeSat: 50,
+            utxoCount: 9,
+          );
+          when(
+            () => consolidate.prepare(walletId: any(named: 'walletId')),
+          ).thenAnswer((_) async => const Ok(preview));
+          await cubit.load();
+          // Sanity: load() did populate a preview, so consolidate() below
+          // has one in hand already.
+          expect(cubit.state.preview, preview);
+          clearInteractions(getWallet);
+          clearInteractions(sync);
+
+          when(
+            () => consolidate.broadcast(
+              walletId: any(named: 'walletId'),
+              batches: any(named: 'batches'),
+            ),
+          ).thenAnswer(
+            (_) async => const Ok(
+              ConsolidationBroadcastResult(
+                txids: ['tx1'],
+                unfrozenDecoyCount: 0,
+              ),
+            ),
+          );
+
+          await cubit.consolidate();
+
+          expect(cubit.state.status, ConsolidationStatus.success);
+          verifyNever(() => getWallet.execute(any()));
+          verifyNever(() => sync.execute(any()));
+        },
+      );
+
+      test('no preview in hand: syncs successfully, then prepares and '
+          'broadcasts as normal', () async {
+        final wallet = buildWallet();
+        when(() => getWallet.execute(walletId)).thenAnswer((_) async => wallet);
+        when(() => sync.execute(wallet)).thenAnswer((_) async {});
+        const preview = ConsolidationPreview(
+          batches: [ConsolidationBatch(pset: 'pset-1', decoyVout: 0)],
+          totalFeeSat: 50,
+          utxoCount: 9,
+        );
+        when(
+          () => consolidate.prepare(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => const Ok(preview));
+        when(
+          () => consolidate.broadcast(
+            walletId: any(named: 'walletId'),
+            batches: any(named: 'batches'),
+          ),
+        ).thenAnswer(
+          (_) async => const Ok(
+            ConsolidationBroadcastResult(txids: ['tx1'], unfrozenDecoyCount: 0),
+          ),
+        );
+
+        await cubit.consolidate();
+
+        expect(cubit.state.status, ConsolidationStatus.success);
+        verify(() => sync.execute(wallet)).called(1);
+        verify(
+          () => consolidate.prepare(walletId: any(named: 'walletId')),
+        ).called(1);
+      });
+
+      test('no preview in hand: sync fails — emits ConsolidationSyncFailure '
+          'and never calls prepare() or broadcast(), rather than attempting '
+          'a build against a view we know may be stale', () async {
+        final wallet = buildWallet();
+        when(() => getWallet.execute(walletId)).thenAnswer((_) async => wallet);
+        when(
+          () => sync.execute(wallet),
+        ).thenThrow(Exception('electrum unreachable'));
 
         await cubit.consolidate();
 
         expect(cubit.state.status, ConsolidationStatus.failed);
-      },
-    );
+        expect(cubit.state.failure, isA<ConsolidationSyncFailure>());
+        verifyNever(
+          () => consolidate.prepare(walletId: any(named: 'walletId')),
+        );
+        verifyNever(
+          () => consolidate.broadcast(
+            walletId: any(named: 'walletId'),
+            batches: any(named: 'batches'),
+          ),
+        );
+      });
 
-    test('a broadcast failure clears the cached preview, so a retry always '
-        'calls prepare() again instead of resubmitting the same (partially '
-        'already-spent) PSETs — the partial-broadcast retry-gap fix', () async {
-      const preview = ConsolidationPreview(
-        unsignedPsets: ['pset-1', 'pset-2'],
-        totalFeeSat: 100,
-      );
-      // First attempt: prepare succeeds, broadcast fails partway through
-      // (batch 1 already broadcast, carried on the exception).
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-      when(
-        () => consolidate.broadcast(
-          walletId: any(named: 'walletId'),
-          unsignedPsets: any(named: 'unsignedPsets'),
-        ),
-      ).thenThrow(ConsolidationException('node unreachable', const ['txid-1']));
+      test('no preview in hand: GetWalletUsecase returning null is treated as '
+          'a no-op (mirrors the old best-effort sync\'s semantics) and still '
+          'proceeds to prepare()', () async {
+        when(() => getWallet.execute(walletId)).thenAnswer((_) async => null);
+        const preview = ConsolidationPreview(
+          batches: [ConsolidationBatch(pset: 'pset-1', decoyVout: 0)],
+          totalFeeSat: 50,
+          utxoCount: 9,
+        );
+        when(
+          () => consolidate.prepare(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => const Ok(preview));
+        when(
+          () => consolidate.broadcast(
+            walletId: any(named: 'walletId'),
+            batches: any(named: 'batches'),
+          ),
+        ).thenAnswer(
+          (_) async => const Ok(
+            ConsolidationBroadcastResult(txids: ['tx1'], unfrozenDecoyCount: 0),
+          ),
+        );
 
-      await cubit.consolidate();
+        await cubit.consolidate();
 
-      expect(cubit.state.status, ConsolidationStatus.failed);
-      expect(cubit.state.preview, isNull);
-
-      // Retry: since preview is now null, it must call prepare() again —
-      // never resubmit the stale `preview` from the failed attempt.
-      clearInteractions(consolidate);
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-      when(
-        () => consolidate.broadcast(
-          walletId: any(named: 'walletId'),
-          unsignedPsets: any(named: 'unsignedPsets'),
-        ),
-      ).thenAnswer((_) async => ['txid-1', 'txid-2']);
-
-      await cubit.consolidate();
-
-      expect(cubit.state.status, ConsolidationStatus.success);
-      verify(() => consolidate.prepare(walletId: walletId)).called(1);
-    });
-
-    test('a re-entrant call while already broadcasting is a no-op — never '
-        'runs the build→sign→broadcast pipeline twice concurrently against '
-        'the same PSETs (the double-tap guard)', () async {
-      const preview = ConsolidationPreview(
-        unsignedPsets: ['pset-1'],
-        totalFeeSat: 50,
-      );
-      when(
-        () => consolidate.prepare(walletId: any(named: 'walletId')),
-      ).thenAnswer((_) async => preview);
-      when(
-        () => consolidate.broadcast(
-          walletId: any(named: 'walletId'),
-          unsignedPsets: any(named: 'unsignedPsets'),
-        ),
-      ).thenAnswer((_) async => ['txid-1']);
-
-      await Future.wait([cubit.consolidate(), cubit.consolidate()]);
-
-      expect(cubit.state.status, ConsolidationStatus.success);
-      // Only one of the two concurrent calls actually ran the pipeline —
-      // the guard made the other an immediate no-op.
-      verify(() => consolidate.prepare(walletId: walletId)).called(1);
-      verify(
-        () => consolidate.broadcast(
-          walletId: walletId,
-          unsignedPsets: preview.unsignedPsets,
-        ),
-      ).called(1);
-    });
-  });
+        expect(cubit.state.status, ConsolidationStatus.success);
+        verifyNever(() => sync.execute(any()));
+      });
+    },
+  );
 }

--- a/test/features/consolidation/presentation/consolidation_failure_l10n_test.dart
+++ b/test/features/consolidation/presentation/consolidation_failure_l10n_test.dart
@@ -1,0 +1,177 @@
+import 'package:bb_mobile/features/consolidation/domain/consolidation_failure.dart';
+import 'package:bb_mobile/features/consolidation/presentation/consolidation_failure_l10n.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// [ConsolidationFailureL10n.toTranslated] is the one place a
+/// [ConsolidationFailure] is allowed to become user-facing text. The
+/// contract under test (rule #11): the end user must never see the raw,
+/// developer-only [Failure.logMessage] — every variant must resolve to one
+/// of the pre-defined, localized strings, regardless of what internal detail
+/// the failure was constructed with.
+void main() {
+  Future<String> translate(
+    WidgetTester tester,
+    ConsolidationFailure failure,
+  ) async {
+    late String result;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            result = failure.toTranslated(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return result;
+  }
+
+  const secretLogMessage = 'raw internal detail the user must never see';
+
+  group('toTranslated never leaks Failure.logMessage', () {
+    testWidgets('ConsolidationRequiredFailure', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationRequiredFailure(secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(message, 'Consolidate the wallet');
+    });
+
+    testWidgets('ConsolidationCountUnavailableFailure', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationCountUnavailableFailure(secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(message, 'Oops! Something went wrong');
+    });
+
+    testWidgets('ConsolidationBuildFailure', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationBuildFailure(secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(
+        message,
+        'An unexpected error occurred. Your funds are safe — no '
+        'transaction was broadcast. Please try again.',
+      );
+    });
+
+    testWidgets('ConsolidationUnexpectedFailure', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationUnexpectedFailure(secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(message, 'Oops! Something went wrong');
+    });
+
+    testWidgets('ConsolidationSyncFailure', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationSyncFailure(secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(
+        message,
+        "Couldn't refresh your wallet's data before retrying. Please "
+        'check your connection and try again.',
+      );
+    });
+  });
+
+  group('ConsolidationSignFailure / ConsolidationBroadcastFailure: the '
+      'succeededTxids-aware message is used instead of the generic one, '
+      'and still never leaks logMessage', () {
+    testWidgets(
+      'sign failure with no prior successes uses the generic message',
+      (tester) async {
+        final message = await translate(
+          tester,
+          const ConsolidationSignFailure([], secretLogMessage),
+        );
+
+        expect(message, isNot(contains(secretLogMessage)));
+        expect(
+          message,
+          'An unexpected error occurred. Your funds are safe — no '
+          'transaction was broadcast. Please try again.',
+        );
+      },
+    );
+
+    testWidgets(
+      'sign failure with prior successes reports how many, singular',
+      (tester) async {
+        final message = await translate(
+          tester,
+          const ConsolidationSignFailure(['txid1'], secretLogMessage),
+        );
+
+        expect(message, isNot(contains(secretLogMessage)));
+        expect(message, contains('1 transaction was'));
+      },
+    );
+
+    testWidgets('sign failure with multiple prior successes reports the count, '
+        'plural', (tester) async {
+      final message = await translate(
+        tester,
+        const ConsolidationSignFailure([
+          'txid1',
+          'txid2',
+          'txid3',
+        ], secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(message, contains('3 transactions were'));
+    });
+
+    testWidgets(
+      'broadcast failure with no prior successes uses the generic message',
+      (tester) async {
+        final message = await translate(
+          tester,
+          const ConsolidationBroadcastFailure([], secretLogMessage),
+        );
+
+        expect(message, isNot(contains(secretLogMessage)));
+        expect(
+          message,
+          'An unexpected error occurred. Your funds are safe — no '
+          'transaction was broadcast. Please try again.',
+        );
+      },
+    );
+
+    testWidgets('broadcast failure with prior successes reports how many', (
+      tester,
+    ) async {
+      final message = await translate(
+        tester,
+        const ConsolidationBroadcastFailure([
+          'txid1',
+          'txid2',
+        ], secretLogMessage),
+      );
+
+      expect(message, isNot(contains(secretLogMessage)));
+      expect(message, contains('2 transactions were'));
+    });
+  });
+}

--- a/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
+++ b/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
@@ -2,13 +2,12 @@ import 'dart:typed_data';
 
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
-import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart'
-    show NoSpendableUtxoException;
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 

--- a/test/features/send/domain/usecases/prepare_liquid_send_usecase_test.dart
+++ b/test/features/send/domain/usecases/prepare_liquid_send_usecase_test.dart
@@ -1,0 +1,346 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/liquid_tx_output.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_build_tx_exceptions.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLiquidWalletRepository extends Mock
+    implements LiquidWalletRepository {}
+
+class _MockWalletUtxoRepository extends Mock implements WalletUtxoRepository {}
+
+class _MockWalletAddressRepository extends Mock
+    implements WalletAddressRepository {}
+
+void main() {
+  late _MockLiquidWalletRepository repo;
+  late _MockWalletUtxoRepository utxoRepo;
+  late _MockWalletAddressRepository addressRepo;
+  late PrepareLiquidSendUsecase usecase;
+
+  const walletId = 'wallet-1';
+  const address = 'lq1qq...';
+  const feeRate = RelativeFee(25);
+  const changeAddress = 'lq1qqchange...';
+
+  WalletAddress buildWalletAddress(String address) => WalletAddress(
+    walletId: walletId,
+    index: 1,
+    address: address,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const RelativeFee(25));
+    registerFallbackValue(const <LiquidTxOutput>[]);
+  });
+
+  setUp(() {
+    repo = _MockLiquidWalletRepository();
+    utxoRepo = _MockWalletUtxoRepository();
+    addressRepo = _MockWalletAddressRepository();
+    usecase = PrepareLiquidSendUsecase(
+      liquidWalletRepository: repo,
+      walletUtxoRepository: utxoRepo,
+      walletAddressRepository: addressRepo,
+    );
+
+    // Default: 1 confirmed, unfrozen outpoint — well under the input limit —
+    // so tests that don't care about the frozen/limit logic get a working
+    // happy path without repeating this setup everywhere.
+    when(
+      () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+    ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+    when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+    when(() => repo.exceedsLiquidInputLimit(any())).thenReturn(false);
+    when(
+      () => addressRepo.generateNewReceiveAddress(
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => buildWalletAddress(changeAddress));
+    when(
+      () => repo.buildCustomTx(
+        walletId: any(named: 'walletId'),
+        utxos: any(named: 'utxos'),
+        outputs: any(named: 'outputs'),
+        drainToAddress: any(named: 'drainToAddress'),
+        feeRate: any(named: 'feeRate'),
+      ),
+    ).thenAnswer((_) async => 'unsigned-pset');
+  });
+
+  group(
+    'frozen-UTXO enforcement: a frozen UTXO (e.g. a consolidation decoy) is '
+    'never offered to the transaction builder, for either a normal send or '
+    'a drain (send-all)',
+    () {
+      test('excludes frozen outpoints from the utxos passed to buildCustomTx '
+          '(normal send)', () async {
+        when(
+          () =>
+              repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+        ).thenAnswer(
+          (_) async => [
+            (txId: 'tx0', vout: 0),
+            (txId: 'tx1', vout: 0),
+            (txId: 'tx2', vout: 0),
+          ],
+        );
+        when(
+          () => utxoRepo.getAllFrozenOutpoints(),
+        ).thenAnswer((_) async => [(txId: 'tx1', vout: 0)]);
+
+        await usecase.execute(
+          walletId: walletId,
+          address: address,
+          feeRate: feeRate,
+          amountSat: 5000,
+        );
+
+        final captured = verify(
+          () => repo.buildCustomTx(
+            walletId: walletId,
+            utxos: captureAny(named: 'utxos'),
+            outputs: any(named: 'outputs'),
+            drainToAddress: any(named: 'drainToAddress'),
+            feeRate: feeRate,
+          ),
+        ).captured;
+        final utxos = captured.single as List;
+        expect(utxos, [(txId: 'tx0', vout: 0), (txId: 'tx2', vout: 0)]);
+      });
+
+      test(
+        'excludes frozen outpoints even on a drain (send-all) send — drain '
+        'means "sweep everything usable", not "sweep the whole wallet"',
+        () async {
+          when(
+            () => repo.getConfirmedLbtcOutpoints(
+              walletId: any(named: 'walletId'),
+            ),
+          ).thenAnswer(
+            (_) async => [(txId: 'tx0', vout: 0), (txId: 'tx1', vout: 0)],
+          );
+          when(
+            () => utxoRepo.getAllFrozenOutpoints(),
+          ).thenAnswer((_) async => [(txId: 'tx1', vout: 0)]);
+
+          await usecase.execute(
+            walletId: walletId,
+            address: address,
+            feeRate: feeRate,
+            drain: true,
+          );
+
+          final captured = verify(
+            () => repo.buildCustomTx(
+              walletId: walletId,
+              utxos: captureAny(named: 'utxos'),
+              outputs: any(named: 'outputs'),
+              drainToAddress: any(named: 'drainToAddress'),
+              feeRate: feeRate,
+            ),
+          ).captured;
+          final utxos = captured.single as List;
+          expect(utxos, [(txId: 'tx0', vout: 0)]);
+        },
+      );
+
+      test(
+        'throws NoSpendableUtxoException when every confirmed UTXO is frozen',
+        () async {
+          when(
+            () => repo.getConfirmedLbtcOutpoints(
+              walletId: any(named: 'walletId'),
+            ),
+          ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+          when(
+            () => utxoRepo.getAllFrozenOutpoints(),
+          ).thenAnswer((_) async => [(txId: 'tx0', vout: 0)]);
+
+          await expectLater(
+            usecase.execute(
+              walletId: walletId,
+              address: address,
+              feeRate: feeRate,
+              amountSat: 1000,
+            ),
+            throwsA(isA<NoSpendableUtxoException>()),
+          );
+          verifyNever(
+            () => repo.buildCustomTx(
+              walletId: any(named: 'walletId'),
+              utxos: any(named: 'utxos'),
+              outputs: any(named: 'outputs'),
+              drainToAddress: any(named: 'drainToAddress'),
+              feeRate: any(named: 'feeRate'),
+            ),
+          );
+        },
+      );
+    },
+  );
+
+  group('crash-prevention contract: a wallet over the Liquid confidential-tx '
+      'input limit (e.g. >256 confirmed L-BTC UTXOs) never reaches the '
+      'native LWK builder — checked against the usable (confirmed, unfrozen) '
+      'count, and surfaced as the catchable ConsolidationRequiredException, '
+      'never left to surface as a crash', () {
+    test('throws ConsolidationRequiredException when over the limit', () async {
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenAnswer(
+        (_) async => List.generate(300, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      when(() => repo.exceedsLiquidInputLimit(300)).thenReturn(true);
+
+      await expectLater(
+        usecase.execute(
+          walletId: walletId,
+          address: address,
+          feeRate: feeRate,
+          amountSat: 1000,
+        ),
+        throwsA(isA<ConsolidationRequiredException>()),
+      );
+      verifyNever(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      );
+    });
+
+    test('checks the limit against the usable count, not the raw confirmed '
+        'count — a wallet over the raw limit but under it once frozen '
+        'UTXOs are excluded should NOT require consolidation', () async {
+      when(
+        () => repo.getConfirmedLbtcOutpoints(walletId: any(named: 'walletId')),
+      ).thenAnswer(
+        (_) async => List.generate(300, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      when(() => utxoRepo.getAllFrozenOutpoints()).thenAnswer(
+        (_) async => List.generate(250, (i) => (txId: 'tx$i', vout: 0)),
+      );
+      // 300 - 250 = 50 usable, under the limit.
+      when(() => repo.exceedsLiquidInputLimit(50)).thenReturn(false);
+
+      await usecase.execute(
+        walletId: walletId,
+        address: address,
+        feeRate: feeRate,
+        amountSat: 1000,
+      );
+
+      verify(() => repo.exceedsLiquidInputLimit(50)).called(1);
+    });
+  });
+
+  group('no regression: a wallet under the input limit builds and sends '
+      'via buildCustomTx', () {
+    test('a normal (non-drain) send pays the recipient and drains change '
+        'to a freshly reserved address of our own', () async {
+      final pset = await usecase.execute(
+        walletId: walletId,
+        address: address,
+        feeRate: feeRate,
+        amountSat: 5000,
+      );
+
+      expect(pset, 'unsigned-pset');
+      final captured = verify(
+        () => repo.buildCustomTx(
+          walletId: walletId,
+          utxos: [(txId: 'tx0', vout: 0)],
+          outputs: captureAny(named: 'outputs'),
+          drainToAddress: changeAddress,
+          feeRate: feeRate,
+        ),
+      ).captured;
+      final outputs = captured.single as List<LiquidTxOutput>;
+      expect(outputs, hasLength(1));
+      expect(outputs.single.address, address);
+      expect(outputs.single.satoshi, 5000);
+      verify(
+        () => addressRepo.generateNewReceiveAddress(walletId: walletId),
+      ).called(1);
+    });
+
+    test('a drain (send-all) send has no payment output — everything usable '
+        'goes to the recipient, no change reserved', () async {
+      final pset = await usecase.execute(
+        walletId: walletId,
+        address: address,
+        feeRate: feeRate,
+        drain: true,
+      );
+
+      expect(pset, 'unsigned-pset');
+      verify(
+        () => repo.buildCustomTx(
+          walletId: walletId,
+          utxos: [(txId: 'tx0', vout: 0)],
+          outputs: const <LiquidTxOutput>[],
+          drainToAddress: address,
+          feeRate: feeRate,
+        ),
+      ).called(1);
+      verifyNever(
+        () => addressRepo.generateNewReceiveAddress(
+          walletId: any(named: 'walletId'),
+        ),
+      );
+    });
+  });
+
+  group('input validation', () {
+    test('throws when amountSat is null and drain is false', () async {
+      await expectLater(
+        usecase.execute(walletId: walletId, address: address, feeRate: feeRate),
+        throwsA(isA<Exception>()),
+      );
+      verifyNever(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      );
+    });
+  });
+
+  group('other failure mapping', () {
+    test('wraps any other error as PrepareLiquidSendException', () async {
+      when(
+        () => repo.buildCustomTx(
+          walletId: any(named: 'walletId'),
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainToAddress: any(named: 'drainToAddress'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).thenThrow(Exception('network down'));
+
+      await expectLater(
+        usecase.execute(
+          walletId: walletId,
+          address: address,
+          feeRate: feeRate,
+          amountSat: 1000,
+        ),
+        throwsA(isA<PrepareLiquidSendException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds Liquid wallet UTXO consolidation: when a wallet accumulates too many
confirmed L-BTC UTXOs, it's offered (via a banner on wallet/send/swap
screens) a guided flow to sweep them into fewer outputs, keeping the wallet
well under the ~256-input confidential-transaction limit before it ever
blocks a real send or swap.

## The decoy output, and why it's there

A naive consolidation transaction is an obvious on-chain signature: many
inputs, one output, no counterparty — a many-in/one-out self-transfer. On a
transparent chain that's a privacy leak (heuristics like this are a
well-known way to cluster a wallet's UTXOs together). On Liquid, amounts and
assets are already blinded by confidential transactions, but the *shape* of
the transaction (input/output count) is still visible.

Each consolidation batch is built with **two outputs instead of one**: the
real drained amount, plus a second, small "decoy" output back to a
fresh address of the wallet's own. This makes the transaction look like an
ordinary two-output payment rather than a textbook consolidation. Because
Liquid hides amounts, the decoy value itself is never visible to
anyone but the wallet — only the shape of the tx (2 outputs, not 1) is
public, and that shape is indistinguishable from a normal payment.

The decoy UTXO is then frozen (best-effort) so it's never accidentally
swept back into a future consolidation round.

## Also included

- **Frozen-UTXO enforcement in real sends/swaps** — Liquid sends and
  auto-swap executions now explicitly exclude frozen UTXOs (previously only
  the UI bookkeeping did), so a frozen decoy or user-frozen coin can never
  be accidentally spent by a normal transaction.
- **Address-reservation datasource** — prevents two addresses (e.g. two
  consolidation batches, or a batch running close to another
  address-generating event) from ever being handed out with the same
  index, closing a real address-reuse bug found during testing.
- **Sync gap-limit fix** — a multi-batch consolidation round now syncs the
  wallet against the actual highest reserved address index afterward,
  closing a real "balance disappeared" bug where funded addresses could
  land outside the default 20-address gap-limit scan.
- **`buildCustomTx`** — a new explicit-UTXO-list Liquid transaction builder
  (vs. the old coin-selecting builder), needed so consolidation, frozen-UTXO
  exclusion, and the decoy output can all specify exact inputs/outputs.
  
## Testing

Tested using small amounts of UTXOs.

https://github.com/user-attachments/assets/5ff3e93b-9486-4df4-9ad4-14c244e4aef8

