### PR TITLE
feat(fees): working network fee selection for sell and pay

### DIFF
--- a/lib/core/widgets/fees/fee_selection_label.dart
+++ b/lib/core/widgets/fees/fee_selection_label.dart
@@ -1,0 +1,38 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/amount_formatting.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:flutter/widgets.dart';
+
+/// Value shown on the "Fee Priority" row of the exchange confirmation screens
+/// (sell, pay) for the committed selection. Presets read as their tier name; a
+/// custom fee reads as the value that was typed, because "Custom Fee" on its
+/// own hides the only number that tells the tiers apart.
+///
+/// [fastestLabel] comes from the caller: each flow ships its own translated
+/// "Fastest" string, while the remaining tiers have no per-flow copy and share
+/// the send keys.
+String feeSelectionRowLabel(
+  BuildContext context, {
+  required FeeSelection selection,
+  required NetworkFee? customFee,
+  required String fastestLabel,
+}) => switch (selection) {
+  FeeSelection.fastest => fastestLabel,
+  FeeSelection.economic => context.loc.sendEconomyFee,
+  FeeSelection.slow => context.loc.feePrioritySlow,
+  FeeSelection.custom => switch (customFee) {
+    RelativeFee(:final satPerKwu) =>
+      '${_formattedRate(satPerKwu / 250.0)} ${context.loc.sendSatsPerVB}',
+    AbsoluteFee(:final sats) =>
+      '${FormatAmount.sats(sats)} ${context.loc.sendSats}',
+    // Custom is selected but nothing has been typed yet — only reachable
+    // while the modal is open, since dismissal rolls an empty field back.
+    null => context.loc.sendCustomFee,
+  },
+};
+
+/// Whole rates lose the decimals: "3 sats/vB" rather than "3.00 sats/vB".
+String _formattedRate(double satPerVbyte) =>
+    satPerVbyte == satPerVbyte.roundToDouble()
+    ? satPerVbyte.toStringAsFixed(0)
+    : satPerVbyte.toStringAsFixed(2);

--- a/lib/features/pay/pay_locator.dart
+++ b/lib/features/pay/pay_locator.dart
@@ -16,6 +16,8 @@ import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolut
 
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:get_it/get_it.dart';
@@ -76,6 +78,9 @@ class PayLocator {
         getAddressAtIndexUsecase: locator<GetAddressAtIndexUsecase>(),
         getWalletUtxosUsecase: locator<GetWalletUtxosUsecase>(),
         getOrderUsecase: locator<GetOrderUsecase>(),
+        previewBitcoinFeeUsecase: locator<PreviewBitcoinFeeUsecase>(),
+        previewBitcoinFeePresetsUsecase:
+            locator<PreviewBitcoinFeePresetsUsecase>(),
       ),
     );
   }

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/core/exchange/domain/errors/pay_error.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
@@ -23,7 +24,10 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_modal_controller.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bip21_uri/bip21_uri.dart';
@@ -34,7 +38,8 @@ part 'pay_bloc.freezed.dart';
 part 'pay_event.dart';
 part 'pay_state.dart';
 
-class PayBloc extends Bloc<PayEvent, PayState> {
+class PayBloc extends Bloc<PayEvent, PayState>
+    implements FeeModalActions, FeeModalViewState {
   PayBloc({
     required this._getExchangeUserSummaryUsecase,
     required this._placePayOrderUsecase,
@@ -52,6 +57,8 @@ class PayBloc extends Bloc<PayEvent, PayState> {
     required this._getAddressAtIndexUsecase,
     required this._getWalletUtxosUsecase,
     required this._getOrderUsecase,
+    required this._previewBitcoinFeeUsecase,
+    required this._previewBitcoinFeePresetsUsecase,
   }) : super(PayRecipientSelectionState()) {
     on<PayStarted>(_onStarted);
     on<PayRecipientSelected>(_onRecipientSelected);
@@ -65,6 +72,13 @@ class PayBloc extends Bloc<PayEvent, PayState> {
     on<PayUtxosSelected>(_onUtxosSelected);
     on<PayLoadUtxos>(_onLoadUtxos);
     on<PayUpdateOrderStatus>(_onUpdateOrderStatus);
+    on<PayFeeOptionSelected>(_onFeeOptionSelected);
+    on<PayCustomFeeChanged>(_onCustomFeeChanged);
+    on<PayCustomFeeArmed>(_onCustomFeeArmed);
+    on<PayCustomFeeDisarmed>(_onCustomFeeDisarmed);
+    on<PayCustomFeeFinalized>(_onCustomFeeFinalized);
+    on<PayCustomFeePreviewRequested>(_onCustomFeePreviewRequested);
+    on<PayPresetFeesPreviewRequested>(_onPresetFeesPreviewRequested);
   }
 
   final GetExchangeUserSummaryUsecase _getExchangeUserSummaryUsecase;
@@ -85,7 +99,15 @@ class PayBloc extends Bloc<PayEvent, PayState> {
   final GetAddressAtIndexUsecase _getAddressAtIndexUsecase;
   final GetWalletUtxosUsecase _getWalletUtxosUsecase;
   final GetOrderUsecase _getOrderUsecase;
+  final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
+  final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   Timer? _pollingTimer;
+
+  /// Bumped whenever the cached previews stop describing the payin being built
+  /// (typed rate, coin selection, RBF, a refreshed payin amount). A preview
+  /// build that started under an older epoch is discarded on return instead of
+  /// writing a slot for a tx shape that no longer exists.
+  int _bitcoinPreviewEpoch = 0;
 
   Future<void> _onStarted(PayStarted event, Emitter<PayState> emit) async {
     final recipientSelectionState = state.cleanRecipientSelectionState;
@@ -201,6 +223,16 @@ class PayBloc extends Bloc<PayEvent, PayState> {
       return;
     }
     int absoluteFees = 0;
+    // Carried into the payment state so the confirmation screen can offer the
+    // fee modal (#2521): it needs the presets to price the tiles and a vsize to
+    // check an absolute custom fee against the relay floor.
+    FeeOptions? bitcoinFees;
+    int? bitcoinTxSize;
+    // This builds a brand-new payment state, with its own order, wallet and
+    // empty preview cache. A preview still in flight for the previous one would
+    // otherwise land in that cache and price this payin with the last order's
+    // fees.
+    _bitcoinPreviewEpoch++;
     try {
       final dummyAddressForFeeCalculation = await _getAddressAtIndexUsecase
           .execute(walletId: event.wallet.id, index: 0);
@@ -217,17 +249,16 @@ class PayBloc extends Bloc<PayEvent, PayState> {
           pset: pset,
         );
       } else {
-        final bitcoinFees = await _getNetworkFeesUsecase.execute(
-          isLiquid: false,
-        );
-        final fastestFee = bitcoinFees.fastest;
-
+        bitcoinFees = await _getNetworkFeesUsecase.execute(isLiquid: false);
+        // Fastest is the default selection, so the estimate shown on arrival is
+        // the estimate for the tier the payin would be built at.
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: event.wallet.id,
           address: dummyAddressForFeeCalculation.address,
           amountSat: requiredAmountSat,
-          networkFee: fastestFee,
+          networkFee: bitcoinFees.fastest,
         );
+        bitcoinTxSize = preparedSend.txSize;
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
         );
@@ -264,6 +295,8 @@ class PayBloc extends Bloc<PayEvent, PayState> {
             absoluteFees: absoluteFees,
             utxos: utxos,
             exchangeRateEstimate: exchangeRateEstimate,
+            bitcoinFees: bitcoinFees,
+            bitcoinTxSize: bitcoinTxSize,
           ),
         );
       } else {
@@ -369,7 +402,14 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         orderId: paymentState.payOrder.orderId,
       );
 
-      emit(paymentState.copyWith(payOrder: refreshedOrder));
+      final refreshed = paymentState.copyWith(payOrder: refreshedOrder);
+      // A new price lock moves the payin amount, which invalidates every
+      // preview built for the old one.
+      emit(
+        refreshedOrder.payinAmount == paymentState.payOrder.payinAmount
+            ? refreshed
+            : _clearedFeePreviews(refreshed),
+      );
     } on PayError catch (e) {
       emit(paymentState.copyWith(error: e));
     } catch (e) {
@@ -418,8 +458,15 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         );
         await _broadcastLiquidTransactionUsecase.execute(signedPset);
       } else {
+        // The rate the user committed in the fee modal, which defaults to
+        // Fastest. The absolute fee from the last estimate is the fallback for
+        // the case where the presets went missing — being unable to pick a fee
+        // must not block paying the order.
         final absoluteFees = payPaymentState.absoluteFees;
-        if (absoluteFees == null) {
+        final networkFee =
+            payPaymentState.selectedFee ??
+            (absoluteFees != null ? NetworkFee.absolute(absoluteFees) : null);
+        if (networkFee == null) {
           throw const PayError.unexpected(
             message: 'Transaction fees not calculated. Please try again.',
           );
@@ -429,7 +476,7 @@ class PayBloc extends Bloc<PayEvent, PayState> {
           walletId: wallet.id,
           address: payPaymentState.payOrder.bitcoinAddress!,
           amountSat: payinAmountSat,
-          networkFee: NetworkFee.absolute(absoluteFees),
+          networkFee: networkFee,
           selectedInputs: payPaymentState.selectedUtxos.isNotEmpty
               ? payPaymentState.selectedUtxos
               : null,
@@ -437,7 +484,26 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         );
         final absoluteFeesUpdated = await _calculateBitcoinAbsoluteFeesUsecase
             .execute(psbt: preparedSend.unsignedPsbt);
-        emit(payPaymentState.copyWith(absoluteFees: absoluteFeesUpdated));
+        // An absolute custom fee was checked against the *previous* vsize; if
+        // this build came out larger it can sit below the relay floor, which
+        // strands the payin unbroadcastable. Re-check the built fee against the
+        // built vsize before signing rather than trusting BDK to refuse.
+        if (!NetworkFee.absolute(absoluteFeesUpdated).aboveMinRelay(
+          txSize: preparedSend.txSize,
+          floorSatPerKwu: payPaymentState.bitcoinFees?.minRelay.satPerKwu,
+        )) {
+          throw const PayError.unexpected(
+            message:
+                'The selected fee is below the network minimum. '
+                'Choose a higher fee priority and try again.',
+          );
+        }
+        emit(
+          (_currentPaymentState ?? payPaymentState).copyWith(
+            absoluteFees: absoluteFeesUpdated,
+            bitcoinTxSize: preparedSend.txSize,
+          ),
+        );
         final signedTx = await _signBitcoinTxUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
           walletId: wallet.id,
@@ -554,7 +620,13 @@ class PayBloc extends Bloc<PayEvent, PayState> {
     if (state is! PayPaymentState) return;
 
     final payPaymentState = state as PayPaymentState;
-    emit(payPaymentState.copyWith(replaceByFee: event.replaceByFee));
+    // RBF changes the sequence numbers, so every cached preview PSBT is for a
+    // different transaction now.
+    emit(
+      _clearedFeePreviews(
+        payPaymentState.copyWith(replaceByFee: event.replaceByFee),
+      ),
+    );
     await _recalculateFees(emit);
   }
 
@@ -568,7 +640,12 @@ class PayBloc extends Bloc<PayEvent, PayState> {
     final payPaymentState = state as PayPaymentState;
     final selectedUtxos = event.utxos;
 
-    emit(payPaymentState.copyWith(selectedUtxos: selectedUtxos));
+    // Coin selection changed — the previews were priced on the old input set.
+    emit(
+      _clearedFeePreviews(
+        payPaymentState.copyWith(selectedUtxos: selectedUtxos),
+      ),
+    );
     await _recalculateFees(emit);
   }
 
@@ -616,13 +693,25 @@ class PayBloc extends Bloc<PayEvent, PayState> {
     }
   }
 
-  // From Sell: Recalculate fees when UTXOs or RBF changes
+  // From Sell: Recalculate fees when UTXOs, RBF or the fee selection changes
+  ///
+  /// Every emit past an await reads the live state and gives up when it is gone:
+  /// this runs across `_getNetworkFeesUsecase` and a PSBT build, so a slow fetch
+  /// routinely outlives the screen. Merging into a pre-await snapshot instead
+  /// would republish the payment state over whatever replaced it, re-arming
+  /// Confirm on a payin already on the wire.
   Future<void> _recalculateFees(Emitter<PayState> emit) async {
-    if (state is! PayPaymentState) return;
-
-    final payPaymentState = state as PayPaymentState;
+    final payPaymentState = _currentPaymentState;
+    if (payPaymentState == null) return;
     final wallet = payPaymentState.selectedWallet;
     if (wallet == null) return;
+
+    // The displayed fee belongs to the previous build until this one lands, so
+    // drop it and let the row show its calculating state — pairing the old
+    // amount with a just-changed fee tier reads as if nothing happened.
+    // Restored on failure so the row can't be left calculating forever.
+    final previousAbsoluteFees = payPaymentState.absoluteFees;
+    emit(payPaymentState.copyWith(absoluteFees: null));
 
     try {
       final payinAmountSat = ConvertAmount.btcToSats(
@@ -642,38 +731,329 @@ class PayBloc extends Bloc<PayEvent, PayState> {
         final absoluteFees = await _calculateLiquidAbsoluteFeesUsecase.execute(
           pset: pset,
         );
-        emit(payPaymentState.copyWith(absoluteFees: absoluteFees));
+        final liveAfterLiquidBuild = _currentPaymentState;
+        if (liveAfterLiquidBuild == null) return;
+        emit(liveAfterLiquidBuild.copyWith(absoluteFees: absoluteFees));
       } else {
         final bitcoinFees = await _getNetworkFeesUsecase.execute(
           isLiquid: false,
         );
-        final fastestFee = bitcoinFees.fastest;
-
-        final dummyAddressForFeeCalculation = await _getAddressAtIndexUsecase
-            .execute(walletId: wallet.id, index: 0);
+        // Reprice the presets without touching the committed tier: a rate
+        // refresh that silently reset the selection to Fastest would undo the
+        // user's choice behind their back.
+        final liveAfterFeeFetch = _currentPaymentState;
+        if (liveAfterFeeFetch == null) return;
+        final repriced = liveAfterFeeFetch.copyWith(bitcoinFees: bitcoinFees);
+        final networkFee = repriced.selectedFee ?? bitcoinFees.fastest;
+        final address = await _payinBuildAddress(repriced, wallet);
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: wallet.id,
-          address: dummyAddressForFeeCalculation.address,
+          address: address,
           amountSat: payinAmountSat,
-          networkFee: fastestFee,
-          selectedInputs: payPaymentState.selectedUtxos.isNotEmpty
-              ? payPaymentState.selectedUtxos
+          networkFee: networkFee,
+          selectedInputs: repriced.selectedUtxos.isNotEmpty
+              ? repriced.selectedUtxos
               : null,
-          replaceByFee: payPaymentState.replaceByFee,
+          replaceByFee: repriced.replaceByFee,
         );
         final absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
         );
-        emit(payPaymentState.copyWith(absoluteFees: absoluteFees));
+        final liveAfterBitcoinBuild = _currentPaymentState;
+        if (liveAfterBitcoinBuild == null) return;
+        emit(
+          liveAfterBitcoinBuild.copyWith(
+            bitcoinFees: bitcoinFees,
+            absoluteFees: absoluteFees,
+            bitcoinTxSize: preparedSend.txSize,
+          ),
+        );
       }
     } catch (e) {
+      final liveAfterFailure = _currentPaymentState;
+      if (liveAfterFailure == null) return;
       emit(
-        payPaymentState.copyWith(
+        liveAfterFailure.copyWith(
+          absoluteFees: previousAbsoluteFees,
           error: PayError.unexpected(message: 'Failed to recalculate fees: $e'),
         ),
       );
     }
   }
+
+  PayPaymentState? get _currentPaymentState {
+    final currentState = state;
+    return currentState is PayPaymentState ? currentState : null;
+  }
+
+  /// Address the payin is (or will be) built for. The order's own address keeps
+  /// the estimate honest — a build against one of our own addresses can differ
+  /// in vsize when the script types differ. Falls back to an own address only
+  /// when the order has none yet.
+  Future<String> _payinBuildAddress(
+    PayPaymentState paymentState,
+    Wallet wallet,
+  ) async {
+    final payinAddress = paymentState.payOrder.bitcoinAddress;
+    if (payinAddress != null && payinAddress.isNotEmpty) return payinAddress;
+    final ownAddress = await _getAddressAtIndexUsecase.execute(
+      walletId: wallet.id,
+      index: 0,
+    );
+    return ownAddress.address;
+  }
+
+  /// Drops every cached preview and invalidates in-flight builds. Call whenever
+  /// the payin's shape changes: a slot still holding the old shape's fee would
+  /// price the modal for a transaction we are no longer building.
+  PayPaymentState _clearedFeePreviews(PayPaymentState paymentState) {
+    _bitcoinPreviewEpoch++;
+    return paymentState.copyWith(
+      feePreviewCache: BitcoinFeePreviewCache.empty,
+    );
+  }
+
+  /// Payment state while fee selection is still allowed, or null when the event
+  /// must be ignored — no payment in flight, a Liquid payin (no fee choice), or
+  /// a confirmation already running.
+  PayPaymentState? get _feeEditablePaymentState {
+    final current = _currentPaymentState;
+    if (current == null) return null;
+    return current.canEditFees ? current : null;
+  }
+
+  Future<void> _onFeeOptionSelected(
+    PayFeeOptionSelected event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    // Picking a preset is itself a commit, so any custom-fee arm is discarded
+    // rather than rolled back.
+    emit(
+      current.copyWith(
+        selectedFeeOption: event.feeSelection,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+    await _recalculateFees(emit);
+  }
+
+  Future<void> _onCustomFeeChanged(
+    PayCustomFeeChanged event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    emit(
+      current.copyWith(
+        customFee: event.fee,
+        selectedFeeOption: FeeSelection.custom,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+    await _recalculateFees(emit);
+  }
+
+  Future<void> _onCustomFeeArmed(
+    PayCustomFeeArmed event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    // The typed rate just changed, so only the cached custom slot is wrong — it
+    // prices the previous rate. The preset slots still describe the same payin
+    // and must survive, or the first keystroke would blank their prices until
+    // the modal is reopened. Bumping the epoch discards a custom preview still
+    // in flight for the older rate, so it cannot land on top of the new one.
+    _bitcoinPreviewEpoch++;
+    final clearedCustomSlot = current.feePreviewCache.withSlot(
+      FeeSelection.custom,
+      const BitcoinFeePreviewSlot(),
+    );
+    if (current.armPriorSelection == null) {
+      emit(
+        current.copyWith(
+          armPriorSelection: current.selectedFeeOption,
+          armPriorCustomFee: current.customFee,
+          selectedFeeOption: FeeSelection.custom,
+          customFee: event.fee,
+          feePreviewCache: clearedCustomSlot,
+        ),
+      );
+    } else {
+      emit(
+        current.copyWith(
+          customFee: event.fee,
+          feePreviewCache: clearedCustomSlot,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onCustomFeeDisarmed(
+    PayCustomFeeDisarmed event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    if (current.armPriorSelection == null) return;
+    emit(
+      current.copyWith(
+        selectedFeeOption: current.armPriorSelection!,
+        customFee: current.armPriorCustomFee,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+  }
+
+  Future<void> _onCustomFeeFinalized(
+    PayCustomFeeFinalized event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    if (current.armPriorSelection == null) return;
+    final fee = current.customFee;
+    final txSize = current.bitcoinTxSize ?? 140;
+    if (fee != null &&
+        fee.aboveMinRelay(
+          txSize: txSize,
+          floorSatPerKwu: current.bitcoinFees?.minRelay.satPerKwu,
+        )) {
+      await _onCustomFeeChanged(PayCustomFeeChanged(fee), emit);
+    } else {
+      await _onCustomFeeDisarmed(const PayCustomFeeDisarmed(), emit);
+    }
+  }
+
+  Future<void> _onCustomFeePreviewRequested(
+    PayCustomFeePreviewRequested event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    final wallet = current.selectedWallet!;
+    emit(
+      current.copyWith(
+        feePreviewCache: current.feePreviewCache.copyWith(customLoading: true),
+      ),
+    );
+    final epoch = _bitcoinPreviewEpoch;
+    final address = await _payinBuildAddress(current, wallet);
+    final slot = await _previewBitcoinFeeUsecase.execute(
+      walletId: wallet.id,
+      address: address,
+      networkFee: event.fee,
+      amountSat: ConvertAmount.btcToSats(current.payOrder.payinAmount),
+      replaceByFee: current.replaceByFee,
+      selectedInputs: current.selectedUtxos,
+      drain: false,
+    );
+    // The payin's shape changed while this build ran, so the slot describes a
+    // transaction we are no longer offering.
+    if (epoch != _bitcoinPreviewEpoch) return;
+    final live = _currentPaymentState;
+    if (live == null) return;
+    emit(
+      live.copyWith(
+        feePreviewCache: live.feePreviewCache
+            .withSlot(FeeSelection.custom, slot)
+            .copyWith(customLoading: false),
+      ),
+    );
+  }
+
+  Future<void> _onPresetFeesPreviewRequested(
+    PayPresetFeesPreviewRequested event,
+    Emitter<PayState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    final presets = current.bitcoinFees;
+    if (presets == null) return;
+    final wallet = current.selectedWallet!;
+    emit(
+      current.copyWith(
+        feePreviewCache: current.feePreviewCache.copyWith(presetsLoading: true),
+      ),
+    );
+    final epoch = _bitcoinPreviewEpoch;
+    final address = await _payinBuildAddress(current, wallet);
+    final slots = await _previewBitcoinFeePresetsUsecase.execute(
+      presets: presets,
+      walletId: wallet.id,
+      address: address,
+      amountSat: ConvertAmount.btcToSats(current.payOrder.payinAmount),
+      replaceByFee: current.replaceByFee,
+      selectedInputs: current.selectedUtxos,
+      drain: false,
+    );
+    if (epoch != _bitcoinPreviewEpoch) return;
+    final live = _currentPaymentState;
+    if (live == null) return;
+    emit(
+      live.copyWith(
+        feePreviewCache: live.feePreviewCache.copyWith(
+          fastest: slots[FeeSelection.fastest] ?? const BitcoinFeePreviewSlot(),
+          economic:
+              slots[FeeSelection.economic] ?? const BitcoinFeePreviewSlot(),
+          slow: slots[FeeSelection.slow] ?? const BitcoinFeePreviewSlot(),
+          presetsLoading: false,
+        ),
+      ),
+    );
+  }
+
+  // ────── FeeModalViewState + FeeModalActions adoption ──────
+  // The shared modal in lib/core/widgets/fees/ sees the same snapshot and
+  // action surface it gets from SendCubit and TransferBloc; the pay flow's own
+  // state shape and event dispatch collapse here. Fee state only exists on
+  // PayPaymentState, so every other state maps to the neutral defaults (the
+  // modal cannot be open from those screens anyway).
+
+  static FeeModalSnapshot _modalSnapshotFromState(PayState s) {
+    final payment = s is PayPaymentState ? s : null;
+    return FeeModalSnapshot(
+      feePresets: payment?.bitcoinFees,
+      customFee: payment?.customFee,
+      selectedFeeOption: payment?.selectedFeeOption ?? FeeSelection.fastest,
+      feePreviewCache: payment?.feePreviewCache ?? BitcoinFeePreviewCache.empty,
+      exchangeRate: payment?.exchangeRateEstimate ?? 0.0,
+      fiatCurrencyCode: payment?.currency.code ?? '',
+      txSize: payment?.bitcoinTxSize ?? 140,
+    );
+  }
+
+  @override
+  FeeModalSnapshot get snapshot => _modalSnapshotFromState(state);
+
+  @override
+  Stream<FeeModalSnapshot> get snapshots => stream.map(_modalSnapshotFromState);
+
+  @override
+  void requestPresetPreviews() =>
+      add(const PayEvent.presetFeesPreviewRequested());
+
+  @override
+  void requestCustomFeePreview(NetworkFee fee) =>
+      add(PayEvent.customFeePreviewRequested(fee));
+
+  @override
+  void armCustomFee(NetworkFee fee) => add(PayEvent.customFeeArmed(fee));
+
+  @override
+  void disarmCustomFee() => add(const PayEvent.customFeeDisarmed());
+
+  @override
+  void finalizeArmedCustomFee() => add(const PayEvent.customFeeFinalized());
+
+  @override
+  void selectFeeOption(FeeSelection selection) =>
+      add(PayEvent.feeOptionSelected(selection));
 
   // From Sell: Manage polling timer
   void _startPolling() {

--- a/lib/features/pay/presentation/pay_event.dart
+++ b/lib/features/pay/presentation/pay_event.dart
@@ -18,10 +18,10 @@ sealed class PayEvent with _$PayEvent {
     required OrderBitcoinNetwork network,
   }) = PayExternalWalletNetworkSelected;
   const factory PayEvent.orderRefreshTimePassed() = PayOrderRefreshTimePassed;
-  const factory PayEvent.sendPaymentConfirmed({
-    required FeeSelection feeSelection,
-    NetworkFee? customFee,
-  }) = PaySendPaymentConfirmed;
+  // The fee to pay comes from the committed selection on PayPaymentState, not
+  // from the event: the modal writes it there and the summary row reads it
+  // back, so a second copy on the event could only ever disagree (#2521).
+  const factory PayEvent.sendPaymentConfirmed() = PaySendPaymentConfirmed;
   const factory PayEvent.pollOrderStatus() = PayPollOrderStatus;
   const factory PayEvent.replaceByFeeChanged({required bool replaceByFee}) =
       PayReplaceByFeeChanged;
@@ -30,4 +30,32 @@ sealed class PayEvent with _$PayEvent {
   const factory PayEvent.loadUtxos() = PayLoadUtxos;
   const factory PayEvent.updateOrderStatus({required String orderId}) =
       PayUpdateOrderStatus;
+
+  // ────── shared fee modal (FeeModalActions) ──────
+  /// A preset tile was picked. Commits the tier and rebuilds the fee estimate.
+  const factory PayEvent.feeOptionSelected(FeeSelection feeSelection) =
+      PayFeeOptionSelected;
+
+  /// The typed custom fee is committed — triggers the fee recalculation.
+  const factory PayEvent.customFeeChanged(NetworkFee fee) = PayCustomFeeChanged;
+
+  /// Custom-fee field changed: select `custom` without rebuilding yet, and
+  /// snapshot the prior selection so dismissal can roll it back.
+  const factory PayEvent.customFeeArmed(NetworkFee fee) = PayCustomFeeArmed;
+
+  /// The custom-fee field was cleared — roll the arm back immediately so a
+  /// stale typed value cannot survive to dismissal.
+  const factory PayEvent.customFeeDisarmed() = PayCustomFeeDisarmed;
+
+  /// The modal was dismissed without picking a preset: commit the armed value
+  /// when it clears the relay floor, otherwise roll back.
+  const factory PayEvent.customFeeFinalized() = PayCustomFeeFinalized;
+
+  /// Debounced preview build for the typed rate (fills the `custom` slot).
+  const factory PayEvent.customFeePreviewRequested(NetworkFee fee) =
+      PayCustomFeePreviewRequested;
+
+  /// Preview builds for the three presets, fired on every modal open.
+  const factory PayEvent.presetFeesPreviewRequested() =
+      PayPresetFeesPreviewRequested;
 }

--- a/lib/features/pay/presentation/pay_state.dart
+++ b/lib/features/pay/presentation/pay_state.dart
@@ -35,6 +35,27 @@ sealed class PayState with _$PayState {
     @Default([]) List<WalletUtxo> selectedUtxos,
     @Default(true) bool replaceByFee,
     double? exchangeRateEstimate,
+    // Bitcoin fee selection (#2521), mirroring SellPaymentState: the payin is
+    // built at the rate picked in the shared fee modal, not a hardcoded
+    // Fastest.
+    FeeOptions? bitcoinFees,
+    NetworkFee? customFee,
+    @Default(FeeSelection.fastest) FeeSelection selectedFeeOption,
+    // Arm/disarm snapshot for the custom-fee field: typing commits `custom` so
+    // the preset tiles deselect, and dismissal either finalizes the value or
+    // rolls back to these. Internal to the modal flow; the UI must not read
+    // them.
+    FeeSelection? armPriorSelection,
+    NetworkFee? armPriorCustomFee,
+    // Real fees read from unsigned PSBTs, one slot per tier, so the modal never
+    // shows rate × vsize arithmetic. Display only: the confirmation rebuilds
+    // the payin at the committed rate rather than broadcasting a cached PSBT,
+    // because a price-lock refresh can move the payin amount.
+    @Default(BitcoinFeePreviewCache.empty)
+    BitcoinFeePreviewCache feePreviewCache,
+    // vsize of the last payin build — needed to express an absolute custom fee
+    // as a rate for the relay-floor checks.
+    int? bitcoinTxSize,
   }) = PayPaymentState;
   const factory PayState.success({required FiatPaymentOrder payOrder}) =
       PaySuccessState;
@@ -191,6 +212,8 @@ extension PayWalletSelectionStateX on PayWalletSelectionState {
     List<WalletUtxo>? utxos,
     int? absoluteFees,
     double? exchangeRateEstimate,
+    FeeOptions? bitcoinFees,
+    int? bitcoinTxSize,
   }) {
     return PayPaymentState(
       userSummary: userSummary,
@@ -202,6 +225,8 @@ extension PayWalletSelectionStateX on PayWalletSelectionState {
       absoluteFees: absoluteFees,
       exchangeRateEstimate: exchangeRateEstimate,
       utxos: utxos ?? [],
+      bitcoinFees: bitcoinFees,
+      bitcoinTxSize: bitcoinTxSize,
     );
   }
 
@@ -230,6 +255,26 @@ extension PayPaymentStateX on PayPaymentState {
   bool get isExternalWallet => selectedWallet == null;
   bool get canConfirmPayment => isInternalWallet && selectedUtxos.isNotEmpty;
   bool get isProcessing => isConfirmingPayment || isPolling;
+
+  /// Fee the payin must be built at, resolved from the committed selection.
+  /// Null while the presets have not loaded (or custom was selected with no
+  /// value) — the caller decides, rather than silently reverting to Fastest,
+  /// which is the bug #2521 describes.
+  NetworkFee? get selectedFee => switch (selectedFeeOption) {
+    FeeSelection.fastest => bitcoinFees?.fastest,
+    FeeSelection.economic => bitcoinFees?.economic,
+    FeeSelection.slow => bitcoinFees?.slow,
+    FeeSelection.custom => customFee,
+  };
+
+  /// Fee selection is only editable before the confirmation starts: the
+  /// transaction on its way to the network was built at the committed rate, so
+  /// rebuilding under it would pay a different fee than the one shown. Liquid
+  /// payins have no fee choice at all.
+  bool get canEditFees =>
+      !isConfirmingPayment &&
+      selectedWallet != null &&
+      !selectedWallet!.isLiquid;
 
   String get bip21InvoiceData {
     final order = payOrder;

--- a/lib/features/pay/ui/screens/pay_send_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_send_payment_screen.dart
@@ -5,6 +5,8 @@ import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_options_modal.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_selection_label.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/scrollable_column.dart';
@@ -207,15 +209,8 @@ class PaySendPaymentScreen extends StatelessWidget {
                           : context.loc.paySecureBitcoinWallet
                       : ''),
             ),
-            if (wallet != null && !wallet.isLiquid) ...[
-              _DetailRow(
-                title: context.loc.payFeePriority,
-                value: context.loc.payFastest,
-                onTap: () {
-                  debugPrint('Tapped Fee Priority');
-                },
-              ),
-            ],
+            // Liquid payins pay the network minimum, so there is nothing to pick.
+            if (wallet != null && !wallet.isLiquid) const _FeePriorityRow(),
             _DetailRow(
               title: context.loc.payNetworkFees,
               value: context.select((PayBloc bloc) {
@@ -232,10 +227,7 @@ class PaySendPaymentScreen extends StatelessWidget {
             _BottomButtons(
               onContinuePressed: () {
                 context.read<PayBloc>().add(
-                  const PayEvent.sendPaymentConfirmed(
-                    feeSelection: FeeSelection.fastest,
-                    customFee: null,
-                  ),
+                  const PayEvent.sendPaymentConfirmed(),
                 );
               },
             ),
@@ -275,6 +267,69 @@ class PaySendPaymentScreen extends StatelessWidget {
       case RecipientType.sinpeMovilCrc:
         return _formatSinpePhoneNumber(recipient.phoneNumber);
     }
+  }
+}
+
+/// "Fee Priority" row: opens the shared fee modal and shows the committed
+/// selection (#2521). The row goes inert — plain text, no chevron — once the
+/// confirmation starts, since the payin being signed was built at the rate
+/// showing here.
+class _FeePriorityRow extends StatelessWidget {
+  const _FeePriorityRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final (selectedFeeOption, customFee, canEditFees) = context.select((
+      PayBloc bloc,
+    ) {
+      final state = bloc.state;
+      if (state is! PayPaymentState) {
+        return (FeeSelection.fastest, null as NetworkFee?, false);
+      }
+      return (state.selectedFeeOption, state.customFee, state.canEditFees);
+    });
+
+    return _DetailRow(
+      title: context.loc.payFeePriority,
+      value: feeSelectionRowLabel(
+        context,
+        selection: selectedFeeOption,
+        customFee: customFee,
+        fastestLabel: context.loc.payFastest,
+      ),
+      onTap: canEditFees
+          ? () async {
+              final bloc = context.read<PayBloc>();
+              final selected = await BlurredBottomSheet.show<String>(
+                context: context,
+                child: FeeOptionsModal(
+                  viewState: bloc,
+                  actions: bloc,
+                  defaultAbsoluteCustomFee: false,
+                  customFeeColors: FeeModalCustomFeeColors(
+                    tile: context.appColors.surface,
+                    shadow: context.appColors.border,
+                    unselectedIcon: context.appColors.textMuted,
+                  ),
+                ),
+              );
+              if (selected != null) {
+                // A preset tile was tapped; the handler discards any arm left
+                // over from typing in the custom field.
+                bloc.add(
+                  PayEvent.feeOptionSelected(
+                    FeeSelectionName.fromString(selected),
+                  ),
+                );
+              } else {
+                // Dismissed without picking. Typing IS the selection and
+                // dismissing IS the apply, so a typed rate is committed here
+                // (or rolled back when it is below the relay floor).
+                bloc.add(const PayEvent.customFeeFinalized());
+              }
+            }
+          : null,
+    );
   }
 }
 

--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/core/exchange/domain/errors/sell_error.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
@@ -27,7 +28,10 @@ import 'package:bb_mobile/features/sell/domain/refresh_sell_order_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_modal_controller.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bip21_uri/bip21_uri.dart';
@@ -39,7 +43,8 @@ part 'sell_bloc.freezed.dart';
 part 'sell_event.dart';
 part 'sell_state.dart';
 
-class SellBloc extends Bloc<SellEvent, SellState> {
+class SellBloc extends Bloc<SellEvent, SellState>
+    implements FeeModalActions, FeeModalViewState {
   SellBloc({
     required this._getExchangeUserSummaryUsecase,
     required this._getSettingsUsecase,
@@ -59,6 +64,8 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     required this._getWalletUtxosUsecase,
     required this._getOrderUsecase,
     required this._labelsFacade,
+    required this._previewBitcoinFeeUsecase,
+    required this._previewBitcoinFeePresetsUsecase,
   }) : super(const SellState.initial()) {
     on<SellStarted>(_onStarted);
     on<SellAmountInputContinuePressed>(_onAmountInputContinuePressed);
@@ -73,6 +80,13 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     on<SellReplaceByFeeChanged>(_onReplaceByFeeChanged);
     on<SellUtxosSelected>(_onUtxosSelected);
     on<SellLoadUtxos>(_onLoadUtxos);
+    on<SellFeeOptionSelected>(_onFeeOptionSelected);
+    on<SellCustomFeeChanged>(_onCustomFeeChanged);
+    on<SellCustomFeeArmed>(_onCustomFeeArmed);
+    on<SellCustomFeeDisarmed>(_onCustomFeeDisarmed);
+    on<SellCustomFeeFinalized>(_onCustomFeeFinalized);
+    on<SellCustomFeePreviewRequested>(_onCustomFeePreviewRequested);
+    on<SellPresetFeesPreviewRequested>(_onPresetFeesPreviewRequested);
   }
 
   final GetExchangeUserSummaryUsecase _getExchangeUserSummaryUsecase;
@@ -94,7 +108,15 @@ class SellBloc extends Bloc<SellEvent, SellState> {
   final GetWalletUtxosUsecase _getWalletUtxosUsecase;
   final GetOrderUsecase _getOrderUsecase;
   final LabelsFacade _labelsFacade;
+  final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
+  final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   Timer? _pollingTimer;
+
+  /// Bumped whenever the cached previews stop describing the payin being
+  /// built (typed rate, coin selection, RBF, a refreshed payin amount). A
+  /// preview build that started under an older epoch is discarded on return
+  /// instead of writing a slot for a tx shape that no longer exists.
+  int _bitcoinPreviewEpoch = 0;
 
   Future<void> _onStarted(SellStarted event, Emitter<SellState> emit) async {
     try {
@@ -151,6 +173,16 @@ class SellBloc extends Bloc<SellEvent, SellState> {
   ) async {
     int absoluteFees = 0;
     double exchangeRateEstimate = 0.0;
+    // Carried into the payment state so the confirmation screen can offer the
+    // fee modal (#2521): it needs the presets to price the tiles and a vsize
+    // to check an absolute custom fee against the relay floor.
+    FeeOptions? bitcoinFees;
+    int? bitcoinTxSize;
+    // This builds a brand-new payment state, with its own order, wallet and
+    // empty preview cache. A preview still in flight for the previous one would
+    // otherwise land in that cache and price this payin with the last order's
+    // fees.
+    _bitcoinPreviewEpoch++;
 
     final walletSelectionState = state.toCleanWalletSelectionState;
     if (walletSelectionState == null) {
@@ -205,17 +237,16 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           pset: pset,
         );
       } else {
-        final bitcoinFees = await _getNetworkFeesUsecase.execute(
-          isLiquid: false,
-        );
-        final fastestFee = bitcoinFees.fastest;
-
+        bitcoinFees = await _getNetworkFeesUsecase.execute(isLiquid: false);
+        // Fastest is the default selection, so the estimate shown on arrival
+        // is the estimate for the tier the payin would be built at.
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: event.wallet.id,
           address: dummyAddressForFeeCalculation.address,
           amountSat: requiredAmountSat,
-          networkFee: fastestFee,
+          networkFee: bitcoinFees.fastest,
         );
+        bitcoinTxSize = preparedSend.txSize;
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
         );
@@ -251,6 +282,8 @@ class SellBloc extends Bloc<SellEvent, SellState> {
             absoluteFees: absoluteFees,
             utxos: utxos,
             exchangeRateEstimate: exchangeRateEstimate,
+            bitcoinFees: bitcoinFees,
+            bitcoinTxSize: bitcoinTxSize,
           ),
         );
       } else {
@@ -372,7 +405,14 @@ class SellBloc extends Bloc<SellEvent, SellState> {
       // The error is kept: when this refresh was triggered by a failed send
       // (see _emitSendPaymentError) clearing it would erase the only
       // explanation the user has. The next confirmation clears it anyway.
-      emit(current.copyWith(sellOrder: refreshedOrder));
+      final refreshed = current.copyWith(sellOrder: refreshedOrder);
+      // A new price lock moves the payin amount, which invalidates every
+      // preview built for the old one.
+      emit(
+        refreshedOrder.payinAmount == current.sellOrder.payinAmount
+            ? refreshed
+            : _clearedFeePreviews(refreshed),
+      );
     } on SellError catch (e) {
       // Same re-read as the success path: a refresh failure must not paint an
       // error over a confirmation that started while it was in flight.
@@ -450,8 +490,15 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           ),
         );
       } else {
+        // The rate the user committed in the fee modal, which defaults to
+        // Fastest. The absolute fee from the last estimate is the fallback for
+        // the case where the presets went missing — being unable to pick a fee
+        // must not block paying the order.
         final absoluteFees = sellPaymentState.absoluteFees;
-        if (absoluteFees == null) {
+        final networkFee =
+            sellPaymentState.selectedFee ??
+            (absoluteFees != null ? NetworkFee.absolute(absoluteFees) : null);
+        if (networkFee == null) {
           throw const SellError.unexpected(
             message: 'Transaction fees not calculated. Please try again.',
           );
@@ -461,7 +508,7 @@ class SellBloc extends Bloc<SellEvent, SellState> {
           walletId: wallet.id,
           address: sellPaymentState.sellOrder.bitcoinAddress!,
           amountSat: payinAmountSat,
-          networkFee: NetworkFee.absolute(absoluteFees),
+          networkFee: networkFee,
           selectedInputs: sellPaymentState.selectedUtxos.isNotEmpty
               ? sellPaymentState.selectedUtxos
               : null,
@@ -469,9 +516,24 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         );
         final absoluteFeesUpdated = await _calculateBitcoinAbsoluteFeesUsecase
             .execute(psbt: preparedSend.unsignedPsbt);
+        // An absolute custom fee was checked against the *previous* vsize; if
+        // this build came out larger it can sit below the relay floor, which
+        // strands the payin unbroadcastable. Re-check the built fee against the
+        // built vsize before signing rather than trusting BDK to refuse.
+        if (!NetworkFee.absolute(absoluteFeesUpdated).aboveMinRelay(
+          txSize: preparedSend.txSize,
+          floorSatPerKwu: sellPaymentState.bitcoinFees?.minRelay.satPerKwu,
+        )) {
+          throw const SellError.unexpected(
+            message:
+                'The selected fee is below the network minimum. '
+                'Choose a higher fee priority and try again.',
+          );
+        }
         emit(
           (_currentPaymentState ?? sellPaymentState).copyWith(
             absoluteFees: absoluteFeesUpdated,
+            bitcoinTxSize: preparedSend.txSize,
           ),
         );
         final signedTx = await _signBitcoinTxUsecase.execute(
@@ -643,7 +705,13 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     if (state is! SellPaymentState) return;
 
     final sellPaymentState = state as SellPaymentState;
-    emit(sellPaymentState.copyWith(replaceByFee: event.replaceByFee));
+    // RBF changes the sequence numbers, so every cached preview PSBT is for a
+    // different transaction now.
+    emit(
+      _clearedFeePreviews(
+        sellPaymentState.copyWith(replaceByFee: event.replaceByFee),
+      ),
+    );
     await _recalculateFees(emit);
   }
 
@@ -656,7 +724,12 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     final sellPaymentState = state as SellPaymentState;
     final selectedUtxos = event.utxos;
 
-    emit(sellPaymentState.copyWith(selectedUtxos: selectedUtxos));
+    // Coin selection changed — the previews were priced on the old input set.
+    emit(
+      _clearedFeePreviews(
+        sellPaymentState.copyWith(selectedUtxos: selectedUtxos),
+      ),
+    );
     await _recalculateFees(emit);
   }
 
@@ -682,12 +755,26 @@ class SellBloc extends Bloc<SellEvent, SellState> {
     }
   }
 
+  /// Rebuilds the payin estimate at the committed fee.
+  ///
+  /// Every emit past an await reads the live state and gives up when it is gone:
+  /// this runs across `_getNetworkFeesUsecase` and a PSBT build, so a slow fetch
+  /// routinely outlives the screen. Merging into a pre-await snapshot instead
+  /// would republish the payment state over whatever replaced it — dropping the
+  /// broadcast latch and re-arming Confirm on a payin already on the wire
+  /// (#2522).
   Future<void> _recalculateFees(Emitter<SellState> emit) async {
-    if (state is! SellPaymentState) return;
-
-    final sellPaymentState = state as SellPaymentState;
+    final sellPaymentState = _currentPaymentState;
+    if (sellPaymentState == null) return;
     final wallet = sellPaymentState.selectedWallet;
     if (wallet == null) return;
+
+    // The displayed fee belongs to the previous build until this one lands, so
+    // drop it and let the row show its calculating state — pairing the old
+    // amount with a just-changed fee tier reads as if nothing happened.
+    // Restored on failure so the row can't be left calculating forever.
+    final previousAbsoluteFees = sellPaymentState.absoluteFees;
+    emit(sellPaymentState.copyWith(absoluteFees: null));
 
     try {
       final payinAmountSat = ConvertAmount.btcToSats(
@@ -707,41 +794,50 @@ class SellBloc extends Bloc<SellEvent, SellState> {
         final absoluteFees = await _calculateLiquidAbsoluteFeesUsecase.execute(
           pset: pset,
         );
-        emit(
-          (_currentPaymentState ?? sellPaymentState).copyWith(
-            absoluteFees: absoluteFees,
-          ),
-        );
+        final liveAfterLiquidBuild = _currentPaymentState;
+        if (liveAfterLiquidBuild == null) return;
+        emit(liveAfterLiquidBuild.copyWith(absoluteFees: absoluteFees));
       } else {
         final bitcoinFees = await _getNetworkFeesUsecase.execute(
           isLiquid: false,
         );
-        final fastestFee = bitcoinFees.fastest;
-
-        final dummyAddressForFeeCalculation = await _getAddressAtIndexUsecase
-            .execute(walletId: wallet.id, index: 0);
+        // Reprice the presets without touching the committed tier: a rate
+        // refresh that silently reset the selection to Fastest would undo the
+        // user's choice behind their back.
+        final liveAfterFeeFetch = _currentPaymentState;
+        if (liveAfterFeeFetch == null) return;
+        final repriced = liveAfterFeeFetch.copyWith(bitcoinFees: bitcoinFees);
+        final networkFee = repriced.selectedFee ?? bitcoinFees.fastest;
+        final address = await _payinBuildAddress(repriced, wallet);
         final preparedSend = await _prepareBitcoinSendUsecase.execute(
           walletId: wallet.id,
-          address: dummyAddressForFeeCalculation.address,
+          address: address,
           amountSat: payinAmountSat,
-          networkFee: fastestFee,
-          selectedInputs: sellPaymentState.selectedUtxos.isNotEmpty
-              ? sellPaymentState.selectedUtxos
+          networkFee: networkFee,
+          selectedInputs: repriced.selectedUtxos.isNotEmpty
+              ? repriced.selectedUtxos
               : null,
-          replaceByFee: sellPaymentState.replaceByFee,
+          replaceByFee: repriced.replaceByFee,
         );
         final absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: preparedSend.unsignedPsbt,
         );
+        final liveAfterBitcoinBuild = _currentPaymentState;
+        if (liveAfterBitcoinBuild == null) return;
         emit(
-          (_currentPaymentState ?? sellPaymentState).copyWith(
+          liveAfterBitcoinBuild.copyWith(
+            bitcoinFees: bitcoinFees,
             absoluteFees: absoluteFees,
+            bitcoinTxSize: preparedSend.txSize,
           ),
         );
       }
     } catch (e) {
+      final liveAfterFailure = _currentPaymentState;
+      if (liveAfterFailure == null) return;
       emit(
-        (_currentPaymentState ?? sellPaymentState).copyWith(
+        liveAfterFailure.copyWith(
+          absoluteFees: previousAbsoluteFees,
           error: SellError.unexpected(
             message: 'Failed to recalculate fees: $e',
           ),
@@ -749,6 +845,275 @@ class SellBloc extends Bloc<SellEvent, SellState> {
       );
     }
   }
+
+  /// Address the payin is (or will be) built for. The order's own address keeps
+  /// the estimate honest — a build against one of our own addresses can differ
+  /// in vsize when the script types differ. Falls back to an own address only
+  /// when the order has none yet.
+  Future<String> _payinBuildAddress(
+    SellPaymentState paymentState,
+    Wallet wallet,
+  ) async {
+    final payinAddress = paymentState.sellOrder.bitcoinAddress;
+    if (payinAddress != null && payinAddress.isNotEmpty) return payinAddress;
+    final ownAddress = await _getAddressAtIndexUsecase.execute(
+      walletId: wallet.id,
+      index: 0,
+    );
+    return ownAddress.address;
+  }
+
+  /// Drops every cached preview and invalidates in-flight builds. Call whenever
+  /// the payin's shape changes: a slot still holding the old shape's fee would
+  /// price the modal for a transaction we are no longer building.
+  SellPaymentState _clearedFeePreviews(SellPaymentState paymentState) {
+    _bitcoinPreviewEpoch++;
+    return paymentState.copyWith(
+      feePreviewCache: BitcoinFeePreviewCache.empty,
+    );
+  }
+
+  /// Payment state while fee selection is still allowed, or null when the
+  /// event must be ignored — no payment in flight, a Liquid payin (no fee
+  /// choice), or a confirmation already running (#2522).
+  SellPaymentState? get _feeEditablePaymentState {
+    final current = _currentPaymentState;
+    if (current == null) return null;
+    return current.canEditFees ? current : null;
+  }
+
+  Future<void> _onFeeOptionSelected(
+    SellFeeOptionSelected event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    // Picking a preset is itself a commit, so any custom-fee arm is discarded
+    // rather than rolled back.
+    emit(
+      current.copyWith(
+        selectedFeeOption: event.feeSelection,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+    await _recalculateFees(emit);
+  }
+
+  Future<void> _onCustomFeeChanged(
+    SellCustomFeeChanged event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    emit(
+      current.copyWith(
+        customFee: event.fee,
+        selectedFeeOption: FeeSelection.custom,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+    await _recalculateFees(emit);
+  }
+
+  Future<void> _onCustomFeeArmed(
+    SellCustomFeeArmed event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    // The typed rate just changed, so only the cached custom slot is wrong — it
+    // prices the previous rate. The preset slots still describe the same payin
+    // and must survive, or the first keystroke would blank their prices until
+    // the modal is reopened. Bumping the epoch discards a custom preview still
+    // in flight for the older rate, so it cannot land on top of the new one.
+    _bitcoinPreviewEpoch++;
+    final clearedCustomSlot = current.feePreviewCache.withSlot(
+      FeeSelection.custom,
+      const BitcoinFeePreviewSlot(),
+    );
+    if (current.armPriorSelection == null) {
+      emit(
+        current.copyWith(
+          armPriorSelection: current.selectedFeeOption,
+          armPriorCustomFee: current.customFee,
+          selectedFeeOption: FeeSelection.custom,
+          customFee: event.fee,
+          feePreviewCache: clearedCustomSlot,
+        ),
+      );
+    } else {
+      emit(
+        current.copyWith(
+          customFee: event.fee,
+          feePreviewCache: clearedCustomSlot,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onCustomFeeDisarmed(
+    SellCustomFeeDisarmed event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    if (current.armPriorSelection == null) return;
+    emit(
+      current.copyWith(
+        selectedFeeOption: current.armPriorSelection!,
+        customFee: current.armPriorCustomFee,
+        armPriorSelection: null,
+        armPriorCustomFee: null,
+      ),
+    );
+  }
+
+  Future<void> _onCustomFeeFinalized(
+    SellCustomFeeFinalized event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    if (current.armPriorSelection == null) return;
+    final fee = current.customFee;
+    final txSize = current.bitcoinTxSize ?? 140;
+    if (fee != null &&
+        fee.aboveMinRelay(
+          txSize: txSize,
+          floorSatPerKwu: current.bitcoinFees?.minRelay.satPerKwu,
+        )) {
+      await _onCustomFeeChanged(SellCustomFeeChanged(fee), emit);
+    } else {
+      await _onCustomFeeDisarmed(const SellCustomFeeDisarmed(), emit);
+    }
+  }
+
+  Future<void> _onCustomFeePreviewRequested(
+    SellCustomFeePreviewRequested event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    final wallet = current.selectedWallet!;
+    emit(
+      current.copyWith(
+        feePreviewCache: current.feePreviewCache.copyWith(customLoading: true),
+      ),
+    );
+    final epoch = _bitcoinPreviewEpoch;
+    final address = await _payinBuildAddress(current, wallet);
+    final slot = await _previewBitcoinFeeUsecase.execute(
+      walletId: wallet.id,
+      address: address,
+      networkFee: event.fee,
+      amountSat: ConvertAmount.btcToSats(current.sellOrder.payinAmount),
+      replaceByFee: current.replaceByFee,
+      selectedInputs: current.selectedUtxos,
+      drain: false,
+    );
+    // The payin's shape changed while this build ran, so the slot describes a
+    // transaction we are no longer offering.
+    if (epoch != _bitcoinPreviewEpoch) return;
+    final live = _currentPaymentState;
+    if (live == null) return;
+    emit(
+      live.copyWith(
+        feePreviewCache: live.feePreviewCache
+            .withSlot(FeeSelection.custom, slot)
+            .copyWith(customLoading: false),
+      ),
+    );
+  }
+
+  Future<void> _onPresetFeesPreviewRequested(
+    SellPresetFeesPreviewRequested event,
+    Emitter<SellState> emit,
+  ) async {
+    final current = _feeEditablePaymentState;
+    if (current == null) return;
+    final presets = current.bitcoinFees;
+    if (presets == null) return;
+    final wallet = current.selectedWallet!;
+    emit(
+      current.copyWith(
+        feePreviewCache: current.feePreviewCache.copyWith(presetsLoading: true),
+      ),
+    );
+    final epoch = _bitcoinPreviewEpoch;
+    final address = await _payinBuildAddress(current, wallet);
+    final slots = await _previewBitcoinFeePresetsUsecase.execute(
+      presets: presets,
+      walletId: wallet.id,
+      address: address,
+      amountSat: ConvertAmount.btcToSats(current.sellOrder.payinAmount),
+      replaceByFee: current.replaceByFee,
+      selectedInputs: current.selectedUtxos,
+      drain: false,
+    );
+    if (epoch != _bitcoinPreviewEpoch) return;
+    final live = _currentPaymentState;
+    if (live == null) return;
+    emit(
+      live.copyWith(
+        feePreviewCache: live.feePreviewCache.copyWith(
+          fastest: slots[FeeSelection.fastest] ?? const BitcoinFeePreviewSlot(),
+          economic:
+              slots[FeeSelection.economic] ?? const BitcoinFeePreviewSlot(),
+          slow: slots[FeeSelection.slow] ?? const BitcoinFeePreviewSlot(),
+          presetsLoading: false,
+        ),
+      ),
+    );
+  }
+
+  // ────── FeeModalViewState + FeeModalActions adoption ──────
+  // The shared modal in lib/core/widgets/fees/ sees the same snapshot and
+  // action surface it gets from SendCubit and TransferBloc; the sell flow's
+  // own state shape and event dispatch collapse here. Fee state only exists
+  // on SellPaymentState, so every other state maps to the neutral defaults
+  // (the modal cannot be open from those screens anyway).
+
+  static FeeModalSnapshot _modalSnapshotFromState(SellState s) {
+    final payment = s is SellPaymentState ? s : null;
+    return FeeModalSnapshot(
+      feePresets: payment?.bitcoinFees,
+      customFee: payment?.customFee,
+      selectedFeeOption: payment?.selectedFeeOption ?? FeeSelection.fastest,
+      feePreviewCache: payment?.feePreviewCache ?? BitcoinFeePreviewCache.empty,
+      exchangeRate: payment?.exchangeRateEstimate ?? 0.0,
+      fiatCurrencyCode: payment?.fiatCurrency.code ?? '',
+      txSize: payment?.bitcoinTxSize ?? 140,
+    );
+  }
+
+  @override
+  FeeModalSnapshot get snapshot => _modalSnapshotFromState(state);
+
+  @override
+  Stream<FeeModalSnapshot> get snapshots => stream.map(_modalSnapshotFromState);
+
+  @override
+  void requestPresetPreviews() =>
+      add(const SellEvent.presetFeesPreviewRequested());
+
+  @override
+  void requestCustomFeePreview(NetworkFee fee) =>
+      add(SellEvent.customFeePreviewRequested(fee));
+
+  @override
+  void armCustomFee(NetworkFee fee) => add(SellEvent.customFeeArmed(fee));
+
+  @override
+  void disarmCustomFee() => add(const SellEvent.customFeeDisarmed());
+
+  @override
+  void finalizeArmedCustomFee() => add(const SellEvent.customFeeFinalized());
+
+  @override
+  void selectFeeOption(FeeSelection selection) =>
+      add(SellEvent.feeOptionSelected(selection));
 
   @override
   Future<void> close() {

--- a/lib/features/sell/presentation/bloc/sell_event.dart
+++ b/lib/features/sell/presentation/bloc/sell_event.dart
@@ -14,14 +14,43 @@ sealed class SellEvent with _$SellEvent {
     required OrderBitcoinNetwork network,
   }) = SellExternalWalletNetworkSelected;
   const factory SellEvent.orderRefreshTimePassed() = SellOrderRefreshTimePassed;
-  const factory SellEvent.sendPaymentConfirmed({
-    required FeeSelection feeSelection,
-    NetworkFee? customFee,
-  }) = SellSendPaymentConfirmed;
+  // The fee to pay comes from the committed selection on SellPaymentState, not
+  // from the event: the modal writes it there and the summary row reads it
+  // back, so a second copy on the event could only ever disagree (#2521).
+  const factory SellEvent.sendPaymentConfirmed() = SellSendPaymentConfirmed;
   const factory SellEvent.pollOrderStatus() = SellPollOrderStatus;
   const factory SellEvent.replaceByFeeChanged({required bool replaceByFee}) =
       SellReplaceByFeeChanged;
   const factory SellEvent.utxosSelected({required List<WalletUtxo> utxos}) =
       SellUtxosSelected;
   const factory SellEvent.loadUtxos() = SellLoadUtxos;
+
+  // ────── shared fee modal (FeeModalActions) ──────
+  /// A preset tile was picked. Commits the tier and rebuilds the fee estimate.
+  const factory SellEvent.feeOptionSelected(FeeSelection feeSelection) =
+      SellFeeOptionSelected;
+
+  /// The typed custom fee is committed — triggers the fee recalculation.
+  const factory SellEvent.customFeeChanged(NetworkFee fee) =
+      SellCustomFeeChanged;
+
+  /// Custom-fee field changed: select `custom` without rebuilding yet, and
+  /// snapshot the prior selection so dismissal can roll it back.
+  const factory SellEvent.customFeeArmed(NetworkFee fee) = SellCustomFeeArmed;
+
+  /// The custom-fee field was cleared — roll the arm back immediately so a
+  /// stale typed value cannot survive to dismissal.
+  const factory SellEvent.customFeeDisarmed() = SellCustomFeeDisarmed;
+
+  /// The modal was dismissed without picking a preset: commit the armed value
+  /// when it clears the relay floor, otherwise roll back.
+  const factory SellEvent.customFeeFinalized() = SellCustomFeeFinalized;
+
+  /// Debounced preview build for the typed rate (fills the `custom` slot).
+  const factory SellEvent.customFeePreviewRequested(NetworkFee fee) =
+      SellCustomFeePreviewRequested;
+
+  /// Preview builds for the three presets, fired on every modal open.
+  const factory SellEvent.presetFeesPreviewRequested() =
+      SellPresetFeesPreviewRequested;
 }

--- a/lib/features/sell/presentation/bloc/sell_state.dart
+++ b/lib/features/sell/presentation/bloc/sell_state.dart
@@ -35,6 +35,27 @@ sealed class SellState with _$SellState {
     @Default([]) List<WalletUtxo> selectedUtxos,
     @Default(true) bool replaceByFee,
     double? exchangeRateEstimate,
+    // Bitcoin fee selection (#2521). The payin is built at the rate the user
+    // picked in the shared fee modal, not at a hardcoded Fastest.
+    FeeOptions? bitcoinFees,
+    NetworkFee? customFee,
+    @Default(FeeSelection.fastest) FeeSelection selectedFeeOption,
+    // Arm/disarm snapshot, internal to the custom-fee field: typing eagerly
+    // commits `selectedFeeOption: custom` so the preset tiles deselect, and
+    // dismissing the modal either finalizes that value or rolls back to these.
+    // Same contract as SendState — the UI must not read them.
+    FeeSelection? armPriorSelection,
+    NetworkFee? armPriorCustomFee,
+    // Real fees read from unsigned PSBTs built per preset / typed rate, so the
+    // modal never shows rate × vsize arithmetic. Display only here: unlike
+    // send, the confirmation rebuilds the payin at the committed rate rather
+    // than broadcasting a cached PSBT, because the order's payin amount can
+    // change under a price-lock refresh.
+    @Default(BitcoinFeePreviewCache.empty)
+    BitcoinFeePreviewCache feePreviewCache,
+    // vsize of the last payin build — the floor checks on an absolute custom
+    // fee need a size to express it as a rate.
+    int? bitcoinTxSize,
   }) = SellPaymentState;
   const factory SellState.success({
     required BitcoinUnit bitcoinUnit,
@@ -181,6 +202,8 @@ extension SellWalletSelectionStateX on SellWalletSelectionState {
     int? absoluteFees,
     List<WalletUtxo>? utxos,
     double? exchangeRateEstimate,
+    FeeOptions? bitcoinFees,
+    int? bitcoinTxSize,
   }) {
     return SellPaymentState(
       userSummary: userSummary,
@@ -192,6 +215,8 @@ extension SellWalletSelectionStateX on SellWalletSelectionState {
       absoluteFees: absoluteFees,
       exchangeRateEstimate: exchangeRateEstimate,
       utxos: utxos ?? [],
+      bitcoinFees: bitcoinFees,
+      bitcoinTxSize: bitcoinTxSize,
     );
   }
 
@@ -214,6 +239,27 @@ extension SellPaymentStateX on SellPaymentState {
   /// The payin transaction is already broadcast, so preparing, signing and
   /// broadcasting again would risk paying the order twice.
   bool get isPayinBroadcast => payinBroadcastTxid != null;
+
+  /// Fee the payin must be built at, resolved from the committed selection.
+  /// Null while the presets have not loaded (or a custom fee was selected
+  /// without a value) — the caller decides what to do rather than silently
+  /// falling back to Fastest, which is the bug #2521 describes.
+  NetworkFee? get selectedFee => switch (selectedFeeOption) {
+    FeeSelection.fastest => bitcoinFees?.fastest,
+    FeeSelection.economic => bitcoinFees?.economic,
+    FeeSelection.slow => bitcoinFees?.slow,
+    FeeSelection.custom => customFee,
+  };
+
+  /// Fee selection is only editable before the confirmation starts: the tx on
+  /// its way to the network was built from the committed rate, so rebuilding
+  /// under it — or after the broadcast latch — is the #2522 double-payment
+  /// window. Liquid payins have no fee choice at all.
+  bool get canEditFees =>
+      !isConfirmingPayment &&
+      !isPayinBroadcast &&
+      selectedWallet != null &&
+      !selectedWallet!.isLiquid;
 
   SellSuccessState toSuccessState({required SellOrder sellOrder}) {
     return SellSuccessState(bitcoinUnit: bitcoinUnit, sellOrder: sellOrder);

--- a/lib/features/sell/sell_locator.dart
+++ b/lib/features/sell/sell_locator.dart
@@ -17,6 +17,8 @@ import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:get_it/get_it.dart';
@@ -83,6 +85,9 @@ class SellLocator {
         getWalletUtxosUsecase: locator<GetWalletUtxosUsecase>(),
         getOrderUsecase: locator<GetOrderUsecase>(),
         labelsFacade: locator<LabelsFacade>(),
+        previewBitcoinFeeUsecase: locator<PreviewBitcoinFeeUsecase>(),
+        previewBitcoinFeePresetsUsecase:
+            locator<PreviewBitcoinFeePresetsUsecase>(),
       ),
     );
   }

--- a/lib/features/sell/ui/screens/sell_send_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_send_payment_screen.dart
@@ -7,6 +7,8 @@ import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_options_modal.dart';
+import 'package:bb_mobile/core/widgets/fees/fee_selection_label.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/scrollable_column.dart';
@@ -158,16 +160,8 @@ class SellSendPaymentScreen extends StatelessWidget {
                           : context.loc.sellSecureBitcoinWallet
                       : ''),
             ),
-            if (wallet != null && !wallet.isLiquid) ...[
-              _DetailRow(
-                title: context.loc.sellFeePriority,
-                value: context.loc.sellFastest,
-                onTap: () {
-                  debugPrint('Tapped Fee Priority');
-                },
-              ),
-            ],
-            // TODO: Implement fee selection
+            // Liquid payins pay the network minimum, so there is nothing to pick.
+            if (wallet != null && !wallet.isLiquid) const _FeePriorityRow(),
             _DetailRow(
               title: context.loc.sellSendPaymentNetworkFees,
               value: context.select((SellBloc bloc) {
@@ -186,16 +180,76 @@ class SellSendPaymentScreen extends StatelessWidget {
             _BottomButtons(
               onContinuePressed: () {
                 context.read<SellBloc>().add(
-                  const SellEvent.sendPaymentConfirmed(
-                    feeSelection: FeeSelection.fastest,
-                    customFee: null,
-                  ),
+                  const SellEvent.sendPaymentConfirmed(),
                 );
               },
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// "Fee Priority" row: opens the shared fee modal and shows the committed
+/// selection (#2521). The row goes inert — plain text, no chevron — once the
+/// confirmation starts, since the payin being signed was built at the rate
+/// showing here and the broadcast latch must not be reopened (#2522).
+class _FeePriorityRow extends StatelessWidget {
+  const _FeePriorityRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final (selectedFeeOption, customFee, canEditFees) = context.select((
+      SellBloc bloc,
+    ) {
+      final state = bloc.state;
+      if (state is! SellPaymentState) {
+        return (FeeSelection.fastest, null as NetworkFee?, false);
+      }
+      return (state.selectedFeeOption, state.customFee, state.canEditFees);
+    });
+
+    return _DetailRow(
+      title: context.loc.sellFeePriority,
+      value: feeSelectionRowLabel(
+        context,
+        selection: selectedFeeOption,
+        customFee: customFee,
+        fastestLabel: context.loc.sellFastest,
+      ),
+      onTap: canEditFees
+          ? () async {
+              final bloc = context.read<SellBloc>();
+              final selected = await BlurredBottomSheet.show<String>(
+                context: context,
+                child: FeeOptionsModal(
+                  viewState: bloc,
+                  actions: bloc,
+                  defaultAbsoluteCustomFee: false,
+                  customFeeColors: FeeModalCustomFeeColors(
+                    tile: context.appColors.surface,
+                    shadow: context.appColors.border,
+                    unselectedIcon: context.appColors.textMuted,
+                  ),
+                ),
+              );
+              if (selected != null) {
+                // A preset tile was tapped; the handler discards any arm left
+                // over from typing in the custom field.
+                bloc.add(
+                  SellEvent.feeOptionSelected(
+                    FeeSelectionName.fromString(selected),
+                  ),
+                );
+              } else {
+                // Dismissed without picking. Typing IS the selection and
+                // dismissing IS the apply, so a typed rate is committed here
+                // (or rolled back when it is below the relay floor).
+                bloc.add(const SellEvent.customFeeFinalized());
+              }
+            }
+          : null,
     );
   }
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -6564,6 +6564,10 @@
   "@feePriorityLabel": {
     "description": "Label for fee selection priority option"
   },
+  "feePrioritySlow": "Slow",
+  "@feePrioritySlow": {
+    "description": "Name of the slow (cheapest) network fee tier"
+  },
   "transferIdLabel": "Transfer ID",
   "@transferIdLabel": {
     "description": "Label for swap transfer ID"

--- a/test/features/pay/presentation/pay_bloc_test.dart
+++ b/test/features/pay/presentation/pay_bloc_test.dart
@@ -1,0 +1,511 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
+import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/features/pay/domain/create_pay_order_usecase.dart';
+import 'package:bb_mobile/features/pay/domain/refresh_pay_order_usecase.dart';
+import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
+import 'package:bb_mobile/features/recipients/domain/value_objects/recipient_type.dart';
+import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart';
+import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetUserSummary extends Mock
+    implements GetExchangeUserSummaryUsecase {}
+
+class _MockPlacePayOrder extends Mock implements PlacePayOrderUsecase {}
+
+class _MockRefreshPayOrder extends Mock implements RefreshPayOrderUsecase {}
+
+class _MockPrepareBitcoinSend extends Mock
+    implements PrepareBitcoinSendUsecase {}
+
+class _MockPrepareLiquidSend extends Mock implements PrepareLiquidSendUsecase {}
+
+class _MockSignBitcoinTx extends Mock implements SignBitcoinTxUsecase {}
+
+class _MockSignLiquidTx extends Mock implements SignLiquidTxUsecase {}
+
+class _MockBroadcastBitcoin extends Mock
+    implements BroadcastBitcoinTransactionUsecase {}
+
+class _MockBroadcastLiquid extends Mock
+    implements BroadcastLiquidTransactionUsecase {}
+
+class _MockGetNetworkFees extends Mock implements GetNetworkFeesUsecase {}
+
+class _MockCalculateLiquidFees extends Mock
+    implements CalculateLiquidAbsoluteFeesUsecase {}
+
+class _MockCalculateBitcoinFees extends Mock
+    implements CalculateBitcoinAbsoluteFeesUsecase {}
+
+class _MockConvertSatsToCurrency extends Mock
+    implements ConvertSatsToCurrencyAmountUsecase {}
+
+class _MockGetAddressAtIndex extends Mock implements GetAddressAtIndexUsecase {}
+
+class _MockGetWalletUtxos extends Mock implements GetWalletUtxosUsecase {}
+
+class _MockGetOrder extends Mock implements GetOrderUsecase {}
+
+class _MockPreviewBitcoinFee extends Mock implements PreviewBitcoinFeeUsecase {}
+
+class _MockPreviewBitcoinFeePresets extends Mock
+    implements PreviewBitcoinFeePresetsUsecase {}
+
+class _MockWallet extends Mock implements Wallet {}
+
+class _MockPayOrder extends Mock implements FiatPaymentOrder {}
+
+/// The confirmation path only ever runs from a [PayPaymentState] that earlier
+/// events built up. Seeding it directly keeps this test to the send path and
+/// avoids the order polling timer that order creation starts.
+class _SeedablePayBloc extends PayBloc {
+  _SeedablePayBloc({
+    required super.getExchangeUserSummaryUsecase,
+    required super.placePayOrderUsecase,
+    required super.refreshPayOrderUsecase,
+    required super.prepareBitcoinSendUsecase,
+    required super.prepareLiquidSendUsecase,
+    required super.signBitcoinTxUsecase,
+    required super.signLiquidTxUsecase,
+    required super.broadcastBitcoinTransactionUsecase,
+    required super.broadcastLiquidTransactionUsecase,
+    required super.getNetworkFeesUsecase,
+    required super.calculateLiquidAbsoluteFeesUsecase,
+    required super.calculateBitcoinAbsoluteFeesUsecase,
+    required super.convertSatsToCurrencyAmountUsecase,
+    required super.getAddressAtIndexUsecase,
+    required super.getWalletUtxosUsecase,
+    required super.getOrderUsecase,
+    required super.previewBitcoinFeeUsecase,
+    required super.previewBitcoinFeePresetsUsecase,
+  });
+
+  void seed(PayState state) => emit(state);
+}
+
+void main() {
+  // Unsigned single-input single-output PSBT with a witness UTXO — enough for
+  // the sign/broadcast mocks to have something to pass around.
+  const unsignedPsbt =
+      'cHNidP8BAFICAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD9////'
+      'AaCGAQAAAAAAFgAUIiIiIiIiIiIiIiIiIiIiIiIiIiIAAAAAAAEBH2iHAQAAAAAAFgAUMzMz'
+      'MzMzMzMzMzMzMzMzMzMzMzMAAA==';
+  const payinAddress = 'bc1q0000000000000000000000000000000000000';
+  const userSummary = UserSummary(
+    userNumber: 1,
+    groups: ['KYC_IDENTITY_VERIFIED'],
+    profile: UserProfile(firstName: 'Sat', lastName: 'Oshi'),
+    email: 'sat@example.com',
+    balances: [],
+    dca: UserDca(isActive: false),
+    autoBuy: UserAutoBuy(isActive: false, addresses: UserAutoBuyAddresses()),
+  );
+  const recipient = RecipientViewModel(
+    id: 'recipient-1',
+    type: RecipientType.interacEmailCad,
+    email: 'payee@example.com',
+  );
+
+  // Tiers far enough apart that the rate handed to the PSBT build identifies
+  // which one the bloc picked.
+  final feeOptions = FeeOptions(
+    fastest: NetworkFee.relativeFromSatPerVbyte(10),
+    economic: NetworkFee.relativeFromSatPerVbyte(5),
+    slow: NetworkFee.relativeFromSatPerVbyte(1),
+    minRelay: NetworkFee.relativeFromSatPerVbyte(0.1),
+  );
+
+  late _MockPrepareBitcoinSend prepareBitcoinSend;
+  late _MockBroadcastBitcoin broadcastBitcoin;
+  late _MockGetNetworkFees getNetworkFees;
+  late _MockGetOrder getOrder;
+  late _MockPreviewBitcoinFeePresets previewBitcoinFeePresets;
+  late _MockPayOrder payOrder;
+  late _MockWallet wallet;
+  late _SeedablePayBloc bloc;
+
+  /// Every `networkFee` the bloc handed to a PSBT build, in call order.
+  List<NetworkFee> capturedBuildFees() =>
+      verify(
+            () => prepareBitcoinSend.execute(
+              walletId: any(named: 'walletId'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: captureAny(named: 'networkFee'),
+              selectedInputs: any(named: 'selectedInputs'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured
+          .cast<NetworkFee>();
+
+  /// Asserts the bloc never asked for a PSBT build. Separate from
+  /// [capturedBuildFees] because `verify` needs at least one matching call.
+  void verifyNoBuilds() => verifyNever(
+    () => prepareBitcoinSend.execute(
+      walletId: any(named: 'walletId'),
+      address: any(named: 'address'),
+      amountSat: any(named: 'amountSat'),
+      networkFee: any(named: 'networkFee'),
+      selectedInputs: any(named: 'selectedInputs'),
+      replaceByFee: any(named: 'replaceByFee'),
+    ),
+  );
+
+  PayPaymentState paymentState({bool isConfirmingPayment = false}) =>
+      PayPaymentState(
+        selectedRecipient: recipient,
+        userSummary: userSummary,
+        amount: const FiatAmount(50),
+        selectedWallet: wallet,
+        payOrder: payOrder,
+        absoluteFees: 200,
+        isConfirmingPayment: isConfirmingPayment,
+        // Present as soon as the confirmation screen is reached: the wallet
+        // selection fetches the tiers to price the first estimate.
+        bitcoinFees: feeOptions,
+        bitcoinTxSize: 110,
+      );
+
+  setUpAll(() {
+    registerFallbackValue(const NetworkFee.absolute(200));
+    registerFallbackValue(<WalletUtxo>[]);
+    registerFallbackValue(
+      FeeOptions(
+        fastest: NetworkFee.relativeFromSatPerVbyte(1),
+        economic: NetworkFee.relativeFromSatPerVbyte(1),
+        slow: NetworkFee.relativeFromSatPerVbyte(1),
+        minRelay: NetworkFee.relativeFromSatPerVbyte(0.1),
+      ),
+    );
+  });
+
+  setUp(() {
+    prepareBitcoinSend = _MockPrepareBitcoinSend();
+    broadcastBitcoin = _MockBroadcastBitcoin();
+    getNetworkFees = _MockGetNetworkFees();
+    getOrder = _MockGetOrder();
+    previewBitcoinFeePresets = _MockPreviewBitcoinFeePresets();
+    payOrder = _MockPayOrder();
+    wallet = _MockWallet();
+
+    when(() => wallet.id).thenReturn('wallet-1');
+    when(() => wallet.isLiquid).thenReturn(false);
+    when(() => payOrder.orderId).thenReturn('order-1');
+    when(() => payOrder.payinAmount).thenReturn(0.001);
+    when(() => payOrder.payoutCurrency).thenReturn('CAD');
+    when(() => payOrder.bitcoinAddress).thenReturn(payinAddress);
+
+    final signBitcoinTx = _MockSignBitcoinTx();
+    final calculateBitcoinFees = _MockCalculateBitcoinFees();
+    when(
+      () => prepareBitcoinSend.execute(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        selectedInputs: any(named: 'selectedInputs'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenAnswer(
+      (_) async => (unsignedPsbt: unsignedPsbt, txSize: 110, isToSelf: false),
+    );
+    when(
+      () => calculateBitcoinFees.execute(psbt: any(named: 'psbt')),
+    ).thenAnswer((_) async => 200);
+    when(
+      () => signBitcoinTx.execute(
+        psbt: any(named: 'psbt'),
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => (signedPsbt: unsignedPsbt, txSize: 110));
+    when(
+      () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+    ).thenAnswer(
+      (_) async =>
+          '813d01e5c0ea01904322222851b2e702d37651be2644f4757cc4421f39261b55',
+    );
+    when(
+      () => getNetworkFees.execute(isLiquid: any(named: 'isLiquid')),
+    ).thenAnswer((_) async => feeOptions);
+    when(
+      () => getOrder.execute(orderId: any(named: 'orderId')),
+    ).thenAnswer((_) async => payOrder);
+
+    bloc = _SeedablePayBloc(
+      getExchangeUserSummaryUsecase: _MockGetUserSummary(),
+      placePayOrderUsecase: _MockPlacePayOrder(),
+      refreshPayOrderUsecase: _MockRefreshPayOrder(),
+      prepareBitcoinSendUsecase: prepareBitcoinSend,
+      prepareLiquidSendUsecase: _MockPrepareLiquidSend(),
+      signBitcoinTxUsecase: signBitcoinTx,
+      signLiquidTxUsecase: _MockSignLiquidTx(),
+      broadcastBitcoinTransactionUsecase: broadcastBitcoin,
+      broadcastLiquidTransactionUsecase: _MockBroadcastLiquid(),
+      getNetworkFeesUsecase: getNetworkFees,
+      calculateLiquidAbsoluteFeesUsecase: _MockCalculateLiquidFees(),
+      calculateBitcoinAbsoluteFeesUsecase: calculateBitcoinFees,
+      convertSatsToCurrencyAmountUsecase: _MockConvertSatsToCurrency(),
+      getAddressAtIndexUsecase: _MockGetAddressAtIndex(),
+      getWalletUtxosUsecase: _MockGetWalletUtxos(),
+      getOrderUsecase: getOrder,
+      previewBitcoinFeeUsecase: _MockPreviewBitcoinFee(),
+      previewBitcoinFeePresetsUsecase: previewBitcoinFeePresets,
+    );
+
+    bloc.seed(paymentState());
+  });
+
+  tearDown(() => bloc.close());
+
+  group('PayBloc — fee selection (#2521)', () {
+    /// Resolves once the fee recalculation triggered by a selection has landed.
+    Future<PayPaymentState> awaitRecalculatedFee() async {
+      final state = await bloc.stream.firstWhere(
+        (state) => state is PayPaymentState && state.absoluteFees != null,
+      );
+      return state as PayPaymentState;
+    }
+
+    /// Parks a fee recalculation inside its network-fee fetch, then moves the
+    /// flow to the success state underneath it. Returns the completer so the
+    /// caller decides whether the parked fetch succeeds or fails.
+    Future<Completer<FeeOptions>> recalculationParkedPastSuccess() async {
+      final feeFetch = Completer<FeeOptions>();
+      when(
+        () => getNetworkFees.execute(isLiquid: any(named: 'isLiquid')),
+      ).thenAnswer((_) => feeFetch.future);
+
+      bloc.add(const PayEvent.feeOptionSelected(FeeSelection.slow));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Stands in for the payin being broadcast and the order catching up while
+      // the recalculation is still waiting on mempool rates.
+      bloc.seed(PayState.success(payOrder: payOrder));
+      return feeFetch;
+    }
+
+    test('a recalculation landing after the success transition emits '
+        'nothing', () async {
+      final feeFetch = await recalculationParkedPastSuccess();
+
+      feeFetch.complete(feeOptions);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Republishing the pre-broadcast payment state here would take the user
+      // off the success screen and re-arm Confirm on a payin already on the
+      // wire. Pay has no broadcast latch, so nothing else would stop a second
+      // payment.
+      expect(bloc.state, isA<PaySuccessState>());
+    });
+
+    test('a recalculation failing after the success transition emits '
+        'nothing', () async {
+      final feeFetch = await recalculationParkedPastSuccess();
+
+      feeFetch.completeError(Exception('mempool unreachable'));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Same for the failure path: an error emitted onto a resurrected payment
+      // state is an invitation to pay twice.
+      expect(bloc.state, isA<PaySuccessState>());
+    });
+
+    /// Prices the three preset tiles the way an opened modal does.
+    void stubPresetPreviews() {
+      when(
+        () => previewBitcoinFeePresets.execute(
+          presets: any(named: 'presets'),
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: any(named: 'drain'),
+        ),
+      ).thenAnswer(
+        (_) async => const {
+          FeeSelection.fastest: BitcoinFeePreviewSlot(
+            feeSat: 1100,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+          FeeSelection.economic: BitcoinFeePreviewSlot(
+            feeSat: 550,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+          FeeSelection.slow: BitcoinFeePreviewSlot(
+            feeSat: 110,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+        },
+      );
+    }
+
+    /// Resolves once the preset previews have filled the cache.
+    Future<PayPaymentState> awaitPricedPresets() async {
+      final state = await bloc.stream.firstWhere(
+        (state) =>
+            state is PayPaymentState &&
+            !state.feePreviewCache.presetsLoading &&
+            state.feePreviewCache.fastest.feeSat != null,
+      );
+      return state as PayPaymentState;
+    }
+
+    test('typing a custom rate leaves the preset prices standing', () async {
+      stubPresetPreviews();
+      bloc.add(const PayEvent.presetFeesPreviewRequested());
+      await awaitPricedPresets();
+
+      bloc.add(PayEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(4)));
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is PayPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+
+      final cache = (bloc.state as PayPaymentState).feePreviewCache;
+      // Only the custom slot priced the rate that just changed; wiping the
+      // presets too would blank their tiles until the modal is reopened.
+      expect(cache.fastest.feeSat, 1100);
+      expect(cache.economic.feeSat, 550);
+      expect(cache.slow.feeSat, 110);
+      expect(cache.custom.feeSat, isNull);
+    });
+
+    test('the payin is built at the selected preset, not Fastest', () async {
+      bloc.add(const PayEvent.feeOptionSelected(FeeSelection.slow));
+      final recalculated = await awaitRecalculatedFee();
+      expect(recalculated.selectedFeeOption, FeeSelection.slow);
+
+      bloc.add(const PayEvent.sendPaymentConfirmed());
+      await bloc.stream.firstWhere((state) => state is PaySuccessState);
+
+      // Both the estimate rebuild and the broadcast build used Slow; the
+      // hardcoded Fastest rate must appear nowhere.
+      expect(capturedBuildFees(), everyElement(equals(feeOptions.slow)));
+      verify(
+        () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+      ).called(1);
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('a typed custom rate is committed on dismissal and paid', () async {
+      final customFee = NetworkFee.relativeFromSatPerVbyte(3);
+
+      // Typing arms the rate without rebuilding; dismissing the modal is what
+      // applies it.
+      bloc.add(PayEvent.customFeeArmed(customFee));
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is PayPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+      verifyNoBuilds();
+
+      bloc.add(const PayEvent.customFeeFinalized());
+      final committed = await awaitRecalculatedFee();
+      expect(committed.customFee, customFee);
+      expect(committed.armPriorSelection, isNull);
+
+      bloc.add(const PayEvent.sendPaymentConfirmed());
+      await bloc.stream.firstWhere((state) => state is PaySuccessState);
+
+      expect(capturedBuildFees(), everyElement(equals(customFee)));
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('a custom rate below the relay floor rolls back on dismissal', () async {
+      // 0.05 sat/vB is under the 0.1 sat/vB floor, so dismissing discards it
+      // rather than staging a transaction the network would not relay.
+      bloc.add(
+        PayEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(0.05)),
+      );
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is PayPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+
+      bloc.add(const PayEvent.customFeeFinalized());
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final state = bloc.state as PayPaymentState;
+      expect(state.selectedFeeOption, FeeSelection.fastest);
+      expect(state.customFee, isNull);
+      verifyNoBuilds();
+    });
+
+    test('fee selection is inert while the confirmation is in flight', () async {
+      bloc.seed(paymentState(isConfirmingPayment: true));
+
+      // Changing the fee now would rebuild the transaction being signed.
+      bloc.add(const PayEvent.feeOptionSelected(FeeSelection.slow));
+      bloc.add(PayEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(9)));
+      bloc.add(const PayEvent.presetFeesPreviewRequested());
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      final state = bloc.state as PayPaymentState;
+      expect(state.selectedFeeOption, FeeSelection.fastest);
+      expect(state.customFee, isNull);
+      verifyNoBuilds();
+      verifyNever(
+        () => previewBitcoinFeePresets.execute(
+          presets: any(named: 'presets'),
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: any(named: 'drain'),
+        ),
+      );
+    });
+
+    test('opening the modal prices each preset from a built PSBT', () async {
+      stubPresetPreviews();
+
+      bloc.add(const PayEvent.presetFeesPreviewRequested());
+      final state = await awaitPricedPresets();
+
+      expect(state.feePreviewCache.fastest.feeSat, 1100);
+      expect(state.feePreviewCache.economic.feeSat, 550);
+      expect(state.feePreviewCache.slow.feeSat, 110);
+      // The previews price the real payin, not a stand-in address.
+      verify(
+        () => previewBitcoinFeePresets.execute(
+          presets: feeOptions,
+          walletId: 'wallet-1',
+          address: payinAddress,
+          amountSat: 100000,
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: false,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/sell/presentation/sell_bloc_test.dart
+++ b/test/features/sell/presentation/sell_bloc_test.dart
@@ -7,12 +7,14 @@ import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_exchange_user_summary_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
+import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
@@ -23,6 +25,8 @@ import 'package:bb_mobile/features/sell/domain/refresh_sell_order_usecase.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -69,6 +73,11 @@ class _MockGetWalletUtxos extends Mock implements GetWalletUtxosUsecase {}
 
 class _MockGetOrder extends Mock implements GetOrderUsecase {}
 
+class _MockPreviewBitcoinFee extends Mock implements PreviewBitcoinFeeUsecase {}
+
+class _MockPreviewBitcoinFeePresets extends Mock
+    implements PreviewBitcoinFeePresetsUsecase {}
+
 class _MockLabelsFacade extends Mock implements LabelsFacade {}
 
 class _MockWallet extends Mock implements Wallet {}
@@ -102,6 +111,8 @@ class _SeedableSellBloc extends SellBloc {
     required super.getWalletUtxosUsecase,
     required super.getOrderUsecase,
     required super.labelsFacade,
+    required super.previewBitcoinFeeUsecase,
+    required super.previewBitcoinFeePresetsUsecase,
   });
 
   void seed(SellState state) => emit(state);
@@ -126,20 +137,68 @@ void main() {
     autoBuy: UserAutoBuy(isActive: false, addresses: UserAutoBuyAddresses()),
   );
 
+  // Tiers far enough apart that the rate handed to the PSBT build identifies
+  // which one the bloc picked.
+  final feeOptions = FeeOptions(
+    fastest: NetworkFee.relativeFromSatPerVbyte(10),
+    economic: NetworkFee.relativeFromSatPerVbyte(5),
+    slow: NetworkFee.relativeFromSatPerVbyte(1),
+    minRelay: NetworkFee.relativeFromSatPerVbyte(0.1),
+  );
+
   late _MockPrepareBitcoinSend prepareBitcoinSend;
   late _MockSignBitcoinTx signBitcoinTx;
   late _MockBroadcastBitcoin broadcastBitcoin;
   late _MockCalculateBitcoinFees calculateBitcoinFees;
+  late _MockGetNetworkFees getNetworkFees;
   late _MockGetOrder getOrder;
   late _MockRefreshSellOrder refreshSellOrder;
   late _MockLabelsFacade labelsFacade;
+  late _MockPreviewBitcoinFee previewBitcoinFee;
+  late _MockPreviewBitcoinFeePresets previewBitcoinFeePresets;
   late _MockSellOrder sellOrder;
   late _MockWallet wallet;
   late _SeedableSellBloc bloc;
 
+  /// Every `networkFee` the bloc handed to a PSBT build, in call order.
+  List<NetworkFee> capturedBuildFees() =>
+      verify(
+            () => prepareBitcoinSend.execute(
+              walletId: any(named: 'walletId'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: captureAny(named: 'networkFee'),
+              selectedInputs: any(named: 'selectedInputs'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured
+          .cast<NetworkFee>();
+
+  /// Asserts the bloc never asked for a PSBT build. Separate from
+  /// [capturedBuildFees] because `verify` needs at least one matching call.
+  void verifyNoBuilds() => verifyNever(
+    () => prepareBitcoinSend.execute(
+      walletId: any(named: 'walletId'),
+      address: any(named: 'address'),
+      amountSat: any(named: 'amountSat'),
+      networkFee: any(named: 'networkFee'),
+      selectedInputs: any(named: 'selectedInputs'),
+      replaceByFee: any(named: 'replaceByFee'),
+    ),
+  );
+
   setUpAll(() {
     registerFallbackValue(_FakeNewLabel());
     registerFallbackValue(const NetworkFee.absolute(200));
+    registerFallbackValue(<WalletUtxo>[]);
+    registerFallbackValue(
+      FeeOptions(
+        fastest: NetworkFee.relativeFromSatPerVbyte(1),
+        economic: NetworkFee.relativeFromSatPerVbyte(1),
+        slow: NetworkFee.relativeFromSatPerVbyte(1),
+        minRelay: NetworkFee.relativeFromSatPerVbyte(0.1),
+      ),
+    );
   });
 
   setUp(() {
@@ -147,9 +206,12 @@ void main() {
     signBitcoinTx = _MockSignBitcoinTx();
     broadcastBitcoin = _MockBroadcastBitcoin();
     calculateBitcoinFees = _MockCalculateBitcoinFees();
+    getNetworkFees = _MockGetNetworkFees();
     getOrder = _MockGetOrder();
     refreshSellOrder = _MockRefreshSellOrder();
     labelsFacade = _MockLabelsFacade();
+    previewBitcoinFee = _MockPreviewBitcoinFee();
+    previewBitcoinFeePresets = _MockPreviewBitcoinFeePresets();
     sellOrder = _MockSellOrder();
     wallet = _MockWallet();
 
@@ -191,6 +253,9 @@ void main() {
     when(
       () => labelsFacade.store(any()),
     ).thenAnswer((_) async => Ok<Label, LabelFailure>(_FakeLabel()));
+    when(
+      () => getNetworkFees.execute(isLiquid: any(named: 'isLiquid')),
+    ).thenAnswer((_) async => feeOptions);
 
     bloc = _SeedableSellBloc(
       getExchangeUserSummaryUsecase: _MockGetUserSummary(),
@@ -203,7 +268,7 @@ void main() {
       signLiquidTxUsecase: _MockSignLiquidTx(),
       broadcastBitcoinTransactionUsecase: broadcastBitcoin,
       broadcastLiquidTransactionUsecase: _MockBroadcastLiquid(),
-      getNetworkFeesUsecase: _MockGetNetworkFees(),
+      getNetworkFeesUsecase: getNetworkFees,
       calculateLiquidAbsoluteFeesUsecase: _MockCalculateLiquidFees(),
       calculateBitcoinAbsoluteFeesUsecase: calculateBitcoinFees,
       convertSatsToCurrencyAmountUsecase: _MockConvertSatsToCurrency(),
@@ -211,6 +276,8 @@ void main() {
       getWalletUtxosUsecase: _MockGetWalletUtxos(),
       getOrderUsecase: getOrder,
       labelsFacade: labelsFacade,
+      previewBitcoinFeeUsecase: previewBitcoinFee,
+      previewBitcoinFeePresetsUsecase: previewBitcoinFeePresets,
     );
 
     bloc.seed(
@@ -222,6 +289,10 @@ void main() {
         selectedWallet: wallet,
         sellOrder: sellOrder,
         absoluteFees: 200,
+        // Present as soon as the confirmation screen is reached: the wallet
+        // selection fetches the tiers to price the first estimate.
+        bitcoinFees: feeOptions,
+        bitcoinTxSize: 110,
       ),
     );
   });
@@ -239,12 +310,7 @@ void main() {
           () => getOrder.execute(orderId: any(named: 'orderId')),
         ).thenThrow(GetOrderException('dns failure'));
 
-        bloc.add(
-          const SellEvent.sendPaymentConfirmed(
-            feeSelection: FeeSelection.fastest,
-            customFee: null,
-          ),
-        );
+        bloc.add(const SellEvent.sendPaymentConfirmed());
         await bloc.stream.firstWhere(
           (state) => state is SellPaymentState && state.isPayinBroadcast,
         );
@@ -254,12 +320,7 @@ void main() {
 
         // Let the failing order fetch settle, then confirm again.
         await Future<void>.delayed(const Duration(seconds: 6));
-        bloc.add(
-          const SellEvent.sendPaymentConfirmed(
-            feeSelection: FeeSelection.fastest,
-            customFee: null,
-          ),
-        );
+        bloc.add(const SellEvent.sendPaymentConfirmed());
         await Future<void>.delayed(const Duration(seconds: 6));
 
         verify(
@@ -294,12 +355,7 @@ void main() {
           () => getOrder.execute(orderId: any(named: 'orderId')),
         ).thenAnswer((_) async => refreshedOrder);
 
-        bloc.add(
-          const SellEvent.sendPaymentConfirmed(
-            feeSelection: FeeSelection.fastest,
-            customFee: null,
-          ),
-        );
+        bloc.add(const SellEvent.sendPaymentConfirmed());
         final successState = await bloc.stream.firstWhere(
           (state) => state is SellSuccessState,
         );
@@ -357,12 +413,7 @@ void main() {
         () => getOrder.execute(orderId: any(named: 'orderId')),
       ).thenThrow(GetOrderException('dns failure'));
 
-      bloc.add(
-        const SellEvent.sendPaymentConfirmed(
-          feeSelection: FeeSelection.fastest,
-          customFee: null,
-        ),
-      );
+      bloc.add(const SellEvent.sendPaymentConfirmed());
       await bloc.stream.firstWhere(
         (state) => state is SellPaymentState && state.isConfirmingPayment,
       );
@@ -401,16 +452,14 @@ void main() {
 
     final refreshedOrder = _MockSellOrder();
     when(() => refreshedOrder.orderId).thenReturn('order-1');
+    // The refresh compares payin amounts to decide whether the cached fee
+    // previews still describe this order.
+    when(() => refreshedOrder.payinAmount).thenReturn(0.001);
     when(
       () => refreshSellOrder.execute(orderId: any(named: 'orderId')),
     ).thenAnswer((_) async => refreshedOrder);
 
-    bloc.add(
-      const SellEvent.sendPaymentConfirmed(
-        feeSelection: FeeSelection.fastest,
-        customFee: null,
-      ),
-    );
+    bloc.add(const SellEvent.sendPaymentConfirmed());
     await Future<void>.delayed(const Duration(milliseconds: 200));
 
     verify(() => refreshSellOrder.execute(orderId: 'order-1')).called(1);
@@ -424,5 +473,261 @@ void main() {
     expect(state.payinBroadcastTxid, isNull);
     // The refresh must not erase why the send failed.
     expect(state.error, isNotNull);
+  });
+
+  group('SellBloc — fee selection (#2521)', () {
+    /// Resolves once the fee recalculation triggered by a selection has landed.
+    Future<SellPaymentState> awaitRecalculatedFee() async {
+      final state = await bloc.stream.firstWhere(
+        (state) => state is SellPaymentState && state.absoluteFees != null,
+      );
+      return state as SellPaymentState;
+    }
+
+    /// Parks a fee recalculation inside its network-fee fetch, then moves the
+    /// flow to the success state underneath it. Returns the completer so the
+    /// caller decides whether the parked fetch succeeds or fails.
+    Future<Completer<FeeOptions>> recalculationParkedPastSuccess() async {
+      final feeFetch = Completer<FeeOptions>();
+      when(
+        () => getNetworkFees.execute(isLiquid: any(named: 'isLiquid')),
+      ).thenAnswer((_) => feeFetch.future);
+
+      bloc.add(const SellEvent.feeOptionSelected(FeeSelection.economic));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Stands in for the payin being broadcast and the order catching up while
+      // the recalculation is still waiting on mempool rates.
+      bloc.seed(
+        SellState.success(bitcoinUnit: BitcoinUnit.sats, sellOrder: sellOrder),
+      );
+      return feeFetch;
+    }
+
+    test('a recalculation landing after the success transition emits '
+        'nothing', () async {
+      final feeFetch = await recalculationParkedPastSuccess();
+
+      feeFetch.complete(feeOptions);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Republishing the pre-broadcast payment state here would take the user
+      // off the success screen, drop the latch and re-arm Confirm on a payin
+      // already on the wire (#2522).
+      expect(bloc.state, isA<SellSuccessState>());
+    });
+
+    test('a recalculation failing after the success transition emits '
+        'nothing', () async {
+      final feeFetch = await recalculationParkedPastSuccess();
+
+      feeFetch.completeError(Exception('mempool unreachable'));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Same for the failure path: an error emitted onto a resurrected payment
+      // state is an invitation to pay twice.
+      expect(bloc.state, isA<SellSuccessState>());
+    });
+
+    test('the payin is built at the selected preset, not Fastest', () async {
+      // Nothing must complete the order — the assertion is about the rate the
+      // build was asked for.
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenThrow(GetOrderException('dns failure'));
+
+      bloc.add(const SellEvent.feeOptionSelected(FeeSelection.economic));
+      final recalculated = await awaitRecalculatedFee();
+      expect(recalculated.selectedFeeOption, FeeSelection.economic);
+
+      bloc.add(const SellEvent.sendPaymentConfirmed());
+      await bloc.stream.firstWhere(
+        (state) => state is SellPaymentState && state.isPayinBroadcast,
+      );
+
+      // Both the estimate rebuild and the broadcast build used Economic; the
+      // hardcoded Fastest rate must appear nowhere.
+      expect(capturedBuildFees(), everyElement(equals(feeOptions.economic)));
+      await Future<void>.delayed(const Duration(seconds: 6));
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('a typed custom rate is committed on dismissal and paid', () async {
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenThrow(GetOrderException('dns failure'));
+      final customFee = NetworkFee.relativeFromSatPerVbyte(3);
+
+      // Typing arms the rate without rebuilding; dismissing the modal is what
+      // applies it.
+      bloc.add(SellEvent.customFeeArmed(customFee));
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is SellPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+      // Arming only deselects the preset tiles; the rebuild waits for the
+      // commit on dismissal.
+      verifyNoBuilds();
+
+      bloc.add(const SellEvent.customFeeFinalized());
+      final committed = await awaitRecalculatedFee();
+      expect(committed.selectedFeeOption, FeeSelection.custom);
+      expect(committed.customFee, customFee);
+      expect(committed.armPriorSelection, isNull);
+
+      bloc.add(const SellEvent.sendPaymentConfirmed());
+      await bloc.stream.firstWhere(
+        (state) => state is SellPaymentState && state.isPayinBroadcast,
+      );
+
+      expect(capturedBuildFees(), everyElement(equals(customFee)));
+      await Future<void>.delayed(const Duration(seconds: 6));
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('a custom rate below the relay floor rolls back on dismissal', () async {
+      // 0.05 sat/vB is under the 0.1 sat/vB floor, so dismissing discards it
+      // rather than staging a transaction the network would not relay.
+      bloc.add(
+        SellEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(0.05)),
+      );
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is SellPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+
+      bloc.add(const SellEvent.customFeeFinalized());
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final state = bloc.state as SellPaymentState;
+      expect(state.selectedFeeOption, FeeSelection.fastest);
+      expect(state.customFee, isNull);
+      verifyNoBuilds();
+    });
+
+    test('fee selection is inert once the payin is broadcast', () async {
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenThrow(GetOrderException('dns failure'));
+
+      bloc.add(const SellEvent.sendPaymentConfirmed());
+      await bloc.stream.firstWhere(
+        (state) => state is SellPaymentState && state.isPayinBroadcast,
+      );
+
+      // Changing the fee now would rebuild under a transaction already on the
+      // wire (#2522), so every fee event is dropped.
+      bloc.add(const SellEvent.feeOptionSelected(FeeSelection.slow));
+      bloc.add(SellEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(9)));
+      bloc.add(const SellEvent.presetFeesPreviewRequested());
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      final state = bloc.state as SellPaymentState;
+      expect(state.selectedFeeOption, FeeSelection.fastest);
+      expect(state.customFee, isNull);
+      expect(state.payinBroadcastTxid, expectedTxid);
+      verifyNever(
+        () => previewBitcoinFeePresets.execute(
+          presets: any(named: 'presets'),
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: any(named: 'drain'),
+        ),
+      );
+      // Only the one build that produced the broadcast transaction.
+      expect(capturedBuildFees(), hasLength(1));
+      await Future<void>.delayed(const Duration(seconds: 6));
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    /// Prices the three preset tiles the way an opened modal does.
+    void stubPresetPreviews() {
+      when(
+        () => previewBitcoinFeePresets.execute(
+          presets: any(named: 'presets'),
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: any(named: 'drain'),
+        ),
+      ).thenAnswer(
+        (_) async => const {
+          FeeSelection.fastest: BitcoinFeePreviewSlot(
+            feeSat: 1100,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+          FeeSelection.economic: BitcoinFeePreviewSlot(
+            feeSat: 550,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+          FeeSelection.slow: BitcoinFeePreviewSlot(
+            feeSat: 110,
+            unsignedPsbt: unsignedPsbt,
+            txSize: 110,
+          ),
+        },
+      );
+    }
+
+    /// Resolves once the preset previews have filled the cache.
+    Future<SellPaymentState> awaitPricedPresets() async {
+      final state = await bloc.stream.firstWhere(
+        (state) =>
+            state is SellPaymentState &&
+            !state.feePreviewCache.presetsLoading &&
+            state.feePreviewCache.fastest.feeSat != null,
+      );
+      return state as SellPaymentState;
+    }
+
+    test('typing a custom rate leaves the preset prices standing', () async {
+      stubPresetPreviews();
+      bloc.add(const SellEvent.presetFeesPreviewRequested());
+      await awaitPricedPresets();
+
+      bloc.add(SellEvent.customFeeArmed(NetworkFee.relativeFromSatPerVbyte(4)));
+      await bloc.stream.firstWhere(
+        (state) =>
+            state is SellPaymentState &&
+            state.selectedFeeOption == FeeSelection.custom,
+      );
+
+      final cache = (bloc.state as SellPaymentState).feePreviewCache;
+      // Only the custom slot priced the rate that just changed; wiping the
+      // presets too would blank their tiles until the modal is reopened.
+      expect(cache.fastest.feeSat, 1100);
+      expect(cache.economic.feeSat, 550);
+      expect(cache.slow.feeSat, 110);
+      expect(cache.custom.feeSat, isNull);
+    });
+
+    test('opening the modal prices each preset from a built PSBT', () async {
+      stubPresetPreviews();
+
+      bloc.add(const SellEvent.presetFeesPreviewRequested());
+      final state = await awaitPricedPresets();
+
+      expect(state.feePreviewCache.fastest.feeSat, 1100);
+      expect(state.feePreviewCache.economic.feeSat, 550);
+      expect(state.feePreviewCache.slow.feeSat, 110);
+      // The previews price the real payin, not a stand-in address.
+      verify(
+        () => previewBitcoinFeePresets.execute(
+          presets: feeOptions,
+          walletId: 'wallet-1',
+          address: 'bc1q0000000000000000000000000000000000000',
+          amountSat: 100000,
+          replaceByFee: any(named: 'replaceByFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          drain: false,
+        ),
+      ).called(1);
+    });
   });
 }


### PR DESCRIPTION
> ⚠️ **Requires emulator/device review before merge** — draft until verified. Test: on a bitcoin-wallet sell (and pay), tapping "Network fee priority" opens the fee dialog; the row shows the actual selection; the summary network fee updates with the choice; and ideally one real staging sell at economy/custom rate confirming the broadcast transaction pays the selected sat/vB. This is the money path — the riskiest PR of the set.

> **Stacked on #2535 (`fix/sell-hardening`)** — review only the last commit. After #2535 merges, this retargets to `main`. **Must merge AFTER #2534** (pay-status PR): that branch constructs `sendPaymentConfirmed` event params this PR removes — the rebase reconciles two one-line call sites (`pay_send_payment_screen.dart`, `test/features/pay/pay_bloc_test.dart`), already verified on the integration branch.

## Problem (#2521)
The "Network fee priority" row on sell and pay confirmation screens was a `debugPrint` stub with a `// TODO`; every transaction paid the fastest rate end-to-end — the bloc ignored the fee selection its confirm event already declared.

## Changes
- `SellBloc`/`PayBloc` implement the shared fee modal's `FeeModalViewState`/`FeeModalActions` ports, following `SendCubit` semantics: presets, custom sat/vB or absolute fees with arm/disarm/finalize, epoch-guarded previews, relay-floor gate
- The row opens the shared `FeeOptionsModal` and displays the committed selection; the summary fee reprices from a real PSBT built at the selected rate
- Confirm prepares/signs/broadcasts at the committed selection. Unlike send/swap, preview PSBTs are display-only: sell/pay rebuild at broadcast time because a price-lock refresh can move the order's payin amount. The built fee is re-asserted against the relay floor before signing
- Fee editing locks while confirming or once the payin is broadcast; every post-await emit merges into live state — a recalculation or preview landing after the flow moved on emits nothing (reviewer-caught blocker, regression-tested in both blocs)
- Previews price against the order's real payin address; Liquid payins keep no fee row

## Validation
Sell suite 13/13, pay suite 8/8 (selected-preset-reaches-prepare, custom-fee path, below-floor rollback, events-inert-once-latched, preset previews, post-success recalc emits nothing — the money-path tests capture every `networkFee` handed to prepare and assert it equals the picked tier); analyze clean; reviewed with a verification pass (1 blocker + 2 should-fixes applied).

Closes #2521