### PR TITLE
fix(pay): show amount and recipient, and let payment status actually update

### DIFF
--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -669,3 +669,29 @@ sealed class Order with _$Order {
     }
   }
 }
+
+extension FiatPaymentOrderDisplayX on FiatPaymentOrder {
+  /// The fiat amount the recipient gets, e.g. "125.00 CAD". The currency code
+  /// is used as returned by the server, without going through
+  /// [FiatCurrency.fromCode], which throws on codes the app doesn't know yet.
+  String get payoutAmountToDisplay =>
+      '${payoutAmount.toStringAsFixed(2)} $payoutCurrency';
+
+  /// The recipient as shown to the user. The server populates
+  /// [beneficiaryName] for most payout processors, but not all (SINPE can
+  /// legitimately have no owner name), so fall back to the label the user gave
+  /// the recipient and then to whichever identifier the payout method carries.
+  /// Null when the order carries nothing identifying at all.
+  String? get recipientToDisplay {
+    for (final candidate in [
+      beneficiaryName,
+      beneficiaryLabel,
+      beneficiaryAccountNumber,
+      beneficiaryETransferAddress,
+      lightningAddress,
+    ]) {
+      if (candidate != null && candidate.isNotEmpty) return candidate;
+    }
+    return null;
+  }
+}

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -462,7 +462,9 @@ class PayBloc extends Bloc<PayEvent, PayState> {
       if (state is PayPaymentState) {
         emit((state as PayPaymentState).copyWith(isConfirmingPayment: false));
       }
-      emit(payPaymentState.toSuccessState(payOrder: payPaymentState.payOrder));
+      // The order fetched after the broadcast, not the pre-broadcast one, so
+      // the success screens show the up-to-date payin status.
+      emit(payPaymentState.toSuccessState(payOrder: latestOrder));
     } on PrepareLiquidSendException catch (e) {
       emit(
         payPaymentState.copyWith(
@@ -608,6 +610,12 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         // Convert Order to FiatPaymentOrder if needed
         if (orderSummary is FiatPaymentOrder) {
           emit(currentState.copyWith(payOrder: orderSummary));
+        } else {
+          log.severe(
+            error:
+                'Expected FiatPaymentOrder for order ${event.orderId} but received ${orderSummary.runtimeType}',
+            trace: StackTrace.current,
+          );
         }
       }
     } catch (e) {

--- a/lib/features/pay/ui/screens/pay_in_progress_screen.dart
+++ b/lib/features/pay/ui/screens/pay_in_progress_screen.dart
@@ -64,6 +64,21 @@ class _PayInProgressScreenState extends State<PayInProgressScreen> {
     _pollingTimer = null;
   }
 
+  /// The copy follows the polled order: once the payin is confirmed onchain the
+  /// message says so, instead of asking the user to keep waiting for a
+  /// confirmation that already happened.
+  String _description(BuildContext context, FiatPaymentOrder order) {
+    final amount = order.payoutAmountToDisplay;
+    final recipient = order.recipientToDisplay ?? context.loc.payNotAvailable;
+
+    return order.isPayinCompleted
+        ? context.loc.payPaymentPayinConfirmedDescriptionDetails(
+            amount,
+            recipient,
+          )
+        : context.loc.payPaymentInProgressDescriptionDetails(amount, recipient);
+  }
+
   @override
   Widget build(BuildContext context) {
     final order = context.select(
@@ -134,15 +149,17 @@ class _PayInProgressScreenState extends State<PayInProgressScreen> {
                     context.loc.payPaymentInProgress,
                     style: context.font.titleLarge,
                   ),
-                  const Gap(10),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 32.0),
-                    child: Text(
-                      context.loc.payPaymentInProgressDescription,
-                      style: context.font.bodyMedium,
-                      textAlign: .center,
+                  if (order != null) ...[
+                    const Gap(10),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                      child: Text(
+                        _description(context, order),
+                        style: context.font.bodyMedium,
+                        textAlign: .center,
+                      ),
                     ),
-                  ),
+                  ],
                 ],
               ),
             ),

--- a/lib/features/pay/ui/screens/pay_success_screen.dart
+++ b/lib/features/pay/ui/screens/pay_success_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
@@ -56,15 +57,20 @@ class PaySuccessScreen extends StatelessWidget {
                 ),
                 const Gap(20),
                 Text(context.loc.payCompleted, style: context.font.titleLarge),
-                const Gap(10),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 32.0),
-                  child: Text(
-                    context.loc.payCompletedDescription,
-                    style: context.font.bodyMedium,
-                    textAlign: .center,
+                if (order != null) ...[
+                  const Gap(10),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                    child: Text(
+                      context.loc.payCompletedDescriptionDetails(
+                        order.payoutAmountToDisplay,
+                        order.recipientToDisplay ?? context.loc.payNotAvailable,
+                      ),
+                      style: context.font.bodyMedium,
+                      textAlign: .center,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
@@ -54,6 +54,11 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   _broadcastOriginalTransactionUsecase;
   final ProcessSwapUsecase _processSwapUsecase;
 
+  /// The load that populated this cubit, so [refresh] can re-run it whichever
+  /// init path the screen used. Orders only load once (they have no watcher),
+  /// which is why the screen needs a way to ask for fresh data.
+  Future<void> Function()? _reload;
+
   StreamSubscription? _walletTransactionSubscription;
   StreamSubscription? _swapSubscription;
   StreamSubscription? _payjoinSubscription;
@@ -72,7 +77,29 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
     return super.close();
   }
 
+  /// Re-runs the load that populated the details, for pull-to-refresh and for
+  /// retrying after a failed load.
+  Future<void> refresh() async {
+    final reload = _reload;
+    if (reload == null) return;
+
+    if (state.err != null || state.notFoundError != null) {
+      emit(state.copyWith(err: null, notFoundError: null));
+    }
+    await reload();
+  }
+
   Future<void> initByWalletTxId(String txId, {required String walletId}) async {
+    // Keep the reload of whichever init the screen started with: an order that
+    // resolves to a wallet tx delegates here, and reloading the wallet tx also
+    // refetches the order.
+    _reload ??= () => _loadDetailsByWalletTxId(txId, walletId: walletId);
+
+    // An order-id entry whose order only later gains a transactionId re-enters
+    // here on every refresh, so drop the previous watcher instead of leaking a
+    // live one that keeps fetching per wallet-tx event.
+    await _walletTransactionSubscription?.cancel();
+
     // Start monitoring the wallet transaction for updates.
     _walletTransactionSubscription = _watchWalletTransactionByTxIdUsecase
         .execute(txId: txId, walletId: walletId)
@@ -191,6 +218,10 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
 
     // Load the initial details of the swap.
     await _loadDetailsBySwapId(swapId, walletId: walletId);
+
+    // Only when the swap didn't resolve to a wallet tx, which sets its own
+    // reload without re-subscribing the watchers.
+    _reload ??= () => _loadDetailsBySwapId(swapId, walletId: walletId);
   }
 
   Future<void> _loadDetailsBySwapId(
@@ -254,6 +285,8 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
 
     // Load the initial details of the payjoin.
     await _loadDetailsByPayjoinId(payjoinId);
+
+    _reload ??= () => _loadDetailsByPayjoinId(payjoinId);
   }
 
   Future<void> _loadDetailsByPayjoinId(String payjoinId) async {
@@ -301,6 +334,10 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
 
   Future<void> initByOrderId(String orderId) async {
     await _loadDetailsByOrderId(orderId);
+
+    // Only when the order didn't resolve to a wallet tx, which sets its own
+    // reload without re-subscribing the watchers.
+    _reload ??= () => _loadDetailsByOrderId(orderId);
   }
 
   Future<void> _loadDetailsByOrderId(String orderId) async {

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_state.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_state.dart
@@ -18,7 +18,12 @@ sealed class TransactionDetailsState with _$TransactionDetailsState {
   }) = _TransactionDetailsState;
   const TransactionDetailsState._();
 
-  bool get isLoading => transaction == null;
+  /// The load failed and there is nothing to show. Without this, a failed load
+  /// left the screen on loading skeletons forever.
+  bool get hasLoadError =>
+      transaction == null && (err != null || notFoundError != null);
+
+  bool get isLoading => transaction == null && !hasLoadError;
 
   WalletTransaction? get walletTransaction => transaction?.walletTransaction;
   Swap? get swap => transaction?.swap;

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/logger.dart' show log;
 import 'package:bb_mobile/core/widgets/badges/transaction_direction_badge.dart';
+import 'package:bb_mobile/core/widgets/bb_refresh_indicator.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_box_content.dart';
@@ -41,6 +42,9 @@ class TransactionDetailsScreen extends StatelessWidget {
         'true';
     final isLoading = context.select(
       (TransactionDetailsCubit cubit) => cubit.state.isLoading,
+    );
+    final hasLoadError = context.select(
+      (TransactionDetailsCubit cubit) => cubit.state.hasLoadError,
     );
     final tx = context.select(
       (TransactionDetailsCubit bloc) => bloc.state.transaction,
@@ -98,142 +102,193 @@ class TransactionDetailsScreen extends StatelessWidget {
         ),
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Center(
-            child: Column(
-              children: [
-                if (isLoading)
-                  const LoadingBoxContent(height: 72, width: 72)
-                else
-                  TransactionDirectionBadge(
-                    isIncoming: isIncoming ?? false,
-                    isSwap: isChainSwap,
+        child: BBRefreshIndicator(
+          onRefresh: () => context.read<TransactionDetailsCubit>().refresh(),
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              if (hasLoadError)
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: _LoadErrorContent(),
+                )
+              else
+                SliverPadding(
+                  padding: const EdgeInsets.all(16),
+                  sliver: SliverToBoxAdapter(
+                    child: Center(
+                      child: Column(
+                        children: [
+                          if (isLoading)
+                            const LoadingBoxContent(height: 72, width: 72)
+                          else
+                            TransactionDirectionBadge(
+                              isIncoming: isIncoming ?? false,
+                              isSwap: isChainSwap,
+                            ),
+                          const Gap(24),
+                          if (isLoading)
+                            const LoadingLineContent(width: 150)
+                          else
+                            const TransactionDetailsStatusLabel(),
+                          if (isOngoingSwap == true && swap != null) ...[
+                            const Gap(8),
+                            SwapProgressIndicator(swap: swap),
+                          ],
+                          if (isLoading)
+                            const LoadingLineContent(
+                              height: 24,
+                              width: 200,
+                              padding: EdgeInsets.zero,
+                            )
+                          else
+                            const TransactionDetailsAmount(),
+                          const Gap(16),
+                          if (isOngoingSwap == true && swap != null) ...[
+                            SwapStatusDescription(swap: swap),
+                            const Gap(16),
+                          ],
+                          if (isOrderType &&
+                              tx?.isBuyOrder == true &&
+                              tx?.order != null &&
+                              (tx!.order! as BuyOrder).bitcoinAddress != null &&
+                              tx.order!.sentAt == null) ...[
+                            AccelerateTransactionListTile(
+                              orderId: tx.order!.orderId,
+                              onTap: () {
+                                context.pushNamed(
+                                  BuyRoute.buyAccelerate.name,
+                                  pathParameters: {
+                                    'orderId': tx.order!.orderId,
+                                  },
+                                );
+                              },
+                            ),
+                            const Gap(16),
+                          ],
+                          if (isLoading)
+                            const LoadingBoxContent(height: 400)
+                          else
+                            const TransactionDetailsTable(),
+                          if (tx?.order is FiatPaymentOrder &&
+                              (tx!.order! as FiatPaymentOrder).payoutMethod ==
+                                  OrderPaymentMethod.sinpe &&
+                              (tx.order! as FiatPaymentOrder).payoutCurrency ==
+                                  'CRC') ...[
+                            const Gap(16),
+                            BBButton.big(
+                              label: context.loc.payViewReceipt,
+                              onPressed: () {
+                                showSinpeReceiptBottomSheet(
+                                  context,
+                                  tx.order! as FiatPaymentOrder,
+                                );
+                              },
+                              bgColor: context.appColors.secondary,
+                              textColor: context.appColors.onSecondary,
+                            ),
+                          ],
+                          const Gap(16),
+                          if (tx?.isOngoingPayjoinSender == true &&
+                              !isPayjoinCompleted) ...[
+                            const SenderBroadcastPayjoinOriginalTxButton(),
+                            const Gap(24),
+                          ],
+                          if (isLoading)
+                            const LoadingLineContent(height: 40)
+                          else
+                            BBButton.big(
+                              label: context.loc.transactionDetailAddNote,
+                              disabled:
+                                  !(walletTransaction != null &&
+                                      walletTransaction.labels.length < 10),
+                              onPressed: () async {
+                                if (walletTransaction == null ||
+                                    walletTransaction.labels.length >= 10) {
+                                  log.warning(
+                                    'A transaction can have up to 10 labels, current length: ${walletTransaction?.labels.length}',
+                                  );
+                                  return;
+                                }
+                                final cubit = context
+                                    .read<TransactionDetailsCubit>();
+                                final saved = await LabelEntryBottomSheet.label(
+                                  context,
+                                  title: context.loc.transactionNoteAddTitle,
+                                  suggestionsFuture: cubit
+                                      .fetchDistinctLabels(),
+                                  hint: context.loc.transactionNoteHint,
+                                );
+                                if (saved == null || !context.mounted) return;
+                                cubit.saveTransactionLabel(
+                                  NewLabel.tx(
+                                    transactionId: walletTransaction.txId,
+                                    label: saved,
+                                  ),
+                                );
+                              },
+                              bgColor: context.appColors.transparent,
+                              textColor: context.appColors.onSurface,
+                              outlined: true,
+                              borderColor: context.appColors.onSurface,
+                            ),
+                          const Gap(16),
+                          if (isOutgoing == true &&
+                              walletTransaction?.isConfirmed == false &&
+                              walletTransaction?.isRbf == true &&
+                              walletTransaction?.isBitcoin == true &&
+                              wallet?.signsLocally == true &&
+                              tx?.txId != null &&
+                              swap == null)
+                            BBButton.big(
+                              label: context.loc.transactionDetailAccelerate,
+                              onPressed: () {
+                                context.pushNamed(
+                                  ReplaceByFeeRoute.replaceByFeeFlow.name,
+                                  extra: walletTransaction,
+                                );
+                              },
+                              bgColor: context.appColors.onSurface,
+                              textColor: context.appColors.surface,
+                            ),
+                        ],
+                      ),
+                    ),
                   ),
-                const Gap(24),
-                if (isLoading)
-                  const LoadingLineContent(width: 150)
-                else
-                  const TransactionDetailsStatusLabel(),
-                if (isOngoingSwap == true && swap != null) ...[
-                  const Gap(8),
-                  SwapProgressIndicator(swap: swap),
-                ],
-                if (isLoading)
-                  const LoadingLineContent(
-                    height: 24,
-                    width: 200,
-                    padding: EdgeInsets.zero,
-                  )
-                else
-                  const TransactionDetailsAmount(),
-                const Gap(16),
-                if (isOngoingSwap == true && swap != null) ...[
-                  SwapStatusDescription(swap: swap),
-                  const Gap(16),
-                ],
-                if (isOrderType &&
-                    tx?.isBuyOrder == true &&
-                    tx?.order != null &&
-                    (tx!.order! as BuyOrder).bitcoinAddress != null &&
-                    tx.order!.sentAt == null) ...[
-                  AccelerateTransactionListTile(
-                    orderId: tx.order!.orderId,
-                    onTap: () {
-                      context.pushNamed(
-                        BuyRoute.buyAccelerate.name,
-                        pathParameters: {'orderId': tx.order!.orderId},
-                      );
-                    },
-                  ),
-                  const Gap(16),
-                ],
-                if (isLoading)
-                  const LoadingBoxContent(height: 400)
-                else
-                  const TransactionDetailsTable(),
-                if (tx?.order is FiatPaymentOrder &&
-                    (tx!.order! as FiatPaymentOrder).payoutMethod ==
-                        OrderPaymentMethod.sinpe &&
-                    (tx.order! as FiatPaymentOrder).payoutCurrency ==
-                        'CRC') ...[
-                  const Gap(16),
-                  BBButton.big(
-                    label: context.loc.payViewReceipt,
-                    onPressed: () {
-                      showSinpeReceiptBottomSheet(
-                        context,
-                        tx.order! as FiatPaymentOrder,
-                      );
-                    },
-                    bgColor: context.appColors.secondary,
-                    textColor: context.appColors.onSecondary,
-                  ),
-                ],
-                const Gap(16),
-                if (tx?.isOngoingPayjoinSender == true &&
-                    !isPayjoinCompleted) ...[
-                  const SenderBroadcastPayjoinOriginalTxButton(),
-                  const Gap(24),
-                ],
-                if (isLoading)
-                  const LoadingLineContent(height: 40)
-                else
-                  BBButton.big(
-                    label: context.loc.transactionDetailAddNote,
-                    disabled:
-                        !(walletTransaction != null &&
-                            walletTransaction.labels.length < 10),
-                    onPressed: () async {
-                      if (walletTransaction == null ||
-                          walletTransaction.labels.length >= 10) {
-                        log.warning(
-                          'A transaction can have up to 10 labels, current length: ${walletTransaction?.labels.length}',
-                        );
-                        return;
-                      }
-                      final cubit = context.read<TransactionDetailsCubit>();
-                      final saved = await LabelEntryBottomSheet.label(
-                        context,
-                        title: context.loc.transactionNoteAddTitle,
-                        suggestionsFuture: cubit.fetchDistinctLabels(),
-                        hint: context.loc.transactionNoteHint,
-                      );
-                      if (saved == null || !context.mounted) return;
-                      cubit.saveTransactionLabel(
-                        NewLabel.tx(
-                          transactionId: walletTransaction.txId,
-                          label: saved,
-                        ),
-                      );
-                    },
-                    bgColor: context.appColors.transparent,
-                    textColor: context.appColors.onSurface,
-                    outlined: true,
-                    borderColor: context.appColors.onSurface,
-                  ),
-                const Gap(16),
-                if (isOutgoing == true &&
-                    walletTransaction?.isConfirmed == false &&
-                    walletTransaction?.isRbf == true &&
-                    walletTransaction?.isBitcoin == true &&
-                    wallet?.signsLocally == true &&
-                    tx?.txId != null &&
-                    swap == null)
-                  BBButton.big(
-                    label: context.loc.transactionDetailAccelerate,
-                    onPressed: () {
-                      context.pushNamed(
-                        ReplaceByFeeRoute.replaceByFeeFlow.name,
-                        extra: walletTransaction,
-                      );
-                    },
-                    bgColor: context.appColors.onSurface,
-                    textColor: context.appColors.surface,
-                  ),
-              ],
-            ),
+                ),
+            ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadErrorContent extends StatelessWidget {
+  const _LoadErrorContent();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              context.loc.transactionDetailLoadError,
+              textAlign: TextAlign.center,
+              style: context.font.bodyMedium,
+            ),
+            const Gap(16),
+            BBButton.small(
+              label: context.loc.retry,
+              onPressed: () =>
+                  context.read<TransactionDetailsCubit>().refresh(),
+              bgColor: context.appColors.secondary,
+              textColor: context.appColors.onSecondary,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -359,9 +359,14 @@ class TransactionDetailsTable extends StatelessWidget {
                     label: context.loc.transactionDetailLabelPaymentDescription,
                     displayValue: order.paymentDescription,
                   ),
+                if (order.recipientToDisplay != null)
+                  DetailsTableItem(
+                    label: context.loc.transactionDetailLabelRecipient,
+                    displayValue: order.recipientToDisplay,
+                  ),
                 DetailsTableItem(
                   label: context.loc.transactionDetailLabelPayoutAmount,
-                  displayValue: '${order.payoutAmount} ${order.payoutCurrency}',
+                  displayValue: order.payoutAmountToDisplay,
                 ),
                 if (order.exchangeRateAmount != null &&
                     order.exchangeRateCurrency != null)

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -2542,14 +2542,6 @@
   "@payInvalidState": {
     "description": "Error message for invalid state"
   },
-  "payInProgress": "Payment In Progress!",
-  "@payInProgress": {
-    "description": "Title for payment in progress screen"
-  },
-  "payInProgressDescription": "Your payment has been initiated and the recipient will receive the funds after your transaction receives 1 confirmation onchain.",
-  "@payInProgressDescription": {
-    "description": "Description for payment in progress"
-  },
   "payViewDetails": "View details",
   "@payViewDetails": {
     "description": "Button to view order details"
@@ -2566,9 +2558,17 @@
   "@payCompleted": {
     "description": "Title for payment completed screen"
   },
-  "payCompletedDescription": "Your payment has been completed and the recipient has received the funds.",
-  "@payCompletedDescription": {
-    "description": "Description for payment completed"
+  "payCompletedDescriptionDetails": "The payment of {fiatAmount} to {recipient} has been completed.",
+  "@payCompletedDescriptionDetails": {
+    "description": "Description for payment completed, with the fiat amount and the recipient",
+    "placeholders": {
+      "fiatAmount": {
+        "type": "String"
+      },
+      "recipient": {
+        "type": "String"
+      }
+    }
   },
   "paySinpeEnviado": "SINPE ENVIADO!",
   "@paySinpeEnviado": {
@@ -2630,9 +2630,29 @@
   "@payPaymentInProgress": {
     "description": "Title for payment in progress screen"
   },
-  "payPaymentInProgressDescription": "Your payment has been initiated and the recipient will receive the funds after your transaction receives 1 confirmation onchain.",
-  "@payPaymentInProgressDescription": {
-    "description": "Description for payment in progress"
+  "payPaymentInProgressDescriptionDetails": "The payment of {fiatAmount} to {recipient} will be sent after your transaction receives 1 confirmation onchain.",
+  "@payPaymentInProgressDescriptionDetails": {
+    "description": "Description for payment in progress, before the payin transaction is confirmed onchain",
+    "placeholders": {
+      "fiatAmount": {
+        "type": "String"
+      },
+      "recipient": {
+        "type": "String"
+      }
+    }
+  },
+  "payPaymentPayinConfirmedDescriptionDetails": "Your transaction is confirmed. The payment of {fiatAmount} to {recipient} is being processed.",
+  "@payPaymentPayinConfirmedDescriptionDetails": {
+    "description": "Description for payment in progress, once the payin transaction is confirmed onchain",
+    "placeholders": {
+      "fiatAmount": {
+        "type": "String"
+      },
+      "recipient": {
+        "type": "String"
+      }
+    }
   },
   "payPriceRefreshIn": "Price will refresh in ",
   "@payPriceRefreshIn": {
@@ -3280,6 +3300,14 @@
   "transactionDetailAccelerate": "Accelerate",
   "@transactionDetailAccelerate": {
     "description": "Button label for accelerating (RBF) an unconfirmed transaction"
+  },
+  "transactionDetailLoadError": "Could not load the transaction details.",
+  "@transactionDetailLoadError": {
+    "description": "Error message shown when the transaction details could not be loaded"
+  },
+  "transactionDetailLabelRecipient": "Recipient",
+  "@transactionDetailLabelRecipient": {
+    "description": "Label for the recipient of a fiat payment order"
   },
   "transactionDetailLabelTransactionId": "Transaction ID",
   "@transactionDetailLabelTransactionId": {

--- a/test/features/pay/pay_bloc_test.dart
+++ b/test/features/pay/pay_bloc_test.dart
@@ -1,0 +1,236 @@
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/features/pay/domain/create_pay_order_usecase.dart';
+import 'package:bb_mobile/features/pay/domain/refresh_pay_order_usecase.dart';
+import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
+import 'package:bb_mobile/features/recipients/domain/value_objects/recipient_type.dart';
+import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart';
+import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetExchangeUserSummaryUsecase extends Mock
+    implements GetExchangeUserSummaryUsecase {}
+
+class _MockPlacePayOrderUsecase extends Mock implements PlacePayOrderUsecase {}
+
+class _MockRefreshPayOrderUsecase extends Mock
+    implements RefreshPayOrderUsecase {}
+
+class _MockPrepareBitcoinSendUsecase extends Mock
+    implements PrepareBitcoinSendUsecase {}
+
+class _MockPrepareLiquidSendUsecase extends Mock
+    implements PrepareLiquidSendUsecase {}
+
+class _MockSignBitcoinTxUsecase extends Mock implements SignBitcoinTxUsecase {}
+
+class _MockSignLiquidTxUsecase extends Mock implements SignLiquidTxUsecase {}
+
+class _MockBroadcastBitcoinTransactionUsecase extends Mock
+    implements BroadcastBitcoinTransactionUsecase {}
+
+class _MockBroadcastLiquidTransactionUsecase extends Mock
+    implements BroadcastLiquidTransactionUsecase {}
+
+class _MockGetNetworkFeesUsecase extends Mock
+    implements GetNetworkFeesUsecase {}
+
+class _MockCalculateLiquidAbsoluteFeesUsecase extends Mock
+    implements CalculateLiquidAbsoluteFeesUsecase {}
+
+class _MockCalculateBitcoinAbsoluteFeesUsecase extends Mock
+    implements CalculateBitcoinAbsoluteFeesUsecase {}
+
+class _MockConvertSatsToCurrencyAmountUsecase extends Mock
+    implements ConvertSatsToCurrencyAmountUsecase {}
+
+class _MockGetAddressAtIndexUsecase extends Mock
+    implements GetAddressAtIndexUsecase {}
+
+class _MockGetWalletUtxosUsecase extends Mock
+    implements GetWalletUtxosUsecase {}
+
+class _MockGetOrderUsecase extends Mock implements GetOrderUsecase {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+/// Exposes [emit] so a test can put the bloc on the state under test instead of
+/// driving the whole pay flow to get there.
+class _SeedablePayBloc extends PayBloc {
+  _SeedablePayBloc({
+    required super.getExchangeUserSummaryUsecase,
+    required super.placePayOrderUsecase,
+    required super.refreshPayOrderUsecase,
+    required super.prepareBitcoinSendUsecase,
+    required super.prepareLiquidSendUsecase,
+    required super.signBitcoinTxUsecase,
+    required super.signLiquidTxUsecase,
+    required super.broadcastBitcoinTransactionUsecase,
+    required super.broadcastLiquidTransactionUsecase,
+    required super.getNetworkFeesUsecase,
+    required super.calculateLiquidAbsoluteFeesUsecase,
+    required super.calculateBitcoinAbsoluteFeesUsecase,
+    required super.convertSatsToCurrencyAmountUsecase,
+    required super.getAddressAtIndexUsecase,
+    required super.getWalletUtxosUsecase,
+    required super.getOrderUsecase,
+  });
+
+  void seed(PayState state) => emit(state);
+}
+
+FiatPaymentOrder _order({
+  required OrderPayinStatus payinStatus,
+  String beneficiaryName = 'Alice',
+}) {
+  return Order.fiatPayment(
+        orderId: 'order-1',
+        orderType: OrderType.fiatPayment,
+        message: OrderMessage(code: '', message: ''),
+        orderNumber: 1,
+        payinAmount: 0.001,
+        payinCurrency: 'LBTC',
+        payoutAmount: 125.0,
+        payoutCurrency: 'CAD',
+        payinMethod: OrderPaymentMethod.liquid,
+        payoutMethod: OrderPaymentMethod.bankTransfer,
+        orderStatus: OrderStatus.inProgress,
+        payinStatus: payinStatus,
+        payoutStatus: OrderPayoutStatus.notStarted,
+        confirmationDeadline: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        liquidAddress: 'lq1address',
+        beneficiaryName: beneficiaryName,
+        isTestnet: false,
+      )
+      as FiatPaymentOrder;
+}
+
+const _userSummary = UserSummary(
+  userNumber: 1,
+  groups: ['KYC_IDENTITY_VERIFIED'],
+  profile: UserProfile(firstName: 'Bob', lastName: 'Builder'),
+  email: 'bob@example.com',
+  balances: [],
+  dca: UserDca(isActive: false),
+  autoBuy: UserAutoBuy(isActive: false, addresses: UserAutoBuyAddresses()),
+);
+
+const _recipient = RecipientViewModel(
+  id: 'recipient-1',
+  type: RecipientType.bankTransferCad,
+);
+
+void main() {
+  late _MockPrepareLiquidSendUsecase prepareLiquidSend;
+  late _MockSignLiquidTxUsecase signLiquidTx;
+  late _MockBroadcastLiquidTransactionUsecase broadcastLiquid;
+  late _MockGetOrderUsecase getOrder;
+  late _MockWallet wallet;
+
+  _SeedablePayBloc buildBloc() => _SeedablePayBloc(
+    getExchangeUserSummaryUsecase: _MockGetExchangeUserSummaryUsecase(),
+    placePayOrderUsecase: _MockPlacePayOrderUsecase(),
+    refreshPayOrderUsecase: _MockRefreshPayOrderUsecase(),
+    prepareBitcoinSendUsecase: _MockPrepareBitcoinSendUsecase(),
+    prepareLiquidSendUsecase: prepareLiquidSend,
+    signBitcoinTxUsecase: _MockSignBitcoinTxUsecase(),
+    signLiquidTxUsecase: signLiquidTx,
+    broadcastBitcoinTransactionUsecase:
+        _MockBroadcastBitcoinTransactionUsecase(),
+    broadcastLiquidTransactionUsecase: broadcastLiquid,
+    getNetworkFeesUsecase: _MockGetNetworkFeesUsecase(),
+    calculateLiquidAbsoluteFeesUsecase:
+        _MockCalculateLiquidAbsoluteFeesUsecase(),
+    calculateBitcoinAbsoluteFeesUsecase:
+        _MockCalculateBitcoinAbsoluteFeesUsecase(),
+    convertSatsToCurrencyAmountUsecase:
+        _MockConvertSatsToCurrencyAmountUsecase(),
+    getAddressAtIndexUsecase: _MockGetAddressAtIndexUsecase(),
+    getWalletUtxosUsecase: _MockGetWalletUtxosUsecase(),
+    getOrderUsecase: getOrder,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(const RelativeFee(25));
+  });
+
+  setUp(() {
+    prepareLiquidSend = _MockPrepareLiquidSendUsecase();
+    signLiquidTx = _MockSignLiquidTxUsecase();
+    broadcastLiquid = _MockBroadcastLiquidTransactionUsecase();
+    getOrder = _MockGetOrderUsecase();
+    wallet = _MockWallet();
+
+    when(() => wallet.id).thenReturn('wallet-1');
+    when(() => wallet.isLiquid).thenReturn(true);
+    when(
+      () => prepareLiquidSend.execute(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        feeRate: any(named: 'feeRate'),
+      ),
+    ).thenAnswer((_) async => 'pset');
+    when(
+      () => signLiquidTx.execute(
+        pset: any(named: 'pset'),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => 'signed-pset');
+    when(() => broadcastLiquid.execute(any())).thenAnswer((_) async => 'txid');
+  });
+
+  // The handler waits 5s after broadcasting to let the backend register the
+  // 0-conf payin before fetching the order, so this test takes that long.
+  test('success state carries the order fetched after the broadcast', () async {
+    final preBroadcastOrder = _order(
+      payinStatus: OrderPayinStatus.awaitingPayment,
+    );
+    final postBroadcastOrder = _order(
+      payinStatus: OrderPayinStatus.awaitingConfirmation,
+    );
+    when(
+      () => getOrder.execute(orderId: any(named: 'orderId')),
+    ).thenAnswer((_) async => postBroadcastOrder);
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+    bloc.seed(
+      PayPaymentState(
+        selectedRecipient: _recipient,
+        userSummary: _userSummary,
+        amount: const FiatAmount(125.0),
+        selectedWallet: wallet,
+        payOrder: preBroadcastOrder,
+      ),
+    );
+
+    final successState = bloc.stream.firstWhere(
+      (state) => state is PaySuccessState,
+    );
+    bloc.add(
+      const PayEvent.sendPaymentConfirmed(feeSelection: FeeSelection.economic),
+    );
+
+    final state = await successState as PaySuccessState;
+    expect(state.payOrder.payinStatus, OrderPayinStatus.awaitingConfirmation);
+    expect(state.payOrder, same(postBroadcastOrder));
+  });
+}


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — draft until verified. Test: complete a pay (sell-to-recipient); the in-progress screen should show "The payment of X [fiat] to [recipient] will be sent after your transaction receives 1 confirmation onchain", flip to "Your transaction is confirmed…" after 1 conf, and the transaction details page should support pull-to-refresh and show an error + Retry instead of eternal skeletons on load failure.

## Problems
1. The "Payment in Progress" screen rendered static copy with no amount or recipient, even though the order in scope carries both — and the bloc emitted the stale pre-broadcast order into the success state despite having just fetched the fresh one.
2. Nothing visible was bound to the 5s poll: the bitcoin transaction confirming changed nothing on screen (only fiat payout completion navigated away — hours later for scheduled bank payouts). The details page was a one-shot fetch with no refresh and no error state.

## Changes
- In-progress and completed screens show fiat amount + recipient (fallback chain: beneficiary name → label → account identifier); details table gains a Recipient row
- Copy switches on payin confirmation, driven by the existing poll
- Success state carries the post-broadcast order
- Details page: pull-to-refresh + error state with Retry
- New localization keys instead of editing old ones, so stale translations fall back to English rather than silently dropping the amount/recipient

Deliberately minimal per issue discussion: no status-code state machine, no staleness indicators, no refresh-on-focus.

## Validation
New bloc test pins the fresh-order emit (fails on old code); analyze clean; pay + transactions suites green; reviewed with a verification pass (watcher-leak fix applied). **Merge note: this PR must merge BEFORE the fee-selection PR**, which removes event params this branch's screen/test still construct — the fee-selection PR reconciles on rebase.

Closes #2524
Closes #2525