### PR TITLE
fix(exchange): stop one unparseable order from wiping the order list

### DIFF
--- a/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
+++ b/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
@@ -258,7 +258,21 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
     final elements = resp.data['result']['elements'] as List<dynamic>?;
     if (elements == null) return [];
     return elements
-        .map((e) => OrderModel.fromJson(e as Map<String, dynamic>))
+        .map((e) {
+          // Parse each order on its own so one malformed element doesn't cost
+          // the user their whole order history. Nulls are filtered out below.
+          try {
+            return OrderModel.fromJson(e as Map<String, dynamic>);
+          } catch (err, stackTrace) {
+            log.severe(
+              message: 'Error parsing order element',
+              error: err,
+              trace: stackTrace,
+            );
+            return null;
+          }
+        })
+        .whereType<OrderModel>()
         .toList();
   }
 

--- a/lib/core/exchange/data/models/order_model.dart
+++ b/lib/core/exchange/data/models/order_model.dart
@@ -5,8 +5,8 @@ class OrderModel {
   final String orderType;
   final String? orderSubtype;
   final int orderNumber;
-  final double exchangeRateAmount;
-  final String exchangeRateCurrency;
+  final double? exchangeRateAmount;
+  final String? exchangeRateCurrency;
   final double? indexRateAmount;
   final String? indexRateCurrency;
   final double payinAmount;
@@ -24,7 +24,7 @@ class OrderModel {
   final String payinMethod;
   final String payoutMethod;
   final String triggerType;
-  final String confirmationDeadline;
+  final String? confirmationDeadline;
   final String? bitcoinTransactionId;
   final String? lnUrl;
   final String? lightningVoucherExpiresAt;
@@ -52,8 +52,8 @@ class OrderModel {
     required this.orderType,
     this.orderSubtype,
     required this.orderNumber,
-    required this.exchangeRateAmount,
-    required this.exchangeRateCurrency,
+    this.exchangeRateAmount,
+    this.exchangeRateCurrency,
     this.indexRateAmount,
     this.indexRateCurrency,
     required this.payinAmount,
@@ -71,7 +71,7 @@ class OrderModel {
     required this.payinMethod,
     required this.payoutMethod,
     required this.triggerType,
-    required this.confirmationDeadline,
+    this.confirmationDeadline,
     this.bitcoinTransactionId,
     this.lnUrl,
     this.lightningVoucherExpiresAt,
@@ -101,26 +101,30 @@ class OrderModel {
       orderType: json['orderType'] as String,
       orderSubtype: json['orderSubtype'] as String?,
       orderNumber: json['orderNumber'] as int,
-      exchangeRateAmount: (json['exchangeRateAmount'] as num).toDouble(),
-      exchangeRateCurrency: json['exchangeRateCurrency'] as String,
+      // Nullable per the server contract: reward, funding, refund and
+      // balance-adjustment orders carry no exchange rate and no deadline. The
+      // amounts and the status strings are read defensively for the same
+      // reason — an admin-initiated order has no real pay-in side.
+      exchangeRateAmount: (json['exchangeRateAmount'] as num?)?.toDouble(),
+      exchangeRateCurrency: json['exchangeRateCurrency'] as String?,
       indexRateAmount: (json['indexRateAmount'] as num?)?.toDouble(),
       indexRateCurrency: json['indexRateCurrency'] as String?,
-      payinAmount: (json['payinAmount'] as num).toDouble(),
-      payinCurrency: json['payinCurrency'] as String,
-      payoutAmount: (json['payoutAmount'] as num).toDouble(),
-      payoutCurrency: json['payoutCurrency'] as String,
-      orderStatus: json['orderStatus'] as String,
-      payinStatus: json['payinStatus'] as String,
-      payoutStatus: json['payoutStatus'] as String,
+      payinAmount: (json['payinAmount'] as num?)?.toDouble() ?? 0,
+      payinCurrency: json['payinCurrency'] as String? ?? '',
+      payoutAmount: (json['payoutAmount'] as num?)?.toDouble() ?? 0,
+      payoutCurrency: json['payoutCurrency'] as String? ?? '',
+      orderStatus: json['orderStatus'] as String? ?? '',
+      payinStatus: json['payinStatus'] as String? ?? '',
+      payoutStatus: json['payoutStatus'] as String? ?? '',
       scheduledPayoutTime: json['scheduledPayoutTime'] as String?,
       createdAt: json['createdAt'] as String,
       completedAt: json['completedAt'] as String?,
       message: json['message'] as Map<String, dynamic>?,
       sentAt: json['sentAt'] as String?,
-      payinMethod: json['payinMethod'] as String,
-      payoutMethod: json['payoutMethod'] as String,
+      payinMethod: json['payinMethod'] as String? ?? '',
+      payoutMethod: json['payoutMethod'] as String? ?? '',
       triggerType: json['triggerType'] as String,
-      confirmationDeadline: json['confirmationDeadline'] as String,
+      confirmationDeadline: json['confirmationDeadline'] as String?,
       bitcoinTransactionId: json['bitcoinTransactionId'] as String?,
       lnUrl: json['lnUrl'] as String?,
       lightningVoucherExpiresAt: json['lightningVoucherExpiresAt'] as String?,
@@ -209,7 +213,9 @@ class OrderModel {
     final orderStatusEnum = OrderStatus.fromValue(orderStatus);
     final payinStatusEnum = OrderPayinStatus.fromValue(payinStatus);
     final payoutStatusEnum = OrderPayoutStatus.fromValue(payoutStatus);
-    final confirmationDeadlineDt = DateTime.parse(confirmationDeadline);
+    final confirmationDeadlineDt = confirmationDeadline != null
+        ? DateTime.tryParse(confirmationDeadline!)
+        : null;
     final createdAtDt = DateTime.parse(createdAt);
     final completedAtDt =
         completedAt != null ? DateTime.tryParse(completedAt!) : null;
@@ -529,6 +535,34 @@ class OrderModel {
           beneficiaryName: beneficiaryName,
           beneficiaryLabel: beneficiaryLabel,
           beneficiaryAccountNumber: beneficiaryAccountNumber,
+          paymentDescription: paymentDescription,
+          completedAt: completedAtDt,
+          sentAt: sentAtDt,
+          isTestnet: isTestnet,
+        );
+      case OrderType.sellUsdt:
+      case OrderType.unknown:
+        return Order.generic(
+          orderId: orderId,
+          orderType: orderTypeEnum,
+          orderTypeName: orderType,
+          orderSubtype: orderSubtype,
+          message: orderMsg,
+          orderNumber: orderNumber,
+          payinAmount: payinAmount,
+          payinCurrency: payinCurrency,
+          payoutAmount: payoutAmount,
+          payoutCurrency: payoutCurrency,
+          exchangeRateAmount: exchangeRateAmount,
+          exchangeRateCurrency: exchangeRateCurrency,
+          payinMethod: payinMethodEnum,
+          payoutMethod: payoutMethodEnum,
+          orderStatus: orderStatusEnum,
+          payinStatus: payinStatusEnum,
+          payoutStatus: payoutStatusEnum,
+          confirmationDeadline: confirmationDeadlineDt,
+          createdAt: createdAtDt,
+          scheduledPayoutTime: scheduledPayoutTimeDt,
           paymentDescription: paymentDescription,
           completedAt: completedAtDt,
           sentAt: sentAtDt,

--- a/lib/core/exchange/data/models/user_summary_model.dart
+++ b/lib/core/exchange/data/models/user_summary_model.dart
@@ -106,8 +106,11 @@ sealed class UserDcaModel with _$UserDcaModel {
         'monthly' => DcaBuyFrequency.monthly,
         _ => null,
       },
-      currency:
-          currencyCode != null ? FiatCurrency.fromCode(currencyCode!) : null,
+      // A DCA currency this build doesn't support must not fail the whole user
+      // summary parse (balances, stats and preferences come with it).
+      currency: currencyCode != null
+          ? FiatCurrency.tryFromCode(currencyCode!)
+          : null,
       amount: amount,
       network: switch (recipientType) {
         'OUT_BITCOIN_ADDRESS' => DcaNetwork.bitcoin,

--- a/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
+++ b/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/core/exchange/domain/errors/sell_error.dart';
 import 'package:bb_mobile/core/exchange/domain/errors/withdraw_error.dart';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
+import 'package:bb_mobile/core/utils/generic_extensions.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/features/dca/domain/dca.dart';
 
@@ -67,12 +68,14 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
         apiKey: apiKeyModel.key,
       );
 
-      final orderModel = orderModels.firstWhere(
+      // A wallet transaction with no matching order is the normal case, not an
+      // error, so it must not be logged as one.
+      final orderModel = orderModels.firstWhereOrNull(
         (model) =>
             model.bitcoinTransactionId == txId ||
             model.liquidTransactionId == txId,
-        orElse: () => throw Exception('Order not found for txId: $txId'),
       );
+      if (orderModel == null) return null;
 
       return orderModel.toEntity(isTestnet: _isTestnet);
     } catch (e) {
@@ -104,8 +107,23 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
         apiKey: apiKeyModel.key,
       );
 
+      // Map each order on its own. The catch-all below returns an empty list, so
+      // a single order the app can't map would otherwise cost the user all of
+      // them.
       List<Order> orders = orderModels
-          .map((model) => model.toEntity(isTestnet: _isTestnet))
+          .map((model) {
+            try {
+              return model.toEntity(isTestnet: _isTestnet);
+            } catch (e, stackTrace) {
+              log.severe(
+                message: 'Error mapping order ${model.orderId}',
+                error: e,
+                trace: stackTrace,
+              );
+              return null;
+            }
+          })
+          .whereType<Order>()
           .toList();
 
       // this filtering should also be done separately, read from disk not over network
@@ -127,6 +145,10 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
             orders = orders.whereType<RefundOrder>().toList();
           case OrderType.balanceAdjustment:
             orders = orders.whereType<BalanceAdjustmentOrder>().toList();
+          case OrderType.sellUsdt:
+          case OrderType.unknown:
+            // Both map onto GenericOrder, so match on the type itself.
+            orders = orders.where((o) => o.orderType == type).toList();
         }
       }
 

--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -18,6 +18,16 @@ enum FiatCurrency {
   final String symbol;
 
   static FiatCurrency fromCode(String code) {
+    final currency = tryFromCode(code);
+    if (currency == null) throw Exception('Unknown FiatCurrency: $code');
+    return currency;
+  }
+
+  // Nullable counterpart of [fromCode], for parsing server payloads where a
+  // currency this build doesn't support must not fail the whole response.
+  // There is deliberately no `unknown` member: [FiatCurrency.values] populates
+  // the user-facing currency pickers.
+  static FiatCurrency? tryFromCode(String code) {
     switch (code.toUpperCase()) {
       case 'USD':
         return FiatCurrency.usd;
@@ -34,7 +44,7 @@ enum FiatCurrency {
       case 'COP':
         return FiatCurrency.cop;
       default:
-        throw Exception('Unknown FiatCurrency: $code');
+        return null;
     }
   }
 }
@@ -42,12 +52,17 @@ enum FiatCurrency {
 enum OrderType {
   buy('Buy Bitcoin'),
   sell('Sell Bitcoin'),
+  sellUsdt('Sell USDT'),
   fiatPayment('Fiat Payment'),
   funding('Funding'),
   withdraw('Withdraw'),
   reward('Reward'),
   refund('Refund'),
-  balanceAdjustment('Balance Adjustment');
+  balanceAdjustment('Balance Adjustment'),
+  // Order types added server-side after this build shipped. The raw string is
+  // carried on [GenericOrder.orderTypeName] instead of here, since an enum
+  // member can't be parameterized — same trade-off as [OrderPaymentMethod].
+  unknown('Unknown');
 
   final String value;
   const OrderType(this.value);
@@ -55,7 +70,7 @@ enum OrderType {
   static OrderType fromValue(String value) {
     return OrderType.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw Exception('Unknown OrderType: $value'),
+      orElse: () => OrderType.unknown,
     );
   }
 }
@@ -98,12 +113,16 @@ class BitcoinAmount extends OrderAmount {
 
 enum OrderStatus {
   canceled('Canceled'),
+  // The server sends both of these as distinct statuses: `expired` is the
+  // pay-in deadline lapsing, `orderExpired` the order itself expiring.
   expired('Payment deadline expired'),
+  orderExpired('Expired'),
   inProgress('In progress'),
   awaitingConfirmation('Awaiting confirmation'),
   completed('Completed'),
   rejected('Rejected'),
-  failed('Failed');
+  failed('Failed'),
+  unknown('Unknown');
 
   final String value;
   const OrderStatus(this.value);
@@ -111,7 +130,7 @@ enum OrderStatus {
   static OrderStatus fromValue(String value) {
     return OrderStatus.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw Exception('Unknown OrderStatus: $value'),
+      orElse: () => OrderStatus.unknown,
     );
   }
 }
@@ -123,7 +142,8 @@ enum OrderPayinStatus {
   underReview('Under review'),
   awaitingConfirmation('Awaiting confirmation'),
   completed('Completed'),
-  rejected('Rejected');
+  rejected('Rejected'),
+  unknown('Unknown');
 
   final String value;
   const OrderPayinStatus(this.value);
@@ -131,7 +151,7 @@ enum OrderPayinStatus {
   static OrderPayinStatus fromValue(String value) {
     return OrderPayinStatus.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw Exception('Unknown OrderPayinStatus: $value'),
+      orElse: () => OrderPayinStatus.unknown,
     );
   }
 }
@@ -142,7 +162,9 @@ enum OrderPayoutStatus {
   scheduled('Scheduled'),
   awaitingClaim('Awaiting claim'),
   completed('Completed'),
-  canceled('Canceled');
+  canceled('Canceled'),
+  failed('Failed'),
+  unknown('Unknown');
 
   final String value;
   const OrderPayoutStatus(this.value);
@@ -150,7 +172,7 @@ enum OrderPayoutStatus {
   static OrderPayoutStatus fromValue(String value) {
     return OrderPayoutStatus.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw Exception('Unknown OrderPayoutStatus: $value'),
+      orElse: () => OrderPayoutStatus.unknown,
     );
   }
 }
@@ -277,7 +299,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? lightningInvoice,
@@ -318,7 +340,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? lightningInvoice,
@@ -362,7 +384,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? lightningInvoice,
@@ -405,7 +427,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? beneficiaryName,
@@ -438,7 +460,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? beneficiaryName,
@@ -470,7 +492,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? lightningInvoice,
@@ -514,7 +536,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? beneficiaryName,
@@ -546,7 +568,7 @@ sealed class Order with _$Order {
     required OrderStatus orderStatus,
     required OrderPayinStatus payinStatus,
     required OrderPayoutStatus payoutStatus,
-    required DateTime confirmationDeadline,
+    DateTime? confirmationDeadline,
     required DateTime createdAt,
     DateTime? scheduledPayoutTime,
     String? lnUrl,
@@ -559,14 +581,58 @@ sealed class Order with _$Order {
     required bool isTestnet,
   }) = BalanceAdjustmentOrder;
 
+  /// Order types that have no dedicated flow in the app: ones we know of but
+  /// don't handle specially ('Sell USDT'), and ones added server-side after this
+  /// build shipped ([OrderType.unknown]). They still render in the transaction
+  /// list — with [orderTypeName], the amount and the status — instead of being
+  /// dropped, which is what an unparseable order used to cost us.
+  const factory Order.generic({
+    required String orderId,
+    required OrderType orderType,
+    required String orderTypeName,
+    String? orderSubtype,
+    required OrderMessage message,
+    required int orderNumber,
+    required double payinAmount,
+    required String payinCurrency,
+    required double payoutAmount,
+    required String payoutCurrency,
+    double? exchangeRateAmount,
+    String? exchangeRateCurrency,
+    required OrderPaymentMethod payinMethod,
+    required OrderPaymentMethod payoutMethod,
+    required OrderStatus orderStatus,
+    required OrderPayinStatus payinStatus,
+    required OrderPayoutStatus payoutStatus,
+    DateTime? confirmationDeadline,
+    required DateTime createdAt,
+    DateTime? scheduledPayoutTime,
+    String? paymentDescription,
+    DateTime? completedAt,
+    DateTime? sentAt,
+    required bool isTestnet,
+  }) = GenericOrder;
+
   bool get isPayinCompleted => payinStatus == OrderPayinStatus.completed;
   bool get isPayoutCompleted => payoutStatus == OrderPayoutStatus.completed;
 
   bool isCompleted() => orderStatus == OrderStatus.completed;
   bool isProcessing() => orderStatus == OrderStatus.inProgress;
   bool isCancelled() => orderStatus == OrderStatus.canceled;
-  bool isExpired() => orderStatus == OrderStatus.expired;
+  bool isExpired() =>
+      orderStatus == OrderStatus.expired ||
+      orderStatus == OrderStatus.orderExpired;
   bool isPending() => orderStatus == OrderStatus.awaitingConfirmation;
+
+  /// Label for the order type. A [GenericOrder] reports the server-sent string,
+  /// so a type this build doesn't know still reads correctly in the UI.
+  String get orderTypeLabel => switch (this) {
+    final GenericOrder order => order.orderTypeName,
+    _ => orderType.value,
+  };
+
+  /// Whether [amountAndCurrencyToDisplay] returns a fiat amount rather than sats.
+  bool get displaysFiatAmount => amountAndCurrencyToDisplay().$2 != 'sats';
 
   (num, String) amountAndCurrencyToDisplay() {
     if (orderType == OrderType.buy) {
@@ -577,7 +643,9 @@ sealed class Order with _$Order {
     }
 
     final (amount, currency) = switch (orderType) {
-      OrderType.reward => (payinAmount, payinCurrency),
+      // Rewards are admin-initiated: there is no real pay-in, so the credit is
+      // only on the payout side.
+      OrderType.reward => (payoutAmount, payoutCurrency),
       OrderType.refund => (payoutAmount, payoutCurrency),
       _ => (payoutAmount, payoutCurrency),
     };
@@ -665,6 +733,9 @@ sealed class Order with _$Order {
       case OrderType.sell:
       case OrderType.withdraw:
       case OrderType.fiatPayment:
+      // Direction isn't known for these, so they stay out of the Receive filter.
+      case OrderType.sellUsdt:
+      case OrderType.unknown:
         return false;
     }
   }

--- a/lib/features/buy/ui/screens/buy_confirm_screen.dart
+++ b/lib/features/buy/ui/screens/buy_confirm_screen.dart
@@ -34,9 +34,12 @@ class BuyConfirmScreen extends StatelessWidget {
     final formattedPayOutAmount = bitcoinUnit == BitcoinUnit.sats
         ? FormatAmount.sats(payoutAmountSat)
         : FormatAmount.btc(buyOrder.payoutAmount);
+    // A buy order always carries a rate, but the model no longer guarantees one,
+    // so derive it from the two amounts rather than crash the screen.
     final formattedExchangeRate = FormatAmount.fiat(
-      buyOrder.exchangeRateAmount!,
-      buyOrder.exchangeRateCurrency!,
+      buyOrder.exchangeRateAmount ??
+          (payoutAmountBtc > 0 ? buyOrder.payinAmount / payoutAmountBtc : 0.0),
+      buyOrder.exchangeRateCurrency ?? buyOrder.payinCurrency,
     );
     final externalBitcoinWalletLabel = context.loc.buyConfirmExternalWallet;
     final selectedWallet = context.select(
@@ -124,14 +127,15 @@ class BuyConfirmScreen extends StatelessWidget {
                       ),
                     ),
                     const Gap(4),
-                    Countdown(
-                      until: buyOrder.confirmationDeadline,
-                      onTimeout: () {
-                        context.read<BuyBloc>().add(
-                          const BuyEvent.refreshOrder(),
-                        );
-                      },
-                    ),
+                    if (buyOrder.confirmationDeadline case final deadline?)
+                      Countdown(
+                        until: deadline,
+                        onTimeout: () {
+                          context.read<BuyBloc>().add(
+                            const BuyEvent.refreshOrder(),
+                          );
+                        },
+                      ),
                   ],
                 ),
               const Gap(16),

--- a/lib/features/pay/ui/screens/pay_receive_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_receive_payment_screen.dart
@@ -94,14 +94,15 @@ class PayReceivePaymentScreen extends StatelessWidget {
                     style: context.font.bodyMedium,
                     color: context.appColors.outline,
                   ),
-                  Countdown(
-                    until: order.confirmationDeadline,
-                    onTimeout: () {
-                      context.read<PayBloc>().add(
-                        const PayEvent.orderRefreshTimePassed(),
-                      );
-                    },
-                  ),
+                  if (order.confirmationDeadline case final deadline?)
+                    Countdown(
+                      until: deadline,
+                      onTimeout: () {
+                        context.read<PayBloc>().add(
+                          const PayEvent.orderRefreshTimePassed(),
+                        );
+                      },
+                    ),
                 ],
               ),
             ),

--- a/lib/features/pay/ui/screens/pay_send_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_send_payment_screen.dart
@@ -110,9 +110,9 @@ class PaySendPaymentScreen extends StatelessWidget {
                     color: context.appColors.outline,
                   ),
                 ),
-                if (order != null)
+                if (order?.confirmationDeadline case final deadline?)
                   Countdown(
-                    until: order.confirmationDeadline,
+                    until: deadline,
                     onTimeout: () {
                       context.read<PayBloc>().add(
                         const PayEvent.orderRefreshTimePassed(),

--- a/lib/features/sell/ui/screens/sell_receive_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_receive_payment_screen.dart
@@ -76,9 +76,9 @@ class SellReceivePaymentScreen extends StatelessWidget {
                     style: context.font.bodyMedium,
                     color: context.appColors.outline,
                   ),
-                  if (order != null)
+                  if (order?.confirmationDeadline case final deadline?)
                     Countdown(
-                      until: order.confirmationDeadline,
+                      until: deadline,
                       onTimeout: () {
                         context.read<SellBloc>().add(
                           const SellEvent.orderRefreshTimePassed(),

--- a/lib/features/sell/ui/screens/sell_send_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_send_payment_screen.dart
@@ -83,9 +83,9 @@ class SellSendPaymentScreen extends StatelessWidget {
                     color: context.appColors.outline,
                   ),
                 ),
-                if (order != null)
+                if (order?.confirmationDeadline case final deadline?)
                   Countdown(
-                    until: order.confirmationDeadline,
+                    until: deadline,
                     onTimeout: () {
                       context.read<SellBloc>().add(
                         const SellEvent.orderRefreshTimePassed(),

--- a/lib/features/transactions/presentation/blocs/transactions_state.dart
+++ b/lib/features/transactions/presentation/blocs/transactions_state.dart
@@ -133,9 +133,12 @@ abstract class TransactionsState with _$TransactionsState {
             tx.isSwap &&
             [SwapStatus.expired, SwapStatus.failed].contains(tx.swap?.status);
 
+        // isExpired() covers both expiry statuses the server sends, so an
+        // 'Expired' order isn't shown while its 'Payment deadline expired' twin
+        // is hidden.
         final isExpiredAndNotStartedOrder =
             tx.isOrder &&
-            (tx.order?.orderStatus == OrderStatus.expired &&
+            (tx.order?.isExpired() == true &&
                 tx.order?.payinStatus == OrderPayinStatus.notStarted);
 
         if (isReceivePayjoinWithoutRequest ||

--- a/lib/features/transactions/ui/widgets/transaction_details_amount.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_amount.dart
@@ -1,4 +1,3 @@
-import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
@@ -28,13 +27,7 @@ class TransactionDetailsAmount extends StatelessWidget {
         ? recoveredReceivedSat
         : tx?.swapDisplayAmountSat;
     final orderAmountAndCurrency = tx?.order?.amountAndCurrencyToDisplay();
-    final showOrderInFiat =
-        isOrder &&
-        tx?.order != null &&
-        (tx!.order is FiatPaymentOrder ||
-            tx.order is BalanceAdjustmentOrder ||
-            tx.order is WithdrawOrder ||
-            tx.order is FundingOrder);
+    final showOrderInFiat = isOrder && tx?.order?.displaysFiatAmount == true;
 
     return Row(
       mainAxisAlignment: .center,

--- a/lib/features/transactions/ui/widgets/transaction_details_status_label.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_status_label.dart
@@ -44,7 +44,7 @@ class TransactionDetailsStatusLabel extends StatelessWidget {
                       ? context.loc.transactionStatusTransferExpired
                       : context.loc.transactionStatusSwapExpired)
           : isOrder == true && order != null
-          ? order.orderType.value
+          ? order.orderTypeLabel
           : payjoinStatus == PayjoinStatus.completed
           ? context.loc.transactionStatusPayjoinCompleted
           : payjoinStatus == PayjoinStatus.requested

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -749,10 +749,12 @@ class TransactionDetailsTable extends StatelessWidget {
                   ),
               ];
             } else {
+              // Order types with no dedicated section land here, so this must
+              // report the server-sent name rather than 'Unknown'.
               return [
                 DetailsTableItem(
                   label: context.loc.transactionDetailLabelOrderType,
-                  displayValue: order?.orderType.value,
+                  displayValue: order?.orderTypeLabel,
                 ),
               ];
             }

--- a/lib/features/transactions/ui/widgets/tx_list_item.dart
+++ b/lib/features/transactions/ui/widgets/tx_list_item.dart
@@ -1,4 +1,3 @@
-import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
@@ -39,7 +38,7 @@ class TxListItem extends StatelessWidget {
         ? context.appColors.onTertiary
         : context.appColors.tertiary;
     final networkLabel = isOrderType
-        ? tx.order!.orderType.value
+        ? tx.order!.orderTypeLabel
         : isLnSwap
         ? context.loc.transactionNetworkLightning
         : isChainSwap
@@ -66,12 +65,7 @@ class TxListItem extends StatelessWidget {
         ? (tx.timestamp != null ? timeago.format(tx.timestamp!) : null)
         : null;
     final orderAmountAndCurrency = tx.order?.amountAndCurrencyToDisplay();
-    final showOrderInFiat =
-        isOrderType &&
-        (tx.order is FiatPaymentOrder ||
-            tx.order is BalanceAdjustmentOrder ||
-            tx.order is WithdrawOrder ||
-            tx.order is FundingOrder);
+    final showOrderInFiat = isOrderType && tx.order!.displaysFiatAmount;
     return InkWell(
       onTap: () {
         if (tx.walletTransaction != null) {

--- a/test/core/exchange/data/datasources/bullbitcoin_api_datasource_test.dart
+++ b/test/core/exchange/data/datasources/bullbitcoin_api_datasource_test.dart
@@ -1,0 +1,62 @@
+import 'package:bb_mobile/core/exchange/data/datasources/bullbitcoin_api_datasource.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../order_json_fixture.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<dynamic> _elements(List<Map<String, dynamic>> elements) => Response(
+  requestOptions: RequestOptions(path: '/ak/api-orders'),
+  statusCode: 200,
+  data: {
+    'result': {'elements': elements},
+  },
+);
+
+void main() {
+  late _MockDio dio;
+  late BullbitcoinApiDatasource datasource;
+
+  setUp(() {
+    dio = _MockDio();
+    datasource = BullbitcoinApiDatasource(bullbitcoinApiHttpClient: dio);
+  });
+
+  void stubList(List<Map<String, dynamic>> elements) {
+    when(
+      () => dio.post(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((_) async => _elements(elements));
+  }
+
+  group('listOrderSummaries', () {
+    test('skips an unparseable element and keeps the rest', () async {
+      stubList([
+        orderJsonFixture(orderId: 'good-1'),
+        // Without orderId the cast in fromJson throws — on this element only.
+        orderJsonFixture()..remove('orderId'),
+        orderJsonFixture(orderId: 'good-2'),
+      ]);
+
+      final orders = await datasource.listOrderSummaries(apiKey: 'key');
+
+      expect(orders.map((o) => o.orderId), ['good-1', 'good-2']);
+    });
+
+    test('an order with an unknown status no longer costs the list', () async {
+      stubList([
+        orderJsonFixture(orderId: 'expired-1', orderStatus: 'Expired'),
+        orderJsonFixture(orderId: 'good-1'),
+      ]);
+
+      final orders = await datasource.listOrderSummaries(apiKey: 'key');
+
+      expect(orders.map((o) => o.orderId), ['expired-1', 'good-1']);
+    });
+  });
+}

--- a/test/core/exchange/data/models/order_model_test.dart
+++ b/test/core/exchange/data/models/order_model_test.dart
@@ -1,0 +1,136 @@
+import 'package:bb_mobile/core/exchange/data/models/order_model.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../order_json_fixture.dart';
+
+void main() {
+  group('OrderModel status parsing', () {
+    test("orderStatus 'Expired' parses instead of throwing", () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(orderStatus: 'Expired'),
+      ).toEntity(isTestnet: false);
+
+      expect(order.orderStatus, OrderStatus.orderExpired);
+      expect(order.isExpired(), isTrue);
+    });
+
+    test("'Payment deadline expired' stays a distinct status", () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(orderStatus: 'Payment deadline expired'),
+      ).toEntity(isTestnet: false);
+
+      expect(order.orderStatus, OrderStatus.expired);
+      expect(order.isExpired(), isTrue);
+    });
+
+    test("payoutStatus 'Failed' parses", () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(payoutStatus: 'Failed'),
+      ).toEntity(isTestnet: false);
+
+      expect(order.payoutStatus, OrderPayoutStatus.failed);
+    });
+
+    test('statuses the app does not know fall back to unknown', () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(
+          orderStatus: 'Some Future Status',
+          payinStatus: '',
+          payoutStatus: 'Another Future Status',
+        ),
+      ).toEntity(isTestnet: false);
+
+      expect(order.orderStatus, OrderStatus.unknown);
+      expect(order.payinStatus, OrderPayinStatus.unknown);
+      expect(order.payoutStatus, OrderPayoutStatus.unknown);
+    });
+  });
+
+  group('OrderModel order type parsing', () {
+    test("orderType 'Sell USDT' parses onto a generic order", () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(orderType: 'Sell USDT'),
+      ).toEntity(isTestnet: false);
+
+      expect(order, isA<GenericOrder>());
+      expect(order.orderType, OrderType.sellUsdt);
+      expect(order.orderTypeLabel, 'Sell USDT');
+    });
+
+    test('an unknown order type keeps the server-sent name for display', () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(orderType: 'Buy Gold Bars'),
+      ).toEntity(isTestnet: false);
+
+      expect(order, isA<GenericOrder>());
+      expect(order.orderType, OrderType.unknown);
+      // The list row renders from these three, so none of them may be lost.
+      expect(order.orderTypeLabel, 'Buy Gold Bars');
+      expect(order.orderStatus, OrderStatus.completed);
+      expect(order.amountAndCurrencyToDisplay(), (100000, 'sats'));
+    });
+  });
+
+  group('OrderModel nullable server fields', () {
+    test('a null exchange rate and deadline parse', () {
+      final order =
+          OrderModel.fromJson(
+                orderJsonFixture(
+                  overrides: const {
+                    'exchangeRateAmount': null,
+                    'exchangeRateCurrency': null,
+                    'confirmationDeadline': null,
+                  },
+                ),
+              ).toEntity(isTestnet: false)
+              as BuyOrder;
+
+      expect(order.exchangeRateAmount, isNull);
+      expect(order.exchangeRateCurrency, isNull);
+      expect(order.confirmationDeadline, isNull);
+    });
+
+    test('absent exchange rate, deadline and amounts parse', () {
+      final json = orderJsonFixture()
+        ..remove('exchangeRateAmount')
+        ..remove('exchangeRateCurrency')
+        ..remove('confirmationDeadline')
+        ..remove('payinAmount')
+        ..remove('payinCurrency');
+
+      final order = OrderModel.fromJson(json).toEntity(isTestnet: false)
+          as BuyOrder;
+
+      expect(order.exchangeRateAmount, isNull);
+      expect(order.confirmationDeadline, isNull);
+      expect(order.payinAmount, 0);
+      expect(order.payinCurrency, '');
+    });
+  });
+
+  group('reward orders', () {
+    // The pay-in side of an admin-initiated reward is empty; the BTC credit is
+    // on the payout side. Reading the pay-in side displayed '0 sats'.
+    test('display the payout-side amount', () {
+      final order = OrderModel.fromJson(
+        orderJsonFixture(
+          orderType: 'Reward',
+          overrides: const {
+            'payinAmount': 0,
+            'payinCurrency': '',
+            'payoutAmount': 0.0005,
+            'payoutCurrency': 'BTC',
+            'exchangeRateAmount': null,
+            'exchangeRateCurrency': null,
+            'confirmationDeadline': null,
+          },
+        ),
+      ).toEntity(isTestnet: false);
+
+      expect(order, isA<RewardOrder>());
+      expect(order.amountAndCurrencyToDisplay(), (50000, 'sats'));
+      expect(order.displaysFiatAmount, isFalse);
+    });
+  });
+}

--- a/test/core/exchange/data/repository/exchange_order_repository_impl_test.dart
+++ b/test/core/exchange/data/repository/exchange_order_repository_impl_test.dart
@@ -1,0 +1,101 @@
+import 'package:bb_mobile/core/exchange/data/datasources/bullbitcoin_api_datasource.dart';
+import 'package:bb_mobile/core/exchange/data/datasources/bullbitcoin_api_key_datasource.dart';
+import 'package:bb_mobile/core/exchange/data/models/api_key_model.dart';
+import 'package:bb_mobile/core/exchange/data/models/order_model.dart';
+import 'package:bb_mobile/core/exchange/data/repository/exchange_order_repository_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../order_json_fixture.dart';
+
+class _MockApiDatasource extends Mock implements BullbitcoinApiDatasource {}
+
+class _MockApiKeyDatasource extends Mock
+    implements BullbitcoinApiKeyDatasource {}
+
+ExchangeApiKeyModel _activeApiKey() => ExchangeApiKeyModel(
+  id: 'id',
+  key: 'key',
+  name: 'name',
+  userId: 'user',
+  isActive: true,
+  createdAt: 0,
+  updatedAt: 0,
+);
+
+void main() {
+  late _MockApiDatasource api;
+  late _MockApiKeyDatasource apiKeys;
+  late ExchangeOrderRepositoryImpl repository;
+
+  setUp(() {
+    api = _MockApiDatasource();
+    apiKeys = _MockApiKeyDatasource();
+    repository = ExchangeOrderRepositoryImpl(
+      bullbitcoinApiDatasource: api,
+      bullbitcoinApiKeyDatasource: apiKeys,
+      isTestnet: false,
+    );
+    when(
+      () => apiKeys.get(isTestnet: any(named: 'isTestnet')),
+    ).thenAnswer((_) async => _activeApiKey());
+  });
+
+  void stubOrders(List<Map<String, dynamic>> json) {
+    when(
+      () => api.listOrderSummaries(apiKey: any(named: 'apiKey')),
+    ).thenAnswer((_) async => json.map(OrderModel.fromJson).toList());
+  }
+
+  group('getOrders', () {
+    test('one order that cannot be mapped no longer empties the list', () async {
+      stubOrders([
+        orderJsonFixture(orderId: 'good-1'),
+        // An unparseable createdAt throws in toEntity, past the JSON layer.
+        orderJsonFixture(
+          orderId: 'bad-1',
+          overrides: const {'createdAt': 'not-a-date'},
+        ),
+        orderJsonFixture(orderId: 'good-2'),
+      ]);
+
+      final orders = await repository.getOrders();
+
+      expect(orders.map((o) => o.orderId), ['good-1', 'good-2']);
+    });
+
+    test('an order list containing an Expired order survives intact', () async {
+      stubOrders([
+        orderJsonFixture(orderId: 'expired-1', orderStatus: 'Expired'),
+        orderJsonFixture(orderId: 'good-1'),
+        orderJsonFixture(orderId: 'usdt-1', orderType: 'Sell USDT'),
+      ]);
+
+      final orders = await repository.getOrders();
+
+      expect(orders.map((o) => o.orderId), ['expired-1', 'good-1', 'usdt-1']);
+    });
+  });
+
+  group('getOrderByTxId', () {
+    test('returns the order whose transaction id matches', () async {
+      stubOrders([
+        orderJsonFixture(orderId: 'good-1'),
+        orderJsonFixture(
+          orderId: 'good-2',
+          overrides: const {'bitcoinTransactionId': 'txid-2'},
+        ),
+      ]);
+
+      final order = await repository.getOrderByTxId('txid-2');
+
+      expect(order?.orderId, 'good-2');
+    });
+
+    test('returns null when no order matches', () async {
+      stubOrders([orderJsonFixture(orderId: 'good-1')]);
+
+      expect(await repository.getOrderByTxId('txid-absent'), isNull);
+    });
+  });
+}

--- a/test/core/exchange/order_json_fixture.dart
+++ b/test/core/exchange/order_json_fixture.dart
@@ -1,0 +1,33 @@
+/// Builds a `listOrderSummaries` element with sensible defaults.
+///
+/// Only the fields under test are overridden per case, so a regression shows up
+/// as a failure on the behaviour being tested rather than as an unrelated
+/// missing-field error. Pass [overrides] to replace or add raw JSON keys.
+Map<String, dynamic> orderJsonFixture({
+  String orderId = 'order-1',
+  String orderType = 'Buy Bitcoin',
+  String orderStatus = 'Completed',
+  String payinStatus = 'Completed',
+  String payoutStatus = 'Completed',
+  Map<String, dynamic> overrides = const {},
+}) => {
+  'orderId': orderId,
+  'orderType': orderType,
+  'orderNumber': 1,
+  'exchangeRateAmount': 100000,
+  'exchangeRateCurrency': 'CAD',
+  'payinAmount': 100,
+  'payinCurrency': 'CAD',
+  'payoutAmount': 0.001,
+  'payoutCurrency': 'BTC',
+  'orderStatus': orderStatus,
+  'payinStatus': payinStatus,
+  'payoutStatus': payoutStatus,
+  'createdAt': '2026-07-01T12:00:00.000Z',
+  'message': null,
+  'payinMethod': 'Interac e-Transfer (CAD)',
+  'payoutMethod': 'Bitcoin On-Chain',
+  'triggerType': 'MANUAL',
+  'confirmationDeadline': '2026-07-01T12:10:00.000Z',
+  ...overrides,
+};


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — draft until verified on a real account. Test: log into an account whose history contains an `Expired`-status order (the reporter's account is the fixture) and confirm the transactions list shows all exchange transactions (Pay, Reward, etc.), rewards show real amounts instead of 0 sats.

## Problem
The API legitimately sends order values the app refused to parse: status `Expired` (distinct from `Payment deadline expired`), payout status `Failed`, order type `Sell USDT`, empty payin/payout statuses, and null exchange-rate/deadline fields on admin-initiated orders. Both batch parse layers (datasource `listOrderSummaries` and repository `getOrders`) turned the first such order into an **empty list**, hiding every exchange transaction in the app. Confirmed in device logs: `Error fetching orders — Exception: Unknown OrderStatus: Expired`. Server contract verified against API-Orders `orderSummary.ts`.

## Changes
- Parse per element with skip-and-log at both layers, and in `getOrderByTxId`
- Unknown-tolerant `fromValue` on `OrderStatus`/`OrderPayinStatus`/`OrderPayoutStatus`/`OrderType`; add missing members (`Expired`, `Failed`, `Sell USDT`)
- Unknown order types render generically via a new `Order.generic` variant carrying the server-sent type name
- `exchangeRateAmount`/`exchangeRateCurrency`/`confirmationDeadline` now nullable (matching the server), with guards at consumers
- Reward amounts read from the payout side (payin is empty for admin-initiated orders → rendered 0 sats)
- Fiat-vs-sats display derived from the order instead of a hardcoded variant list (fixes fiat refunds shown as sats, BTC balance adjustments formatted as fiat)

## Validation
15 new regression tests (poisoned-list survival at both layers, each new enum value, null fields, reward amount); `flutter analyze` clean; reviewed with a verification pass (2 should-fixes applied). Note: this branch touches `Countdown` null-guards in buy/pay/sell screens — minor line-disjoint overlap with the sibling fix PRs at merge.

Closes #2526
Closes #2527