### PR TITLE
fix(sell): close the post-broadcast double-payment window

### DIFF
--- a/lib/core/exchange/domain/entity/order.dart
+++ b/lib/core/exchange/domain/entity/order.dart
@@ -231,6 +231,21 @@ enum OrderPaymentMethod {
   final String value;
   const OrderPaymentMethod(this.value);
 
+  /// The payin/payout methods that debit or credit one of the user's in-app
+  /// fiat balances instead of an external account. Refund-to-balance methods
+  /// are deliberately excluded: they are not selectable as a payout.
+  static const balanceMethods = <OrderPaymentMethod>{
+    cadBalance,
+    eurBalance,
+    mxnBalance,
+    arsBalance,
+    copBalance,
+    crcBalance,
+    usdBalance,
+  };
+
+  bool get isBalance => balanceMethods.contains(this);
+
   static OrderPaymentMethod fromValue(String value) {
     return OrderPaymentMethod.values.firstWhere(
       (e) => e.value == value,
@@ -561,6 +576,10 @@ sealed class Order with _$Order {
 
   bool get isPayinCompleted => payinStatus == OrderPayinStatus.completed;
   bool get isPayoutCompleted => payoutStatus == OrderPayoutStatus.completed;
+
+  /// Whether the payout credits one of the user's in-app fiat balances rather
+  /// than an external recipient.
+  bool get isBalancePayout => payoutMethod.isBalance;
 
   bool isCompleted() => orderStatus == OrderStatus.completed;
   bool isProcessing() => orderStatus == OrderStatus.inProgress;

--- a/lib/core/widgets/success_screen_scaffold.dart
+++ b/lib/core/widgets/success_screen_scaffold.dart
@@ -1,0 +1,112 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+/// Shared layout for the exchange flows' success screens (buy, sell, pay) so
+/// they stay structurally aligned: a success icon, a headline, an optional
+/// amount line and message, and a bottom action area.
+///
+/// Back navigation is intercepted; the flow can only be left through [onClose],
+/// which is called both by the close button and by a back gesture.
+class SuccessScreenScaffold extends StatelessWidget {
+  const SuccessScreenScaffold({
+    super.key,
+    required this.title,
+    required this.headline,
+    required this.onClose,
+    this.icon,
+    this.amountLine,
+    this.message,
+    this.actions = const <Widget>[],
+  });
+
+  /// App bar title, usually the name of the flow.
+  final String title;
+
+  /// Headline under the icon, e.g. "Order completed!".
+  final String headline;
+
+  /// Leaves the flow. Called by the close button and by a back gesture.
+  final VoidCallback onClose;
+
+  /// Defaults to a large success check mark.
+  final Widget? icon;
+
+  /// Line under the headline, e.g. "You sold 100 000 sats for $50.00".
+  final String? amountLine;
+
+  /// Explanatory content under the amount line. Styled as centered body text
+  /// unless the widget overrides it, so a plain [Text] is enough.
+  final Widget? message;
+
+  /// Pinned to the bottom of the screen, typically buttons.
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        onClose();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(title),
+          automaticallyImplyLeading: false,
+          actions: [
+            IconButton(icon: const Icon(Icons.close), onPressed: onClose),
+          ],
+        ),
+        body: SafeArea(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: Column(
+                mainAxisAlignment: .center,
+                children: [
+                  icon ??
+                      Icon(
+                        Icons.check_circle,
+                        size: 100,
+                        color: context.appColors.success,
+                      ),
+                  const Gap(20),
+                  Text(
+                    headline,
+                    style: context.font.titleLarge,
+                    textAlign: .center,
+                  ),
+                  if (amountLine != null) ...[
+                    const Gap(8),
+                    Text(
+                      amountLine!,
+                      style: context.font.bodyLarge,
+                      textAlign: .center,
+                    ),
+                  ],
+                  if (message != null) ...[
+                    const Gap(10),
+                    DefaultTextStyle.merge(
+                      style: context.font.bodyMedium,
+                      textAlign: .center,
+                      child: message!,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+        bottomNavigationBar: actions.isEmpty
+            ? null
+            : SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(mainAxisSize: .min, children: actions),
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/recipients/application/dtos/recipient_details_dto.dart
+++ b/lib/features/recipients/application/dtos/recipient_details_dto.dart
@@ -397,49 +397,43 @@ class RecipientDetailsDto {
         );
 
       // COSTA RICA
+      // ownerName is nullable by design for the SINPE types: the server fills it
+      // from a Ridivi lookup that can fail or be empty on older records.
+      // Requiring it here silently dropped those recipients (#2529).
       case RecipientType.sinpeIbanUsd:
         if (iban == null) {
           throw StateError('iban is required for SINPE_IBAN_USD.');
-        }
-        if (ownerName == null) {
-          throw StateError('ownerName is required for SINPE_IBAN_USD.');
         }
         return SinpeIbanUsdDetails.create(
           label: label,
           isDefault: def,
           isOwner: isOwner,
           iban: iban!,
-          ownerName: ownerName!,
+          ownerName: ownerName,
         );
 
       case RecipientType.sinpeIbanCrc:
         if (iban == null) {
           throw StateError('iban is required for SINPE_IBAN_CRC.');
         }
-        if (ownerName == null) {
-          throw StateError('ownerName is required for SINPE_IBAN_CRC.');
-        }
         return SinpeIbanCrcDetails.create(
           label: label,
           isDefault: def,
           isOwner: isOwner,
           iban: iban!,
-          ownerName: ownerName!,
+          ownerName: ownerName,
         );
 
       case RecipientType.sinpeMovilCrc:
         if (phoneNumber == null) {
           throw StateError('phoneNumber is required for SINPE_MOVIL_CRC.');
         }
-        if (ownerName == null) {
-          throw StateError('ownerName is required for SINPE_MOVIL_CRC.');
-        }
         return SinpeMovilCrcDetails.create(
           label: label,
           isDefault: def,
           isOwner: isOwner,
           phoneNumber: phoneNumber!,
-          ownerName: ownerName!,
+          ownerName: ownerName,
         );
 
       // ARGENTINA

--- a/lib/features/recipients/domain/value_objects/recipient_details.dart
+++ b/lib/features/recipients/domain/value_objects/recipient_details.dart
@@ -378,17 +378,26 @@ class SpeiCardMxnDetails extends RecipientDetails {
 }
 
 // ── SINPE (CRC/USD)
+//
+// The owner name comes from a Ridivi lookup on the server, which can fail or be
+// empty on older records, so it is nullable by design (#2529). Display sites
+// fall back to the label and then to the account identifier.
+String? _nullIfBlank(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
 @immutable
 class SinpeIbanUsdDetails extends RecipientDetails {
   final String iban;
-  final String ownerName;
+  final String? ownerName;
 
   const SinpeIbanUsdDetails._({
     super.label,
     super.isDefault = false,
     super.isOwner,
     required this.iban,
-    required this.ownerName,
+    this.ownerName,
   });
 
   factory SinpeIbanUsdDetails.create({
@@ -396,13 +405,10 @@ class SinpeIbanUsdDetails extends RecipientDetails {
     bool isDefault = false,
     bool? isOwner,
     required String iban,
-    required String ownerName,
+    String? ownerName,
   }) {
     if (iban.trim().isEmpty) {
       throw ArgumentError('IBAN cannot be empty');
-    }
-    if (ownerName.trim().isEmpty) {
-      throw ArgumentError('Owner name cannot be empty');
     }
 
     return SinpeIbanUsdDetails._(
@@ -410,7 +416,7 @@ class SinpeIbanUsdDetails extends RecipientDetails {
       isDefault: isDefault,
       isOwner: isOwner,
       iban: iban.trim(),
-      ownerName: ownerName.trim(),
+      ownerName: _nullIfBlank(ownerName),
     );
   }
 
@@ -421,14 +427,14 @@ class SinpeIbanUsdDetails extends RecipientDetails {
 @immutable
 class SinpeIbanCrcDetails extends RecipientDetails {
   final String iban;
-  final String ownerName;
+  final String? ownerName;
 
   const SinpeIbanCrcDetails._({
     super.label,
     super.isDefault = false,
     super.isOwner,
     required this.iban,
-    required this.ownerName,
+    this.ownerName,
   });
 
   factory SinpeIbanCrcDetails.create({
@@ -436,13 +442,10 @@ class SinpeIbanCrcDetails extends RecipientDetails {
     bool isDefault = false,
     bool? isOwner,
     required String iban,
-    required String ownerName,
+    String? ownerName,
   }) {
     if (iban.trim().isEmpty) {
       throw ArgumentError('IBAN cannot be empty');
-    }
-    if (ownerName.trim().isEmpty) {
-      throw ArgumentError('Owner name cannot be empty');
     }
 
     return SinpeIbanCrcDetails._(
@@ -450,7 +453,7 @@ class SinpeIbanCrcDetails extends RecipientDetails {
       isDefault: isDefault,
       isOwner: isOwner,
       iban: iban.trim(),
-      ownerName: ownerName.trim(),
+      ownerName: _nullIfBlank(ownerName),
     );
   }
 
@@ -461,14 +464,14 @@ class SinpeIbanCrcDetails extends RecipientDetails {
 @immutable
 class SinpeMovilCrcDetails extends RecipientDetails {
   final String phoneNumber;
-  final String ownerName;
+  final String? ownerName;
 
   const SinpeMovilCrcDetails._({
     super.label,
     super.isDefault = false,
     super.isOwner,
     required this.phoneNumber,
-    required this.ownerName,
+    this.ownerName,
   });
 
   factory SinpeMovilCrcDetails.create({
@@ -476,13 +479,10 @@ class SinpeMovilCrcDetails extends RecipientDetails {
     bool isDefault = false,
     bool? isOwner,
     required String phoneNumber,
-    required String ownerName,
+    String? ownerName,
   }) {
     if (phoneNumber.trim().isEmpty) {
       throw ArgumentError('Phone number cannot be empty');
-    }
-    if (ownerName.trim().isEmpty) {
-      throw ArgumentError('Owner name cannot be empty');
     }
 
     return SinpeMovilCrcDetails._(
@@ -490,7 +490,7 @@ class SinpeMovilCrcDetails extends RecipientDetails {
       isDefault: isDefault,
       isOwner: isOwner,
       phoneNumber: phoneNumber.trim(),
-      ownerName: ownerName.trim(),
+      ownerName: _nullIfBlank(ownerName),
     );
   }
 

--- a/lib/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart
+++ b/lib/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart
@@ -138,19 +138,21 @@ sealed class RecipientViewModel with _$RecipientViewModel {
         if (label != null && label!.isNotEmpty) return label!;
         return null;
 
+      // ownerName is often absent for the SINPE types (#2529), so fall all the
+      // way back to the account identifier rather than showing nothing.
       case RecipientType.sinpeIbanUsd:
-        if (ownerName != null && ownerName!.isNotEmpty) return ownerName!;
-        if (label != null && label!.isNotEmpty) return label!;
-        return null;
-
       case RecipientType.sinpeIbanCrc:
         if (ownerName != null && ownerName!.isNotEmpty) return ownerName!;
         if (label != null && label!.isNotEmpty) return label!;
+        if (iban != null && iban!.isNotEmpty) return iban!;
         return null;
 
       case RecipientType.sinpeMovilCrc:
         if (ownerName != null && ownerName!.isNotEmpty) return ownerName!;
         if (label != null && label!.isNotEmpty) return label!;
+        if (phoneNumber != null && phoneNumber!.isNotEmpty) {
+          return phoneNumber!;
+        }
         return null;
       case RecipientType.bankAccountArgentina:
         if (name != null && name!.isNotEmpty) return name!;

--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -342,7 +342,7 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     Emitter<SellState> emit,
   ) async {
     // We should be on a SellPaymentState
-    final paymentState = state.toCleanPaymentState;
+    final paymentState = _currentPaymentState;
     if (paymentState == null) {
       log.severe(
         error: 'Expected to be on SellPaymentState',
@@ -351,14 +351,35 @@ class SellBloc extends Bloc<SellEvent, SellState> {
       return;
     }
 
+    // Never refresh the price lock while a payment is in flight: the pending
+    // transaction pays the current order's amount, and going through
+    // toCleanPaymentState would clear isConfirmingPayment and visually re-arm
+    // the Confirm button mid-confirmation (#2522).
+    if (paymentState.isConfirmingPayment || paymentState.isPayinBroadcast) {
+      return;
+    }
+
     try {
       final refreshedOrder = await _refreshSellOrderUsecase.execute(
         orderId: paymentState.sellOrder.orderId,
       );
 
-      emit(paymentState.copyWith(sellOrder: refreshedOrder));
+      // A confirmation may have started while the refresh was in flight, so
+      // work from the current state instead of the snapshot above.
+      final current = _currentPaymentState;
+      if (current == null) return;
+      if (current.isConfirmingPayment || current.isPayinBroadcast) return;
+      // The error is kept: when this refresh was triggered by a failed send
+      // (see _emitSendPaymentError) clearing it would erase the only
+      // explanation the user has. The next confirmation clears it anyway.
+      emit(current.copyWith(sellOrder: refreshedOrder));
     } on SellError catch (e) {
-      emit(paymentState.copyWith(error: e));
+      // Same re-read as the success path: a refresh failure must not paint an
+      // error over a confirmation that started while it was in flight.
+      final current = _currentPaymentState;
+      if (current == null) return;
+      if (current.isConfirmingPayment || current.isPayinBroadcast) return;
+      emit(current.copyWith(error: e));
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
     }
@@ -375,6 +396,19 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         error: 'Expected to be on SellPaymentState',
         trace: StackTrace.current,
       );
+      return;
+    }
+
+    // The payin is already on the wire. Re-running prepare/sign/broadcast could
+    // pay the order a second time from different UTXOs, so only wait for the
+    // order to catch up (#2522).
+    if (sellPaymentState.isPayinBroadcast) {
+      emit(sellPaymentState.copyWith(isConfirmingPayment: true));
+      try {
+        await _completeAfterBroadcast(emit);
+      } catch (e) {
+        log.severe(error: e, trace: StackTrace.current);
+      }
       return;
     }
 
@@ -402,9 +436,12 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           pset: pset,
           walletId: wallet.id,
         );
-        await _broadcastLiquidTransactionUsecase.execute(signedPset);
+        // Derived before broadcasting so the latch can be set on the very next
+        // line: nothing may run between the broadcast and the latch.
         final tx = await LiquidTx.fromPset(signedPset);
         final txid = tx.txid;
+        await _broadcastLiquidTransactionUsecase.execute(signedPset);
+        _latchBroadcast(emit, txid);
         await _labelsFacade.store(
           NewLabel.tx(
             transactionId: txid,
@@ -432,17 +469,24 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         );
         final absoluteFeesUpdated = await _calculateBitcoinAbsoluteFeesUsecase
             .execute(psbt: preparedSend.unsignedPsbt);
-        emit(sellPaymentState.copyWith(absoluteFees: absoluteFeesUpdated));
+        emit(
+          (_currentPaymentState ?? sellPaymentState).copyWith(
+            absoluteFees: absoluteFeesUpdated,
+          ),
+        );
         final signedTx = await _signBitcoinTxUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
           walletId: wallet.id,
         );
+        // Derived before broadcasting so the latch can be set on the very next
+        // line: nothing may run between the broadcast and the latch.
+        final tx = await BitcoinTx.fromPsbt(preparedSend.unsignedPsbt);
+        final txid = tx.txid;
         await _broadcastBitcoinTransactionUsecase.execute(
           signedTx.signedPsbt,
           isPsbt: true,
         );
-        final tx = await BitcoinTx.fromPsbt(preparedSend.unsignedPsbt);
-        final txid = tx.txid;
+        _latchBroadcast(emit, txid);
         await _labelsFacade.store(
           NewLabel.tx(
             transactionId: txid,
@@ -451,63 +495,86 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           ),
         );
       }
-      // 5s delay gives backend time to register the 0 conf
-      await Future.delayed(const Duration(seconds: 5));
-      final latestOrder = await _getOrderUsecase.execute(
-        orderId: sellPaymentState.sellOrder.orderId,
-      );
-
-      if (latestOrder is! SellOrder) {
-        throw const SellError.unexpected(
-          message: 'Expected SellOrder but received a different order type',
-        );
-      }
-
-      emit(
-        sellPaymentState.toSuccessState(sellOrder: sellPaymentState.sellOrder),
-      );
+      await _completeAfterBroadcast(emit);
     } on PrepareLiquidSendException catch (e) {
-      emit(
-        sellPaymentState.copyWith(
-          error: SellError.unexpected(message: e.message),
-          isConfirmingPayment: false,
-        ),
-      );
+      _emitSendPaymentError(emit, SellError.unexpected(message: e.message));
     } on PrepareBitcoinSendException catch (e) {
-      emit(
-        sellPaymentState.copyWith(
-          error: SellError.unexpected(message: e.toString()),
-          isConfirmingPayment: false,
-        ),
-      );
+      _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } on SignLiquidTxException catch (e) {
-      emit(
-        sellPaymentState.copyWith(
-          error: SellError.unexpected(message: e.toString()),
-          isConfirmingPayment: false,
-        ),
-      );
+      _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } on SignBitcoinTxException catch (e) {
       // Handle SellError and emit error state
-      emit(
-        sellPaymentState.copyWith(
-          error: SellError.unexpected(message: e.toString()),
-          isConfirmingPayment: false,
-        ),
-      );
+      _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } catch (e) {
       // Log unexpected errors
       log.severe(error: e, trace: StackTrace.current);
-      emit(
-        sellPaymentState.copyWith(
-          error: SellError.unexpected(message: e.toString()),
-          isConfirmingPayment: false,
-        ),
-      );
+      _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } finally {
-      if (state is SellPaymentState) {
-        emit((state as SellPaymentState).copyWith(isConfirmingPayment: false));
+      final current = _currentPaymentState;
+      // Once broadcast, the confirmation stays in flight until the order
+      // reflects the payment; polling takes it to the success state.
+      if (current != null && !current.isPayinBroadcast) {
+        emit(current.copyWith(isConfirmingPayment: false));
       }
+    }
+  }
+
+  SellPaymentState? get _currentPaymentState {
+    final currentState = state;
+    return currentState is SellPaymentState ? currentState : null;
+  }
+
+  void _latchBroadcast(Emitter<SellState> emit, String txid) {
+    final current = _currentPaymentState;
+    if (current == null) return;
+    emit(
+      current.copyWith(
+        payinBroadcastTxid: txid,
+        isConfirmingPayment: true,
+        error: null,
+      ),
+    );
+  }
+
+  /// Waits for the order to reflect the broadcast payin and moves to the
+  /// success state with the refreshed order (#2530).
+  Future<void> _completeAfterBroadcast(Emitter<SellState> emit) async {
+    // 5s delay gives backend time to register the 0 conf
+    await Future.delayed(const Duration(seconds: 5));
+
+    final paymentState = _currentPaymentState;
+    if (paymentState == null) return;
+
+    final latestOrder = await _getOrderUsecase.execute(
+      orderId: paymentState.sellOrder.orderId,
+    );
+
+    if (latestOrder is! SellOrder) {
+      throw const SellError.unexpected(
+        message: 'Expected SellOrder but received a different order type',
+      );
+    }
+
+    emit(paymentState.toSuccessState(sellOrder: latestOrder));
+  }
+
+  void _emitSendPaymentError(Emitter<SellState> emit, SellError error) {
+    final current = _currentPaymentState;
+    if (current == null) return;
+    if (current.isPayinBroadcast) {
+      // The transaction is already on the wire. Showing a retryable error here
+      // would re-arm Confirm and risk a second payment (#2522), so stay in the
+      // "payment sent, refreshing order" state and let polling finish the job.
+      return;
+    }
+    emit(current.copyWith(error: error, isConfirmingPayment: false));
+
+    // Confirm is live again, but the price-lock countdown fires onTimeout only
+    // once. If the deadline elapsed during this failed attempt, the skip in
+    // _onOrderRefreshTimePassed dropped that one refresh and nothing else will
+    // ask for it, leaving the user retrying against a stale quote.
+    if (!current.sellOrder.confirmationDeadline.isAfter(DateTime.now())) {
+      add(const SellEvent.orderRefreshTimePassed());
     }
   }
 
@@ -544,9 +611,13 @@ class SellBloc extends Bloc<SellEvent, SellState> {
               .toSuccessState(sellOrder: latestOrder),
         );
       } else {
-        emit(
-          sellPaymentState.copyWith(sellOrder: latestOrder, isPolling: true),
-        );
+        // The fetch takes seconds and the poll runs for the life of the screen,
+        // so it routinely spans the broadcast. Emitting the pre-await snapshot
+        // would drop the latch and re-arm Confirm (#2522), so merge into the
+        // current state instead.
+        final current = _currentPaymentState;
+        if (current == null) return;
+        emit(current.copyWith(sellOrder: latestOrder, isPolling: true));
       }
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
@@ -601,10 +672,10 @@ class SellBloc extends Bloc<SellEvent, SellState> {
 
     try {
       final utxos = await _getWalletUtxosUsecase.execute(walletId: wallet.id);
-      emit(sellPaymentState.copyWith(utxos: utxos));
+      emit((_currentPaymentState ?? sellPaymentState).copyWith(utxos: utxos));
     } catch (e) {
       emit(
-        sellPaymentState.copyWith(
+        (_currentPaymentState ?? sellPaymentState).copyWith(
           error: SellError.unexpected(message: 'Failed to load UTXOs: $e'),
         ),
       );
@@ -636,7 +707,11 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         final absoluteFees = await _calculateLiquidAbsoluteFeesUsecase.execute(
           pset: pset,
         );
-        emit(sellPaymentState.copyWith(absoluteFees: absoluteFees));
+        emit(
+          (_currentPaymentState ?? sellPaymentState).copyWith(
+            absoluteFees: absoluteFees,
+          ),
+        );
       } else {
         final bitcoinFees = await _getNetworkFeesUsecase.execute(
           isLiquid: false,
@@ -658,11 +733,15 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         final absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
         );
-        emit(sellPaymentState.copyWith(absoluteFees: absoluteFees));
+        emit(
+          (_currentPaymentState ?? sellPaymentState).copyWith(
+            absoluteFees: absoluteFees,
+          ),
+        );
       }
     } catch (e) {
       emit(
-        sellPaymentState.copyWith(
+        (_currentPaymentState ?? sellPaymentState).copyWith(
           error: SellError.unexpected(
             message: 'Failed to recalculate fees: $e',
           ),

--- a/lib/features/sell/presentation/bloc/sell_state.dart
+++ b/lib/features/sell/presentation/bloc/sell_state.dart
@@ -26,6 +26,9 @@ sealed class SellState with _$SellState {
     required SellOrder sellOrder,
     @Default(false) bool isConfirmingPayment,
     @Default(false) bool isPolling,
+    // Txid of the payin transaction once it is on the wire. Acts as a latch:
+    // the send path must never run again for this order (#2522).
+    String? payinBroadcastTxid,
     SellError? error,
     int? absoluteFees,
     @Default([]) List<WalletUtxo> utxos,
@@ -208,6 +211,10 @@ extension SellWalletSelectionStateX on SellWalletSelectionState {
 }
 
 extension SellPaymentStateX on SellPaymentState {
+  /// The payin transaction is already broadcast, so preparing, signing and
+  /// broadcasting again would risk paying the order twice.
+  bool get isPayinBroadcast => payinBroadcastTxid != null;
+
   SellSuccessState toSuccessState({required SellOrder sellOrder}) {
     return SellSuccessState(bitcoinUnit: bitcoinUnit, sellOrder: sellOrder);
   }

--- a/lib/features/sell/ui/screens/sell_send_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_send_payment_screen.dart
@@ -320,6 +320,11 @@ class _BottomButtons extends StatelessWidget {
           bloc.state is SellPaymentState &&
           (bloc.state as SellPaymentState).isConfirmingPayment,
     );
+    final isPayinBroadcast = context.select(
+      (SellBloc bloc) =>
+          bloc.state is SellPaymentState &&
+          (bloc.state as SellPaymentState).isPayinBroadcast,
+    );
     final wallet = context.select(
       (SellBloc bloc) =>
           bloc.state is SellPaymentState
@@ -329,9 +334,13 @@ class _BottomButtons extends StatelessWidget {
     return Column(
       children: [
         const _SellError(),
+        const _PaymentInFlightStatus(),
         if (wallet != null && !wallet.isLiquid) ...[
           BBButton.big(
             label: context.loc.sellAdvancedSettings,
+            // Changing coin selection or RBF mid-confirmation would rebuild the
+            // transaction under the payment being sent.
+            disabled: isConfirmingPayment || isPayinBroadcast,
             onPressed: () {
               BlurredBottomSheet.show(
                 context: context,
@@ -350,12 +359,62 @@ class _BottomButtons extends StatelessWidget {
         ],
         BBButton.big(
           label: context.loc.sellSendPaymentContinue,
-          disabled: isConfirmingPayment,
+          disabled: isConfirmingPayment || isPayinBroadcast,
           onPressed: onContinuePressed,
           bgColor: context.appColors.secondary,
           textColor: context.appColors.onSecondary,
         ),
       ],
+    );
+  }
+}
+
+/// Spinner and status text right above the confirm button, so the in-flight
+/// payment is visible where the user is looking (#2522).
+class _PaymentInFlightStatus extends StatelessWidget {
+  const _PaymentInFlightStatus();
+
+  @override
+  Widget build(BuildContext context) {
+    final (isConfirmingPayment, isPayinBroadcast) = context.select((
+      SellBloc bloc,
+    ) {
+      final state = bloc.state;
+      if (state is! SellPaymentState) return (false, false);
+      return (state.isConfirmingPayment, state.isPayinBroadcast);
+    });
+
+    if (!isConfirmingPayment && !isPayinBroadcast) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16.0),
+      child: Row(
+        mainAxisAlignment: .center,
+        children: [
+          SizedBox(
+            height: 16,
+            width: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: context.appColors.primary,
+            ),
+          ),
+          const Gap(8),
+          Flexible(
+            child: Text(
+              isPayinBroadcast
+                  ? context.loc.sellPaymentSentRefreshingOrder
+                  : context.loc.sellSendingPayment,
+              style: context.font.bodyMedium?.copyWith(
+                color: context.appColors.outline,
+              ),
+              textAlign: .center,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/sell/ui/screens/sell_success_screen.dart
+++ b/lib/features/sell/ui/screens/sell_success_screen.dart
@@ -1,9 +1,13 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/amount_conversions.dart';
+import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
-import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
+import 'package:bb_mobile/core/widgets/success_screen_scaffold.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
+import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -13,78 +17,48 @@ class SellSuccessScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final order = context.select(
+    final successState = context.select(
       (SellBloc bloc) => bloc.state is SellSuccessState
-          ? (bloc.state as SellSuccessState).sellOrder
+          ? bloc.state as SellSuccessState
           : null,
     );
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop) return; // Don't allow back navigation
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(context.loc.sellTitle),
-          automaticallyImplyLeading: false,
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: () {
-                context.goNamed(ExchangeRoute.exchangeHome.name);
-              },
-            ),
-          ],
-        ),
-        body: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisAlignment: .center,
-              children: [
-                Icon(
-                  Icons.check_circle,
-                  size: 100,
-                  color: context.appColors.success,
-                ),
-                const SizedBox(height: 20),
-                Text(
-                  context.loc.sellOrderCompleted,
-                  style: context.font.titleLarge,
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  context.loc.sellBalanceWillBeCredited,
-                  style: context.font.bodyMedium,
-                  textAlign: .center,
-                ),
-              ],
-            ),
+    final order = successState?.sellOrder;
+
+    String? amountLine;
+    if (successState != null && order != null) {
+      final formattedPayinAmount = successState.bitcoinUnit == BitcoinUnit.sats
+          ? FormatAmount.sats(ConvertAmount.btcToSats(order.payinAmount))
+          : FormatAmount.btc(order.payinAmount);
+      amountLine = context.loc.sellYouSold(
+        formattedPayinAmount,
+        FormatAmount.fiat(order.payoutAmount, order.payoutCurrency),
+      );
+    }
+
+    return SuccessScreenScaffold(
+      title: context.loc.sellTitle,
+      headline: context.loc.sellOrderCompleted,
+      // Same exit as buy: back to the wallet home, including on a back gesture.
+      onClose: () => context.goNamed(WalletRoute.walletHome.name),
+      amountLine: amountLine,
+      message: order != null && order.isBalancePayout
+          ? Text(context.loc.sellBalanceWillBeCredited)
+          : null,
+      actions: [
+        if (order != null)
+          BBButton.big(
+            label: context.loc.sellViewDetailsButton,
+            onPressed: () {
+              context.pushNamed(
+                TransactionsRoute.orderTransactionDetails.name,
+                pathParameters: {'orderId': order.orderId},
+                queryParameters: {'returnToExchange': 'true'},
+              );
+            },
+            bgColor: context.appColors.secondary,
+            textColor: context.appColors.onSecondary,
           ),
-        ),
-        bottomNavigationBar: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              mainAxisSize: .min,
-              children: [
-                if (order != null)
-                  BBButton.big(
-                    label: context.loc.sellViewDetailsButton,
-                    onPressed: () {
-                      context.pushNamed(
-                        TransactionsRoute.orderTransactionDetails.name,
-                        pathParameters: {'orderId': order.orderId},
-                        queryParameters: {'returnToExchange': 'true'},
-                      );
-                    },
-                    bgColor: context.appColors.secondary,
-                    textColor: context.appColors.onSecondary,
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ),
+      ],
     );
   }
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -2081,6 +2081,18 @@
   "@sellBalanceWillBeCredited": {
     "description": "Information about balance crediting"
   },
+  "sellYouSold": "You sold {amount} for {fiatAmount}",
+  "@sellYouSold": {
+    "description": "Success message with the amount sold and the fiat amount received",
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      },
+      "fiatAmount": {
+        "type": "String"
+      }
+    }
+  },
   "payTitle": "Pay",
   "@payTitle": {
     "description": "Screen title for pay feature"
@@ -11401,6 +11413,14 @@
   "sellSendPaymentContinue": "Continue",
   "@sellSendPaymentContinue": {
     "description": "Continue button on sell payment"
+  },
+  "sellSendingPayment": "Sending payment…",
+  "@sellSendingPayment": {
+    "description": "In-flight status shown next to the sell confirm button while the payment transaction is being prepared, signed and broadcast"
+  },
+  "sellPaymentSentRefreshingOrder": "Payment sent, refreshing your order…",
+  "@sellPaymentSentRefreshingOrder": {
+    "description": "In-flight status shown after the sell payment transaction is broadcast, while waiting for the order to reflect it"
   },
   "sellSendPaymentAboveMax": "You are trying to sell above the maximum amount that can be sold with this wallet.",
   "@sellSendPaymentAboveMax": {

--- a/test/features/sell/presentation/sell_bloc_test.dart
+++ b/test/features/sell/presentation/sell_bloc_test.dart
@@ -1,0 +1,428 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/sell/domain/create_sell_order_usecase.dart';
+import 'package:bb_mobile/features/sell/domain/refresh_sell_order_usecase.dart';
+import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
+import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetUserSummary extends Mock
+    implements GetExchangeUserSummaryUsecase {}
+
+class _MockGetSettings extends Mock implements GetSettingsUsecase {}
+
+class _MockCreateSellOrder extends Mock implements CreateSellOrderUsecase {}
+
+class _MockRefreshSellOrder extends Mock implements RefreshSellOrderUsecase {}
+
+class _MockPrepareBitcoinSend extends Mock
+    implements PrepareBitcoinSendUsecase {}
+
+class _MockPrepareLiquidSend extends Mock implements PrepareLiquidSendUsecase {}
+
+class _MockSignBitcoinTx extends Mock implements SignBitcoinTxUsecase {}
+
+class _MockSignLiquidTx extends Mock implements SignLiquidTxUsecase {}
+
+class _MockBroadcastBitcoin extends Mock
+    implements BroadcastBitcoinTransactionUsecase {}
+
+class _MockBroadcastLiquid extends Mock
+    implements BroadcastLiquidTransactionUsecase {}
+
+class _MockGetNetworkFees extends Mock implements GetNetworkFeesUsecase {}
+
+class _MockCalculateLiquidFees extends Mock
+    implements CalculateLiquidAbsoluteFeesUsecase {}
+
+class _MockCalculateBitcoinFees extends Mock
+    implements CalculateBitcoinAbsoluteFeesUsecase {}
+
+class _MockConvertSatsToCurrency extends Mock
+    implements ConvertSatsToCurrencyAmountUsecase {}
+
+class _MockGetAddressAtIndex extends Mock implements GetAddressAtIndexUsecase {}
+
+class _MockGetWalletUtxos extends Mock implements GetWalletUtxosUsecase {}
+
+class _MockGetOrder extends Mock implements GetOrderUsecase {}
+
+class _MockLabelsFacade extends Mock implements LabelsFacade {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+class _MockSellOrder extends Mock implements SellOrder {}
+
+class _FakeNewLabel extends Fake implements NewLabel {}
+
+class _FakeLabel extends Fake implements Label {}
+
+/// The confirmation path only ever runs from a [SellPaymentState] that earlier
+/// events built up. Seeding it directly keeps this test to the send path and
+/// avoids the order polling timer that order creation starts.
+class _SeedableSellBloc extends SellBloc {
+  _SeedableSellBloc({
+    required super.getExchangeUserSummaryUsecase,
+    required super.getSettingsUsecase,
+    required super.createSellOrderUsecase,
+    required super.refreshSellOrderUsecase,
+    required super.prepareBitcoinSendUsecase,
+    required super.prepareLiquidSendUsecase,
+    required super.signBitcoinTxUsecase,
+    required super.signLiquidTxUsecase,
+    required super.broadcastBitcoinTransactionUsecase,
+    required super.broadcastLiquidTransactionUsecase,
+    required super.getNetworkFeesUsecase,
+    required super.calculateLiquidAbsoluteFeesUsecase,
+    required super.calculateBitcoinAbsoluteFeesUsecase,
+    required super.convertSatsToCurrencyAmountUsecase,
+    required super.getAddressAtIndexUsecase,
+    required super.getWalletUtxosUsecase,
+    required super.getOrderUsecase,
+    required super.labelsFacade,
+  });
+
+  void seed(SellState state) => emit(state);
+}
+
+void main() {
+  // Unsigned single-input single-output PSBT with a witness UTXO, enough for
+  // BitcoinTx.fromPsbt to extract a txid.
+  const unsignedPsbt =
+      'cHNidP8BAFICAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD9////'
+      'AaCGAQAAAAAAFgAUIiIiIiIiIiIiIiIiIiIiIiIiIiIAAAAAAAEBH2iHAQAAAAAAFgAUMzMz'
+      'MzMzMzMzMzMzMzMzMzMzMzMAAA==';
+  const expectedTxid =
+      '813d01e5c0ea01904322222851b2e702d37651be2644f4757cc4421f39261b55';
+  const userSummary = UserSummary(
+    userNumber: 1,
+    groups: ['KYC_IDENTITY_VERIFIED'],
+    profile: UserProfile(firstName: 'Sat', lastName: 'Oshi'),
+    email: 'sat@example.com',
+    balances: [],
+    dca: UserDca(isActive: false),
+    autoBuy: UserAutoBuy(isActive: false, addresses: UserAutoBuyAddresses()),
+  );
+
+  late _MockPrepareBitcoinSend prepareBitcoinSend;
+  late _MockSignBitcoinTx signBitcoinTx;
+  late _MockBroadcastBitcoin broadcastBitcoin;
+  late _MockCalculateBitcoinFees calculateBitcoinFees;
+  late _MockGetOrder getOrder;
+  late _MockRefreshSellOrder refreshSellOrder;
+  late _MockLabelsFacade labelsFacade;
+  late _MockSellOrder sellOrder;
+  late _MockWallet wallet;
+  late _SeedableSellBloc bloc;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeNewLabel());
+    registerFallbackValue(const NetworkFee.absolute(200));
+  });
+
+  setUp(() {
+    prepareBitcoinSend = _MockPrepareBitcoinSend();
+    signBitcoinTx = _MockSignBitcoinTx();
+    broadcastBitcoin = _MockBroadcastBitcoin();
+    calculateBitcoinFees = _MockCalculateBitcoinFees();
+    getOrder = _MockGetOrder();
+    refreshSellOrder = _MockRefreshSellOrder();
+    labelsFacade = _MockLabelsFacade();
+    sellOrder = _MockSellOrder();
+    wallet = _MockWallet();
+
+    when(() => wallet.id).thenReturn('wallet-1');
+    when(() => wallet.isLiquid).thenReturn(false);
+    when(() => sellOrder.orderId).thenReturn('order-1');
+    when(() => sellOrder.payinAmount).thenReturn(0.001);
+    when(
+      () => sellOrder.bitcoinAddress,
+    ).thenReturn('bc1q0000000000000000000000000000000000000');
+    when(
+      () => sellOrder.confirmationDeadline,
+    ).thenReturn(DateTime.now().add(const Duration(minutes: 5)));
+
+    when(
+      () => prepareBitcoinSend.execute(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        selectedInputs: any(named: 'selectedInputs'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenAnswer(
+      (_) async => (unsignedPsbt: unsignedPsbt, txSize: 110, isToSelf: false),
+    );
+    when(
+      () => calculateBitcoinFees.execute(psbt: any(named: 'psbt')),
+    ).thenAnswer((_) async => 200);
+    when(
+      () => signBitcoinTx.execute(
+        psbt: any(named: 'psbt'),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => (signedPsbt: unsignedPsbt, txSize: 110));
+    when(
+      () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+    ).thenAnswer((_) async => expectedTxid);
+    when(
+      () => labelsFacade.store(any()),
+    ).thenAnswer((_) async => Ok<Label, LabelFailure>(_FakeLabel()));
+
+    bloc = _SeedableSellBloc(
+      getExchangeUserSummaryUsecase: _MockGetUserSummary(),
+      getSettingsUsecase: _MockGetSettings(),
+      createSellOrderUsecase: _MockCreateSellOrder(),
+      refreshSellOrderUsecase: refreshSellOrder,
+      prepareBitcoinSendUsecase: prepareBitcoinSend,
+      prepareLiquidSendUsecase: _MockPrepareLiquidSend(),
+      signBitcoinTxUsecase: signBitcoinTx,
+      signLiquidTxUsecase: _MockSignLiquidTx(),
+      broadcastBitcoinTransactionUsecase: broadcastBitcoin,
+      broadcastLiquidTransactionUsecase: _MockBroadcastLiquid(),
+      getNetworkFeesUsecase: _MockGetNetworkFees(),
+      calculateLiquidAbsoluteFeesUsecase: _MockCalculateLiquidFees(),
+      calculateBitcoinAbsoluteFeesUsecase: calculateBitcoinFees,
+      convertSatsToCurrencyAmountUsecase: _MockConvertSatsToCurrency(),
+      getAddressAtIndexUsecase: _MockGetAddressAtIndex(),
+      getWalletUtxosUsecase: _MockGetWalletUtxos(),
+      getOrderUsecase: getOrder,
+      labelsFacade: labelsFacade,
+    );
+
+    bloc.seed(
+      SellState.payment(
+        userSummary: userSummary,
+        bitcoinUnit: BitcoinUnit.sats,
+        orderAmount: BitcoinAmount(0.001),
+        fiatCurrency: FiatCurrency.cad,
+        selectedWallet: wallet,
+        sellOrder: sellOrder,
+        absoluteFees: 200,
+      ),
+    );
+  });
+
+  tearDown(() => bloc.close());
+
+  group('SellBloc — broadcast latch', () {
+    test(
+      'a second confirmation after the payin is broadcast does not broadcast '
+      'again',
+      () async {
+        // The post-broadcast order fetch fails, which used to re-enable Confirm
+        // with the transaction already on the wire (#2522).
+        when(
+          () => getOrder.execute(orderId: any(named: 'orderId')),
+        ).thenThrow(GetOrderException('dns failure'));
+
+        bloc.add(
+          const SellEvent.sendPaymentConfirmed(
+            feeSelection: FeeSelection.fastest,
+            customFee: null,
+          ),
+        );
+        await bloc.stream.firstWhere(
+          (state) => state is SellPaymentState && state.isPayinBroadcast,
+        );
+
+        final latched = bloc.state as SellPaymentState;
+        expect(latched.payinBroadcastTxid, expectedTxid);
+
+        // Let the failing order fetch settle, then confirm again.
+        await Future<void>.delayed(const Duration(seconds: 6));
+        bloc.add(
+          const SellEvent.sendPaymentConfirmed(
+            feeSelection: FeeSelection.fastest,
+            customFee: null,
+          ),
+        );
+        await Future<void>.delayed(const Duration(seconds: 6));
+
+        verify(
+          () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+        ).called(1);
+        verify(
+          () => prepareBitcoinSend.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            amountSat: any(named: 'amountSat'),
+            networkFee: any(named: 'networkFee'),
+            selectedInputs: any(named: 'selectedInputs'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        ).called(1);
+
+        final state = bloc.state as SellPaymentState;
+        expect(state.payinBroadcastTxid, expectedTxid);
+        // No retryable error, and Confirm stays disabled.
+        expect(state.error, isNull);
+        expect(state.isConfirmingPayment, isTrue);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'success state carries the order fetched after the broadcast',
+      () async {
+        final refreshedOrder = _MockSellOrder();
+        when(() => refreshedOrder.orderId).thenReturn('order-1');
+        when(
+          () => getOrder.execute(orderId: any(named: 'orderId')),
+        ).thenAnswer((_) async => refreshedOrder);
+
+        bloc.add(
+          const SellEvent.sendPaymentConfirmed(
+            feeSelection: FeeSelection.fastest,
+            customFee: null,
+          ),
+        );
+        final successState = await bloc.stream.firstWhere(
+          (state) => state is SellSuccessState,
+        );
+
+        expect(
+          (successState as SellSuccessState).sellOrder,
+          same(refreshedOrder),
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test('an order poll spanning the broadcast keeps the latch', () async {
+      // The poll runs for the life of the screen, so its fetch routinely spans
+      // the broadcast. Holding the fetch open puts the latch inside that
+      // window — where the poll used to emit its pre-await snapshot and re-arm
+      // Confirm with the transaction already sent (#2522).
+      final pollFetch = Completer<Order>();
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenAnswer((_) => pollFetch.future);
+
+      final polledOrder = _MockSellOrder();
+      when(() => polledOrder.orderId).thenReturn('order-1');
+      when(
+        () => polledOrder.payinStatus,
+      ).thenReturn(OrderPayinStatus.awaitingPayment);
+
+      bloc.add(const SellEvent.pollOrderStatus());
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Stands in for the broadcast landing while the poll awaits its fetch.
+      bloc.seed(
+        (bloc.state as SellPaymentState).copyWith(
+          isConfirmingPayment: true,
+          payinBroadcastTxid: expectedTxid,
+        ),
+      );
+
+      pollFetch.complete(polledOrder);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = bloc.state as SellPaymentState;
+      expect(state.payinBroadcastTxid, expectedTxid);
+      expect(state.isConfirmingPayment, isTrue);
+      // The fresh order is still picked up, just merged into the live state.
+      expect(state.sellOrder, same(polledOrder));
+    });
+  });
+
+  test(
+    'the price-lock refresh leaves a confirmation in flight alone',
+    () async {
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenThrow(GetOrderException('dns failure'));
+
+      bloc.add(
+        const SellEvent.sendPaymentConfirmed(
+          feeSelection: FeeSelection.fastest,
+          customFee: null,
+        ),
+      );
+      await bloc.stream.firstWhere(
+        (state) => state is SellPaymentState && state.isConfirmingPayment,
+      );
+
+      bloc.add(const SellEvent.orderRefreshTimePassed());
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      verifyNever(
+        () => refreshSellOrder.execute(orderId: any(named: 'orderId')),
+      );
+      expect((bloc.state as SellPaymentState).isConfirmingPayment, isTrue);
+
+      // Let the confirmation settle so nothing emits after tearDown closes.
+      await Future<void>.delayed(const Duration(seconds: 6));
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('a failure past the price-lock deadline asks for a refresh', () async {
+    // The countdown fires onTimeout once, and _onOrderRefreshTimePassed skipped
+    // that one refresh because a confirmation was in flight. Nothing else would
+    // ask again, so the bloc has to.
+    when(
+      () => sellOrder.confirmationDeadline,
+    ).thenReturn(DateTime.now().subtract(const Duration(seconds: 1)));
+    when(
+      () => prepareBitcoinSend.execute(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        selectedInputs: any(named: 'selectedInputs'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenThrow(PrepareBitcoinSendException('cannot build'));
+
+    final refreshedOrder = _MockSellOrder();
+    when(() => refreshedOrder.orderId).thenReturn('order-1');
+    when(
+      () => refreshSellOrder.execute(orderId: any(named: 'orderId')),
+    ).thenAnswer((_) async => refreshedOrder);
+
+    bloc.add(
+      const SellEvent.sendPaymentConfirmed(
+        feeSelection: FeeSelection.fastest,
+        customFee: null,
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    verify(() => refreshSellOrder.execute(orderId: 'order-1')).called(1);
+    verifyNever(
+      () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+    );
+
+    final state = bloc.state as SellPaymentState;
+    expect(state.sellOrder, same(refreshedOrder));
+    expect(state.isConfirmingPayment, isFalse);
+    expect(state.payinBroadcastTxid, isNull);
+    // The refresh must not erase why the send failed.
+    expect(state.error, isNotNull);
+  });
+}


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — draft until verified. Test: sell success page shows "You sold X sats for Y [fiat]" and closes (button AND back gesture) to wallet home; Confirm shows an in-flight spinner; SINPE Móvil recipients without an owner name appear in the recipients list (name falls back to label/phone). The double-payment latch itself is not manually testable (requires a mid-broadcast network failure) — it is covered by 5 bloc regression tests, each proven to fail on the old code.

## Problems
1. **Double-payment risk (#2522):** after broadcasting, the confirm handler fetched the order; any failure re-enabled Confirm with the transaction already on the wire — a second tap re-ran prepare/sign/broadcast. Concurrent handlers (fee recalc, utxo load, order poll, price-lock refresh) also emitted pre-await snapshots that could silently revert in-flight state.
2. Success state carried the stale pre-broadcast order (#2530).
3. Success screen lacked the amount line and diverged from buy (#2523).
4. SINPE recipients were dropped when `ownerName` was absent — the server schema has it nullable by design (Ridivi lookup can fail) (#2529).

## Changes
- Broadcast latch (`payinBroadcastTxid`) emitted immediately after broadcast on both bitcoin and liquid paths; a latched bloc never re-enters the send path, never surfaces a retryable error, keeps Confirm disabled, and lets the existing poll carry the order to success
- Concurrent emits merge into live state (incl. an order poll spanning the broadcast — reviewer-caught blocker with a deterministic regression test)
- Price-lock refresh preserves in-flight state; a pre-broadcast failure past the deadline re-arms the countdown
- In-flight spinner + status next to Confirm; Advanced settings disabled mid-confirmation
- Success screen on a new shared `SuccessScreenScaffold` (buy/pay can adopt later): "You sold {amount} for {fiatAmount}", credit message gated on balance payouts (`Order.isBalancePayout`), closes to wallet home
- SINPE `ownerName` optional with display fallback chain

## Validation
5 bloc regression tests (double-confirm, poll race, stale order, countdown race, deadline recovery) — each demonstrated failing without its fix; analyze clean; full suite green. Reviewed with a verification pass (1 blocker + 2 should-fixes applied).

Closes #2522
Closes #2523
Closes #2529
Closes #2530