### PR TITLE
fix(payjoin): harden session recovery and convergence

### DIFF
--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
+import 'package:bb_mobile/core/payjoin/data/datasources/pdk_payjoin_datasource.dart';
 import 'package:bb_mobile/core/payjoin/domain/entity/payjoin.dart';
 import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/payjoin/domain/usecases/receive_with_payjoin_usecase.dart';
@@ -38,6 +39,7 @@ Future<void> main({bool isInitialized = false}) async {
   final utxoRepository = locator<WalletUtxoRepository>();
   final payjoinRepository = locator<PayjoinRepository>();
   final localPayjoinDatasource = locator<LocalPayjoinDatasource>();
+  final pdkPayjoinDatasource = locator<PdkPayjoinDatasource>();
   final receiveWithPayjoinUsecase = locator<ReceiveWithPayjoinUsecase>();
   final sendWithPayjoinUsecase = locator<SendWithPayjoinUsecase>();
   final prepareBitcoinSendUsecase = locator<PrepareBitcoinSendUsecase>();
@@ -112,9 +114,9 @@ Future<void> main({bool isInitialized = false}) async {
     // Drain any persisted payjoin state so the test starts clean. Ongoing
     // payjoins left behind by a previous (possibly crashed) run keep their
     // inputs frozen via getUtxosFrozenByOngoingPayjoins(), which would starve
-    // the sender wallet. _resumePayjoins in PayjoinRepositoryImpl's
-    // constructor runs unawaited and writes its own updates concurrently, so
-    // we expire + recheck until the ongoing set stays empty for several polls.
+    // the sender wallet. Foreground recovery starts unawaited in Bull.init, so
+    // stop each recovered poll before expiring its row and require the ongoing
+    // set to remain empty for several checks.
     const pollInterval = Duration(milliseconds: 500);
     const requiredStableChecks = 3;
     const maxIterations = 40;
@@ -129,7 +131,8 @@ Future<void> main({bool isInitialized = false}) async {
       } else {
         stableChecks = 0;
         for (final payjoin in ongoing) {
-          await localPayjoinDatasource.update(
+          pdkPayjoinDatasource.stopPolling(payjoin.id);
+          await localPayjoinDatasource.markExpired(
             payjoin.copyWith(isExpired: true),
           );
         }
@@ -309,11 +312,23 @@ Future<void> main({bool isInitialized = false}) async {
         timeout: const Timeout(Duration(seconds: 120)),
       );
 
-      test('should successfully resume after a restart', () {});
+      test(
+        'should successfully resume after a restart',
+        () {},
+        skip: 'Requires an integration harness that restarts the app and DB',
+      );
 
-      test('should fail if the receiver does not have enough funds', () {});
+      test(
+        'should fail if the receiver does not have enough funds',
+        () {},
+        skip: 'Requires a funded sender and an underfunded receiver fixture',
+      );
 
-      test('should fail if the sender does not have enough funds', () {});
+      test(
+        'should fail if the sender does not have enough funds',
+        () {},
+        skip: 'Requires an underfunded sender fixture',
+      );
 
       test('should expire if time to wait for a request is over', () async {
         // Make the payjoin receiver expire before it polls the

--- a/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
@@ -343,20 +343,11 @@ class LocalPayjoinDatasource {
     ];
   }
 
-  Future<List<PayjoinReceiverModel>> fetchReceivers({
-    bool onlyOngoing = false,
-  }) async {
-    final receiversTable = _db.managers.payjoinReceivers;
-    List<PayjoinReceiverRow> receivers;
-    if (onlyOngoing) {
-      receivers = await receiversTable
-          .filter((f) => f.isExpired(false))
-          .filter((f) => f.isCompleted(false))
-          .filter((f) => f.isAborted(false))
-          .get();
-    } else {
-      receivers = await receiversTable.get();
-    }
+  /// Every receiver row, terminal ones included: the callers are the disable
+  /// sweep and startup recovery, which both decide what to settle from the
+  /// freshest row under a session lock. Filtered reads go through [fetchAll].
+  Future<List<PayjoinReceiverModel>> fetchReceivers() async {
+    final receivers = await _db.managers.payjoinReceivers.get();
 
     return receivers
         .map(
@@ -366,21 +357,9 @@ class LocalPayjoinDatasource {
         .toList();
   }
 
-  Future<List<PayjoinSenderModel>> fetchSenders({
-    bool onlyOngoing = false,
-  }) async {
-    final sendersTable = _db.managers.payjoinSenders;
-    List<PayjoinSenderRow> senders;
-
-    if (onlyOngoing) {
-      senders = await sendersTable
-          .filter((f) => f.isExpired(false))
-          .filter((f) => f.isCompleted(false))
-          .filter((f) => f.isAborted(false))
-          .get();
-    } else {
-      senders = await sendersTable.get();
-    }
+  /// Every sender row — same rationale as [fetchReceivers].
+  Future<List<PayjoinSenderModel>> fetchSenders() async {
+    final senders = await _db.managers.payjoinSenders.get();
 
     return senders
         .map(

--- a/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
+++ b/lib/core/payjoin/data/datasources/local_payjoin_datasource.dart
@@ -12,7 +12,7 @@ class LocalPayjoinDatasource {
   Future<void> storeReceiver(PayjoinReceiverModel receiver) async {
     try {
       final row = receiver.toSqlite();
-      await _db.into(_db.payjoinReceivers).insertOnConflictUpdate(row);
+      await _db.into(_db.payjoinReceivers).insert(row);
     } catch (e) {
       throw CreateReceiverException('$e');
     }
@@ -21,11 +21,42 @@ class LocalPayjoinDatasource {
   Future<void> storeSender(PayjoinSenderModel sender) async {
     try {
       final row = sender.toSqlite();
-      await _db.into(_db.payjoinSenders).insertOnConflictUpdate(row);
+      await _db.into(_db.payjoinSenders).insert(row);
     } catch (e) {
       throw CreateSenderException('$e');
     }
   }
+
+  /// Replaces only a sender that expired without a known broadcast outcome.
+  /// Completed and aborted payments remain immutable so retry cannot create a
+  /// second payment for an already-resolved request.
+  Future<bool> replaceExpiredSender(PayjoinSenderModel sender) =>
+      _writeTransition(() {
+        return (_db.update(_db.payjoinSenders)..where(
+              (row) =>
+                  row.uri.equals(sender.id) &
+                  row.isExpired.equals(true) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false),
+            ))
+            .write(
+              PayjoinSendersCompanion(
+                isTestnet: Value(sender.isTestnet),
+                sender: Value(sender.sender),
+                walletId: Value(sender.walletId),
+                originalPsbt: Value(sender.originalPsbt),
+                originalTxId: Value(sender.originalTxId),
+                amountSat: Value(sender.amountSat),
+                createdAt: Value(sender.createdAt),
+                expireAfterSec: Value(sender.expireAfterSec),
+                proposalPsbt: Value(sender.proposalPsbt),
+                txId: Value(sender.txId),
+                isExpired: Value(sender.isExpired),
+                isCompleted: Value(sender.isCompleted),
+                isAborted: Value(sender.isAborted),
+              ),
+            );
+      });
 
   Future<PayjoinReceiverModel?> fetchReceiver(String id) async {
     final receiver = await _db.managers.payjoinReceivers
@@ -47,8 +78,177 @@ class LocalPayjoinDatasource {
     return PayjoinModel.fromSenderTable(sender) as PayjoinSenderModel;
   }
 
-  Future<void> deleteReceiver(String id) async {
-    await _db.managers.payjoinReceivers.filter((f) => f.id(id)).delete();
+  Future<bool> deleteIdleReceiver(String id) => _writeTransition(() {
+    return (_db.delete(_db.payjoinReceivers)..where(
+          (row) =>
+              row.id.equals(id) &
+              row.originalTxBytes.isNull() &
+              row.proposalPsbt.isNull() &
+              row.isCompleted.equals(false) &
+              row.isAborted.equals(false),
+        ))
+        .go();
+  });
+
+  Future<bool> recordReceiverRequest(PayjoinReceiverModel receiver) =>
+      _writeTransition(() {
+        return (_db.update(_db.payjoinReceivers)..where(
+              (row) =>
+                  row.id.equals(receiver.id) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false),
+            ))
+            .write(
+              PayjoinReceiversCompanion(
+                receiver: Value(receiver.receiver),
+                originalTxBytes: Value(receiver.originalTxBytes),
+                originalTxId: Value(receiver.originalTxId),
+                amountSat: Value(receiver.amountSat),
+              ),
+            );
+      });
+
+  Future<bool> recordReceiverProposal(PayjoinReceiverModel receiver) =>
+      _writeTransition(() {
+        return (_db.update(_db.payjoinReceivers)..where(
+              (row) =>
+                  row.id.equals(receiver.id) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false),
+            ))
+            .write(
+              PayjoinReceiversCompanion(
+                receiver: Value(receiver.receiver),
+                proposalPsbt: Value(receiver.proposalPsbt),
+                txId: Value(receiver.txId),
+              ),
+            );
+      });
+
+  Future<bool> recordSenderProposal(PayjoinSenderModel sender) =>
+      _writeTransition(() {
+        return (_db.update(_db.payjoinSenders)..where(
+              (row) =>
+                  row.uri.equals(sender.id) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false),
+            ))
+            .write(
+              PayjoinSendersCompanion(
+                sender: Value(sender.sender),
+                proposalPsbt: Value(sender.proposalPsbt),
+                txId: Value(sender.txId),
+              ),
+            );
+      });
+
+  Future<bool> markCompleted(PayjoinModel payjoin) {
+    if (payjoin is PayjoinReceiverModel) {
+      return _writeTransition(() {
+        return (_db.update(_db.payjoinReceivers)..where(
+              (row) =>
+                  row.id.equals(payjoin.id) & row.isCompleted.equals(false),
+            ))
+            .write(
+              PayjoinReceiversCompanion(
+                txId: payjoin.txId == null
+                    ? const Value.absent()
+                    : Value(payjoin.txId),
+                isExpired: const Value(false),
+                isCompleted: const Value(true),
+                isAborted: const Value(false),
+              ),
+            );
+      });
+    }
+
+    return _writeTransition(() {
+      return (_db.update(_db.payjoinSenders)..where(
+            (row) => row.uri.equals(payjoin.id) & row.isCompleted.equals(false),
+          ))
+          .write(
+            PayjoinSendersCompanion(
+              txId: payjoin.txId == null
+                  ? const Value.absent()
+                  : Value(payjoin.txId),
+              isExpired: const Value(false),
+              isCompleted: const Value(true),
+              isAborted: const Value(false),
+            ),
+          );
+    });
+  }
+
+  Future<bool> markAborted(PayjoinModel payjoin) {
+    if (payjoin is PayjoinReceiverModel) {
+      return _writeTransition(() {
+        return (_db.update(_db.payjoinReceivers)..where(
+              (row) =>
+                  row.id.equals(payjoin.id) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false),
+            ))
+            .write(
+              const PayjoinReceiversCompanion(
+                txId: Value(null),
+                isExpired: Value(false),
+                isAborted: Value(true),
+              ),
+            );
+      });
+    }
+
+    return _writeTransition(() {
+      return (_db.update(_db.payjoinSenders)..where(
+            (row) =>
+                row.uri.equals(payjoin.id) &
+                row.isCompleted.equals(false) &
+                row.isAborted.equals(false),
+          ))
+          .write(
+            const PayjoinSendersCompanion(
+              txId: Value(null),
+              isExpired: Value(false),
+              isAborted: Value(true),
+            ),
+          );
+    });
+  }
+
+  Future<bool> markExpired(PayjoinModel payjoin, {bool clearTxId = false}) {
+    if (payjoin is PayjoinReceiverModel) {
+      return _writeTransition(() {
+        return (_db.update(_db.payjoinReceivers)..where(
+              (row) =>
+                  row.id.equals(payjoin.id) &
+                  row.isCompleted.equals(false) &
+                  row.isAborted.equals(false) &
+                  row.isExpired.equals(false),
+            ))
+            .write(
+              PayjoinReceiversCompanion(
+                txId: clearTxId ? const Value(null) : const Value.absent(),
+                isExpired: const Value(true),
+              ),
+            );
+      });
+    }
+
+    return _writeTransition(() {
+      return (_db.update(_db.payjoinSenders)..where(
+            (row) =>
+                row.uri.equals(payjoin.id) &
+                row.isCompleted.equals(false) &
+                row.isAborted.equals(false) &
+                row.isExpired.equals(false),
+          ))
+          .write(
+            PayjoinSendersCompanion(
+              txId: clearTxId ? const Value(null) : const Value.absent(),
+              isExpired: const Value(true),
+            ),
+          );
+    });
   }
 
   Future<List<PayjoinModel>> fetchAll({
@@ -190,13 +390,9 @@ class LocalPayjoinDatasource {
         .toList();
   }
 
-  Future<void> update(PayjoinModel payjoin) async {
+  Future<bool> _writeTransition(Future<int> Function() write) async {
     try {
-      if (payjoin is PayjoinReceiverModel) {
-        await storeReceiver(payjoin);
-      } else if (payjoin is PayjoinSenderModel) {
-        await storeSender(payjoin);
-      }
+      return await write() == 1;
     } catch (e) {
       throw UpdateException('$e');
     }

--- a/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
+++ b/lib/core/payjoin/data/repository/payjoin_repository_impl.dart
@@ -38,26 +38,23 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   final BdkWalletDatasource _bdkWallet;
   final BdkBitcoinBlockchainDatasource _blockchain;
   final ElectrumServersPort _serversPort;
-  // Wallet repositories are resolved lazily (via closures, not injected
-  // instances) because this repository is an eager singleton constructed
-  // BEFORE WalletLocator registers them (see core_locator.dart ordering).
-  // They are only ever called well after startup, from broadcast /
-  // proposal / completion handlers.
+  // Lazy accessors keep this core repository independent from locator
+  // registration order.
   final WalletRepository Function() _walletRepository;
   final WalletTransactionRepository Function() _walletTransactionRepository;
   final SettingsRepository _settingsRepository;
-  // Lazy accessor, not a direct LabelsFacade — matches the existing
-  // core/exchange and core/swaps precedent of injecting LabelsFacade
-  // straight into core code that needs to label something (see
-  // LabelExchangeOrdersUsecase, AutoSwapExecutionUsecase). The indirection
-  // here is purely a registration-order workaround, not an architectural
-  // boundary: PayjoinRepositoryImpl is an eager registerSingleton built
-  // during PayjoinLocator.registerRepositories, which runs before
-  // LabelsLocator.registerFacade (see core_locator.dart) — resolving
-  // LabelsFacade eagerly at construction time would throw.
+  // Lazy accessor, not a direct LabelsFacade, keeps registration order
+  // independent.
   final LabelsFacade Function() _labelsFacade;
-  // Lock to prevent the same utxo from being used in multiple payjoin proposals
-  final Lock _lock;
+  // Shared across receiver sessions so two proposals cannot select the same
+  // wallet UTXO before either proposal has been persisted.
+  final Lock _utxoSelectionLock;
+  final Lock _resumeLock;
+
+  // All effects for one protocol session run in order. These locks are kept
+  // until repository disposal so a lock is never replaced while callbacks are
+  // queued on it.
+  final Map<String, Lock> _sessionLocks = {};
 
   final StreamController<Payjoin> _payjoinStreamController;
 
@@ -112,7 +109,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   }) : _seed = seedDatasource,
        _bdkWallet = bdkWalletDatasource,
        _blockchain = blockchainDatasource,
-       _lock = Lock(),
+       _utxoSelectionLock = Lock(),
+       _resumeLock = Lock(),
        _payjoinStreamController = StreamController<Payjoin>.broadcast() {
     // Listen to payjoin events from the datasource and process them
     _datasourceSubscriptions.addAll([
@@ -121,15 +119,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       _pdkPayjoinDatasource.expiredPayjoins.listen(_processExpiredPayjoin),
     ]);
 
-    // Deliberately NOT resuming here: this is an eager singleton constructed
-    //  before WalletLocator / the labels facade register their dependencies
-    //  (see core_locator.dart ordering). A resumed session that reaches
-    //  _watchForBroadcast or the labels facade before those are registered
-    //  would throw inside this unawaited constructor call, silently aborting
-    //  resume for every remaining session. resumePayjoinsOnStartup() is
-    //  called explicitly by AppLocator.setup once every core dependency it
-    //  needs (wallet repositories, settings, the labels facade) is
-    //  registered.
+    // The foreground composition root explicitly starts session recovery.
+    // Registration alone must not start protocol work in background locators.
   }
 
   /// Releases all long-lived subscriptions and closes the payjoin stream.
@@ -166,6 +157,11 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
   @override
   Stream<Payjoin> get payjoinStream => _payjoinStreamController.stream;
+
+  Future<T> _withSessionLock<T>(
+    String payjoinId,
+    Future<T> Function() action,
+  ) => _sessionLocks.putIfAbsent(payjoinId, Lock.new).synchronized(action);
 
   @override
   Future<Payjoin?> getPayjoinById(String payjoinId) async {
@@ -264,7 +260,12 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     required bool isTestnet,
     required BigInt maxFeeRateSatPerVb,
     required int expireAfterSec,
-  }) => _lock.synchronized(() async {
+  }) async {
+    final initialSettings = await _settingsRepository.fetch();
+    if (!initialSettings.isPayjoinEnabled) {
+      throw StateError('Payjoin is disabled');
+    }
+
     final model = await _pdkPayjoinDatasource.createReceiver(
       walletId: walletId,
       address: address,
@@ -273,15 +274,35 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       expireAfterSec: expireAfterSec,
     );
 
-    final settings = await _settingsRepository.fetch();
-    if (!settings.isPayjoinEnabled) {
-      _pdkPayjoinDatasource.stopPolling(model.id);
-      throw StateError('Payjoin was disabled while creating the receiver');
-    }
+    return _withSessionLock(model.id, () async {
+      var stored = false;
+      var settled = false;
+      try {
+        // Persist before the final settings check. A concurrent disable sweep
+        // can now either see this row and wait for this lock, or finish first
+        // and make the check below fail closed.
+        await _localPayjoinDatasource.storeReceiver(model);
+        stored = true;
 
-    await _localPayjoinDatasource.storeReceiver(model);
-    return model.toEntity() as PayjoinReceiver;
-  });
+        final settings = await _settingsRepository.fetch();
+        if (!settings.isPayjoinEnabled) {
+          await _settleReceiverAfterDisable(model);
+          settled = true;
+          throw StateError('Payjoin was disabled while creating the receiver');
+        }
+
+        return model.toEntity() as PayjoinReceiver;
+      } catch (_) {
+        _pdkPayjoinDatasource.stopPolling(model.id);
+        if (stored && !settled) {
+          // The row is still idle while this session lock is held. If another
+          // path already settled it, the conditional delete is a no-op.
+          await _localPayjoinDatasource.deleteIdleReceiver(model.id);
+        }
+        rethrow;
+      }
+    });
+  }
 
   @override
   Future<PayjoinSender> createPayjoinSender({
@@ -292,8 +313,20 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     required int amountSat,
     required double networkFeesSatPerVb,
     int? expireAfterSec,
-  }) async {
-    // Create the payjoin sender session
+  }) => _withSessionLock(bip21, () async {
+    // A sender id is the payment request itself. Reject a live or resolved
+    // duplicate before posting another original proposal to the directory;
+    // only an expired payment with no known broadcast outcome is retryable.
+    final existing = await _localPayjoinDatasource.fetchSender(bip21);
+    final canRetry =
+        existing != null &&
+        existing.isExpired &&
+        !existing.isCompleted &&
+        !existing.isAborted;
+    if (existing != null && !canRetry) {
+      throw StateError('A Payjoin session already exists for this payment');
+    }
+
     final model = await _pdkPayjoinDatasource.createSender(
       walletId: walletId,
       isTestnet: isTestnet,
@@ -304,29 +337,34 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       expireAfterSec: expireAfterSec,
     );
 
-    // Store the payjoin sender in the local database
-    await _localPayjoinDatasource.storeSender(model);
+    try {
+      if (existing == null) {
+        await _localPayjoinDatasource.storeSender(model);
+      } else {
+        final replaced = await _localPayjoinDatasource.replaceExpiredSender(
+          model,
+        );
+        if (!replaced) {
+          throw StateError('The expired Payjoin session could not be replaced');
+        }
+      }
+    } catch (_) {
+      _pdkPayjoinDatasource.stopPolling(model.id);
+      rethrow;
+    }
 
-    // Arm the fallback safety net now: the receiver could decline
-    //  below-minimum (or its own session could expire) and broadcast the
-    //  original transaction well before this sender's own session would
-    //  otherwise notice (see _watchForFallback's doc comment).
     _watchForFallback(
       payjoinId: model.id,
       walletId: model.walletId,
       originalTxId: model.originalTxId,
     );
-
-    // Return a payjoin entity with send details
-    final payjoin = model.toEntity();
-
-    return payjoin as PayjoinSender;
-  }
+    return model.toEntity() as PayjoinSender;
+  });
 
   @override
   Future<Payjoin?> tryBroadcastOriginalTransaction(
     Payjoin payjoin,
-  ) => _lock.synchronized(() async {
+  ) => _withSessionLock(payjoin.id, () async {
     // Idempotency/safety guard for MANUAL/external callers only (the
     // BroadcastOriginalTransactionUsecase invoked from
     // ReceiveBloc._onPayjoinOriginalTxBroadcasted and
@@ -380,30 +418,87 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   });
 
   @override
-  Future<void> disableReceivers() => _lock.synchronized(() async {
-    final receivers = await _localPayjoinDatasource.fetchReceivers(
-      onlyOngoing: true,
-    );
+  Future<void> disableReceivers() async {
+    final receivers = await _localPayjoinDatasource.fetchReceivers();
+    Object? firstError;
+    StackTrace? firstStackTrace;
     for (final receiver in receivers) {
-      final fresh = await _localPayjoinDatasource.fetchReceiver(receiver.id);
-      if (fresh == null || fresh.isCompleted || fresh.isAborted) continue;
+      try {
+        await _withSessionLock(receiver.id, () async {
+          final fresh = await _localPayjoinDatasource.fetchReceiver(
+            receiver.id,
+          );
+          if (fresh == null || fresh.isCompleted || fresh.isAborted) return;
+          await _settleReceiverAfterDisable(fresh);
+        });
+      } catch (e, st) {
+        firstError ??= e;
+        firstStackTrace ??= st;
+        log.severe(
+          message:
+              'Failed to settle disabled receiver ${receiver.toEntity().logRef}',
+          error: e,
+          trace: st,
+        );
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
+  }
 
-      // Once a proposal has been posted, the sender owns the final
-      // transaction. Keep its broadcast/fallback watchers alive.
-      if (fresh.proposalPsbt != null) continue;
+  Future<PayjoinReceiver?> _settleReceiverAfterDisable(
+    PayjoinReceiverModel receiver,
+  ) async {
+    if (receiver.proposalPsbt != null) {
+      _watchCommittedReceiver(receiver);
+      return receiver.toEntity() as PayjoinReceiver;
+    }
 
-      if (fresh.originalTxBytes != null) {
-        final result = await _broadcastOriginalWithRetry(fresh.toEntity());
-        if (result == null) {
-          throw StateError('Failed to fall back an active Payjoin receiver');
-        }
-        continue;
+    if (receiver.originalTxBytes != null) {
+      var declined = receiver;
+      try {
+        declined = receiver.copyWith(
+          receiver: _pdkPayjoinDatasource.declineReceiverSession(receiver),
+        );
+        final recorded = await _localPayjoinDatasource.recordReceiverRequest(
+          declined,
+        );
+        if (!recorded) return null;
+      } on StateError catch (e) {
+        // A previous attempt may already have advanced the PDK typestate.
+        // Broadcasting the persisted original remains the safe recovery.
+        log.warning('Receiver decline already applied: $e');
       }
 
-      _stopWatching(fresh.id);
-      await _localPayjoinDatasource.deleteReceiver(fresh.id);
+      final result = await _broadcastOriginalWithRetry(declined.toEntity());
+      if (result == null) {
+        throw StateError('Failed to settle an active Payjoin receiver');
+      }
+      return result as PayjoinReceiver;
     }
-  });
+
+    _stopWatching(receiver.id);
+    await _localPayjoinDatasource.deleteIdleReceiver(receiver.id);
+    return null;
+  }
+
+  void _watchCommittedReceiver(PayjoinReceiverModel receiver) {
+    if (receiver.txId != null) {
+      _watchForBroadcast(
+        payjoinId: receiver.id,
+        walletId: receiver.walletId,
+        txId: receiver.txId!,
+      );
+    }
+    if (receiver.originalTxId != null) {
+      _watchForFallback(
+        payjoinId: receiver.id,
+        walletId: receiver.walletId,
+        originalTxId: receiver.originalTxId!,
+      );
+    }
+  }
 
   /// The actual original-transaction broadcast mechanism, shared by the
   /// public (guarded) [tryBroadcastOriginalTransaction] entry point and this
@@ -462,8 +557,21 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       // a txid that was never broadcast. This clearing is display hygiene,
       // not status derivation: the status comes from the explicit isAborted
       // flag (see PayjoinModel.status).
-      final abortedModel = model.copyWith(isAborted: true, txId: null);
-      await _localPayjoinDatasource.update(abortedModel);
+      final abortedModel = model.copyWith(
+        isExpired: false,
+        isAborted: true,
+        txId: null,
+      );
+      final applied = await _localPayjoinDatasource.markAborted(abortedModel);
+      final resolvedModel = applied
+          ? abortedModel
+          : payjoin is PayjoinReceiver
+          ? await _localPayjoinDatasource.fetchReceiver(payjoin.id)
+          : await _localPayjoinDatasource.fetchSender(payjoin.id);
+      if (resolvedModel == null) {
+        throw Exception('Payjoin disappeared while recording fallback');
+      }
+      if (!resolvedModel.isAborted) return resolvedModel.toEntity();
       // Deliberately NOT labelling this transaction "payjoin": every call
       // site of this method is, by definition, a case where no real payjoin
       // ever happened — declined below the anti-probing minimum, the
@@ -486,7 +594,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       // reflect this broadcast promptly instead of waiting on whatever
       // unrelated sync happens to run next (the same staleness class of gap
       // as the receiver's own payjoin-tx watcher — see _watchForBroadcast).
-      _syncWalletAfterBroadcast(abortedModel.walletId);
+      _syncWalletAfterBroadcast(resolvedModel.walletId);
 
       // That single sync is not enough on its own: it can be throttled by
       // the sync coordinator or race the broadcast (observed live: a
@@ -499,15 +607,15 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       // _onOriginalTransactionSeen stops all watchers first and its
       // terminal guard makes it a pure teardown for this already-persisted
       // session.
-      if (abortedModel.originalTxId != null) {
+      if (resolvedModel.originalTxId != null) {
         _watchForFallback(
           payjoinId: payjoin.id,
-          walletId: abortedModel.walletId,
-          originalTxId: abortedModel.originalTxId!,
+          walletId: resolvedModel.walletId,
+          originalTxId: resolvedModel.originalTxId!,
         );
       }
 
-      return abortedModel.toEntity();
+      return resolvedModel.toEntity();
     } catch (e) {
       log.severe(
         message: 'Error broadcasting original transaction',
@@ -518,7 +626,10 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     }
   }
 
-  Future<void> _processPayjoinRequest(PayjoinReceiverModel model) async {
+  Future<void> _processPayjoinRequest(PayjoinReceiverModel model) =>
+      _withSessionLock(model.id, () => _processPayjoinRequestInner(model));
+
+  Future<void> _processPayjoinRequestInner(PayjoinReceiverModel model) async {
     // The whole handler is inside this try/catch, including the initial DB
     // update and stream emit below: a fallible await left outside a try (as
     // this used to be) can throw straight out of the datasource's
@@ -529,7 +640,10 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     PayjoinReceiver? result;
     try {
       log.info('Processing payjoin request: ${model.id}');
-      await _localPayjoinDatasource.update(model);
+      final recorded = await _localPayjoinDatasource.recordReceiverRequest(
+        model,
+      );
+      if (!recorded) return;
 
       final payjoin = model.toEntity() as PayjoinReceiver;
 
@@ -558,7 +672,13 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       // probing our UTXO set to at least a real payment above the
       // threshold. See PayjoinConstants.defaultMinAmountSat.
       final settings = await _settingsRepository.fetch();
-      if (isBelowPayjoinMinimum(
+      if (!settings.isPayjoinEnabled) {
+        log.warning(
+          'Payjoin request ${model.id} arrived after Payjoin was disabled; '
+          'broadcasting the original transaction instead',
+        );
+        result = await _settleReceiverAfterDisable(model);
+      } else if (isBelowPayjoinMinimum(
         amountSat: model.amountSat,
         minAmountSat: settings.payjoinMinAmountSat,
       )) {
@@ -567,13 +687,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
           '(${settings.payjoinMinAmountSat} sat); declining and '
           'broadcasting original instead',
         );
-        final declinedReceiverJson = _pdkPayjoinDatasource
-            .declineReceiverSession(model);
-        final declinedModel = model.copyWith(receiver: declinedReceiverJson);
-        await _localPayjoinDatasource.update(declinedModel);
-        result =
-            (await _broadcastOriginalWithRetry(declinedModel.toEntity()))
-                as PayjoinReceiver?;
+        result = await _settleReceiverAfterDisable(model);
       } else {
         final wallet = await _loadWallet(model.walletId);
         final unspentUtxos = await _bdkWallet.getUtxos(wallet: wallet);
@@ -661,23 +775,24 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     required int minAmountSat,
   }) => amountSat != null && amountSat < minAmountSat;
 
-  Future<void> _processPayjoinProposal(PayjoinSenderModel payjoinModel) async {
-    // Same hardening as _processPayjoinRequest: this runs as a bare stream
-    // .listen() callback, so any await throwing outside a try (the re-fetch
-    // and update below, or the terminal-persist tail) would surface as an
-    // unhandled zone error — and with the sender poll already cancelled by
-    // the time this fires, nothing else would ever emit a terminal event,
-    // stranding the session until the app restarts.
-    try {
-      await _processPayjoinProposalInner(payjoinModel);
-    } catch (e) {
-      log.severe(
-        message: 'Error processing payjoin proposal event',
-        error: e,
-        trace: StackTrace.current,
-      );
-    }
-  }
+  Future<void> _processPayjoinProposal(PayjoinSenderModel payjoinModel) =>
+      _withSessionLock(payjoinModel.id, () async {
+        // Same hardening as _processPayjoinRequest: this runs as a bare stream
+        // .listen() callback, so any await throwing outside a try (the re-fetch
+        // and update below, or the terminal-persist tail) would surface as an
+        // unhandled zone error — and with the sender poll already cancelled by
+        // the time this fires, nothing else would ever emit a terminal event,
+        // stranding the session until the app restarts.
+        try {
+          await _processPayjoinProposalInner(payjoinModel);
+        } catch (e) {
+          log.severe(
+            message: 'Error processing payjoin proposal event',
+            error: e,
+            trace: StackTrace.current,
+          );
+        }
+      });
 
   Future<void> _processPayjoinProposalInner(
     PayjoinSenderModel payjoinModel,
@@ -686,9 +801,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     // may have resolved since (e.g. the fallback watcher aborted the session
     // when the counterparty broadcast the original while this proposal was in
     // flight). Re-fetch and bail on an already-terminal session — mirroring
-    // _processExpiredPayjoin — so we neither resurrect an aborted row (the
-    // insertOnConflictUpdate below replaces the whole row) nor sign/broadcast
-    // against a session that already resolved another way.
+    // _processExpiredPayjoin — so we neither act on an aborted row nor
+    // sign/broadcast against a session that already resolved another way.
     final persisted = await _localPayjoinDatasource.fetchSender(
       payjoinModel.id,
     );
@@ -697,21 +811,25 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     }
 
     // Update the local database with the new payjoin proposal
-    await _localPayjoinDatasource.update(payjoinModel);
+    final recorded = await _localPayjoinDatasource.recordSenderProposal(
+      payjoinModel,
+    );
+    if (!recorded) return;
 
     final payjoin = payjoinModel.toEntity() as PayjoinSender;
 
     _payjoinStreamController.add(payjoin);
 
     PayjoinSender? result;
+    String? finalizedPsbt;
     try {
       final wallet = await _loadWallet(payjoin.walletId);
-      final finalizedPsbt = await _bdkWallet.signPsbt(
+      finalizedPsbt = await _bdkWallet.signPsbt(
         payjoin.proposalPsbt!,
         wallet: wallet,
       );
       result = await _broadcastPsbt(
-        payjoinId: payjoin.id,
+        payjoinModel: payjoinModel,
         finalizedPsbt: finalizedPsbt,
         network: payjoinModel.isTestnet
             ? Network.bitcoinTestnet
@@ -721,20 +839,6 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       //  and a raw txid identifies the payment on-chain — both off-limits in
       //  logs.
       log.info('Payjoin proposal broadcasted for ${payjoin.logRef}');
-      // Label the transaction now that a REAL payjoin actually broadcast
-      // (never a fallback — see _broadcastOriginalTransaction, which marks
-      // aborted sessions aborted, not completed) and the final txid is known.
-      // Deliberately re-derived from [finalizedPsbt] — the bytes actually
-      // broadcast — rather than trusting `result.txId`/the pre-existing
-      // `payjoin.txId`: those are computed from the proposal PSBT before this
-      // signPsbt call above, and finalizing a signature can change the txid
-      // for non-native-segwit inputs (never label a txid that wasn't derived
-      // from the actually-broadcast bytes). The receiver side has the
-      // watch-for-broadcast infra to notice its own completion, but labels
-      // the pre-finalization txid because it never sees the finalized bytes —
-      // an inherent limitation, not a missing feature.
-      final broadcastTxId = (await BitcoinTx.fromPsbt(finalizedPsbt)).txid;
-      await labelCompletedPayjoinSend(broadcastTxId);
     } catch (e) {
       log.severe(
         message: 'Error broadcasting payjoin proposal',
@@ -753,6 +857,21 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
     if (result != null) {
       _payjoinStreamController.add(result);
+      if (result.isCompleted && finalizedPsbt != null) {
+        // The payment is already on the network. Txid derivation and labeling
+        // are local best-effort work and must never route into the competing
+        // original-transaction fallback if either fails.
+        try {
+          final broadcastTxId = (await BitcoinTx.fromPsbt(finalizedPsbt)).txid;
+          await labelCompletedPayjoinSend(broadcastTxId);
+        } catch (e, st) {
+          log.warning(
+            'Payjoin broadcast succeeded but labeling failed',
+            error: e,
+            trace: st,
+          );
+        }
+      }
     } else {
       // Both the payjoin and the original-transaction fallback failed: mark
       //  the session terminally failed (modelled as expired, which
@@ -771,6 +890,23 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       //  on already-spent inputs, and the original re-broadcast fail as
       //  already-known). Persisting from the stale `payjoinModel` here would
       //  overwrite that correct `aborted` outcome with `expired`.
+      // Either broadcast may actually have reached the network before its
+      // client observed an error. Keep both known txids under observation so
+      // the persisted row can still converge instead of repeating failed
+      // broadcasts on every startup.
+      if (payjoinModel.txId != null) {
+        _watchForBroadcast(
+          payjoinId: payjoinModel.id,
+          walletId: payjoinModel.walletId,
+          txId: payjoinModel.txId!,
+        );
+      }
+      _watchForFallback(
+        payjoinId: payjoinModel.id,
+        walletId: payjoinModel.walletId,
+        originalTxId: payjoinModel.originalTxId,
+      );
+
       final freshModel = await _localPayjoinDatasource.fetchSender(
         payjoinModel.id,
       );
@@ -782,25 +918,29 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         isExpired: true,
         txId: null,
       );
-      await _localPayjoinDatasource.update(failedModel);
-      _payjoinStreamController.add(failedModel.toEntity());
+      final recorded = await _localPayjoinDatasource.markExpired(
+        failedModel,
+        clearTxId: true,
+      );
+      if (recorded) _payjoinStreamController.add(failedModel.toEntity());
     }
   }
 
-  Future<void> _processExpiredPayjoin(PayjoinModel payjoinModel) async {
-    // Same hardening as _processPayjoinRequest/_processPayjoinProposal: a
-    // bare stream .listen() callback — a DB throw here must be logged, not
-    // escape as an unhandled zone error that strands the session.
-    try {
-      await _processExpiredPayjoinInner(payjoinModel);
-    } catch (e) {
-      log.severe(
-        message: 'Error processing expired payjoin event',
-        error: e,
-        trace: StackTrace.current,
-      );
-    }
-  }
+  Future<void> _processExpiredPayjoin(PayjoinModel payjoinModel) =>
+      _withSessionLock(payjoinModel.id, () async {
+        // Same hardening as _processPayjoinRequest/_processPayjoinProposal: a
+        // bare stream .listen() callback — a DB throw here must be logged, not
+        // escape as an unhandled zone error that strands the session.
+        try {
+          await _processExpiredPayjoinInner(payjoinModel);
+        } catch (e) {
+          log.severe(
+            message: 'Error processing expired payjoin event',
+            error: e,
+            trace: StackTrace.current,
+          );
+        }
+      });
 
   Future<void> _processExpiredPayjoinInner(PayjoinModel payjoinModel) async {
     // The expiry event carries the emitter's own in-memory copy of the
@@ -822,9 +962,8 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
     // Continue with the fresh row (expired-marked, like every caller marks
     // its own copy), not the event's copy: the branches below decide on
-    // proposalPsbt/originalTxBytes, and the last branch persists the model —
-    // doing either with the stale copy could clobber fields persisted since
-    // the emitter captured it (insertOnConflictUpdate replaces the row).
+    // proposalPsbt/originalTxBytes. Persistence below is a conditional partial
+    // update, so it cannot clobber fields changed by another transition.
     final expiredModel = freshModel.copyWith(isExpired: true);
     final payjoin = expiredModel.toEntity();
 
@@ -836,8 +975,10 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
       // must not leave a terminal 0-sat row in history. Notify the live
       // receive flow so it can rotate to a fresh endpoint, then remove it.
       _stopWatching(expiredModel.id);
-      await _localPayjoinDatasource.deleteReceiver(expiredModel.id);
-      _payjoinStreamController.add(payjoin);
+      final deleted = await _localPayjoinDatasource.deleteIdleReceiver(
+        expiredModel.id,
+      );
+      if (deleted) _payjoinStreamController.add(payjoin);
       return;
     }
 
@@ -937,20 +1078,16 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
       // Nothing left for us to retry from this side, so persist the expired
       //  marker now (unlike the two fallback branches above).
-      await _localPayjoinDatasource.update(expiredModel);
-      _payjoinStreamController.add(payjoin);
+      final recorded = await _localPayjoinDatasource.markExpired(expiredModel);
+      if (recorded) _payjoinStreamController.add(payjoin);
     }
   }
 
   @override
-  Future<void> resumePayjoinsOnStartup() async {
-    // The whole body is inside this try/catch: this method is invoked as
-    //  `unawaited(...)` from AppLocator.setup, so anything that throws here
-    //  (e.g. the DB not yet ready, a fetch failing) would otherwise surface
-    //  as an unhandled zone error during app startup instead of a logged,
-    //  contained failure. Per-session failures inside the resume loop below
-    //  are already isolated by their own try/catch; this outer one covers
-    //  the sweep queries and loops themselves.
+  Future<void> resumePayjoinsOnStartup() => _resumeLock.synchronized(() async {
+    // Cold-start recovery and an immediate foreground lifecycle callback can
+    // overlap. Serialize complete sweeps so the second one reads fresh rows
+    // rather than processing snapshots captured before the first converged.
     try {
       await _resumePayjoinsOnStartupUnguarded();
     } catch (e, st) {
@@ -960,9 +1097,10 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         trace: st,
       );
     }
-  }
+  });
 
   Future<void> _resumePayjoinsOnStartupUnguarded() async {
+    final settings = await _settingsRepository.fetch();
     // Sweep receivers whose expiry-time fallback broadcast FAILED on a
     // previous run and were persisted as expired (e.g. by pre-port code that
     // persisted isExpired before broadcasting): the onlyUnfinished resume
@@ -976,27 +1114,47 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     // recovery retry, not a manual action.
     final receivers = await _localPayjoinDatasource.fetchReceivers();
     for (final receiver in receivers) {
-      if (receiver.isExpired &&
-          !receiver.isAborted &&
-          !receiver.isCompleted &&
-          receiver.originalTxBytes != null &&
-          receiver.proposalPsbt == null) {
-        await _broadcastOriginalTransaction(receiver.toEntity());
-        // Arm the fallback watch regardless of the attempt's outcome above:
-        //  _broadcastOriginalTransaction only arms it on SUCCESS. If it
-        //  failed because the tx is already on-chain (the other side beat
-        //  us to broadcasting it) rather than a transient error, this row
-        //  would otherwise never be marked aborted and this sweep would
-        //  retry — and log SEVERE — on every subsequent app start
-        //  indefinitely. Idempotent: a no-op if already armed by a
-        //  successful attempt above.
-        if (receiver.originalTxId != null) {
-          _watchForFallback(
-            payjoinId: receiver.id,
-            walletId: receiver.walletId,
-            originalTxId: receiver.originalTxId!,
+      if (receiver.isCompleted || receiver.isAborted) continue;
+      try {
+        await _withSessionLock(receiver.id, () async {
+          final fresh = await _localPayjoinDatasource.fetchReceiver(
+            receiver.id,
           );
-        }
+          if (fresh == null || fresh.isCompleted || fresh.isAborted) return;
+          if (!settings.isPayjoinEnabled) {
+            await _settleReceiverAfterDisable(fresh);
+            return;
+          }
+          if (!fresh.isExpired) return;
+          if (fresh.proposalPsbt != null) {
+            _watchCommittedReceiver(fresh);
+            return;
+          }
+          if (fresh.originalTxBytes == null) {
+            _stopWatching(fresh.id);
+            await _localPayjoinDatasource.deleteIdleReceiver(fresh.id);
+            return;
+          }
+
+          await _broadcastOriginalTransaction(fresh.toEntity());
+          // A broadcast error can mean the other side already put this same
+          // transaction on-chain. Keep watching so the row converges instead
+          // of logging the same failed retry on every startup.
+          if (fresh.originalTxId != null) {
+            _watchForFallback(
+              payjoinId: fresh.id,
+              walletId: fresh.walletId,
+              originalTxId: fresh.originalTxId!,
+            );
+          }
+        });
+      } catch (e, st) {
+        log.severe(
+          message:
+              'Failed to resume payjoin receiver ${receiver.toEntity().logRef}',
+          error: e,
+          trace: st,
+        );
       }
     }
 
@@ -1006,25 +1164,58 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     // proposalPsbt == null — mirroring the receiver branch above.
     final senders = await _localPayjoinDatasource.fetchSenders();
     for (final sender in senders) {
-      if (sender.isExpired &&
-          !sender.isAborted &&
-          !sender.isCompleted &&
-          sender.proposalPsbt == null) {
-        await _broadcastOriginalTransaction(sender.toEntity());
-        // Same reasoning as the receiver sweep above: converge a failed
-        //  attempt (e.g. already on-chain via the other side) via the
-        //  fallback watch instead of retrying forever. A sender's
-        //  originalTxId is always present (set at session creation).
-        _watchForFallback(
-          payjoinId: sender.id,
-          walletId: sender.walletId,
-          originalTxId: sender.originalTxId,
+      if (!sender.isExpired || sender.isAborted || sender.isCompleted) continue;
+      try {
+        if (sender.proposalPsbt != null) {
+          if (sender.txId != null) {
+            _watchForBroadcast(
+              payjoinId: sender.id,
+              walletId: sender.walletId,
+              txId: sender.txId!,
+            );
+          }
+          _watchForFallback(
+            payjoinId: sender.id,
+            walletId: sender.walletId,
+            originalTxId: sender.originalTxId,
+          );
+          await _processPayjoinProposal(sender);
+          continue;
+        }
+
+        PayjoinSenderModel? proposalReceived;
+        await _withSessionLock(sender.id, () async {
+          final fresh = await _localPayjoinDatasource.fetchSender(sender.id);
+          if (fresh == null || fresh.isCompleted || fresh.isAborted) return;
+          if (fresh.proposalPsbt != null) {
+            proposalReceived = fresh;
+            return;
+          }
+          await _broadcastOriginalTransaction(fresh.toEntity());
+          _watchForFallback(
+            payjoinId: fresh.id,
+            walletId: fresh.walletId,
+            originalTxId: fresh.originalTxId,
+          );
+        });
+        if (proposalReceived != null) {
+          await _processPayjoinProposal(proposalReceived!);
+        }
+      } catch (e, st) {
+        log.severe(
+          message:
+              'Failed to resume payjoin sender ${sender.toEntity().logRef}',
+          error: e,
+          trace: st,
         );
       }
     }
 
     final models = await _localPayjoinDatasource.fetchAll(onlyUnfinished: true);
     for (final model in models) {
+      if (!settings.isPayjoinEnabled && model is PayjoinReceiverModel) {
+        continue;
+      }
       // Each session is independent: a bug or a transient failure resuming
       //  one (e.g. a missing wallet, a bad persisted event log) must not
       //  abort the loop and silently leave every other unfinished session
@@ -1130,7 +1321,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     PrivateBdkWalletModel wallet,
     List<WalletUtxoModel> unspentUtxos,
   ) {
-    return _lock.synchronized(() async {
+    return _utxoSelectionLock.synchronized(() async {
       final lockedUtxos = await getUtxosFrozenByOngoingPayjoins();
       final inputPairs = _filterAvailableUtxos(
         unspentUtxos,
@@ -1174,7 +1365,39 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         processPsbt: signPsbtSync,
       );
 
-      await _localPayjoinDatasource.update(updatedModel);
+      try {
+        final recorded = await _localPayjoinDatasource.recordReceiverProposal(
+          updatedModel,
+        );
+        if (!recorded) {
+          final resolved = await _localPayjoinDatasource.fetchReceiver(
+            payjoin.id,
+          );
+          if (resolved != null &&
+              (resolved.isCompleted || resolved.isAborted)) {
+            return null;
+          }
+          log.severe(
+            message:
+                'Payjoin proposal was sent but its state was not persisted',
+            error: StateError('Receiver proposal transition was rejected'),
+            trace: StackTrace.current,
+          );
+        }
+      } catch (e, st) {
+        // proposePayjoin posts to the directory before returning. Falling back
+        // to the original now would race the sender finalizing that proposal.
+        // The selected UTXO is no longer represented by persisted state, so
+        // another receiver can select it after this lock releases and restart
+        // can attempt this request again. Closing that residual race requires
+        // a durable write-ahead proposal reservation before publication; an
+        // original-transaction fallback here would be more dangerous.
+        log.severe(
+          message: 'Payjoin proposal was sent but persistence failed',
+          error: e,
+          trace: st,
+        );
+      }
       return updatedModel.toEntity() as PayjoinReceiver;
     });
   }
@@ -1223,7 +1446,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   }
 
   Future<PayjoinSender> _broadcastPsbt({
-    required String payjoinId,
+    required PayjoinSenderModel payjoinModel,
     required String finalizedPsbt,
     required Network network,
   }) async {
@@ -1236,28 +1459,46 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
           _blockchain.broadcastPsbt(finalizedPsbt, connection: connection),
     );
 
-    // Update the local database with the completed payjoin
-    final model = await _localPayjoinDatasource.fetchSender(payjoinId);
-    if (model == null) {
-      throw Exception('Payjoin sender not found');
-    }
-    if (model.isAborted) {
-      // The fallback watcher aborted this session (the ORIGINAL transaction
-      //  was seen on-chain) while we were signing/broadcasting the proposal.
-      //  Our payjoin transaction nonetheless made it onto the network and,
-      //  spending the same inputs, will confirm instead of the original — so
-      //  completing (real payjoin) is the correct on-chain outcome and wins
-      //  over the aborted marker (model derivation orders isCompleted first).
-      //  Logged so this genuinely-rare race is visible rather than an
-      //  implicit derivation-order side effect.
-      log.warning(
-        'Payjoin ${model.toEntity().logRef} completed via a real payjoin '
-        'after having been marked aborted (both transactions raced onto the '
-        'network; the payjoin tx wins)',
+    // From this point the real payjoin is on the network. Local persistence,
+    // syncing and watcher setup must never throw back to the caller's fallback
+    // catch, which would broadcast the competing original transaction.
+    var completedModel = payjoinModel.copyWith(
+      isExpired: false,
+      isCompleted: true,
+      isAborted: false,
+    );
+    try {
+      final persisted = await _localPayjoinDatasource.fetchSender(
+        payjoinModel.id,
+      );
+      if (persisted?.isAborted == true) {
+        log.warning(
+          'Payjoin ${payjoinModel.toEntity().logRef} broadcast after the '
+          'original transaction was observed; the network will resolve the '
+          'conflict',
+        );
+      }
+      completedModel = (persisted ?? payjoinModel).copyWith(
+        isExpired: false,
+        isCompleted: true,
+        isAborted: false,
+      );
+      final applied = await _localPayjoinDatasource.markCompleted(
+        completedModel,
+      );
+      if (!applied) {
+        final resolved = await _localPayjoinDatasource.fetchSender(
+          payjoinModel.id,
+        );
+        if (resolved?.isCompleted == true) completedModel = resolved!;
+      }
+    } catch (e, st) {
+      log.severe(
+        message: 'Payjoin broadcast succeeded but completion was not persisted',
+        error: e,
+        trace: st,
       );
     }
-    final completedModel = model.copyWith(isCompleted: true);
-    await _localPayjoinDatasource.update(completedModel);
 
     // Best-effort, non-blocking: see _broadcastOriginalTransaction's call
     // for why this can't wait on some unrelated sync to run.
@@ -1273,10 +1514,10 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     // watch: _onPayjoinTransactionSeen stops all watchers first, and its
     // fetchReceiver returns null for this SENDER session, making it a pure
     // teardown.
-    _stopWatching(payjoinId);
+    _stopWatching(payjoinModel.id);
     if (completedModel.txId != null) {
       _watchForBroadcast(
-        payjoinId: payjoinId,
+        payjoinId: payjoinModel.id,
         walletId: completedModel.walletId,
         txId: completedModel.txId!,
       );
@@ -1329,7 +1570,7 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     txId: txId,
     watchers: _broadcastWatchers,
     pollTimers: _broadcastPollTimers,
-    onSeen: _onPayjoinTransactionSeen,
+    onSeen: (payjoinId) => _onPayjoinTransactionSeen(payjoinId, txId),
     kind: 'broadcast',
   );
 
@@ -1494,6 +1735,18 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
         } catch (e) {
           log.warning('Payjoin $kind completion handler failed: $e');
         }
+        if (watchers.containsKey(payjoinId)) {
+          _scheduleTransactionPoll(
+            payjoinId: payjoinId,
+            walletId: walletId,
+            txId: txId,
+            watchers: watchers,
+            pollTimers: pollTimers,
+            onSeen: onSeen,
+            kind: kind,
+            attempt: attempt + 1,
+          );
+        }
       } else {
         _scheduleTransactionPoll(
           payjoinId: payjoinId,
@@ -1509,25 +1762,54 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
     });
   }
 
-  Future<void> _onPayjoinTransactionSeen(String payjoinId) async {
-    // Stop first: the watch stream re-emits on every sync, and completion is
-    // a one-shot side effect.
+  Future<void> _onPayjoinTransactionSeen(
+    String payjoinId,
+    String observedTxId,
+  ) => _withSessionLock(payjoinId, () async {
+    final receiver = await _localPayjoinDatasource.fetchReceiver(payjoinId);
+    final PayjoinModel? model =
+        receiver ?? await _localPayjoinDatasource.fetchSender(payjoinId);
+    if (model == null || model.isCompleted) {
+      _stopWatching(payjoinId);
+      return;
+    }
+
+    final PayjoinModel completedModel = model is PayjoinReceiverModel
+        ? model.copyWith(
+            txId: model.txId ?? observedTxId,
+            isExpired: false,
+            isCompleted: true,
+            isAborted: false,
+          )
+        : (model as PayjoinSenderModel).copyWith(
+            txId: model.txId ?? observedTxId,
+            isExpired: false,
+            isCompleted: true,
+            isAborted: false,
+          );
+    final applied = await _localPayjoinDatasource.markCompleted(completedModel);
+    if (!applied) {
+      final refreshed = model is PayjoinReceiverModel
+          ? await _localPayjoinDatasource.fetchReceiver(payjoinId)
+          : await _localPayjoinDatasource.fetchSender(payjoinId);
+      if (refreshed?.isCompleted == true) _stopWatching(payjoinId);
+      return;
+    }
+
+    // Persistence won. Any already-delivered duplicate callback now observes
+    // the terminal row under the same session lock and becomes a no-op.
     _stopWatching(payjoinId);
-
-    final model = await _localPayjoinDatasource.fetchReceiver(payjoinId);
-    if (model == null || model.isCompleted || model.isAborted) return;
-
-    final completedModel = model.copyWith(isCompleted: true);
-    await _localPayjoinDatasource.update(completedModel);
-    if (completedModel.txId != null) {
+    if (completedModel is PayjoinReceiverModel && completedModel.txId != null) {
       await _labelPayjoinTransaction(
         txId: completedModel.txId!,
         walletId: completedModel.walletId,
       );
     }
     _payjoinStreamController.add(completedModel.toEntity());
-    log.info('Payjoin receiver completed on broadcast: $payjoinId');
-  }
+    log.info(
+      'Payjoin ${completedModel.toEntity().logRef} completed on broadcast',
+    );
+  });
 
   /// The original transaction landed on-chain — regardless of which side
   /// actually broadcast it (this repository's own attempt, possibly already
@@ -1536,35 +1818,47 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
   /// a real payjoin. `txId` is cleared for the same reason
   /// [_broadcastOriginalTransaction] clears it. Never labels the transaction
   /// "payjoin" — this is by definition not a real one.
-  Future<void> _onOriginalTransactionSeen(
-    String payjoinId,
-  ) => _lock.synchronized(() async {
-    // Stop first: the watch stream re-emits on every sync, and completion is
-    // a one-shot side effect. Whichever of the real payjoin txid or this
-    // original txid lands first resolves the session, so both watchers are
-    // torn down together.
-    _stopWatching(payjoinId);
+  Future<void> _onOriginalTransactionSeen(String payjoinId) => _withSessionLock(
+    payjoinId,
+    () async {
+      final receiverModel = await _localPayjoinDatasource.fetchReceiver(
+        payjoinId,
+      );
+      final PayjoinModel? model =
+          receiverModel ?? await _localPayjoinDatasource.fetchSender(payjoinId);
+      if (model == null || model.isCompleted || model.isAborted) {
+        _stopWatching(payjoinId);
+        return;
+      }
 
-    final receiverModel = await _localPayjoinDatasource.fetchReceiver(
-      payjoinId,
-    );
-    final PayjoinModel? model =
-        receiverModel ?? await _localPayjoinDatasource.fetchSender(payjoinId);
-    if (model == null || model.isCompleted || model.isAborted) return;
-
-    final PayjoinModel abortedModel = model is PayjoinReceiverModel
-        ? model.copyWith(isAborted: true, txId: null)
-        : (model as PayjoinSenderModel).copyWith(isAborted: true, txId: null);
-    await _localPayjoinDatasource.update(abortedModel);
-    _syncWalletAfterBroadcast(abortedModel.walletId);
-    final abortedEntity = abortedModel.toEntity();
-    _payjoinStreamController.add(abortedEntity);
-    log.info(
-      'Payjoin ${abortedEntity.logRef} resolved via the original '
-      'transaction observed on-chain (fallback, not necessarily broadcast '
-      'by this device)',
-    );
-  });
+      final PayjoinModel abortedModel = model is PayjoinReceiverModel
+          ? model.copyWith(isExpired: false, isAborted: true, txId: null)
+          : (model as PayjoinSenderModel).copyWith(
+              isExpired: false,
+              isAborted: true,
+              txId: null,
+            );
+      final applied = await _localPayjoinDatasource.markAborted(abortedModel);
+      if (!applied) {
+        final refreshed = model is PayjoinReceiverModel
+            ? await _localPayjoinDatasource.fetchReceiver(payjoinId)
+            : await _localPayjoinDatasource.fetchSender(payjoinId);
+        if (refreshed?.isCompleted == true || refreshed?.isAborted == true) {
+          _stopWatching(payjoinId);
+        }
+        return;
+      }
+      _stopWatching(payjoinId);
+      _syncWalletAfterBroadcast(abortedModel.walletId);
+      final abortedEntity = abortedModel.toEntity();
+      _payjoinStreamController.add(abortedEntity);
+      log.info(
+        'Payjoin ${abortedEntity.logRef} resolved via the original '
+        'transaction observed on-chain (fallback, not necessarily broadcast '
+        'by this device)',
+      );
+    },
+  );
 
   /// Stops every watcher of a session — the real-payjoin broadcast watch
   /// ([_watchForBroadcast]), the original-transaction fallback watch

--- a/lib/core/payjoin/domain/repositories/payjoin_repository.dart
+++ b/lib/core/payjoin/domain/repositories/payjoin_repository.dart
@@ -36,10 +36,8 @@ abstract class PayjoinRepository {
   Future<void> disableReceivers();
 
   /// Resumes polling/watching for every unfinished payjoin session left over
-  /// from a previous app run. A composition-root lifecycle hook: the
-  /// repository is constructed as an eager singleton before every dependency
-  /// it needs (wallet repositories, the labels facade) is registered, so this
-  /// must be called explicitly once every core dependency it needs is
-  /// registered, rather than fired from the constructor — see AppLocator.setup.
+  /// from a previous app run. The foreground composition root calls this
+  /// explicitly after dependency registration; background locators must not
+  /// start protocol work.
   Future<void> resumePayjoinsOnStartup();
 }

--- a/lib/core/payjoin/payjoin_locator.dart
+++ b/lib/core/payjoin/payjoin_locator.dart
@@ -63,12 +63,11 @@ class PayjoinLocator {
   }
 
   static void registerRepositories(GetIt locator) {
-    // Eager (not lazy) singleton: it subscribes to the datasource's event
-    // streams at construction. Resuming unfinished sessions is deferred to
-    // an explicit resumePayjoinsOnStartup() call from AppLocator.setup (see
-    // that method), once every dependency it needs is registered.
-    locator.registerSingleton<PayjoinRepository>(
-      PayjoinRepositoryImpl(
+    // The foreground resolves this singleton explicitly before resuming
+    // sessions. Background locators must not instantiate a second protocol
+    // executor merely by registering dependencies.
+    locator.registerLazySingleton<PayjoinRepository>(
+      () => PayjoinRepositoryImpl(
         localPayjoinDatasource: locator<LocalPayjoinDatasource>(),
         pdkPayjoinDatasource: locator<PdkPayjoinDatasource>(),
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
@@ -76,18 +75,11 @@ class PayjoinLocator {
         seedDatasource: locator<SeedDatasource>(),
         blockchainDatasource: locator<BdkBitcoinBlockchainDatasource>(),
         serversPort: locator<ElectrumServersPort>(),
-        // Lazy: WalletLocator registers these AFTER
-        // PayjoinLocator.registerRepositories (see core_locator.dart), and
-        // this repository is an eager registerSingleton. They are only
-        // called from broadcast/completion watchers, well after startup.
+        // Lazy accessors keep registration order independent.
         walletRepository: () => locator<WalletRepository>(),
         walletTransactionRepository: () =>
             locator<WalletTransactionRepository>(),
         settingsRepository: locator<SettingsRepository>(),
-        // Lazy: LabelsLocator.registerFacade runs after
-        // PayjoinLocator.registerRepositories (see core_locator.dart), and
-        // this repository is an eager registerSingleton — see
-        // PayjoinRepositoryImpl's _labelsFacade doc comment.
         labelsFacade: () => locator<LabelsFacade>(),
       ),
     );

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -160,10 +160,8 @@ class Logger {
   /// Best-effort log loss is acceptable in isolation, but here it
   /// destroys the most recent (and most diagnostically useful) BG
   /// lines — the exact lines a user would share to support after a
-  /// crash. Each isolate prunes its own file: FG cold-start prunes
-  /// `bull_logs.tsv` via `Bull.initLogs`; BG `logs-prune` task fires
-  /// every 15 minutes (Android) / on iOS BGTaskScheduler windows and
-  /// prunes `bull_background_logs.tsv`.
+  /// crash. Each isolate must therefore prune its own file; foreground
+  /// cold-start pruning is triggered by `Bull.initLogs`.
   Future<void> prune() => _enqueue(() async {
     final sizeInKb = (await logsFile.stat()).size ~/ 1000;
     if (sizeInKb <= _maxLogSizeKb) return;

--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -235,18 +235,6 @@ class ReceiveQRDetails extends StatelessWidget {
 class ReceiveInfoDetails extends StatelessWidget {
   const ReceiveInfoDetails({super.key});
 
-  /// Suffix showing the unit the user entered in, when it wasn't BTC:
-  /// sats → " (N sats)", fiat → " (~X CUR)". Entered-in-BTC shows nothing —
-  /// the BTC value on the row already IS what the user typed.
-  String _enteredUnitSuffix(BuildContext context, int amountSat) {
-    final state = context.read<ReceiveBloc>().state;
-    if (state.inputAmountCurrencyCode == BitcoinUnit.btc.code) return '';
-    if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
-      return ' (${FormatAmount.sats(amountSat)})';
-    }
-    return ' (~${state.formattedConfirmedAmountFiat})';
-  }
-
   @override
   Widget build(BuildContext context) {
     final amountSat = context.select(
@@ -256,6 +244,18 @@ class ReceiveInfoDetails extends StatelessWidget {
     final type = context.select<ReceiveBloc, ReceiveType?>(
       (bloc) => bloc.state.type,
     );
+    final enteredUnitSuffix = context.select<ReceiveBloc, String>((bloc) {
+      final state = bloc.state;
+      final sats = state.confirmedAmountSat;
+      if (sats == null ||
+          state.inputAmountCurrencyCode == BitcoinUnit.btc.code) {
+        return '';
+      }
+      if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
+        return ' (${FormatAmount.sats(sats)})';
+      }
+      return ' (~${state.formattedConfirmedAmountFiat})';
+    });
 
     if (type == ReceiveType.lightning) return const ReceiveLnInfoDetails();
 
@@ -294,7 +294,7 @@ class ReceiveInfoDetails extends StatelessWidget {
                         BBText(
                           '${context.loc.coreScreensAmountLabel}: '
                           '${FormatAmount.btc(ConvertAmount.satsToBtc(amountSat))}'
-                          '${_enteredUnitSuffix(context, amountSat)}',
+                          '$enteredUnitSuffix',
                           style: context.font.bodyMedium,
                           maxLines: 1,
                           overflow: .ellipsis,

--- a/lib/features/settings/domain/settings_failure.dart
+++ b/lib/features/settings/domain/settings_failure.dart
@@ -11,7 +11,3 @@ final class SettingsStorageFailure extends SettingsFailure {
 final class SettingsConsentFailure extends SettingsFailure {
   const SettingsConsentFailure([super.logMessage]);
 }
-
-final class SettingsPayjoinFailure extends SettingsFailure {
-  const SettingsPayjoinFailure([super.logMessage]);
-}

--- a/lib/features/settings/domain/usecases/set_payjoin_enabled_usecase.dart
+++ b/lib/features/settings/domain/usecases/set_payjoin_enabled_usecase.dart
@@ -24,17 +24,22 @@ class SetPayjoinEnabledUsecase {
     required Future<bool> Function() requestConsent,
   }) async {
     if (!enabled) {
+      final persistResult = await _persist(false);
+      if (persistResult case Err(:final failure)) return Err(failure);
+
       try {
         await _disablePayjoinReceiversUsecase.execute();
       } catch (e, stackTrace) {
+        // The user intent is already persisted and remains authoritative.
+        // Unsettled receivers stay in SQLite and are retried at foreground
+        // startup without accepting new requests.
         log.warning(
-          'Failed to stop active Payjoin receivers',
+          'Payjoin disabled; active receiver settlement will be retried',
           error: e,
           trace: stackTrace,
         );
-        return Err(SettingsPayjoinFailure(e.toString()));
       }
-      return _persist(false);
+      return const Ok(false);
     }
 
     final shownResult = await _getPayjoinDisclaimerShownUsecase.execute();

--- a/lib/features/settings/presentation/settings_failure_l10n.dart
+++ b/lib/features/settings/presentation/settings_failure_l10n.dart
@@ -6,6 +6,5 @@ extension SettingsFailureL10n on SettingsFailure {
   String toTranslated(BuildContext context) => switch (this) {
     SettingsStorageFailure() => context.loc.oopsSomethingWentWrong,
     SettingsConsentFailure() => context.loc.oopsSomethingWentWrong,
-    SettingsPayjoinFailure() => context.loc.oopsSomethingWentWrong,
   };
 }

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -1,8 +1,5 @@
-import 'dart:async';
-
 import 'package:bb_mobile/core/ark/locator.dart';
 import 'package:bb_mobile/core/core_locator.dart';
-import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/status/status_locator.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/sync/sync_locator.dart';
@@ -69,14 +66,6 @@ class AppLocator {
     CoreLocator.registerUsecases(locator);
     CoreLocator.registerFrameworks(locator);
     CoreLocator.registerFacades(locator);
-
-    // Every dependency PayjoinRepositoryImpl needs (wallet repositories,
-    //  settings, the labels facade) is now guaranteed registered — resume any
-    //  unfinished payjoin sessions left over from a previous run. Not awaited:
-    //  this is background work (relay polling, wallet syncs) that must not
-    //  delay app startup. See resumePayjoinsOnStartup's doc for why this
-    //  can't just run in the repository's constructor.
-    unawaited(locator<PayjoinRepository>().resumePayjoinsOnStartup());
 
     SyncLocator.setup(locator);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:io' show Platform;
 
 import 'package:bb_mobile/bloc_observer.dart';
 import 'package:bb_mobile/core/background_tasks/handler.dart';
-import 'package:bb_mobile/core/background_tasks/tasks.dart';
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/screens/app_init_error_screen.dart';
@@ -49,6 +49,16 @@ import 'package:workmanager/workmanager.dart';
 /// identically in both timing paths.
 WizardRepository _buildPreInitWizardRepository() =>
     WizardRepositoryImpl(WizardLocalDatasourceImpl());
+
+@visibleForTesting
+void resumePayjoinsOnAppResume(
+  AppLifecycleState state,
+  PayjoinRepository repository,
+) {
+  if (state == AppLifecycleState.resumed) {
+    unawaited(repository.resumePayjoinsOnStartup());
+  }
+}
 
 class Bull {
   static Future<void> init() async {
@@ -112,9 +122,9 @@ class Bull {
       // definition — cross-isolate truncation races with the other
       // isolate's open IOSink and can destroy recently-buffered
       // lines). FG file pruning therefore only happens here; the BG
-      // file is pruned by the `logs-prune` workmanager fire. Long
-      // FG-only sessions (rare cold restarts, no BG fires) can let
-      // the FG file grow past the cap until the next cold launch —
+      // file no longer grows because background tasks are disabled. Long
+      // FG-only sessions (rare cold restarts) can let the FG file grow past
+      // the cap until the next cold launch —
       // acceptable: worst case is a few hundred KB until the user
       // restarts.
       //
@@ -126,23 +136,16 @@ class Bull {
 
   static Future<void> initLocator() async {
     await AppLocator.setup(locator, SqliteDatabase());
+    unawaited(locator<PayjoinRepository>().resumePayjoinsOnStartup());
     Bloc.observer = AppBlocObserver();
   }
 
   static Future<void> initWorkmanager() async {
     await Workmanager().initialize(backgroundTasksHandler);
+    // Background execution is intentionally disabled. Cancel schedules left
+    // by previous releases, but keep initialization so upgrades reliably
+    // remove those persisted native tasks.
     await Workmanager().cancelAll();
-    await Workmanager().registerPeriodicTask(
-      BackgroundTask.logsPrune.id,
-      BackgroundTask.logsPrune.name,
-      frequency: const Duration(minutes: 15),
-      constraints: Constraints(
-        requiresBatteryNotLow: true,
-        requiresStorageNotLow: false,
-        requiresDeviceIdle: false,
-        requiresCharging: false,
-      ),
-    );
   }
 }
 
@@ -235,6 +238,7 @@ class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
   // AppLifecycleListener — see lib/core/sync/sync_coordinator.dart.
   void _onStateChanged(AppLifecycleState state) {
     log.info(state.name);
+    resumePayjoinsOnAppResume(state, locator<PayjoinRepository>());
     // iOS lifecycle is `active → inactive → hidden → paused`. The user can
     // force-quit from the app switcher during `inactive` and skip both the
     // `hidden` and `paused` flushes, so flush there too.

--- a/test/core_test/payjoin/local_payjoin_datasource_test.dart
+++ b/test/core_test/payjoin/local_payjoin_datasource_test.dart
@@ -1,8 +1,10 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/payjoin/data/datasources/local_payjoin_datasource.dart';
 import 'package:bb_mobile/core/payjoin/data/models/payjoin_model.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -42,6 +44,25 @@ void main() {
             isAborted: isAborted,
           )
           as PayjoinReceiverModel;
+
+  PayjoinSenderModel buildSender({
+    bool isExpired = false,
+    bool isCompleted = false,
+  }) =>
+      PayjoinModel.sender(
+            uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+            isTestnet: true,
+            sender: '[]',
+            walletId: 'w1',
+            originalPsbt: 'cHNidP8=',
+            originalTxId: originalTxId,
+            amountSat: 5000,
+            createdAt: 1700000000,
+            expireAfterSec: 86400,
+            isExpired: isExpired,
+            isCompleted: isCompleted,
+          )
+          as PayjoinSenderModel;
 
   group('fetchByTxId', () {
     test('finds an aborted session by its ORIGINAL transaction id — the only '
@@ -90,6 +111,165 @@ void main() {
 
       expect(unfinished, isEmpty);
       expect(all, hasLength(1));
+    });
+  });
+
+  group('replaceExpiredSender', () {
+    test('atomically replaces only an unresolved expired session', () async {
+      final expired = buildSender(isExpired: true);
+      await datasource.storeSender(expired);
+      final retry = buildSender().copyWith(
+        sender: '["retry"]',
+        createdAt: 1800000000,
+      );
+
+      expect(await datasource.replaceExpiredSender(retry), isTrue);
+
+      final persisted = await datasource.fetchSender(retry.id);
+      expect(persisted?.sender, '["retry"]');
+      expect(persisted?.createdAt, 1800000000);
+      expect(persisted?.isExpired, isFalse);
+    });
+
+    test('does not replace a completed payment', () async {
+      final completed = buildSender(isCompleted: true);
+      await datasource.storeSender(completed);
+
+      expect(await datasource.replaceExpiredSender(buildSender()), isFalse);
+      expect((await datasource.fetchSender(completed.id))?.isCompleted, isTrue);
+    });
+  });
+
+  group('atomic transitions across connections', () {
+    late Directory tempDirectory;
+    late SqliteDatabase firstDb;
+    late SqliteDatabase secondDb;
+    late LocalPayjoinDatasource first;
+    late LocalPayjoinDatasource second;
+
+    setUpAll(() {
+      // Multiple independent connections are the subject of these tests.
+      driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+    });
+
+    tearDownAll(() {
+      driftRuntimeOptions.dontWarnAboutMultipleDatabases = false;
+    });
+
+    setUp(() async {
+      tempDirectory = await Directory.systemTemp.createTemp(
+        'payjoin-transitions-',
+      );
+      final file = File('${tempDirectory.path}/payjoin.sqlite');
+      firstDb = SqliteDatabase(NativeDatabase(file));
+      first = LocalPayjoinDatasource(db: firstDb);
+      // Open and migrate the first connection before opening the second one.
+      await firstDb.customSelect('SELECT 1').get();
+      secondDb = SqliteDatabase(NativeDatabase(file));
+      second = LocalPayjoinDatasource(db: secondDb);
+      await secondDb.customSelect('SELECT 1').get();
+    });
+
+    tearDown(() async {
+      await secondDb.close();
+      await firstDb.close();
+      await tempDirectory.delete(recursive: true);
+    });
+
+    test('a stale expiry cannot overwrite completion', () async {
+      final receiver = buildReceiver(
+        txId: proposalTxId,
+        originalTxIdValue: originalTxId,
+      );
+      await first.storeReceiver(receiver);
+
+      await Future.wait([
+        first.markExpired(receiver.copyWith(isExpired: true)),
+        second.markCompleted(receiver.copyWith(isCompleted: true)),
+      ]);
+
+      final persisted = await first.fetchReceiver(receiver.id);
+      expect(persisted?.isCompleted, isTrue);
+      expect(persisted?.isExpired, isFalse);
+    });
+
+    test('a stale sender proposal cannot overwrite an abort', () async {
+      final sender =
+          PayjoinModel.sender(
+                uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
+                isTestnet: true,
+                sender: '[]',
+                walletId: 'w1',
+                originalPsbt: 'cHNidP8=',
+                originalTxId: originalTxId,
+                amountSat: 5000,
+                createdAt: 1700000000,
+                expireAfterSec: 86400,
+              )
+              as PayjoinSenderModel;
+      await first.storeSender(sender);
+      final proposal = sender.copyWith(
+        sender: '["proposal"]',
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        txId: proposalTxId,
+      );
+
+      await Future.wait([
+        first.recordSenderProposal(proposal),
+        second.markAborted(sender.copyWith(isAborted: true)),
+      ]);
+
+      final persisted = await first.fetchSender(sender.id);
+      expect(persisted?.isAborted, isTrue);
+      expect(persisted?.txId, isNull);
+    });
+
+    test(
+      'completion wins over an abort and records the observed txid',
+      () async {
+        final receiver = buildReceiver(originalTxIdValue: originalTxId);
+        await first.storeReceiver(receiver);
+
+        await Future.wait([
+          first.markAborted(receiver.copyWith(isAborted: true)),
+          second.markCompleted(
+            receiver.copyWith(isCompleted: true, txId: proposalTxId),
+          ),
+        ]);
+
+        final persisted = await first.fetchReceiver(receiver.id);
+        expect(persisted?.isCompleted, isTrue);
+        expect(persisted?.isAborted, isFalse);
+        expect(persisted?.txId, proposalTxId);
+      },
+    );
+
+    test('a stale abort cannot overwrite completion', () async {
+      final sender =
+          PayjoinModel.sender(
+                uri: 'bitcoin:tb1qsender2?pj=https://payjo.in',
+                isTestnet: true,
+                sender: '[]',
+                walletId: 'w1',
+                originalPsbt: 'cHNidP8=',
+                originalTxId: originalTxId,
+                amountSat: 5000,
+                createdAt: 1700000000,
+                expireAfterSec: 86400,
+              )
+              as PayjoinSenderModel;
+      await first.storeSender(sender);
+
+      await second.markCompleted(
+        sender.copyWith(isCompleted: true, txId: proposalTxId),
+      );
+      final applied = await first.markAborted(sender.copyWith(isAborted: true));
+
+      expect(applied, isFalse);
+      final persisted = await first.fetchSender(sender.id);
+      expect(persisted?.isCompleted, isTrue);
+      expect(persisted?.isAborted, isFalse);
+      expect(persisted?.txId, proposalTxId);
     });
   });
 }

--- a/test/core_test/payjoin/payjoin_repository_impl_test.dart
+++ b/test/core_test/payjoin/payjoin_repository_impl_test.dart
@@ -104,6 +104,7 @@ PayjoinSenderModel _senderModel({
   String walletId = 'w1',
   String originalTxId = 'sender-orig-txid',
   String? proposalPsbt,
+  String? txId,
 }) {
   return PayjoinModel.sender(
         uri: uri,
@@ -116,17 +117,21 @@ PayjoinSenderModel _senderModel({
         createdAt: 0,
         expireAfterSec: 300,
         proposalPsbt: proposalPsbt,
+        txId: txId,
       )
       as PayjoinSenderModel;
 }
 
-SettingsEntity _testSettings({int payjoinMinAmountSat = 10000}) =>
-    SettingsEntity(
-      environment: Environment.mainnet,
-      bitcoinUnit: BitcoinUnit.sats,
-      currencyCode: 'USD',
-      payjoinMinAmountSat: payjoinMinAmountSat,
-    );
+SettingsEntity _testSettings({
+  int payjoinMinAmountSat = 10000,
+  bool isPayjoinEnabled = true,
+}) => SettingsEntity(
+  environment: Environment.mainnet,
+  bitcoinUnit: BitcoinUnit.sats,
+  currencyCode: 'USD',
+  isPayjoinEnabled: isPayjoinEnabled,
+  payjoinMinAmountSat: payjoinMinAmountSat,
+);
 
 Wallet _testWallet({String origin = 'w1'}) => Wallet(
   origin: origin,
@@ -177,10 +182,12 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(ElectrumServerNetwork.bitcoinTestnet);
+    registerFallbackValue(BigInt.zero);
     registerFallbackValue(_FakeNewLabel());
     // PayjoinModel is sealed and can't be Fake-implemented from outside its
     // library — register a real (throwaway) instance instead.
     registerFallbackValue(_receiverModel());
+    registerFallbackValue(_senderModel());
     // Fallback for any() matchers against BdkWalletDatasource.signPsbt's
     // `wallet` param in the real-signing-stack tests.
     registerFallbackValue(
@@ -237,8 +244,39 @@ void main() {
       () => localDatasource.fetchReceivers(onlyOngoing: true),
     ).thenAnswer((_) async => []);
     when(() => localDatasource.fetchSenders()).thenAnswer((_) async => []);
-    when(() => localDatasource.update(any())).thenAnswer((_) async {});
-    when(() => localDatasource.deleteReceiver(any())).thenAnswer((_) async {});
+    when(
+      () => localDatasource.recordReceiverRequest(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.recordReceiverProposal(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.recordSenderProposal(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.markCompleted(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.markAborted(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.markExpired(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.markExpired(
+        any(),
+        clearTxId: any(named: 'clearTxId'),
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.deleteIdleReceiver(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => localDatasource.replaceExpiredSender(any()),
+    ).thenAnswer((_) async => true);
+    when(
+      () => settingsRepository.fetch(),
+    ).thenAnswer((_) async => _testSettings());
 
     // Passive watchers must never fire spuriously: an empty sync stream and
     // a not-found transaction lookup keep _watchForFallback/_watchForBroadcast
@@ -304,6 +342,198 @@ void main() {
           )
           as PayjoinReceiverModel;
 
+  group('session creation persistence boundaries', () {
+    test(
+      'does not create a receiver while Payjoin is already disabled',
+      () async {
+        when(
+          () => settingsRepository.fetch(),
+        ).thenAnswer((_) async => _testSettings(isPayjoinEnabled: false));
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        await expectLater(
+          repository.createPayjoinReceiver(
+            walletId: 'w1',
+            address: 'tb1qtest',
+            isTestnet: true,
+            maxFeeRateSatPerVb: BigInt.from(10),
+            expireAfterSec: 300,
+          ),
+          throwsStateError,
+        );
+
+        verifyNever(
+          () => pdkDatasource.createReceiver(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            isTestnet: any(named: 'isTestnet'),
+            maxFeeRateSatPerVb: any(named: 'maxFeeRateSatPerVb'),
+            expireAfterSec: any(named: 'expireAfterSec'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'removes a receiver when Payjoin is disabled during creation',
+      () async {
+        final receiver = _receiverModel(
+          hasRequest: false,
+          expireAfterSec: 9999999999,
+        );
+        var settingsRead = 0;
+        when(() => settingsRepository.fetch()).thenAnswer(
+          (_) async => _testSettings(isPayjoinEnabled: settingsRead++ == 0),
+        );
+        when(
+          () => pdkDatasource.createReceiver(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            isTestnet: any(named: 'isTestnet'),
+            maxFeeRateSatPerVb: any(named: 'maxFeeRateSatPerVb'),
+            expireAfterSec: any(named: 'expireAfterSec'),
+          ),
+        ).thenAnswer((_) async => receiver);
+        when(
+          () => localDatasource.storeReceiver(receiver),
+        ).thenAnswer((_) async {});
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        await expectLater(
+          repository.createPayjoinReceiver(
+            walletId: receiver.walletId,
+            address: receiver.address,
+            isTestnet: receiver.isTestnet,
+            maxFeeRateSatPerVb: receiver.maxFeeRateSatPerVb,
+            expireAfterSec: receiver.expireAfterSec,
+          ),
+          throwsStateError,
+        );
+
+        verify(
+          () => pdkDatasource.stopPolling(receiver.id),
+        ).called(greaterThan(0));
+        verify(() => localDatasource.deleteIdleReceiver(receiver.id)).called(1);
+      },
+    );
+
+    test('stops a sender poll when the initial insert fails', () async {
+      final sender = _senderModel();
+      when(
+        () => localDatasource.fetchSender(sender.id),
+      ).thenAnswer((_) async => null);
+      when(
+        () => pdkDatasource.createSender(
+          walletId: any(named: 'walletId'),
+          isTestnet: any(named: 'isTestnet'),
+          bip21: any(named: 'bip21'),
+          originalPsbt: any(named: 'originalPsbt'),
+          amountSat: any(named: 'amountSat'),
+          networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+          expireAfterSec: any(named: 'expireAfterSec'),
+        ),
+      ).thenAnswer((_) async => sender);
+      when(
+        () => localDatasource.storeSender(sender),
+      ).thenThrow(Exception('disk full'));
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await expectLater(
+        repository.createPayjoinSender(
+          walletId: sender.walletId,
+          isTestnet: sender.isTestnet,
+          bip21: sender.id,
+          originalPsbt: sender.originalPsbt,
+          amountSat: sender.amountSat,
+          networkFeesSatPerVb: 1,
+        ),
+        throwsException,
+      );
+
+      verify(() => pdkDatasource.stopPolling(sender.id)).called(1);
+    });
+
+    test(
+      'rejects a duplicate sender before posting to the directory',
+      () async {
+        final sender = _senderModel();
+        when(
+          () => localDatasource.fetchSender(sender.id),
+        ).thenAnswer((_) async => sender);
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        await expectLater(
+          repository.createPayjoinSender(
+            walletId: sender.walletId,
+            isTestnet: sender.isTestnet,
+            bip21: sender.id,
+            originalPsbt: sender.originalPsbt,
+            amountSat: sender.amountSat,
+            networkFeesSatPerVb: 1,
+          ),
+          throwsStateError,
+        );
+
+        verifyNever(
+          () => pdkDatasource.createSender(
+            walletId: any(named: 'walletId'),
+            isTestnet: any(named: 'isTestnet'),
+            bip21: any(named: 'bip21'),
+            originalPsbt: any(named: 'originalPsbt'),
+            amountSat: any(named: 'amountSat'),
+            networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+            expireAfterSec: any(named: 'expireAfterSec'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'replaces an expired sender so the failed payment can retry',
+      () async {
+        final expired = _senderModel().copyWith(isExpired: true);
+        final retry = _senderModel().copyWith(
+          sender: '["retry"]',
+          createdAt: 1,
+        );
+        when(
+          () => localDatasource.fetchSender(expired.id),
+        ).thenAnswer((_) async => expired);
+        when(
+          () => pdkDatasource.createSender(
+            walletId: any(named: 'walletId'),
+            isTestnet: any(named: 'isTestnet'),
+            bip21: any(named: 'bip21'),
+            originalPsbt: any(named: 'originalPsbt'),
+            amountSat: any(named: 'amountSat'),
+            networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+            expireAfterSec: any(named: 'expireAfterSec'),
+          ),
+        ).thenAnswer((_) async => retry);
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        final result = await repository.createPayjoinSender(
+          walletId: retry.walletId,
+          isTestnet: retry.isTestnet,
+          bip21: retry.id,
+          originalPsbt: retry.originalPsbt,
+          amountSat: retry.amountSat,
+          networkFeesSatPerVb: 1,
+        );
+
+        expect(result.isExpired, isFalse);
+        verify(() => localDatasource.replaceExpiredSender(retry)).called(1);
+        verifyNever(() => localDatasource.storeSender(any()));
+      },
+    );
+  });
+
   group('disabling receivers', () {
     test(
       'stops and deletes an endpoint that no sender has contacted',
@@ -313,7 +543,7 @@ void main() {
           expireAfterSec: 9999999999,
         );
         when(
-          () => localDatasource.fetchReceivers(onlyOngoing: true),
+          () => localDatasource.fetchReceivers(),
         ).thenAnswer((_) async => [receiver]);
         when(
           () => localDatasource.fetchReceiver(receiver.id),
@@ -324,7 +554,7 @@ void main() {
         await repository.disableReceivers();
 
         verify(() => pdkDatasource.stopPolling(receiver.id)).called(1);
-        verify(() => localDatasource.deleteReceiver(receiver.id)).called(1);
+        verify(() => localDatasource.deleteIdleReceiver(receiver.id)).called(1);
         verifyNever(
           () => serversPort.runWithFallback<void>(
             network: any(named: 'network'),
@@ -340,7 +570,7 @@ void main() {
         expireAfterSec: 9999999999,
       );
       when(
-        () => localDatasource.fetchReceivers(onlyOngoing: true),
+        () => localDatasource.fetchReceivers(),
       ).thenAnswer((_) async => [receiver]);
       when(
         () => localDatasource.fetchReceiver(receiver.id),
@@ -350,13 +580,81 @@ void main() {
 
       await repository.disableReceivers();
 
-      verifyNever(() => localDatasource.deleteReceiver(any()));
+      verifyNever(() => localDatasource.deleteIdleReceiver(any()));
       verifyNever(
         () => serversPort.runWithFallback<void>(
           network: any(named: 'network'),
           operation: any(named: 'operation'),
         ),
       );
+    });
+
+    test('attempts every receiver even when one settlement fails', () async {
+      final failing = _receiverModel(id: 'bad', amountSat: 50000);
+      final idle = _receiverModel(
+        id: 'idle',
+        hasRequest: false,
+        expireAfterSec: 9999999999,
+      );
+      when(
+        () => localDatasource.fetchReceivers(),
+      ).thenAnswer((_) async => [failing, idle]);
+      when(
+        () => localDatasource.fetchReceiver('bad'),
+      ).thenAnswer((_) async => failing);
+      when(
+        () => localDatasource.fetchReceiver('idle'),
+      ).thenAnswer((_) async => idle);
+      when(
+        () => pdkDatasource.declineReceiverSession(failing),
+      ).thenThrow(Exception('PDK unavailable'));
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await expectLater(repository.disableReceivers(), throwsException);
+
+      verify(() => localDatasource.deleteIdleReceiver('idle')).called(1);
+      verify(() => pdkDatasource.stopPolling('idle')).called(1);
+    });
+
+    test('declines a queued request after Payjoin was disabled', () async {
+      when(
+        () => settingsRepository.fetch(),
+      ).thenAnswer((_) async => _testSettings(isPayjoinEnabled: false));
+      final request = _receiverModel(
+        amountSat: 50000,
+        expireAfterSec: 9999999999,
+      );
+      when(
+        () => localDatasource.fetchReceiver(request.id),
+      ).thenAnswer((_) async => request);
+      when(
+        () => pdkDatasource.declineReceiverSession(request),
+      ).thenReturn('["cancelled"]');
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      requestsController.add(request);
+      await pumpEventQueue();
+
+      verify(() => pdkDatasource.declineReceiverSession(request)).called(1);
+      verifyNever(
+        () => pdkDatasource.proposePayjoin(
+          receiverModel: any(named: 'receiverModel'),
+          hasOwnedInputs: any(named: 'hasOwnedInputs'),
+          hasReceiverOutput: any(named: 'hasReceiverOutput'),
+          inputPairs: any(named: 'inputPairs'),
+          processPsbt: any(named: 'processPsbt'),
+        ),
+      );
+      verify(() => localDatasource.markAborted(any())).called(1);
     });
 
     test(
@@ -375,8 +673,8 @@ void main() {
         expiredController.add(receiver.copyWith(isExpired: true));
         await pumpEventQueue();
 
-        verify(() => localDatasource.deleteReceiver(receiver.id)).called(1);
-        verifyNever(() => localDatasource.update(any()));
+        verify(() => localDatasource.deleteIdleReceiver(receiver.id)).called(1);
+        verifyNever(() => localDatasource.markExpired(any()));
         expect(emitted.single.status, PayjoinStatus.expired);
       },
     );
@@ -506,7 +804,7 @@ void main() {
         ),
       ).called(1);
       final updated = verify(
-        () => localDatasource.update(captureAny()),
+        () => localDatasource.markAborted(captureAny()),
       ).captured;
       expect(
         updated.whereType<PayjoinReceiverModel>().any((m) => m.isAborted),
@@ -908,14 +1206,6 @@ void main() {
       expect(result, isNotNull);
       expect(result!.isAborted, isTrue);
     });
-
-    // SKIP: the _broadcastPsbt real-payjoin sync test. The work tree's
-    // _processPayjoinProposal re-derives the label txid via
-    // BitcoinTx.fromPsbt('signed-psbt'), which throws under FFI in a unit
-    // context and routes into the fallback path — the getWallet(sync: true)
-    // call inside _broadcastPsbt is not cleanly isolatable from the fallback
-    // path's own sync. The two fallback-side sync tests above cover the same
-    // _syncWalletAfterBroadcast machinery.
   });
 
   group('_processExpiredPayjoin sender terminal emission (#2246)', () {
@@ -1011,7 +1301,7 @@ void main() {
           operation: any(named: 'operation'),
         ),
       );
-      verifyNever(() => localDatasource.update(any()));
+      verifyNever(() => localDatasource.markExpired(any()));
       expect(emitted, isEmpty);
       await sub.cancel();
     });
@@ -1038,7 +1328,7 @@ void main() {
           operation: any(named: 'operation'),
         ),
       );
-      verifyNever(() => localDatasource.update(any()));
+      verifyNever(() => localDatasource.markExpired(any()));
       expect(emitted, isEmpty);
       await sub.cancel();
     });
@@ -1096,11 +1386,12 @@ void main() {
             operation: any(named: 'operation'),
           ),
         );
-        // The expired marker is persisted on the FRESH row: persisting the
-        // stale copy would clobber the proposal (insertOnConflictUpdate
-        // replaces the whole row).
+        // The expiry transition uses the fresh row and updates only the status
+        // column, so the persisted proposal cannot be clobbered.
         final persisted =
-            verify(() => localDatasource.update(captureAny())).captured.single
+            verify(
+                  () => localDatasource.markExpired(captureAny()),
+                ).captured.single
                 as PayjoinSenderModel;
         expect(persisted.proposalPsbt, 'cHNidP9wcm9wb3NhbA==');
         expect(persisted.isExpired, isTrue);
@@ -1194,6 +1485,72 @@ void main() {
       },
     );
 
+    test('does not broadcast the original after the payjoin broadcast succeeds '
+        'but completion persistence fails', () async {
+      final model = _senderModel(
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        txId: 'payjoin-txid',
+      );
+      when(
+        () => localDatasource.fetchSender(model.id),
+      ).thenAnswer((_) async => model);
+      when(
+        () => localDatasource.markCompleted(any()),
+      ).thenThrow(Exception('database unavailable'));
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final origin = WalletMetadataService.encodeOrigin(
+        fingerprint: '00000000',
+        network: Network.bitcoinTestnet,
+        scriptType: ScriptType.bip84,
+      );
+      when(() => walletMetadataDatasource.fetch('w1')).thenAnswer(
+        (_) async => WalletMetadataModel(
+          id: origin,
+          masterFingerprint: '00000000',
+          xpubFingerprint: '00000000',
+          isEncryptedVaultTested: false,
+          isPhysicalBackupTested: false,
+          xpub: '',
+          externalPublicDescriptor: '',
+          internalPublicDescriptor: '',
+          signer: Signer.local,
+          isDefault: false,
+        ),
+      );
+      when(() => seedDatasource.get('00000000')).thenAnswer(
+        (_) async =>
+            const SeedModel.mnemonic(mnemonicWords: ['abandon'])
+                as MnemonicSeedModel,
+      );
+      when(
+        () => bdkWalletDatasource.signPsbt(any(), wallet: any(named: 'wallet')),
+      ).thenAnswer((_) async => 'signed-psbt');
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      proposalsController.add(model);
+      await pumpEventQueue();
+
+      verify(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).called(1);
+      verify(() => walletRepository.getWallet('w1', sync: true)).called(1);
+      expect(emitted.last.isCompleted, isTrue);
+    });
+
     test('bails out when the persisted session already aborted — a proposal '
         'event arriving after the counterparty fell back must not resurrect '
         'the row nor sign/broadcast', () async {
@@ -1225,7 +1582,7 @@ void main() {
           operation: any(named: 'operation'),
         ),
       );
-      verifyNever(() => localDatasource.update(any()));
+      verifyNever(() => localDatasource.recordSenderProposal(any()));
       expect(emitted, isEmpty);
       await sub.cancel();
     });
@@ -1276,6 +1633,76 @@ void main() {
   });
 
   group('resumePayjoinsOnStartup', () {
+    test('serializes overlapping cold-start and app-resume recovery', () async {
+      final firstFetchStarted = Completer<void>();
+      final releaseFirstFetch = Completer<void>();
+      var settingsFetches = 0;
+      when(() => settingsRepository.fetch()).thenAnswer((_) async {
+        settingsFetches++;
+        if (settingsFetches == 1) {
+          firstFetchStarted.complete();
+          await releaseFirstFetch.future;
+        }
+        return _testSettings();
+      });
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      final coldStart = repository.resumePayjoinsOnStartup();
+      await firstFetchStarted.future;
+      final appResume = repository.resumePayjoinsOnStartup();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(settingsFetches, 1);
+      releaseFirstFetch.complete();
+      await Future.wait([coldStart, appResume]);
+      expect(settingsFetches, 2);
+    });
+
+    test(
+      'does not restart an idle receiver when Payjoin is disabled',
+      () async {
+        final receiver = _receiverModel(
+          hasRequest: false,
+          expireAfterSec: 9999999999,
+        );
+        when(
+          () => settingsRepository.fetch(),
+        ).thenAnswer((_) async => _testSettings(isPayjoinEnabled: false));
+        when(
+          () => localDatasource.fetchReceivers(),
+        ).thenAnswer((_) async => [receiver]);
+        when(
+          () => localDatasource.fetchReceiver(receiver.id),
+        ).thenAnswer((_) async => receiver);
+
+        final repository = buildRepository();
+        addTearDown(repository.dispose);
+
+        await repository.resumePayjoinsOnStartup();
+
+        verify(() => localDatasource.deleteIdleReceiver(receiver.id)).called(1);
+        verifyNever(() => pdkDatasource.startListeningForRequest(any()));
+      },
+    );
+
+    test('still resumes a sender when Payjoin is disabled', () async {
+      final sender = _senderModel().copyWith(expireAfterSec: 9999999999);
+      when(
+        () => settingsRepository.fetch(),
+      ).thenAnswer((_) async => _testSettings(isPayjoinEnabled: false));
+      when(
+        () => localDatasource.fetchAll(onlyUnfinished: true),
+      ).thenAnswer((_) async => [sender]);
+
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+
+      await repository.resumePayjoinsOnStartup();
+
+      verify(() => pdkDatasource.startListeningForProposal(sender)).called(1);
+    });
+
     test(
       'one session failing to resume does not stop the others from resuming',
       () async {
@@ -1307,15 +1734,15 @@ void main() {
         // "bad"'s persist throws (e.g. a transient DB failure); "ok"'s must
         //  still go through despite "bad" throwing first in the loop.
         when(
-          () => localDatasource.update(
+          () => localDatasource.markExpired(
             any(that: predicate<PayjoinModel>((m) => m.id == 'bad')),
           ),
         ).thenThrow(Exception('boom'));
         when(
-          () => localDatasource.update(
+          () => localDatasource.markExpired(
             any(that: predicate<PayjoinModel>((m) => m.id == 'ok')),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => true);
 
         final repository = buildRepository();
         addTearDown(repository.dispose);
@@ -1332,6 +1759,64 @@ void main() {
         await sub.cancel();
       },
     );
+
+    test('an expired sender proposal converges when its payjoin transaction '
+        'is on-chain despite resume recovery reporting failure', () async {
+      final syncController = StreamController<Wallet>.broadcast();
+      addTearDown(syncController.close);
+      when(
+        () => walletRepository.walletSyncFinishedStream,
+      ).thenAnswer((_) => syncController.stream);
+      final sender = _senderModel(
+        proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
+        txId: 'payjoin-txid',
+      ).copyWith(isExpired: true);
+      when(
+        () => localDatasource.fetchSenders(),
+      ).thenAnswer((_) async => [sender]);
+      when(
+        () => localDatasource.fetchSender(sender.id),
+      ).thenAnswer((_) async => sender);
+      when(
+        () => localDatasource.fetchReceiver(sender.id),
+      ).thenAnswer((_) async => null);
+      when(
+        () => walletMetadataDatasource.fetch(sender.walletId),
+      ).thenAnswer((_) async => null);
+      when(
+        () => serversPort.runWithFallback<void>(
+          network: any(named: 'network'),
+          operation: any(named: 'operation'),
+        ),
+      ).thenThrow(Exception('already known'));
+      when(
+        () => walletTransactionRepository.getWalletTransaction(
+          sender.txId!,
+          walletId: sender.walletId,
+        ),
+      ).thenAnswer(
+        (_) async =>
+            _testWalletTx(txId: sender.txId!, walletId: sender.walletId),
+      );
+      final repository = buildRepository();
+      addTearDown(repository.dispose);
+      final emitted = <Payjoin>[];
+      final sub = repository.payjoinStream.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await repository.resumePayjoinsOnStartup();
+      syncController.add(_testWallet(origin: sender.walletId));
+      await pumpEventQueue();
+
+      expect(emitted.any((payjoin) => payjoin.isCompleted), isTrue);
+      verify(
+        () => localDatasource.markCompleted(
+          any(
+            that: predicate<PayjoinModel>((model) => model.txId == sender.txId),
+          ),
+        ),
+      ).called(1);
+    });
   });
 
   group('_watchForBroadcast active polling', () {
@@ -1421,6 +1906,42 @@ void main() {
             sync: true,
           ),
         );
+      });
+    });
+
+    test('keeps polling when the transaction is visible but the completion '
+        'write fails transiently', () {
+      fakeAsync((async) {
+        when(
+          () => walletTransactionRepository.getWalletTransaction(
+            'payjoin-txid',
+            walletId: 'w1',
+            sync: true,
+          ),
+        ).thenAnswer(
+          (_) async => _testWalletTx(txId: 'payjoin-txid', walletId: 'w1'),
+        );
+        var writes = 0;
+        when(() => localDatasource.markCompleted(any())).thenAnswer((_) async {
+          writes++;
+          if (writes == 1) throw Exception('database busy');
+          return true;
+        });
+
+        final repo = buildRepository();
+        unawaited(repo.resumePayjoinsOnStartup());
+        async.flushMicrotasks();
+        final emitted = <Payjoin>[];
+        repo.payjoinStream.listen(emitted.add);
+
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay);
+        async.flushMicrotasks();
+        expect(emitted, isEmpty);
+
+        async.elapse(PayjoinRepositoryImpl.broadcastPollInitialDelay * 2);
+        async.flushMicrotasks();
+        expect(writes, 2);
+        expect(emitted.single.isCompleted, isTrue);
       });
     });
 
@@ -1533,10 +2054,11 @@ void main() {
         when(
           () => localDatasource.fetchReceiver('pj1'),
         ).thenAnswer((_) async => row);
-        when(() => localDatasource.update(any())).thenAnswer((
+        when(() => localDatasource.markAborted(any())).thenAnswer((
           invocation,
         ) async {
           row = invocation.positionalArguments.single as PayjoinReceiverModel;
+          return true;
         });
 
         final repo = buildRepository();
@@ -1742,19 +2264,32 @@ void main() {
       when(
         () => localDatasource.fetchReceiver(requestModel.id),
       ).thenAnswer((_) async => persistedModel);
-      when(() => localDatasource.update(any())).thenAnswer((invocation) async {
-        final model = invocation.positionalArguments.single as PayjoinModel;
-        if (model case final PayjoinReceiverModel receiver
-            when receiver.id == requestModel.id) {
-          persistedModel = receiver;
-          persistedUpdates.add(receiver);
-          if (receiver.proposalPsbt != null && !receiver.isAborted) {
-            if (!proposalPersisted.isCompleted) proposalPersisted.complete();
-          }
-          if (receiver.isAborted && !fallbackPersisted.isCompleted) {
-            fallbackPersisted.complete();
-          }
-        }
+      when(() => localDatasource.recordReceiverRequest(any())).thenAnswer((
+        invocation,
+      ) async {
+        persistedModel =
+            invocation.positionalArguments.single as PayjoinReceiverModel;
+        return true;
+      });
+      when(() => localDatasource.recordReceiverProposal(any())).thenAnswer((
+        invocation,
+      ) async {
+        final receiver =
+            invocation.positionalArguments.single as PayjoinReceiverModel;
+        persistedModel = receiver;
+        persistedUpdates.add(receiver);
+        if (!proposalPersisted.isCompleted) proposalPersisted.complete();
+        return true;
+      });
+      when(() => localDatasource.markAborted(any())).thenAnswer((
+        invocation,
+      ) async {
+        final receiver =
+            invocation.positionalArguments.single as PayjoinReceiverModel;
+        persistedModel = receiver;
+        persistedUpdates.add(receiver);
+        if (!fallbackPersisted.isCompleted) fallbackPersisted.complete();
+        return true;
       });
 
       final proposalStarted = Completer<void>();
@@ -1859,7 +2394,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(emitted, isEmpty);
-      verifyNever(() => localDatasource.update(any()));
+      verifyNever(() => localDatasource.markAborted(any()));
       await sub.cancel();
     });
 
@@ -1886,12 +2421,18 @@ void main() {
       when(
         () => localDatasource.fetchReceiver('pj1'),
       ).thenAnswer((_) async => model);
+      var broadcastAttempts = 0;
+      final fallbackAttemptsFinished = Completer<void>();
       when(
         () => serversPort.runWithFallback<void>(
           network: any(named: 'network'),
           operation: any(named: 'operation'),
         ),
-      ).thenThrow(Exception('no network'));
+      ).thenAnswer((_) async {
+        broadcastAttempts++;
+        if (broadcastAttempts == 3) fallbackAttemptsFinished.complete();
+        throw Exception('no network');
+      });
       when(
         () => walletTransactionRepository.getWalletTransaction(
           'orig-txid',
@@ -1903,7 +2444,8 @@ void main() {
       final sub = repo.payjoinStream.listen(emitted.add);
 
       requestsController.add(model);
-      await Future<void>.delayed(Duration.zero);
+      await fallbackAttemptsFinished.future;
+      await pumpEventQueue();
 
       // Own attempt failed: _processPayjoinRequest's below-minimum branch
       // only emits on success, so just the initial "requested" event is on
@@ -1924,7 +2466,7 @@ void main() {
         (_) async => _testWalletTx(txId: 'orig-txid', walletId: 'w1'),
       );
       syncController.add(_testWallet(origin: 'w1'));
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue();
 
       expect(emitted, hasLength(2));
       expect(emitted.last.status, PayjoinStatus.aborted);
@@ -2114,9 +2656,9 @@ void main() {
       ).thenAnswer((_) async => Ok<Label, LabelFailure>(_MockLabel()));
     });
 
-    test('_processPayjoinRequest arms _watchForBroadcast after a successful '
-        'propose — the receiver session completes once the sender broadcasts '
-        'the payjoin transaction', () {
+    test('_processPayjoinRequest never falls back after a proposal was posted, '
+        'even if proposal persistence fails; the broadcast watcher still '
+        'completes the receiver', () {
       fakeAsync((async) {
         // A request AT the minimum, so _processPayjoinRequest takes the
         // propose path (not the below-minimum decline).
@@ -2218,6 +2760,9 @@ void main() {
             txId: 'payjoin-txid',
           ),
         );
+        when(
+          () => localDatasource.recordReceiverProposal(any()),
+        ).thenThrow(Exception('database unavailable'));
 
         var txSeen = false;
         when(
@@ -2231,13 +2776,11 @@ void main() {
               ? _testWalletTx(txId: 'payjoin-txid', walletId: 'w1')
               : null,
         );
-        // The completion handler re-fetches the receiver row.
-        when(() => localDatasource.fetchReceiver('pj1')).thenAnswer(
-          (_) async => requestModel.copyWith(
-            proposalPsbt: 'cHNidP9wcm9wb3NhbA==',
-            txId: 'payjoin-txid',
-          ),
-        );
+        // Persistence failed, so the completion handler sees the pre-proposal
+        // row and must recover the observed txid through markCompleted.
+        when(
+          () => localDatasource.fetchReceiver('pj1'),
+        ).thenAnswer((_) async => requestModel);
 
         final repo = buildRepository();
         final emitted = <Payjoin>[];
@@ -2259,6 +2802,12 @@ void main() {
           reason:
               'the armed _watchForBroadcast should complete the session '
               'once the payjoin txid becomes visible via a forced sync',
+        );
+        verifyNever(
+          () => serversPort.runWithFallback<void>(
+            network: any(named: 'network'),
+            operation: any(named: 'operation'),
+          ),
         );
       });
     });
@@ -2364,7 +2913,7 @@ void main() {
 
         // The expired marker was persisted...
         verify(
-          () => localDatasource.update(
+          () => localDatasource.markExpired(
             any(that: predicate<PayjoinModel>((m) => m.isExpired)),
           ),
         ).called(greaterThanOrEqualTo(1));

--- a/test/core_test/payjoin/payjoin_repository_impl_test.dart
+++ b/test/core_test/payjoin/payjoin_repository_impl_test.dart
@@ -240,9 +240,6 @@ void main() {
     // empty by default, overridden in the sweep tests. Only runs from
     // resumePayjoinsOnStartup, never the constructor.
     when(() => localDatasource.fetchReceivers()).thenAnswer((_) async => []);
-    when(
-      () => localDatasource.fetchReceivers(onlyOngoing: true),
-    ).thenAnswer((_) async => []);
     when(() => localDatasource.fetchSenders()).thenAnswer((_) async => []);
     when(
       () => localDatasource.recordReceiverRequest(any()),

--- a/test/features/settings/domain/usecases/set_payjoin_enabled_usecase_test.dart
+++ b/test/features/settings/domain/usecases/set_payjoin_enabled_usecase_test.dart
@@ -67,7 +67,24 @@ void main() {
     verifyNever(() => getDisclaimerShown.execute());
   });
 
-  test('keeps the setting enabled if active receivers cannot stop', () async {
+  test(
+    'does not settle receivers when the disabled setting cannot persist',
+    () async {
+      when(
+        () => settingsRepository.setPayjoinEnabled(false),
+      ).thenThrow(Exception('storage unavailable'));
+
+      final result = await usecase.execute(
+        false,
+        requestConsent: () async => true,
+      );
+
+      expect(result, isA<Err<bool, SettingsFailure>>());
+      verifyNever(() => disablePayjoinReceivers.execute());
+    },
+  );
+
+  test('keeps Payjoin disabled when receiver settlement must retry', () async {
     when(
       () => disablePayjoinReceivers.execute(),
     ).thenThrow(StateError('fallback failed'));
@@ -77,12 +94,8 @@ void main() {
       requestConsent: () async => true,
     );
 
-    expect(result, isA<Err<bool, SettingsFailure>>());
-    expect(
-      (result as Err<bool, SettingsFailure>).failure,
-      isA<SettingsPayjoinFailure>(),
-    );
-    verifyNever(() => settingsRepository.setPayjoinEnabled(false));
+    expect((result as Ok<bool, SettingsFailure>).value, isFalse);
+    verify(() => settingsRepository.setPayjoinEnabled(false)).called(1);
   });
 
   test('enables immediately when consent was previously recorded', () async {

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/core/payjoin/domain/repositories/payjoin_repository.dart';
+import 'package:bb_mobile/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPayjoinRepository extends Mock implements PayjoinRepository {}
+
+void main() {
+  test('resumes Payjoin recovery when the app returns to the foreground', () {
+    final repository = _MockPayjoinRepository();
+    when(repository.resumePayjoinsOnStartup).thenAnswer((_) async {});
+
+    resumePayjoinsOnAppResume(AppLifecycleState.paused, repository);
+    verifyNever(repository.resumePayjoinsOnStartup);
+
+    resumePayjoinsOnAppResume(AppLifecycleState.resumed, repository);
+    verify(repository.resumePayjoinsOnStartup).called(1);
+  });
+}


### PR DESCRIPTION
This PR is stacked on #2509 and should be reviewed after it. It also carries the merge that propagates the native dependency pin from #2506.

## `b098d5821` Keep Session Recovery in the Foreground

**Problem:** Payjoin recovery was coupled to dependency-locator setup. Because locator setup can run in different execution contexts, registering dependencies could start protocol processing outside the foreground lifecycle. Obsolete Workmanager schedules could also keep background execution paths alive.

**Solution:** Register the Payjoin repository lazily and start recovery explicitly from foreground app initialization. Cancel previously registered Workmanager schedules while keeping foreground cold-start log pruning.

## `bcf77bc23` Make Payjoin Sessions Converge

**Problem:** A session is driven by several independent signals: PDK callbacks, user actions, expiry timers, startup recovery, SQLite state, network publication, and blockchain observations. These could overlap, while whole-row writes and broad error boundaries let stale handlers overwrite newer state or repeat protocol side effects.

This was one class of concurrency and convergence bugs with several possible outcomes:

- two receiver sessions selecting the same UTXO before either proposal was persisted
- proposal, expiry, fallback, and watcher callbacks acting on the same session concurrently
- a duplicate sender request published before SQLite rejected it
- a stale transition replacing a newer terminal outcome
- a local failure after successful publication entering the competing original-transaction fallback
- a watcher observing the right transaction but stopping before its terminal state was persisted
- expired or partially processed sessions remaining stranded after restart

**Solution:** Make session processing serialized, monotonic, and retryable:

- serialize all effects for a session with a session-specific lock
- serialize receiver UTXO selection across sessions until the proposal state is recorded
- reject duplicate sender sessions before publishing another request
- replace whole-row updates with conditional SQLite transitions using the priority `completed > aborted > expired > pending`
- treat successful publication as an irreversible boundary: persistence, synchronization, txid derivation, labeling, and watcher failures cannot trigger the competing fallback afterward
- keep watchers active when a terminal transition fails to persist, so a later observation retries
- reconcile both Payjoin and original transaction ids for receiver and sender sessions
- sweep recoverable expired sessions at startup, isolating failures per session

Repository tests and independent SQLite-connection tests cover the transition races and retry behavior.

## `03aace4c5` Persist Payjoin Disable Intent First

**Problem:** Disabling Payjoin settled active receivers before storing the setting. If settlement failed, Payjoin stayed enabled and could keep accepting requests despite the user's choice.

**Solution:** Persist the disabled setting first, then settle every receiver best-effort. A failed settlement stays durable and is retried at foreground startup, while new receiver creation fails closed.

## `ad9e30ddb` Keep the Receive Amount Summary Reactive

**Problem:** The receive summary derived its sats or fiat suffix through a non-reactive bloc read, so unit, currency, or exchange-rate changes could leave stale text on screen.

**Solution:** Derive the suffix through a `ReceiveBloc` selector so the summary rebuilds whenever a relevant input changes.

## `4363594d6` Make Integration-Test Gaps Explicit

**Problem:** Integration cleanup could mark rows expired while their PDK polling timers were still active. Three unimplemented scenarios also had empty bodies and reported success without testing anything.

**Solution:** Stop PDK polling before expiring cleanup rows, and mark the restart and insufficient-funds scenarios as explicitly skipped with the fixture or harness each still requires.

## `84dac6271` Drop the Unused Ongoing-Only Fetches

**Problem:** `fetchReceivers` and `fetchSenders` still carried an `onlyOngoing` branch with no caller, since the disable sweep and startup recovery read every row and decide from the freshest one under a session lock. A test stub also still referenced the dead parameter.

**Solution:** Remove the parameter and its branch, leaving filtered reads to `fetchAll`, and drop the stale stub.

## Deliberately Unchanged

- **Unconfirmed receiver UTXOs stay supported.** Suitable confirmed candidates are preferred, but fresh wallets can Payjoin immediately.
- **Proposal publication still precedes durable persistence of `proposed`.** This PR prevents an immediate competing fallback after a persistence failure, but does not introduce a transactional outbox. The blockchain arbitrates, and both transactions spend the same sender inputs, so the worst case is a lost negotiation falling back to a plain transaction — never a double payment.
- **Session locks are not purged on terminal outcomes.** Removing a lock while a callback is still queued on it would break mutual exclusion; the map is in-memory only and cleared on restart.
- **A failed receiver settlement is only logged.** It is retried at the next foreground cold start, not at app resume.
- **The receiver path with no candidate UTXO has no test.** Restart behavior is covered by the `resumePayjoinsOnStartup` unit tests.
- No key material, signing primitive, or secret-handling path changes.