### PR TITLE
fix(theme): stop using onPrimary as a surface or on flipping fills

### DIFF
--- a/lib/core/widgets/cards/balance_card.dart
+++ b/lib/core/widgets/cards/balance_card.dart
@@ -27,7 +27,7 @@ class BalanceCard extends StatelessWidget {
         child: Material(
           clipBehavior: .antiAlias,
           elevation: 2,
-          color: context.appColors.onPrimary,
+          color: context.appColors.surface,
           borderRadius: BorderRadius.circular(2),
           child: Row(
             children: [

--- a/lib/core/widgets/dropdown/bb_dropdown.dart
+++ b/lib/core/widgets/dropdown/bb_dropdown.dart
@@ -32,7 +32,7 @@ class BBDropdown<T> extends StatelessWidget {
               borderRadius: BorderRadius.circular(4.0),
               side: BorderSide(color: context.appColors.primary, width: 1.0),
             ),
-            color: context.appColors.onPrimary,
+            color: context.appColors.surface,
             elevation: 8,
           ),
         ),

--- a/lib/core/widgets/nfc_scanner_widget.dart
+++ b/lib/core/widgets/nfc_scanner_widget.dart
@@ -85,7 +85,7 @@ class _NfcPageState extends State<NfcScannerWidget> {
           BBButton.big(
             label: context.loc.scanNfcButton,
             onPressed: _scan,
-            bgColor: context.appColors.onPrimary,
+            bgColor: context.appColors.surface,
             textColor: context.appColors.secondary,
             iconData: Icons.nfc,
           ),

--- a/lib/core/widgets/not_logged_in_bottom_sheet.dart
+++ b/lib/core/widgets/not_logged_in_bottom_sheet.dart
@@ -68,7 +68,7 @@ class NotLoggedInBottomSheet extends StatelessWidget {
                   context.goNamed(ExchangeRoute.exchangeHome.name);
                 },
                 bgColor: context.appColors.secondary,
-                textColor: context.appColors.onPrimary,
+                textColor: context.appColors.onSecondary,
               ),
             ],
           ),

--- a/lib/features/ark/ui/ark_tx_widget.dart
+++ b/lib/features/ark/ui/ark_tx_widget.dart
@@ -70,7 +70,7 @@ class ArkTxWidget extends StatelessWidget {
         margin: const EdgeInsets.only(bottom: 8.0),
         padding: const EdgeInsets.all(16.0),
         decoration: BoxDecoration(
-          color: context.appColors.onPrimary,
+          color: context.appColors.surface,
           borderRadius: BorderRadius.circular(2.0),
           boxShadow: const [],
         ),
@@ -79,9 +79,9 @@ class ArkTxWidget extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(8.0),
               decoration: BoxDecoration(
-                color: context.appColors.onPrimary,
+                color: context.appColors.surface,
                 borderRadius: BorderRadius.circular(2.0),
-                border: Border.all(color: context.appColors.surface),
+                border: Border.all(color: context.appColors.border),
               ),
               child: Icon(icon, color: context.appColors.secondary),
             ),

--- a/lib/features/ark/ui/collaborative_redeem_bottom_sheet.dart
+++ b/lib/features/ark/ui/collaborative_redeem_bottom_sheet.dart
@@ -33,7 +33,7 @@ class CollaborativeRedeemBottomSheet extends StatelessWidget {
         maxHeight: MediaQuery.of(context).size.height * 0.4,
       ),
       decoration: BoxDecoration(
-        color: context.appColors.onPrimary,
+        color: context.appColors.surface,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
       ),
       child: BlocBuilder<ArkCubit, ArkState>(

--- a/lib/features/ark/ui/send_recipient_page.dart
+++ b/lib/features/ark/ui/send_recipient_page.dart
@@ -122,7 +122,7 @@ class _SendRecipientPageState extends State<SendRecipientPage> {
                           focusNode: _focusNode,
                           textInputAction: .done,
                           decoration: InputDecoration(
-                            fillColor: context.appColors.onPrimary,
+                            fillColor: context.appColors.surface,
                             filled: true,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(8.0),

--- a/lib/features/buy/ui/screens/buy_accelerate_screen.dart
+++ b/lib/features/buy/ui/screens/buy_accelerate_screen.dart
@@ -115,6 +115,8 @@ class BuyAccelerateScreen extends StatelessWidget {
                     },
                     bgColor: context.appColors.surface,
                     textColor: context.appColors.secondary,
+                    outlined: true,
+                    borderColor: context.appColors.border,
                   ),
                 const Gap(16),
                 BBButton.big(
@@ -126,7 +128,7 @@ class BuyAccelerateScreen extends StatelessWidget {
                     );
                   },
                   bgColor: context.appColors.secondary,
-                  textColor: context.appColors.onPrimary,
+                  textColor: context.appColors.onSecondary,
                 ),
               ],
             ),

--- a/lib/features/buy/ui/widgets/accelerate_transaction_list_tile.dart
+++ b/lib/features/buy/ui/widgets/accelerate_transaction_list_tile.dart
@@ -17,7 +17,7 @@ class AccelerateTransactionListTile extends StatelessWidget {
     final theme = Theme.of(context);
     return Container(
       decoration: BoxDecoration(
-        color: context.appColors.onPrimary, // or Colors.white
+        color: context.appColors.surface,
         borderRadius: BorderRadius.circular(4),
         border: Border.all(color: context.appColors.secondary),
         boxShadow: [
@@ -43,24 +43,24 @@ class AccelerateTransactionListTile extends StatelessWidget {
                 backgroundColor: context.appColors.shimmerBase,
               ),
             ),
-            Icon(Icons.schedule, size: 16, color: context.appColors.secondary),
+            Icon(Icons.schedule, size: 16, color: context.appColors.onSurface),
           ],
         ),
         title: Text(
           context.loc.buyAccelerateTransaction,
           style: theme.textTheme.headlineLarge?.copyWith(
-            color: context.appColors.secondary,
+            color: context.appColors.onSurface,
           ),
         ),
         subtitle: Text(
           context.loc.buyGetConfirmedFaster,
           style: theme.textTheme.bodySmall?.copyWith(
-            color: context.appColors.secondary,
+            color: context.appColors.onSurface,
           ),
         ),
         trailing: Icon(
           Icons.fast_forward_outlined,
-          color: context.appColors.secondary,
+          color: context.appColors.onSurface,
         ),
         onTap: onTap,
       ),

--- a/lib/features/dca/ui/screens/dca_wallet_selection_screen.dart
+++ b/lib/features/dca/ui/screens/dca_wallet_selection_screen.dart
@@ -87,13 +87,13 @@ class _DcaWalletSelectionScreenState extends State<DcaWalletSelectionScreen> {
                     style: context.font.headlineSmall?.copyWith(
                       color: _useDefaultLightningAddress
                           ? context.appColors.surfaceContainer
-                          : context.appColors.onSecondary,
+                          : context.appColors.onSurface,
                     ),
                     enabled: !_useDefaultLightningAddress,
                     decoration: InputDecoration(
                       fillColor: _useDefaultLightningAddress
                           ? context.appColors.secondaryFixedDim
-                          : context.appColors.onPrimary,
+                          : context.appColors.surface,
                       filled: true,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8.0),

--- a/lib/features/electrum_settings/frameworks/ui/widgets/privacy_notice.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/privacy_notice.dart
@@ -22,7 +22,7 @@ class PrivacyNoticeBottomSheet extends StatelessWidget {
         maxHeight: MediaQuery.of(context).size.height * 0.8,
       ),
       decoration: BoxDecoration(
-        color: context.appColors.onPrimary,
+        color: context.appColors.surface,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
       ),
       child: Column(

--- a/lib/features/labels/ui/page.dart
+++ b/lib/features/labels/ui/page.dart
@@ -46,7 +46,7 @@ class Bip329LabelsPage extends StatelessWidget {
               builder: (context, isLoading) => FadingLinearProgress(
                 height: 3,
                 trigger: isLoading,
-                backgroundColor: context.appColors.onPrimary,
+                backgroundColor: context.appColors.surface,
                 foregroundColor: context.appColors.primary,
               ),
             ),

--- a/lib/features/pay/ui/screens/pay_external_wallet_network_selection_screen.dart
+++ b/lib/features/pay/ui/screens/pay_external_wallet_network_selection_screen.dart
@@ -27,7 +27,7 @@ class PayExternalWalletNetworkSelectionScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isCreatingPayOrder,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             Expanded(

--- a/lib/features/pay/ui/screens/pay_send_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_send_payment_screen.dart
@@ -90,7 +90,7 @@ class PaySendPaymentScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isConfirmingPayment,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             const Gap(24.0),

--- a/lib/features/pay/ui/screens/pay_sinpe_success_screen.dart
+++ b/lib/features/pay/ui/screens/pay_sinpe_success_screen.dart
@@ -101,7 +101,7 @@ class _PaySinpeSuccessScreenState extends State<PaySinpeSuccessScreen> {
                     context.goNamed(ExchangeRoute.exchangeHome.name);
                   },
                   bgColor: context.appColors.secondary,
-                  textColor: context.appColors.onPrimary,
+                  textColor: context.appColors.onSecondary,
                 ),
               ),
               const Gap(24),

--- a/lib/features/pay/ui/screens/pay_wallet_selection_screen.dart
+++ b/lib/features/pay/ui/screens/pay_wallet_selection_screen.dart
@@ -39,7 +39,7 @@ class PayWalletSelectionScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isCreatingPayOrder,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             Expanded(

--- a/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
@@ -45,7 +45,7 @@ class ReceivePayjoinInProgressScreen extends StatelessWidget {
             preferredSize: const Size.fromHeight(3.0),
             child: FadingLinearProgress(
               trigger: isBroadcasting,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
           ),

--- a/lib/features/sell/ui/screens/sell_external_wallet_network_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_external_wallet_network_selection_screen.dart
@@ -27,7 +27,7 @@ class SellExternalWalletNetworkSelectionScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isCreatingSellOrder,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             Expanded(

--- a/lib/features/sell/ui/screens/sell_send_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_send_payment_screen.dart
@@ -63,7 +63,7 @@ class SellSendPaymentScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isConfirmingPayment,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             const Gap(24.0),

--- a/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
@@ -38,7 +38,7 @@ class SellWalletSelectionScreen extends StatelessWidget {
             FadingLinearProgress(
               height: 3,
               trigger: isCreatingSellOrder,
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             Expanded(

--- a/lib/features/send/request_identifier/request_identifier_screen.dart
+++ b/lib/features/send/request_identifier/request_identifier_screen.dart
@@ -59,7 +59,7 @@ class RequestIdentifierScreen extends StatelessWidget {
                 child: SingleChildScrollView(
                   child: Container(
                     decoration: BoxDecoration(
-                      color: context.appColors.onPrimary,
+                      color: context.appColors.surface,
                       borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(12),
                         topRight: Radius.circular(12),
@@ -172,7 +172,7 @@ class ContinueButtonWidget extends StatelessWidget {
       onPressed: cubit.validatePaymentRequest,
       disabled: !hasRequest || hasError,
       bgColor: context.appColors.secondary,
-      textColor: context.appColors.onPrimary,
+      textColor: context.appColors.onSecondary,
     );
   }
 }

--- a/lib/features/settings/ui/widgets/failed_wallet_deletion_alert_dialog.dart
+++ b/lib/features/settings/ui/widgets/failed_wallet_deletion_alert_dialog.dart
@@ -14,7 +14,7 @@ class FailedWalletDeletionAlertDialog extends StatelessWidget {
       (WalletBloc bloc) => bloc.state.walletDeletionError,
     );
     return AlertDialog(
-      backgroundColor: context.appColors.onPrimary,
+      backgroundColor: context.appColors.surface,
       title: Text(context.loc.walletDeletionFailedTitle),
       content: Text(
         error is CannotDeleteDefaultWalletError

--- a/lib/features/swap/ui/pages/swap_confirm_page.dart
+++ b/lib/features/swap/ui/pages/swap_confirm_page.dart
@@ -51,7 +51,7 @@ class SwapConfirmPage extends StatelessWidget {
           child: FadingLinearProgress(
             height: 3,
             trigger: isConfirming,
-            backgroundColor: context.appColors.onPrimary,
+            backgroundColor: context.appColors.surface,
             foregroundColor: context.appColors.primary,
           ),
         ),

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -101,7 +101,7 @@ class SwapPageState extends State<SwapPage> {
               builder: (context, isLoading) => FadingLinearProgress(
                 height: 3,
                 trigger: isLoading,
-                backgroundColor: context.appColors.onPrimary,
+                backgroundColor: context.appColors.surface,
                 foregroundColor: context.appColors.primary,
               ),
             ),

--- a/lib/features/transactions/ui/screens/export_transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/export_transactions_screen.dart
@@ -69,7 +69,7 @@ class _ExportTransactionsScreenState extends State<ExportTransactionsScreen> {
                 builder: (context, isLoading) => FadingLinearProgress(
                   height: 3,
                   trigger: isLoading,
-                  backgroundColor: context.appColors.onPrimary,
+                  backgroundColor: context.appColors.surface,
                   foregroundColor: context.appColors.primary,
                 ),
               ),

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -92,7 +92,7 @@ class TransactionDetailsScreen extends StatelessWidget {
           preferredSize: const Size.fromHeight(3.0),
           child: FadingLinearProgress(
             trigger: isBroadcastingPayjoinOriginalTx,
-            backgroundColor: context.appColors.onPrimary,
+            backgroundColor: context.appColors.surface,
             foregroundColor: context.appColors.primary,
           ),
         ),

--- a/lib/features/transactions/ui/screens/transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/transactions_screen.dart
@@ -33,7 +33,7 @@ class TransactionsScreen extends StatelessWidget {
           onAction: () =>
               context.pushNamed(TransactionsRoute.exportTransactions.name),
         ),
-        backgroundColor: context.appColors.onPrimary,
+        backgroundColor: context.appColors.surface,
         elevation: 0,
       ),
       body: const _Screen(),

--- a/lib/features/withdraw/ui/screens/withdraw_confirmation_screen.dart
+++ b/lib/features/withdraw/ui/screens/withdraw_confirmation_screen.dart
@@ -51,7 +51,7 @@ class WithdrawConfirmationScreen extends StatelessWidget {
                     (bloc.state as WithdrawConfirmationState)
                         .isConfirmingWithdrawal,
               ),
-              backgroundColor: context.appColors.onPrimary,
+              backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.primary,
             ),
             Expanded(

--- a/lib/features/withdraw/ui/widgets/account_ownership_widget.dart
+++ b/lib/features/withdraw/ui/widgets/account_ownership_widget.dart
@@ -59,7 +59,7 @@ class AccountOwnershipWidget extends StatelessWidget {
         height: 56,
         child: Material(
           elevation: 4,
-          color: context.appColors.onPrimary,
+          color: context.appColors.surface,
           borderRadius: BorderRadius.circular(4),
           child: Container(
             decoration: BoxDecoration(


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — this PR had **no visual verification** (no widget tests exist for these screens); correctness was argued from token values in both palettes and independently re-verified. Test in dark mode: accelerate tile on buy success/order details, both buttons on the express-withdrawal screen, DCA wallet selection input (light mode too — it was invisible there), SINPE success screen, and loading bars across the app (they flashed white in dark mode).

## Problem
`onPrimary` is white in BOTH themes by design (text on the red primary). Using it as a background produced white surfaces in dark mode; pairing it with the theme-flipping `secondary` fill produced white-on-white buttons — e.g. the invisible "Accelerate Transaction" tile (#2519) and "Confirm express" button (#2520).

## Changes — full audit of all 131 `onPrimary` usages
- 27 background/fill uses → `surface` (pixel-identical in light mode, where both are white; 13 of these were `FadingLinearProgress` tracks)
- 4 foregrounds on `secondary` fills → `onSecondary` (matches the 62 existing correct call sites)
- Accelerate tile keeps an explicit surface fill (themed tileColor would paint a mismatched radius-2 shape) with foregrounds on `onSurface`
- "Wait for free withdrawal" gains an outline so it reads on the light scaffold
- Beyond-brief fix: DCA lightning-address field was invisible in **light** mode (inverse mistake)
- Deliberately deferred: `bb_segmented_button` thumb (white thumb + primary-red label needs a paired design change, not a token swap — follow-up issue candidate)

## Validation
analyze clean; the audit table (file:line → classification → action for all 131) is available on request; reviewer independently re-inspected ~50 sites and ran exhaustive pattern hunts — no missed cases found.

Closes #2519
Closes #2520