### PR TITLE
fix(buy): surface order-creation errors and clarify payout wallet vs method

### DIFF
--- a/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
+++ b/lib/core/exchange/data/datasources/bullbitcoin_api_datasource.dart
@@ -171,29 +171,7 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
     final error = resp.data['error'];
     if (statusCode != 200) throw Exception('Failed to create order');
     if (error != null) {
-      final reason = error['data']['reason'];
-      if (reason != null) {
-        final limitReason = reason['limit'];
-        if (limitReason != null) {
-          final isBelowLimit =
-              limitReason['conditionalOperator'] == 'GREATER_THAN_OR_EQUAL';
-          final limitAmount = limitReason['amount'] as String;
-          final limitCurrency = limitReason['currencyCode'] as String;
-          if (isBelowLimit) {
-            throw BullBitcoinApiMinAmountException(
-              minAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          } else {
-            throw BullBitcoinApiMaxAmountException(
-              maxAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          }
-        }
-      } else {
-        throw Exception('Failed to create buy order: ${error['message']}');
-      }
+      _throwOrderApiError(error, 'Failed to create buy order');
     }
     return OrderModel.fromJson(resp.data['result'] as Map<String, dynamic>);
   }
@@ -357,29 +335,7 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
     final error = resp.data['error'];
     if (statusCode != 200) throw Exception('Failed to create sell order');
     if (error != null) {
-      final reason = error['data']['reason'];
-      if (reason != null) {
-        final limitReason = reason['limit'];
-        if (limitReason != null) {
-          final isBelowLimit =
-              limitReason['conditionalOperator'] == 'GREATER_THAN_OR_EQUAL';
-          final limitAmount = limitReason['amount'] as String;
-          final limitCurrency = limitReason['currencyCode'] as String;
-          if (isBelowLimit) {
-            throw BullBitcoinApiMinAmountException(
-              minAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          } else {
-            throw BullBitcoinApiMaxAmountException(
-              maxAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          }
-        }
-      } else {
-        throw Exception('Failed to create sell order: ${error['message']}');
-      }
+      _throwOrderApiError(error, 'Failed to create sell order');
     }
     return OrderModel.fromJson(resp.data['result'] as Map<String, dynamic>);
   }
@@ -424,31 +380,7 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
       throw Exception('Failed to create sell to recipient order');
     }
     if (error != null) {
-      final reason = error['data']['reason'];
-      if (reason != null) {
-        final limitReason = reason['limit'];
-        if (limitReason != null) {
-          final isBelowLimit =
-              limitReason['conditionalOperator'] == 'GREATER_THAN_OR_EQUAL';
-          final limitAmount = limitReason['amount'] as String;
-          final limitCurrency = limitReason['currencyCode'] as String;
-          if (isBelowLimit) {
-            throw BullBitcoinApiMinAmountException(
-              minAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          } else {
-            throw BullBitcoinApiMaxAmountException(
-              maxAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          }
-        }
-      } else {
-        throw Exception(
-          'Failed to create sell to recipient order: ${error['message']}',
-        );
-      }
+      _throwOrderApiError(error, 'Failed to create sell to recipient order');
     }
 
     return OrderModel.fromJson(resp.data['result'] as Map<String, dynamic>);
@@ -492,32 +424,7 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
     final error = resp.data['error'];
     if (statusCode != 200) throw Exception('Failed to create withdrawal order');
     if (error != null) {
-      final reason = error['data']['reason'];
-      if (reason != null) {
-        final limitReason = reason['limit'];
-        if (limitReason != null) {
-          final isBelowLimit =
-              limitReason['conditionalOperator'] == 'GREATER_THAN_OR_EQUAL';
-          final limitAmount = limitReason['amount'] as String;
-          final limitCurrency = limitReason['currencyCode'] as String;
-          if (isBelowLimit) {
-            throw BullBitcoinApiMinAmountException(
-              minAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          } else {
-            throw BullBitcoinApiMaxAmountException(
-              maxAmount: double.parse(limitAmount),
-              currency: limitCurrency,
-            );
-          }
-        }
-        throw Exception('Failed to create withdrawal order: $reason');
-      } else {
-        throw Exception(
-          'Failed to create withdrawal order: ${error['message']}',
-        );
-      }
+      _throwOrderApiError(error, 'Failed to create withdrawal order');
     }
     return OrderModel.fromJson(resp.data['result'] as Map<String, dynamic>);
   }
@@ -880,6 +787,108 @@ class BullbitcoinApiDatasource implements BitcoinPriceDatasource {
       rethrow;
     }
   }
+}
+
+const _minLimitOperator = 'GREATER_THAN_OR_EQUAL';
+const _maxLimitOperator = 'LESS_THAN_OR_EQUAL';
+
+/// A single limit that the api rejected an order against.
+class _OrderLimit {
+  final double amount;
+  final String currency;
+  final String conditionalOperator;
+
+  const _OrderLimit({
+    required this.amount,
+    required this.currency,
+    required this.conditionalOperator,
+  });
+
+  /// Returns null for anything that isn't a limit we can act on, so a payload
+  /// change on the api side degrades to the generic error instead of throwing
+  /// a cast error.
+  static _OrderLimit? tryParse(dynamic json) {
+    if (json is! Map) return null;
+    final rawAmount = json['amount'];
+    final amount = switch (rawAmount) {
+      final num n => n.toDouble(),
+      final String s => double.tryParse(s),
+      _ => null,
+    };
+    final currency = json['currencyCode'];
+    final conditionalOperator = json['conditionalOperator'];
+    if (amount == null ||
+        currency is! String ||
+        conditionalOperator is! String) {
+      return null;
+    }
+    return _OrderLimit(
+      amount: amount,
+      currency: currency,
+      conditionalOperator: conditionalOperator,
+    );
+  }
+}
+
+/// Translates a JSON-RPC `error` object from the orders api into a typed
+/// exception. Always throws: an error response must never fall through to
+/// parsing `result`.
+///
+/// Two payload shapes are supported. A single rejected payment option carries
+/// `data.reason.limit`; when every payment option was rejected the aggregate
+/// error carries one structured reason per rejection in `data.reasons`.
+///
+/// `reasons` is legitimately empty for rejections that produce no structured
+/// reason (group-access denial, non-positive amounts), so an empty or absent
+/// array has to reach the generic error rather than be treated as a bug. The
+/// aggregate also carries a legacy `data.details`, always an array of nulls;
+/// it is deliberately never read.
+Never _throwOrderApiError(dynamic error, String contextMessage) {
+  final errorMap = error is Map ? error : const <dynamic, dynamic>{};
+  final data = errorMap['data'];
+  final dataMap = data is Map ? data : const <dynamic, dynamic>{};
+
+  final limits = <_OrderLimit>[];
+  final reasons = dataMap['reasons'];
+  if (reasons is List) {
+    for (final reason in reasons) {
+      final limit = _OrderLimit.tryParse(
+        reason is Map ? reason['limit'] : null,
+      );
+      if (limit != null) limits.add(limit);
+    }
+  }
+  final singleReason = dataMap['reason'];
+  final singleLimit = _OrderLimit.tryParse(
+    singleReason is Map ? singleReason['limit'] : null,
+  );
+  if (singleLimit != null) limits.add(singleLimit);
+
+  final operators = limits.map((l) => l.conditionalOperator).toSet();
+  // Amounts are only comparable within one currency, and a single message can
+  // only name one limit, so anything mixed falls back to the generic error.
+  final currencies = limits.map((l) => l.currency).toSet();
+  if (operators.length == 1 && currencies.length == 1) {
+    switch (operators.single) {
+      case _minLimitOperator:
+        // Every option was below its minimum, so the lowest minimum is the
+        // amount that unlocks at least one of them.
+        final min = limits.reduce((a, b) => a.amount <= b.amount ? a : b);
+        throw BullBitcoinApiMinAmountException(
+          minAmount: min.amount,
+          currency: min.currency,
+        );
+      case _maxLimitOperator:
+        final max = limits.reduce((a, b) => a.amount >= b.amount ? a : b);
+        throw BullBitcoinApiMaxAmountException(
+          maxAmount: max.amount,
+          currency: max.currency,
+        );
+    }
+  }
+
+  final message = errorMap['message'];
+  throw Exception('$contextMessage${message is String ? ': $message' : ''}');
 }
 
 class BullBitcoinApiMinAmountException extends BullException {

--- a/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
+++ b/lib/core/exchange/data/repository/exchange_order_repository_impl.dart
@@ -7,7 +7,6 @@ import 'package:bb_mobile/core/exchange/domain/errors/pay_error.dart';
 import 'package:bb_mobile/core/exchange/domain/errors/sell_error.dart';
 import 'package:bb_mobile/core/exchange/domain/errors/withdraw_error.dart';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
-import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/features/dca/domain/dca.dart';
 
@@ -183,13 +182,15 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
 
       return order;
     } on BullBitcoinApiMinAmountException catch (e) {
-      final minAmountBtc = e.minAmount;
-      final minAmountSat = ConvertAmount.btcToSats(minAmountBtc);
-      throw BuyError.belowMinAmount(minAmountSat: minAmountSat);
+      throw BuyError.belowMinAmount(
+        minAmount: e.minAmount,
+        currency: e.currency,
+      );
     } on BullBitcoinApiMaxAmountException catch (e) {
-      final maxAmountBtc = e.maxAmount;
-      final maxAmountSat = ConvertAmount.btcToSats(maxAmountBtc);
-      throw BuyError.aboveMaxAmount(maxAmountSat: maxAmountSat);
+      throw BuyError.aboveMaxAmount(
+        maxAmount: e.maxAmount,
+        currency: e.currency,
+      );
     } catch (e) {
       throw Exception('Failed to place buy order: $e');
     }
@@ -221,13 +222,15 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
 
       return order;
     } on BullBitcoinApiMinAmountException catch (e) {
-      final minAmountBtc = e.minAmount;
-      final minAmountSat = ConvertAmount.btcToSats(minAmountBtc);
-      throw SellError.belowMinAmount(minAmountSat: minAmountSat);
+      throw SellError.belowMinAmount(
+        minAmount: e.minAmount,
+        currency: e.currency,
+      );
     } on BullBitcoinApiMaxAmountException catch (e) {
-      final maxAmountBtc = e.maxAmount;
-      final maxAmountSat = ConvertAmount.btcToSats(maxAmountBtc);
-      throw SellError.aboveMaxAmount(maxAmountSat: maxAmountSat);
+      throw SellError.aboveMaxAmount(
+        maxAmount: e.maxAmount,
+        currency: e.currency,
+      );
     } catch (e) {
       throw Exception('Failed to place sell order: $e');
     }
@@ -262,13 +265,15 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
 
       return order;
     } on BullBitcoinApiMinAmountException catch (e) {
-      final minAmountBtc = e.minAmount;
-      final minAmountSat = ConvertAmount.btcToSats(minAmountBtc);
-      throw PayError.belowMinAmount(minAmountSat: minAmountSat);
+      throw PayError.belowMinAmount(
+        minAmount: e.minAmount,
+        currency: e.currency,
+      );
     } on BullBitcoinApiMaxAmountException catch (e) {
-      final maxAmountBtc = e.maxAmount;
-      final maxAmountSat = ConvertAmount.btcToSats(maxAmountBtc);
-      throw PayError.aboveMaxAmount(maxAmountSat: maxAmountSat);
+      throw PayError.aboveMaxAmount(
+        maxAmount: e.maxAmount,
+        currency: e.currency,
+      );
     } catch (e) {
       throw Exception('Failed to place pay order: $e');
     }
@@ -524,13 +529,15 @@ class ExchangeOrderRepositoryImpl implements ExchangeOrderRepository {
 
       return order;
     } on BullBitcoinApiMinAmountException catch (e) {
-      final minAmountBtc = e.minAmount;
-      final minAmountSat = ConvertAmount.btcToSats(minAmountBtc);
-      throw WithdrawError.belowMinAmount(minAmountSat: minAmountSat);
+      throw WithdrawError.belowMinAmount(
+        minAmount: e.minAmount,
+        currency: e.currency,
+      );
     } on BullBitcoinApiMaxAmountException catch (e) {
-      final maxAmountBtc = e.maxAmount;
-      final maxAmountSat = ConvertAmount.btcToSats(maxAmountBtc);
-      throw WithdrawError.aboveMaxAmount(maxAmountSat: maxAmountSat);
+      throw WithdrawError.aboveMaxAmount(
+        maxAmount: e.maxAmount,
+        currency: e.currency,
+      );
     } catch (e) {
       throw Exception('Failed to create withdrawal order: $e');
     }

--- a/lib/core/exchange/domain/errors/buy_error.dart
+++ b/lib/core/exchange/domain/errors/buy_error.dart
@@ -7,10 +7,17 @@ part 'buy_error.freezed.dart';
 @freezed
 sealed class BuyError with _$BuyError {
   const factory BuyError.unauthenticated() = UnauthenticatedBuyError;
-  const factory BuyError.belowMinAmount({required int minAmountSat}) =
-      BelowMinAmountBuyError;
-  const factory BuyError.aboveMaxAmount({required int maxAmountSat}) =
-      AboveMaxAmountBuyError;
+
+  /// [minAmount] is denominated in [currency], which the api picks and can be
+  /// either a fiat currency or BTC/LBTC.
+  const factory BuyError.belowMinAmount({
+    required double minAmount,
+    required String currency,
+  }) = BelowMinAmountBuyError;
+  const factory BuyError.aboveMaxAmount({
+    required double maxAmount,
+    required String currency,
+  }) = AboveMaxAmountBuyError;
   const factory BuyError.insufficientFunds() = InsufficientFundsBuyError;
   const factory BuyError.orderNotFound() = OrderNotFoundBuyError;
   const factory BuyError.orderAlreadyConfirmed() =
@@ -23,11 +30,12 @@ sealed class BuyError with _$BuyError {
   /// Returns the localized error message.
   String toTranslated(BuildContext context) => when(
     unauthenticated: () => context.loc.buyUnauthenticatedError,
-    belowMinAmount: (_) => context.loc.buyBelowMinAmountError,
-    aboveMaxAmount: (_) => context.loc.buyAboveMaxAmountError,
+    belowMinAmount: (_, _) => context.loc.buyBelowMinAmountError,
+    aboveMaxAmount: (_, _) => context.loc.buyAboveMaxAmountError,
     insufficientFunds: () => context.loc.buyInsufficientFundsError,
     orderNotFound: () => context.loc.buyOrderNotFoundError,
     orderAlreadyConfirmed: () => context.loc.buyOrderAlreadyConfirmedError,
-    unexpected: (message) => message,
+    // The raw message is logged by the bloc; it is never fit to show to a user.
+    unexpected: (_) => context.loc.buyUnexpectedError,
   );
 }

--- a/lib/core/exchange/domain/errors/pay_error.dart
+++ b/lib/core/exchange/domain/errors/pay_error.dart
@@ -7,10 +7,17 @@ part 'pay_error.freezed.dart';
 @freezed
 sealed class PayError with _$PayError {
   const factory PayError.unauthenticated() = UnauthenticatedPayError;
-  const factory PayError.belowMinAmount({required int minAmountSat}) =
-      BelowMinAmountPayError;
-  const factory PayError.aboveMaxAmount({required int maxAmountSat}) =
-      AboveMaxAmountPayError;
+
+  /// [minAmount] is denominated in [currency], which the api picks and can be
+  /// either a fiat currency or BTC/LBTC.
+  const factory PayError.belowMinAmount({
+    required double minAmount,
+    required String currency,
+  }) = BelowMinAmountPayError;
+  const factory PayError.aboveMaxAmount({
+    required double maxAmount,
+    required String currency,
+  }) = AboveMaxAmountPayError;
   const factory PayError.insufficientBalance() = InsufficientBalancePayError;
   const factory PayError.orderNotFound() = OrderNotFoundPayError;
   const factory PayError.orderAlreadyConfirmed() =
@@ -23,8 +30,8 @@ sealed class PayError with _$PayError {
   /// Returns the localized error message.
   String toTranslated(BuildContext context) => when(
     unauthenticated: () => context.loc.payNotAuthenticated,
-    belowMinAmount: (_) => context.loc.payBelowMinAmount,
-    aboveMaxAmount: (_) => context.loc.payAboveMaxAmount,
+    belowMinAmount: (_, _) => context.loc.payBelowMinAmount,
+    aboveMaxAmount: (_, _) => context.loc.payAboveMaxAmount,
     insufficientBalance: () => context.loc.payInsufficientBalance,
     orderNotFound: () => context.loc.payOrderNotFound,
     orderAlreadyConfirmed: () => context.loc.payOrderAlreadyConfirmed,

--- a/lib/core/exchange/domain/errors/sell_error.dart
+++ b/lib/core/exchange/domain/errors/sell_error.dart
@@ -7,10 +7,17 @@ part 'sell_error.freezed.dart';
 @freezed
 sealed class SellError with _$SellError {
   const factory SellError.unauthenticated() = UnauthenticatedSellError;
-  const factory SellError.belowMinAmount({required int minAmountSat}) =
-      BelowMinAmountSellError;
-  const factory SellError.aboveMaxAmount({required int maxAmountSat}) =
-      AboveMaxAmountSellError;
+
+  /// [minAmount] is denominated in [currency], which the api picks and can be
+  /// either a fiat currency or BTC/LBTC.
+  const factory SellError.belowMinAmount({
+    required double minAmount,
+    required String currency,
+  }) = BelowMinAmountSellError;
+  const factory SellError.aboveMaxAmount({
+    required double maxAmount,
+    required String currency,
+  }) = AboveMaxAmountSellError;
   const factory SellError.orderNotFound() = OrderNotFoundSellError;
   const factory SellError.orderAlreadyConfirmed() =
       OrderAlreadyConfirmedSellError;
@@ -25,8 +32,8 @@ sealed class SellError with _$SellError {
   /// Returns the localized error message.
   String toTranslated(BuildContext context) => when(
     unauthenticated: () => context.loc.sellUnauthenticatedError,
-    belowMinAmount: (_) => context.loc.sellBelowMinAmountError,
-    aboveMaxAmount: (_) => context.loc.sellAboveMaxAmountError,
+    belowMinAmount: (_, _) => context.loc.sellBelowMinAmountError,
+    aboveMaxAmount: (_, _) => context.loc.sellAboveMaxAmountError,
     orderNotFound: () => context.loc.sellOrderNotFoundError,
     orderAlreadyConfirmed: () => context.loc.sellOrderAlreadyConfirmedError,
     unexpected: (message) => message,

--- a/lib/core/exchange/domain/errors/withdraw_error.dart
+++ b/lib/core/exchange/domain/errors/withdraw_error.dart
@@ -7,10 +7,17 @@ part 'withdraw_error.freezed.dart';
 @freezed
 sealed class WithdrawError with _$WithdrawError {
   const factory WithdrawError.unauthenticated() = UnauthenticatedWithdrawError;
-  const factory WithdrawError.belowMinAmount({required int minAmountSat}) =
-      BelowMinAmountWithdrawError;
-  const factory WithdrawError.aboveMaxAmount({required int maxAmountSat}) =
-      AboveMaxAmountWithdrawError;
+
+  /// [minAmount] is denominated in [currency], which the api picks and can be
+  /// either a fiat currency or BTC/LBTC.
+  const factory WithdrawError.belowMinAmount({
+    required double minAmount,
+    required String currency,
+  }) = BelowMinAmountWithdrawError;
+  const factory WithdrawError.aboveMaxAmount({
+    required double maxAmount,
+    required String currency,
+  }) = AboveMaxAmountWithdrawError;
   const factory WithdrawError.orderNotFound() = OrderNotFoundWithdrawError;
   const factory WithdrawError.orderAlreadyConfirmed() =
       OrderAlreadyConfirmedWithdrawError;
@@ -22,8 +29,8 @@ sealed class WithdrawError with _$WithdrawError {
   /// Returns the localized error message.
   String toTranslated(BuildContext context) => when(
     unauthenticated: () => context.loc.withdrawUnauthenticatedError,
-    belowMinAmount: (_) => context.loc.withdrawBelowMinAmountError,
-    aboveMaxAmount: (_) => context.loc.withdrawAboveMaxAmountError,
+    belowMinAmount: (_, _) => context.loc.withdrawBelowMinAmountError,
+    aboveMaxAmount: (_, _) => context.loc.withdrawAboveMaxAmountError,
     orderNotFound: () => context.loc.withdrawOrderNotFoundError,
     orderAlreadyConfirmed: () => context.loc.withdrawOrderAlreadyConfirmedError,
     unexpected: (message) => message,

--- a/lib/features/buy/ui/buy_payout_method_label.dart
+++ b/lib/features/buy/ui/buy_payout_method_label.dart
@@ -1,0 +1,10 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:flutter/widgets.dart';
+
+/// The network a buy pays out over, worded for the user. Shared by the wallet
+/// dropdown and the confirmation screen so that the two cannot drift.
+String buyPayoutMethodLabel(BuildContext context, {required bool isLiquid}) {
+  return isLiquid
+      ? context.loc.buyPayoutMethodLiquid
+      : context.loc.buyPayoutMethodBitcoin;
+}

--- a/lib/features/buy/ui/screens/buy_confirm_screen.dart
+++ b/lib/features/buy/ui/screens/buy_confirm_screen.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/core/widgets/timers/countdown.dart';
 import 'package:bb_mobile/features/buy/presentation/buy_bloc.dart';
+import 'package:bb_mobile/features/buy/ui/buy_payout_method_label.dart';
 import 'package:bb_mobile/features/buy/ui/widgets/buy_confirm_detail_row.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
@@ -42,9 +43,15 @@ class BuyConfirmScreen extends StatelessWidget {
     final selectedWallet = context.select(
       (BuyBloc bloc) => bloc.state.selectedWallet,
     );
-    final payoutMethod = selectedWallet == null
+    final payoutWallet = selectedWallet == null
         ? externalBitcoinWalletLabel
         : selectedWallet.displayLabel(context);
+    // With no wallet of ours selected the payout goes to an address the user
+    // pasted, so the order itself is the only source for the network.
+    final payoutMethod = buyPayoutMethodLabel(
+      context,
+      isLiquid: selectedWallet?.network.isLiquid ?? buyOrder.isLiquid,
+    );
 
     final isConfirmingOrder = context.select(
       (BuyBloc bloc) => bloc.state.isConfirmingOrder,
@@ -93,6 +100,10 @@ class BuyConfirmScreen extends StatelessWidget {
                 BuyConfirmDetailRow(
                   label: context.loc.buyConfirmBitcoinPrice,
                   value: formattedExchangeRate,
+                ),
+                BuyConfirmDetailRow(
+                  label: context.loc.buyConfirmPayoutWallet,
+                  value: payoutWallet,
                 ),
                 BuyConfirmDetailRow(
                   label: context.loc.buyConfirmPayoutMethod,

--- a/lib/features/buy/ui/screens/buy_input_screen.dart
+++ b/lib/features/buy/ui/screens/buy_input_screen.dart
@@ -1,5 +1,7 @@
 import 'package:bb_mobile/core/exchange/domain/errors/buy_error.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/amount_conversions.dart';
+import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/cards/info_card.dart';
@@ -16,6 +18,68 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
+
+/// Renders whichever error the order creation failed with. Amount limits get
+/// the amount appended, everything else falls back to its translation so that
+/// the Continue button is never silently dead.
+class _CreateOrderError extends StatelessWidget {
+  const _CreateOrderError({required this.error});
+
+  final BuyError error;
+
+  @override
+  Widget build(BuildContext context) {
+    final errorStyle = context.font.bodyMedium?.copyWith(
+      color: context.appColors.error,
+    );
+
+    final (String label, double amount, String currency)? limit =
+        switch (error) {
+          BelowMinAmountBuyError(:final minAmount, :final currency) => (
+            context.loc.buyInputMinAmountError,
+            minAmount,
+            currency,
+          ),
+          AboveMaxAmountBuyError(:final maxAmount, :final currency) => (
+            context.loc.buyInputMaxAmountError,
+            maxAmount,
+            currency,
+          ),
+          _ => null,
+        };
+
+    if (limit == null) {
+      return Center(
+        child: Text(
+          error.toTranslated(context),
+          style: errorStyle,
+          textAlign: .center,
+        ),
+      );
+    }
+
+    final (label, amount, currency) = limit;
+    // The api denominates a limit either in fiat or in bitcoin; only the latter
+    // can be shown in the user's bitcoin unit.
+    final isBitcoinLimit = currency == 'BTC' || currency == 'LBTC';
+    return Row(
+      mainAxisAlignment: .center,
+      children: [
+        Text(label, style: errorStyle),
+        const Gap(4),
+        if (isBitcoinLimit)
+          CurrencyText(
+            ConvertAmount.btcToSats(amount),
+            showFiat: false,
+            style: errorStyle,
+            overrideHideAmounts: true,
+          )
+        else
+          Text(FormatAmount.fiat(amount, currency), style: errorStyle),
+      ],
+    );
+  }
+}
 
 class BuyInputScreen extends StatefulWidget {
   const BuyInputScreen({super.key});
@@ -42,14 +106,9 @@ class _BuyInputScreenState extends State<BuyInputScreen> {
     final isCreatingOrder = context.select(
       (BuyBloc bloc) => bloc.state.isCreatingOrder,
     );
-    final belowMinAmountError = context.select((BuyBloc bloc) {
-      final error = bloc.state.createOrderBuyError;
-      return error is BelowMinAmountBuyError ? error : null;
-    });
-    final aboveMaxAmountError = context.select((BuyBloc bloc) {
-      final error = bloc.state.createOrderBuyError;
-      return error is AboveMaxAmountBuyError ? error : null;
-    });
+    final createOrderError = context.select(
+      (BuyBloc bloc) => bloc.state.createOrderBuyError,
+    );
     final needsKycUpgrade = context.select(
       (BuyBloc bloc) => bloc.state.needsKycUpgrade(bloc.state.amount ?? 0),
     );
@@ -88,32 +147,8 @@ class _BuyInputScreenState extends State<BuyInputScreen> {
                 children: [
                   if (isCreatingOrder)
                     const Center(child: CircularProgressIndicator()),
-                  if (belowMinAmountError != null ||
-                      aboveMaxAmountError != null)
-                    Row(
-                      mainAxisAlignment: .center,
-                      children: [
-                        Text(
-                          belowMinAmountError != null
-                              ? context.loc.buyInputMinAmountError
-                              : context.loc.buyInputMaxAmountError,
-                          style: context.font.bodyMedium?.copyWith(
-                            color: context.appColors.error,
-                          ),
-                        ),
-                        const Gap(4),
-                        CurrencyText(
-                          belowMinAmountError != null
-                              ? belowMinAmountError.minAmountSat
-                              : aboveMaxAmountError!.maxAmountSat,
-                          showFiat: false,
-                          style: context.font.bodyMedium?.copyWith(
-                            color: context.appColors.error,
-                          ),
-                          overrideHideAmounts: true,
-                        ),
-                      ],
-                    ),
+                  if (createOrderError != null)
+                    _CreateOrderError(error: createOrderError),
 
                   const Gap(16),
                   if (isStarted) ...[

--- a/lib/features/buy/ui/screens/buy_success_screen.dart
+++ b/lib/features/buy/ui/screens/buy_success_screen.dart
@@ -32,6 +32,10 @@ class BuySuccessScreen extends StatelessWidget {
     final formattedPayOutAmount = bitcoinUnit == BitcoinUnit.sats
         ? FormatAmount.sats(payoutAmountSat)
         : FormatAmount.btc(buyOrder.payoutAmount);
+    final formattedPayInAmount = FormatAmount.fiat(
+      buyOrder.payinAmount,
+      buyOrder.payinCurrency,
+    );
     final payoutTime = buyOrder.scheduledPayoutTime;
 
     return PopScope(
@@ -67,8 +71,12 @@ class BuySuccessScreen extends StatelessWidget {
                 ),
                 const SizedBox(height: 20),
                 Text(
-                  context.loc.buyYouBought(formattedPayOutAmount),
+                  context.loc.buyYouBought(
+                    formattedPayOutAmount,
+                    formattedPayInAmount,
+                  ),
                   style: context.font.titleLarge,
+                  textAlign: .center,
                 ),
                 const SizedBox(height: 10),
                 if (payoutTime != null)

--- a/lib/features/buy/ui/widgets/buy_destination_input_fields.dart
+++ b/lib/features/buy/ui/widgets/buy_destination_input_fields.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/buy/presentation/buy_bloc.dart';
+import 'package:bb_mobile/features/buy/ui/buy_payout_method_label.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -65,6 +66,9 @@ class _BuyDestinationInputFieldsState extends State<BuyDestinationInputFields> {
             child: Center(
               child: DropdownButtonFormField<String>(
                 alignment: Alignment.centerLeft,
+                // The default wallet labels carry a network suffix, which is
+                // wide enough to overflow the field on narrow screens.
+                isExpanded: true,
                 decoration: const InputDecoration(
                   border: InputBorder.none,
                   contentPadding: EdgeInsets.symmetric(horizontal: 16.0),
@@ -76,11 +80,19 @@ class _BuyDestinationInputFieldsState extends State<BuyDestinationInputFields> {
                 initialValue: selectedWallet?.id,
                 items: [
                   ...wallets.map((w) {
-                    final label = w.displayLabel(context);
+                    // Default wallets carry a network suffix here so the user
+                    // can tell the two apart; externally added wallets keep
+                    // their custom name untouched.
+                    final label = w.isDefault
+                        ? '${w.displayLabel(context)} '
+                              '(${buyPayoutMethodLabel(context, isLiquid: w.network.isLiquid)})'
+                        : w.displayLabel(context);
                     return DropdownMenuItem(
                       value: w.id,
                       child: Text(
                         label,
+                        maxLines: 1,
+                        overflow: .ellipsis,
                         style: context.font.headlineSmall?.copyWith(
                           color: context.appColors.secondary,
                         ),
@@ -90,6 +102,8 @@ class _BuyDestinationInputFieldsState extends State<BuyDestinationInputFields> {
                   DropdownMenuItem(
                     child: Text(
                       !isStarted ? '' : externalBitcoinWalletLabel,
+                      maxLines: 1,
+                      overflow: .ellipsis,
                       style: context.font.headlineSmall?.copyWith(
                         color: context.appColors.secondary,
                       ),

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -1268,6 +1268,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "محفظة الدفع",
+  "buyPayoutMethodLiquid": "L-BTC على Liquid",
+  "buyPayoutMethodBitcoin": "BTC على سلسلة بيتكوين",
   "buyConfirmPayoutMethod": "طريقة الدفع",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2024,6 +2027,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "لم نتمكن من إنشاء طلبك في الوقت الحالي. يُرجى المحاولة مرة أخرى أو الاتصال بالدعم.",
   "buyOrderAlreadyConfirmedError": "تم تأكيد أمر الشراء هذا.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3288,7 +3292,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "إشتريت {amount}",
+  "buyYouBought": "إشتريت {amount} مقابل {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -688,7 +688,7 @@
   "buyPayoutMethod": "পেআউট পদ্ধতি",
   "buyAwaitingConfirmation": "নিশ্চিতকৰণৰ বাবে অপেক্ষা কৰা হৈছে ",
   "buyConfirmPurchase": "কেনাকাটা নিশ্চিত কৰক",
-  "buyYouBought": "আপুনি {amount} কিনিলে",
+  "buyYouBought": "আপুনি {fiatAmount}ৰ বিনিময়ত {amount} কিনিলে",
   "@buyYouBought": {
     "placeholders": {
       "amount": {
@@ -7724,6 +7724,9 @@
   "@buyConfirmBitcoinPrice": {
     "description": "Field label for Bitcoin price"
   },
+  "buyConfirmPayoutWallet": "পৰিশোধ ৱালেট",
+  "buyPayoutMethodLiquid": "Liquid-ত L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin শৃংখলত BTC",
   "buyConfirmPayoutMethod": "Payout পদ্ধতি",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -9397,6 +9400,7 @@
   "@buyOrderNotFoundError": {
     "description": "Error message for order not found during buy"
   },
+  "buyUnexpectedError": "আপোনাৰ অৰ্ডাৰ এই মুহূৰ্তত সৃষ্টি কৰিব পৰা নগ'ল। অনুগ্ৰহ কৰি পুনৰ চেষ্টা কৰক বা সমৰ্থনৰ সৈতে যোগাযোগ কৰক।",
   "buyOrderAlreadyConfirmedError": "এই ক্ৰয় অৰ্ডাৰ ইতিমধ্যে নিশ্চিত হৈছে।",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -1,4 +1,8 @@
 {
+  "buyUnexpectedError": "Вашата заявка не може да бъде създадена в момента. Опитайте отново или се свържете с поддръжката.",
+  "buyConfirmPayoutWallet": "Портфейл за изплащане",
+  "buyPayoutMethodLiquid": "L-BTC в Liquid",
+  "buyPayoutMethodBitcoin": "BTC в блокчейна на Bitcoin",
   "backupWarningDescription": "Без резервно копие ще загубите достъп до своите биткоини, ако:",
   "backupWarningLoseReasonLostPhone": "Загубите телефона си",
   "backupWarningLoseReasonDeletedApp": "Изтриете приложението",
@@ -2897,7 +2901,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "Купихте {amount}",
+  "buyYouBought": "Купихте {amount} за {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -1333,6 +1333,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "পেআউট ওয়ালেট",
+  "buyPayoutMethodLiquid": "Liquid-এ L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin চেইনে BTC",
   "buyConfirmPayoutMethod": "পাওআউট পদ্ধতি",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2119,6 +2122,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "আপনার অর্ডার এই মুহূর্তে তৈরি করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন বা সহায়তার সাথে যোগাযোগ করুন।",
   "buyOrderAlreadyConfirmedError": "এই ক্রয় অর্ডারটি ইতিমধ্যেই নিশ্চিত করা হয়েছে।",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3409,7 +3413,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "আপনি {amount} কিনেছেন",
+  "buyYouBought": "আপনি {fiatAmount} দিয়ে {amount} কিনেছেন",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -1592,6 +1592,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "Peněženka pro výplatu",
+  "buyPayoutMethodLiquid": "L-BTC na Liquid",
+  "buyPayoutMethodBitcoin": "BTC na blockchainu Bitcoin",
   "buyConfirmPayoutMethod": "Metoda výplaty",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2358,6 +2361,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "Vaši objednávku nyní nelze vytvořit. Zkuste to prosím znovu nebo kontaktujte podporu.",
   "buyOrderAlreadyConfirmedError": "Tato objednávka byla potvrzena.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3628,7 +3632,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "Koupili jste {amount}",
+  "buyYouBought": "Koupili jste {amount} za {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -455,6 +455,9 @@
   "backupWalletGoogleDrivePrivacyMessage3": "Ihr Telefon verlassen und ist.",
   "backupCompletedDescription": "Jetzt testen wir Ihr Backup, um sicherzustellen, dass alles korrekt durchgeführt wurde.",
   "sendErrorInsufficientFundsForFees": "Nicht genügend Guthaben, um Betrag und Gebühren zu decken.",
+  "buyConfirmPayoutWallet": "Auszahlungs-Wallet",
+  "buyPayoutMethodLiquid": "L-BTC auf Liquid",
+  "buyPayoutMethodBitcoin": "BTC auf der Bitcoin-Blockchain",
   "buyConfirmPayoutMethod": "Auszahlungsmethode",
   "durationMinutes": "{minutes} Minuten",
   "@durationMinutes": {
@@ -712,6 +715,7 @@
     }
   },
   "mempoolCustomServerUrl": "Server-URL",
+  "buyUnexpectedError": "Ihre Order konnte derzeit nicht erstellt werden. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support.",
   "buyOrderAlreadyConfirmedError": "Diese Kauforder wurde bereits bestätigt.",
   "fundExchangeArsBankTransferTitle": "Banküberweisung",
   "transactionLabelReceiveAmount": "Empfangsbetrag",
@@ -1143,7 +1147,7 @@
   "testCompletedSuccessMessage": "Sie können den Zugang zu einer verlorenen Bitcoin-Wallet wiederherstellen.",
   "importWatchOnlyScanQR": "QR scannen",
   "selectAmountTitle": "Betrag auswählen",
-  "buyYouBought": "Sie haben {amount} gekauft",
+  "buyYouBought": "Sie haben {amount} für {fiatAmount} gekauft",
   "@buyYouBought": {
     "placeholders": {
       "amount": {

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -1160,6 +1160,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "Πορτοφόλι πληρωμής",
+  "buyPayoutMethodLiquid": "L-BTC στο Liquid",
+  "buyPayoutMethodBitcoin": "BTC στην αλυσίδα Bitcoin",
   "buyConfirmPayoutMethod": "Μέθοδος πληρωμής",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -1815,6 +1818,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "Η εντολή σας δεν μπόρεσε να δημιουργηθεί αυτή τη στιγμή. Δοκιμάστε ξανά ή επικοινωνήστε με την υποστήριξη.",
   "buyOrderAlreadyConfirmedError": "Αυτή η παραγγελία αγοράς έχει ήδη επιβεβαιωθεί.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -2932,7 +2936,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "Αγοράσατε {amount}",
+  "buyYouBought": "Αγοράσατε {amount} με {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -1808,11 +1808,14 @@
   "@buyConfirmPurchase": {
     "description": "Button to confirm purchase"
   },
-  "buyYouBought": "You bought {amount}",
+  "buyYouBought": "You bought {amount} with {fiatAmount}",
   "@buyYouBought": {
-    "description": "Success message with amount bought",
+    "description": "Success message with amount bought and the fiat amount debited",
     "placeholders": {
       "amount": {
+        "type": "String"
+      },
+      "fiatAmount": {
         "type": "String"
       }
     }
@@ -11306,9 +11309,21 @@
   "@buyConfirmBitcoinPrice": {
     "description": "Field label for Bitcoin price"
   },
+  "buyConfirmPayoutWallet": "Payout wallet",
+  "@buyConfirmPayoutWallet": {
+    "description": "Field label for the wallet a buy pays out to"
+  },
   "buyConfirmPayoutMethod": "Payout method",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
+  },
+  "buyPayoutMethodLiquid": "L-BTC on Liquid",
+  "@buyPayoutMethodLiquid": {
+    "description": "Payout method for buys paid out over the Liquid network"
+  },
+  "buyPayoutMethodBitcoin": "BTC on Bitcoin chain",
+  "@buyPayoutMethodBitcoin": {
+    "description": "Payout method for buys paid out over the Bitcoin network"
   },
   "buyConfirmExternalWallet": "External Bitcoin wallet",
   "@buyConfirmExternalWallet": {
@@ -12990,6 +13005,10 @@
   "buyOrderAlreadyConfirmedError": "This buy order has already been confirmed.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
+  },
+  "buyUnexpectedError": "Your order could not be created right now. Please try again or contact support.",
+  "@buyUnexpectedError": {
+    "description": "Generic error message shown when a buy order could not be created for any unrecognized reason, including connectivity failures, so it must not blame the amount"
   },
   "withdrawUnauthenticatedError": "You are not authenticated. Please log in to continue.",
   "@withdrawUnauthenticatedError": {

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -385,7 +385,7 @@
   "buyPayoutMethod": "Método de pago",
   "buyAwaitingConfirmation": "Esperando confirmación ",
   "buyConfirmPurchase": "Confirmar compra",
-  "buyYouBought": "Ha comprado {amount}",
+  "buyYouBought": "Ha comprado {amount} por {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {
@@ -3463,6 +3463,9 @@
   "buyConfirmYouPay": "Usted paga",
   "buyConfirmYouReceive": "Usted recibe",
   "buyConfirmBitcoinPrice": "Precio de Bitcoin",
+  "buyConfirmPayoutWallet": "Cartera de pago",
+  "buyPayoutMethodLiquid": "L-BTC en Liquid",
+  "buyPayoutMethodBitcoin": "BTC en la cadena de Bitcoin",
   "buyConfirmPayoutMethod": "Método de pago",
   "buyConfirmExternalWallet": "Billetera Bitcoin externo",
   "buyConfirmAwaitingConfirmation": "Esperando confirmación ",
@@ -4109,6 +4112,7 @@
   "buyAboveMaxAmountError": "Está intentando comprar por encima del monto máximo.",
   "buyInsufficientFundsError": "Fondos insuficientes en su cuenta Bull Bitcoin para completar esta compra.",
   "buyOrderNotFoundError": "No se encontró la orden de compra. Por favor, inténtelo de nuevo.",
+  "buyUnexpectedError": "No se ha podido crear su orden en este momento. Vuelva a intentarlo o contacte con el soporte.",
   "buyOrderAlreadyConfirmedError": "Esta orden de compra ya ha sido confirmada.",
   "withdrawUnauthenticatedError": "No está autenticado. Por favor, inicie sesión para continuar.",
   "withdrawBelowMinAmountError": "Está intentando retirar por debajo del monto mínimo.",

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -1121,6 +1121,7 @@
   "@buyOrderNotFoundError": {
     "description": "Error message for order not found during buy"
   },
+  "buyUnexpectedError": "سفارش شما در حال حاضر ایجاد نشد. لطفاً دوباره تلاش کنید یا با پشتیبانی تماس بگیرید.",
   "buyOrderAlreadyConfirmedError": "این سفارش خرید قبلا تایید شده است.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -2383,6 +2384,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "کیف پول پرداخت",
+  "buyPayoutMethodLiquid": "L-BTC در Liquid",
+  "buyPayoutMethodBitcoin": "BTC در زنجیره بیت‌کوین",
   "buyConfirmPayoutMethod": "روش پرداخت",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -4178,7 +4182,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "You bought {amount}",
+  "buyYouBought": "شما {amount} را با {fiatAmount} خریدید",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -347,7 +347,7 @@
   "buyPayoutMethod": "Maksutapa",
   "buyAwaitingConfirmation": "Odotetaan vahvistusta ",
   "buyConfirmPurchase": "Vahvista osto",
-  "buyYouBought": "Ostit {amount}",
+  "buyYouBought": "Ostit {amount} hintaan {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {
@@ -3397,6 +3397,9 @@
   "buyConfirmYouPay": "Maksat",
   "buyConfirmYouReceive": "Saat",
   "buyConfirmBitcoinPrice": "Bitcoinin hinta",
+  "buyConfirmPayoutWallet": "Maksun lompakko",
+  "buyPayoutMethodLiquid": "L-BTC Liquid-verkossa",
+  "buyPayoutMethodBitcoin": "BTC Bitcoin-lohkoketjussa",
   "buyConfirmPayoutMethod": "Maksutapa",
   "buyConfirmExternalWallet": "Ulkoinen Bitcoin-lompakko",
   "buyConfirmAwaitingConfirmation": "Odottaa vahvistusta ",
@@ -4043,6 +4046,7 @@
   "buyAboveMaxAmountError": "Yrität ostaa yli enimmäismäärän.",
   "buyInsufficientFundsError": "Bull Bitcoin -tililläsi ei ole riittävästi varoja tämän oston suorittamiseen.",
   "buyOrderNotFoundError": "Ostopyyntöä ei löytynyt. Yritä uudelleen.",
+  "buyUnexpectedError": "Tilaustasi ei voitu luoda juuri nyt. Yritä uudelleen tai ota yhteyttä tukeen.",
   "buyOrderAlreadyConfirmedError": "Tämä ostopyyntö on jo vahvistettu.",
   "withdrawUnauthenticatedError": "Et ole kirjautunut sisään. Kirjaudu jatkaaksesi.",
   "withdrawBelowMinAmountError": "Yrität nostaa alle vähimmäismäärän.",

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -385,7 +385,7 @@
   "buyPayoutMethod": "Méthode de paiement",
   "buyAwaitingConfirmation": "En attente de confirmation ",
   "buyConfirmPurchase": "Confirmer l'achat",
-  "buyYouBought": "Vous avez acheté {amount}",
+  "buyYouBought": "Vous avez acheté {amount} pour {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {
@@ -3449,6 +3449,9 @@
   "buyConfirmYouPay": "Vous payez",
   "buyConfirmYouReceive": "Vous recevez",
   "buyConfirmBitcoinPrice": "Prix du Bitcoin",
+  "buyConfirmPayoutWallet": "Portefeuille de paiement",
+  "buyPayoutMethodLiquid": "L-BTC sur Liquid",
+  "buyPayoutMethodBitcoin": "BTC sur la chaîne Bitcoin",
   "buyConfirmPayoutMethod": "Méthode de paiement",
   "buyConfirmExternalWallet": "Portefeuille Bitcoin externe",
   "buyConfirmAwaitingConfirmation": "En attente de confirmation ",
@@ -4095,6 +4098,7 @@
   "buyAboveMaxAmountError": "Vous essayez d'acheter au-dessus du montant maximum.",
   "buyInsufficientFundsError": "Fonds insuffisants dans votre compte Bull Bitcoin pour compléter cet achat.",
   "buyOrderNotFoundError": "La commande d'achat n'a pas été trouvée. Veuillez réessayer.",
+  "buyUnexpectedError": "Votre ordre n'a pas pu être créé pour le moment. Veuillez réessayer ou contacter le support.",
   "buyOrderAlreadyConfirmedError": "Cette commande d'achat a déjà été confirmée.",
   "withdrawUnauthenticatedError": "Vous n'êtes pas authentifié. Veuillez vous connecter pour continuer.",
   "withdrawBelowMinAmountError": "Vous essayez de retirer en dessous du montant minimum.",

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -1342,6 +1342,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "भुगतान वॉलेट",
+  "buyPayoutMethodLiquid": "Liquid पर L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin चेन पर BTC",
   "buyConfirmPayoutMethod": "भुगतान विधि",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2146,6 +2149,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "आपका ऑर्डर अभी नहीं बनाया जा सका। कृपया दोबारा कोशिश करें या सहायता से संपर्क करें।",
   "buyOrderAlreadyConfirmedError": "यह खरीद आदेश पहले ही पुष्टि की गई है।।",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3482,7 +3486,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "आपने {amount} खरीदा",
+  "buyYouBought": "आपने {fiatAmount} में {amount} खरीदा",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -1688,7 +1688,7 @@
   "@buyConfirmPurchase": {
     "description": "Button to confirm purchase"
   },
-  "buyYouBought": "Aapne {amount} kharida",
+  "buyYouBought": "Aapne {fiatAmount} mein {amount} kharida",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {
@@ -9900,6 +9900,9 @@
   "@buyConfirmBitcoinPrice": {
     "description": "Field label for Bitcoin price"
   },
+  "buyConfirmPayoutWallet": "Bhugtaan wallet",
+  "buyPayoutMethodLiquid": "Liquid par L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin chain par BTC",
   "buyConfirmPayoutMethod": "Payout method",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -11574,6 +11577,7 @@
   "@buyOrderNotFoundError": {
     "description": "Error message for order not found during buy"
   },
+  "buyUnexpectedError": "Aapka order abhi nahi banaya ja saka. Kripya dobara koshish karein ya support se sampark karein.",
   "buyOrderAlreadyConfirmedError": "Ye buy order pehle se confirm ho chuka hai.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -1,4 +1,8 @@
 {
+  "buyUnexpectedError": "Ձեր պատվերը հնարավոր չեղավ ստեղծել այս պահին։ Փորձեք կրկին կամ դիմեք աջակցման ծառայությանը։",
+  "buyConfirmPayoutWallet": "Վճարման դրամապանակ",
+  "buyPayoutMethodLiquid": "L-BTC Liquid-ում",
+  "buyPayoutMethodBitcoin": "BTC Bitcoin-ի շղթայում",
   "fundExchangeRestrictedTitle": "Ֆինանսավորումն անհասանելի է",
   "fundExchangeRestrictedMessage": "Ֆինանսավորումն անհասանելի է ձեր հաշվի համար։ Լրացուցիչ տեղեկությունների համար խնդրում ենք կապվել աջակցման ծառայության հետ։",
   "recipientsListLoadError": "Չհաջողվեց բեռնել ստացողներին։ Քաշեք ներքև՝ կրկին փորձելու համար։",

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -461,6 +461,9 @@
   "backupWalletGoogleDrivePrivacyMessage3": "lasciare il telefono ed è ",
   "backupCompletedDescription": "Ora testiamo il backup per assicurarci che tutto sia stato fatto correttamente.",
   "sendErrorInsufficientFundsForFees": "Non abbastanza fondi per coprire l'importo e le tasse",
+  "buyConfirmPayoutWallet": "Portafoglio di pagamento",
+  "buyPayoutMethodLiquid": "L-BTC su Liquid",
+  "buyPayoutMethodBitcoin": "BTC sulla catena Bitcoin",
   "buyConfirmPayoutMethod": "Metodo di pagamento",
   "dcaCancelButton": "Annulla",
   "durationMinutes": "{minutes} minuti",
@@ -724,6 +727,7 @@
     }
   },
   "mempoolCustomServerUrl": "URL del server",
+  "buyUnexpectedError": "Non è stato possibile creare il tuo ordine in questo momento. Riprova o contatta l'assistenza.",
   "buyOrderAlreadyConfirmedError": "Questo ordine di acquisto è già stato confermato.",
   "fundExchangeArsBankTransferTitle": "Trasferimento bancario",
   "transactionLabelReceiveAmount": "Ricevi l'importo",
@@ -1161,7 +1165,7 @@
   "importWatchOnlyScanQR": "Scansione del QR",
   "walletBalanceUnconfirmedIncoming": "In corso",
   "selectAmountTitle": "Selezionare la quantità",
-  "buyYouBought": "Hai comprato {amount}",
+  "buyYouBought": "Hai comprato {amount} con {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -1,4 +1,8 @@
 {
+  "buyUnexpectedError": "თქვენი შეკვეთის შექმნა ამჟამად ვერ მოხერხდა. სცადეთ ხელახლა ან დაუკავშირდით მხარდაჭერას.",
+  "buyConfirmPayoutWallet": "გადახდის საფულე",
+  "buyPayoutMethodLiquid": "L-BTC Liquid-ზე",
+  "buyPayoutMethodBitcoin": "BTC Bitcoin-ის ჯაჭვზე",
   "fundExchangeRestrictedTitle": "დაფინანსება მიუწვდომელია",
   "fundExchangeRestrictedMessage": "დაფინანსება მიუწვდომელია თქვენს ანგარიშზე. დამატებითი ინფორმაციისთვის დაუკავშირდით მხარდაჭერას.",
   "recipientsListLoadError": "მიმღებების ჩატვირთვა ვერ მოხერხდა. ხელახლა საცდელად ჩამოწიეთ ქვემოთ.",

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -1342,6 +1342,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "지급 지갑",
+  "buyPayoutMethodLiquid": "Liquid의 L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin 체인의 BTC",
   "buyConfirmPayoutMethod": "Payout 방법",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2146,6 +2149,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "현재 주문을 생성할 수 없습니다. 다시 시도하거나 고객 지원에 문의해 주세요.",
   "buyOrderAlreadyConfirmedError": "이 구매 순서는 이미 확인되었습니다.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3482,7 +3486,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "당신은 구입 {amount}",
+  "buyYouBought": "{fiatAmount}으로 {amount}을 구매했습니다",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -459,6 +459,9 @@
   "backupWalletGoogleDrivePrivacyMessage3": "deixar seu telefone e é ",
   "backupCompletedDescription": "Agora vamos testar seu backup para garantir que tudo foi feito corretamente.",
   "sendErrorInsufficientFundsForFees": "Não há fundos suficientes para cobrir o montante e as taxas",
+  "buyConfirmPayoutWallet": "Carteira de pagamento",
+  "buyPayoutMethodLiquid": "L-BTC na Liquid",
+  "buyPayoutMethodBitcoin": "BTC na cadeia Bitcoin",
   "buyConfirmPayoutMethod": "Método de pagamento",
   "dcaCancelButton": "Cancelar",
   "durationMinutes": "{minutes}",
@@ -721,6 +724,7 @@
     }
   },
   "mempoolCustomServerUrl": "URL do servidor",
+  "buyUnexpectedError": "Não foi possível criar a sua ordem neste momento. Tente novamente ou contacte o suporte.",
   "buyOrderAlreadyConfirmedError": "Esta ordem de compra já foi confirmada.",
   "fundExchangeArsBankTransferTitle": "Transferência bancária",
   "transactionLabelReceiveAmount": "Receber valor",
@@ -1158,7 +1162,7 @@
   "importWatchOnlyScanQR": "Digitalização QR",
   "walletBalanceUnconfirmedIncoming": "Em progresso",
   "selectAmountTitle": "Selecione o valor",
-  "buyYouBought": "Você comprou {amount}",
+  "buyYouBought": "Você comprou {amount} por {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -1083,6 +1083,9 @@
   "@transactionLabelStatus": {
     "description": "Label for transaction status"
   },
+  "buyConfirmPayoutWallet": "Carteira de pagamento",
+  "buyPayoutMethodLiquid": "L-BTC na Liquid",
+  "buyPayoutMethodBitcoin": "BTC na cadeia Bitcoin",
   "buyConfirmPayoutMethod": "Método de pagamento",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -3115,7 +3118,7 @@
   "@exchangeKycLight": {
     "description": "Light KYC level label"
   },
-  "buyYouBought": "Você comprou {amount}",
+  "buyYouBought": "Você comprou {amount} por {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {
@@ -12387,6 +12390,7 @@
   "@buyAboveMaxAmountError": {
     "description": "Error message for amount above maximum during buy"
   },
+  "buyUnexpectedError": "Não foi possível criar seu pedido neste momento. Tente novamente ou entre em contato com o suporte.",
   "buyOrderAlreadyConfirmedError": "Esta ordem de compra já foi confirmada.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -460,6 +460,9 @@
   "backupWalletGoogleDrivePrivacyMessage3": "оставьте свой телефон и ",
   "backupCompletedDescription": "Теперь давайте проверим вашу резервную копию, чтобы убедиться, что все было сделано правильно.",
   "sendErrorInsufficientFundsForFees": "Недостаточно средств для покрытия суммы и сборов",
+  "buyConfirmPayoutWallet": "Кошелёк для выплаты",
+  "buyPayoutMethodLiquid": "L-BTC в сети Liquid",
+  "buyPayoutMethodBitcoin": "BTC в сети Bitcoin",
   "buyConfirmPayoutMethod": "Метод выплаты",
   "dcaCancelButton": "Отмена",
   "durationMinutes": "{minutes}",
@@ -721,6 +724,7 @@
     }
   },
   "mempoolCustomServerUrl": "Адрес сервера",
+  "buyUnexpectedError": "Не удалось создать ваш заказ. Попробуйте снова или обратитесь в поддержку.",
   "buyOrderAlreadyConfirmedError": "Этот заказ уже подтвержден.",
   "fundExchangeArsBankTransferTitle": "Банковский перевод",
   "transactionLabelReceiveAmount": "Получить сумму",
@@ -1158,7 +1162,7 @@
   "importWatchOnlyScanQR": "Scan QR",
   "walletBalanceUnconfirmedIncoming": "Прогресс",
   "selectAmountTitle": "Выберите сумму",
-  "buyYouBought": "Вы купили {amount}",
+  "buyYouBought": "Вы купили {amount} за {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -1,4 +1,8 @@
 {
+  "buyUnexpectedError": "Oda yako haikuweza kuundwa kwa sasa. Tafadhali jaribu tena au wasiliana na usaidizi.",
+  "buyConfirmPayoutWallet": "Pochi ya malipo",
+  "buyPayoutMethodLiquid": "L-BTC kwenye Liquid",
+  "buyPayoutMethodBitcoin": "BTC kwenye chaini ya Bitcoin",
   "fundExchangeRestrictedTitle": "Ufadhili haupatikani",
   "fundExchangeRestrictedMessage": "Ufadhili haupatikani kwenye akaunti yako. Tafadhali wasiliana na usaidizi kwa maelezo zaidi.",
   "recipientsListLoadError": "Imeshindwa kupakia wapokeaji. Vuta chini ili ujaribu tena.",

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -1342,6 +1342,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "กระเป๋าเงินรับการจ่าย",
+  "buyPayoutMethodLiquid": "L-BTC บน Liquid",
+  "buyPayoutMethodBitcoin": "BTC บนเชน Bitcoin",
   "buyConfirmPayoutMethod": "วิธีการชําระเงิน",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2146,6 +2149,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "ไม่สามารถสร้างคำสั่งซื้อของคุณได้ในขณะนี้ กรุณาลองอีกครั้งหรือติดต่อฝ่ายสนับสนุน",
   "buyOrderAlreadyConfirmedError": "ซื้อการสั่งซื้อนี้ได้รับการยืนยัน.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3482,7 +3486,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "You bought {amount}",
+  "buyYouBought": "คุณซื้อ {amount} ด้วย {fiatAmount}",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -1338,6 +1338,9 @@
   "@sendErrorInsufficientFundsForFees": {
     "description": "Error when wallet cannot cover transaction amount plus fees"
   },
+  "buyConfirmPayoutWallet": "Ödeme cüzdanı",
+  "buyPayoutMethodLiquid": "Liquid üzerinde L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin zincirinde BTC",
   "buyConfirmPayoutMethod": "Payout yöntemi",
   "@buyConfirmPayoutMethod": {
     "description": "Field label for payout method"
@@ -2138,6 +2141,7 @@
   "@mempoolCustomServerUrl": {
     "description": "Label for custom mempool server URL input field"
   },
+  "buyUnexpectedError": "Siparişiniz şu anda oluşturulamadı. Lütfen tekrar deneyin veya destek ile iletişime geçin.",
   "buyOrderAlreadyConfirmedError": "Bu satın sipariş zaten doğrulandı.",
   "@buyOrderAlreadyConfirmedError": {
     "description": "Error message for already confirmed buy order"
@@ -3470,7 +3474,7 @@
   "@selectAmountTitle": {
     "description": "Title for manual coin selection bottom sheet"
   },
-  "buyYouBought": "You buy {amount}",
+  "buyYouBought": "{fiatAmount} karşılığında {amount} satın aldınız",
   "@buyYouBought": {
     "description": "Success message with amount bought",
     "placeholders": {

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -837,7 +837,7 @@
   "buyPayoutMethod": "Спосіб виплати",
   "buyAwaitingConfirmation": "Підтвердження ",
   "buyConfirmPurchase": "Підтвердити покупку",
-  "buyYouBought": "Ви придбали {amount}",
+  "buyYouBought": "Ви придбали {amount} за {fiatAmount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {
@@ -1156,6 +1156,9 @@
   "buyConfirmYouPay": "Ви платите",
   "buyConfirmYouReceive": "Ви отримуєте",
   "buyConfirmBitcoinPrice": "Ціна Bitcoin",
+  "buyConfirmPayoutWallet": "Гаманець для виплати",
+  "buyPayoutMethodLiquid": "L-BTC у мережі Liquid",
+  "buyPayoutMethodBitcoin": "BTC у мережі Bitcoin",
   "buyConfirmPayoutMethod": "Спосіб виплати",
   "buyConfirmExternalWallet": "Зовнішні біткоїни гаманець",
   "buyConfirmAwaitingConfirmation": "Підтвердження ",
@@ -1685,6 +1688,7 @@
     }
   },
   "mempoolCustomServerUrl": "Статус на сервери",
+  "buyUnexpectedError": "Не вдалося створити ваше замовлення. Спробуйте ще раз або зверніться до підтримки.",
   "buyOrderAlreadyConfirmedError": "Цей замовлення було підтверджено.",
   "sendServerNetworkFees": "Статус на сервери",
   "importWatchOnlyImport": "Імпорт",

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -1,4 +1,8 @@
 {
+  "buyUnexpectedError": "Không thể tạo đơn hàng của bạn ngay lúc này. Vui lòng thử lại hoặc liên hệ bộ phận hỗ trợ.",
+  "buyConfirmPayoutWallet": "Ví nhận tiền",
+  "buyPayoutMethodLiquid": "L-BTC trên Liquid",
+  "buyPayoutMethodBitcoin": "BTC trên chuỗi Bitcoin",
   "fundExchangeRestrictedTitle": "Nạp tiền không khả dụng",
   "fundExchangeRestrictedMessage": "Nạp tiền không khả dụng trên tài khoản của bạn. Vui lòng liên hệ bộ phận hỗ trợ để biết thêm thông tin.",
   "recipientsListLoadError": "Không thể tải danh sách người nhận. Kéo xuống để thử lại.",

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -133,7 +133,7 @@
   "autoswapUpdateSettingsError": "未能更新汽车互换环境",
   "transactionStatusTransferFailed": "3. 汇款",
   "jadeStep11": "然后,Jade将显示自己的QR代码.",
-  "buyConfirmExternalWallet": "外墙",
+  "buyConfirmExternalWallet": "外部比特币钱包",
   "bitboxActionPairDeviceProcessing": "付费装置",
   "exchangeCurrencyDropdownTitle": "选择性货币",
   "receiveServerNetworkFees": "服务器网",
@@ -462,7 +462,10 @@
   "backupWalletGoogleDrivePrivacyMessage3": "页: 1 ",
   "backupCompletedDescription": "现在让我考验你们的支持,以确保一切都得到妥善执行.",
   "sendErrorInsufficientFundsForFees": "资金不足以支付数额和费用",
-  "buyConfirmPayoutMethod": "薪酬办法",
+  "buyConfirmPayoutWallet": "支付钱包",
+  "buyPayoutMethodLiquid": "Liquid 上的 L-BTC",
+  "buyPayoutMethodBitcoin": "Bitcoin 链上的 BTC",
+  "buyConfirmPayoutMethod": "支付方式",
   "dcaCancelButton": "Cancel",
   "durationMinutes": "{minutes}分钟",
   "@durationMinutes": {
@@ -725,6 +728,7 @@
     }
   },
   "mempoolCustomServerUrl": "服务器 URL",
+  "buyUnexpectedError": "当前无法创建您的订单。请重试或联系客服。",
   "buyOrderAlreadyConfirmedError": "这项购买令已经确认.",
   "fundExchangeArsBankTransferTitle": "银行转账",
   "transactionLabelReceiveAmount": "收款情况",
@@ -1162,7 +1166,7 @@
   "importWatchOnlyScanQR": "Scan",
   "walletBalanceUnconfirmedIncoming": "A. 进展",
   "selectAmountTitle": "选择性数额",
-  "buyYouBought": "页: 1",
+  "buyYouBought": "您用 {fiatAmount} 购买了 {amount}",
   "@buyYouBought": {
     "placeholders": {
       "amount": {

--- a/test/core_test/exchange/bullbitcoin_api_datasource_create_buy_order_test.dart
+++ b/test/core_test/exchange/bullbitcoin_api_datasource_create_buy_order_test.dart
@@ -1,0 +1,329 @@
+import 'package:bb_mobile/core/exchange/data/datasources/bullbitcoin_api_datasource.dart';
+import 'package:bb_mobile/core/exchange/data/models/order_model.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+const _ordersPath = '/ak/api-orders';
+
+Response<dynamic> _response(Map<String, dynamic> body) => Response(
+  requestOptions: RequestOptions(path: _ordersPath),
+  statusCode: 200,
+  data: body,
+);
+
+Map<String, dynamic> _limit({
+  required Object amount,
+  required String currencyCode,
+  required String conditionalOperator,
+}) => {
+  'entity': 'ORDER',
+  'code': 'LIMIT_AMOUNT',
+  'amount': amount,
+  'conditionalOperator': conditionalOperator,
+  'currencyCode': currencyCode,
+  'timePeriod': 'DAY',
+  'recurringFrequency': 'DAILY',
+};
+
+void main() {
+  late _MockDio dio;
+  late BullbitcoinApiDatasource datasource;
+
+  setUp(() {
+    dio = _MockDio();
+    datasource = BullbitcoinApiDatasource(bullbitcoinApiHttpClient: dio);
+  });
+
+  Future<OrderModel> createBuyOrder() => datasource.createBuyOrder(
+    apiKey: 'key',
+    fiatCurrency: FiatCurrency.cad,
+    orderAmount: const FiatAmount(5),
+    network: OrderBitcoinNetwork.liquid,
+    isOwner: true,
+    address: 'lq1address',
+  );
+
+  void stub(Map<String, dynamic> body) {
+    when(
+      () => dio.post<dynamic>(
+        _ordersPath,
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((_) async => _response(body));
+  }
+
+  group('BullbitcoinApiDatasource.createBuyOrder error parsing', () {
+    test('aggregate minimums throw the lowest one with its currency', () async {
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {
+            'reasons': [
+              {
+                'amount': '5',
+                'limit': _limit(
+                  amount: '20',
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+                ),
+                'accessDescription': 'e-Transfer',
+              },
+              {
+                'amount': '5',
+                'limit': _limit(
+                  amount: 50,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+                ),
+                'accessDescription': 'Wire',
+              },
+            ],
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<BullBitcoinApiMinAmountException>()
+              .having((e) => e.minAmount, 'minAmount', 20)
+              .having((e) => e.currency, 'currency', 'CAD'),
+        ),
+      );
+    });
+
+    test('aggregate maximums throw the highest one', () async {
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {
+            'reasons': [
+              {
+                'limit': _limit(
+                  amount: 1000,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'LESS_THAN_OR_EQUAL',
+                ),
+              },
+              {
+                'limit': _limit(
+                  amount: 2500.5,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'LESS_THAN_OR_EQUAL',
+                ),
+              },
+            ],
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<BullBitcoinApiMaxAmountException>()
+              .having((e) => e.maxAmount, 'maxAmount', 2500.5)
+              .having((e) => e.currency, 'currency', 'CAD'),
+        ),
+      );
+    });
+
+    test('mixed operators fall back to the generic error', () async {
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {
+            'reasons': [
+              {
+                'limit': _limit(
+                  amount: 20,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+                ),
+              },
+              {
+                'limit': _limit(
+                  amount: 1000,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'LESS_THAN_OR_EQUAL',
+                ),
+              },
+            ],
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('No valid payment options available'),
+          ),
+        ),
+      );
+    });
+
+    test('mixed currencies fall back to the generic error', () async {
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {
+            'reasons': [
+              {
+                'limit': _limit(
+                  amount: 20,
+                  currencyCode: 'CAD',
+                  conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+                ),
+              },
+              {
+                'limit': _limit(
+                  amount: 0.0002,
+                  currencyCode: 'BTC',
+                  conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+                ),
+              },
+            ],
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('No valid payment options available'),
+          ),
+        ),
+      );
+    });
+
+    test('single reason.limit shape is still supported', () async {
+      stub({
+        'error': {
+          'message': 'Amount too low',
+          'data': {
+            'reason': {
+              'limit': _limit(
+                amount: '0.0001',
+                currencyCode: 'BTC',
+                conditionalOperator: 'GREATER_THAN_OR_EQUAL',
+              ),
+            },
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<BullBitcoinApiMinAmountException>()
+              .having((e) => e.minAmount, 'minAmount', 0.0001)
+              .having((e) => e.currency, 'currency', 'BTC'),
+        ),
+      );
+    });
+
+    test('an empty reasons array falls back to the generic error', () async {
+      // Some rejection paths (group-access denial, non-positive amounts)
+      // produce no structured reason at all.
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {'reasons': <dynamic>[], 'details': <dynamic>[null, null]},
+        },
+        'result': null,
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('No valid payment options available'),
+          ),
+        ),
+      );
+    });
+
+    test('reasons without limits fall back to the generic error', () async {
+      stub({
+        'error': {
+          'message': 'No valid payment options available after applying limits',
+          'data': {
+            'reasons': [
+              {'accessDescription': 'e-Transfer'},
+              {'amount': '5'},
+            ],
+            'details': <dynamic>[null],
+          },
+        },
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('No valid payment options available'),
+          ),
+        ),
+      );
+    });
+
+    test('an error with data but no reason at all still throws', () async {
+      stub({
+        'error': {
+          'message': 'Order could not be created',
+          'data': {'details': <dynamic>[null, null]},
+        },
+        'result': null,
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Order could not be created'),
+          ),
+        ),
+      );
+    });
+
+    test('an unrecognized error never falls through to the result', () async {
+      stub({
+        'error': {'message': 'Something else went wrong', 'data': null},
+        'result': null,
+      });
+
+      await expectLater(
+        createBuyOrder(),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Something else went wrong'),
+          ),
+        ),
+      );
+    });
+
+    test('an error with no message at all still throws', () async {
+      stub({'error': <String, dynamic>{}});
+
+      await expectLater(createBuyOrder(), throwsA(isA<Exception>()));
+    });
+  });
+}


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — draft until verified. Test: buy dropdown shows the network suffix on default wallets; confirmation page shows Payout wallet + Payout method rows; success page shows "You bought X sats with Y [fiat]"; entering a below-minimum amount and tapping Continue shows an error instead of doing nothing.

## Problems
1. Below-minimum (and most other) order-creation failures were invisible: the amount screen rendered only two specific error types, the datasource error parsing fell through to a null cast on unrecognized payloads, and when a limit *was* parsed its fiat amount was converted with `btcToSats` (a 20 CAD minimum rendered as 2,000,000,000 sats).
2. The "select wallet" dropdown didn't say which network each default wallet pays out on.
3. The confirmation page's "Payout method" row actually showed the wallet name.
4. The success page omitted what was paid.

## Changes
- Buy dropdown: default wallets get "(L-BTC on Liquid)" / "(BTC on Bitcoin chain)" suffixes, composed locally — the shared `displayLabel`/global ARB keys used by 24 other call sites are untouched
- Confirm page: split into **Payout wallet** and **Payout method** rows, sharing the network phrases with the dropdown
- Success: "You bought {amount} with {fiatAmount}" from the order's payin side
- Order-creation error parsing made total via a shared `Never`-typed helper across buy/sell/pay/withdraw; parses the server's singular `reason` and new plural `reasons` shapes (SatoshiPortal/API-Orders#865), tolerating empty and limit-less entries
- Limit errors carry (amount, currency) verbatim; render site formats fiat as fiat
- Any other `BuyError` renders through a neutral fallback message — Continue is never silently dead
- Repairs broken translations on touched keys (zh/fa/th/tr)

## Validation
10 new datasource parsing tests (all server error shapes incl. empty/mixed/null); analyze + gen-l10n clean across 27 locales; reviewed with a verification pass (wording + zh fixes applied). Full "minimum is X" copy for multi-option rejections additionally needs API-Orders#865 deployed; the app degrades gracefully without it.

Closes #2515
Closes #2516
Closes #2517
Closes #2518