### PR TITLE
Pin payjoin crate to 1.0.0-rc.5 via SatoshiPortal fork

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1536,10 +1536,11 @@ packages:
   payjoin:
     dependency: "direct main"
     description:
-      name: payjoin
-      sha256: "2b8e3f2c0f78e2054fcee9c25a8ce670df3fb4bec7ea66c4524dbac5e5b654eb"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "26595d9821250bbd88f4e43b97acc85f17a93d71"
+      resolved-ref: "26595d9821250bbd88f4e43b97acc85f17a93d71"
+      url: "https://github.com/SatoshiPortal/payjoin-dart"
+    source: git
     version: "0.1.2"
   permission_handler:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,15 @@ dependencies:
       path: flutter_secure_storage
   path_provider: ^2.1.5
   shared_preferences: ^2.3.0
-  payjoin: ^0.1.2
+  # Vendored copy of pub.dev payjoin 0.1.2 with the payjoin Rust crate
+  # exact-pinned to 1.0.0-rc.5: rc.6 (published 2026-07-23) broke the
+  # package's from-source FFI build (UriExt/PjUri API changes), failing every
+  # fresh CI/container build. Point back to pub.dev once upstream ships a
+  # release built against a newer payjoin-ffi.
+  payjoin:
+    git:
+      url: https://github.com/SatoshiPortal/payjoin-dart
+      ref: 26595d9821250bbd88f4e43b97acc85f17a93d71
   qr_flutter: ^4.1.0
   dio: ^5.9.0
   timeago: ^3.7.1


### PR DESCRIPTION
Fixes the Android CI build failure (run 30099216662).

payjoin 1.0.0-rc.6 (published 2026-07-23 on crates.io) changed the UriExt/PjUri API and breaks the from-source FFI build of pub.dev payjoin 0.1.2. Fresh containers re-resolve to rc.6 and fail; local builds coasted on caches/lockfile.

- Vendored pub payjoin 0.1.2 onto SatoshiPortal/payjoin-dart branch pin/payjoin-0.1.2-rc5 with the crate exact-pinned to 1.0.0-rc.5 and a committed Cargo.lock
- pubspec points at that ref, restoring the pinned-git pattern used before (and same as bdk_dart)
- Verified: from-scratch cargo build resolves rc.5 and compiles; analyze clean; 789/789 tests pass with the native lib built fresh from the pinned package

Revert to pub.dev once upstream ships a release built against a newer payjoin-ffi.