### PR TITLE
refactor: replace `hex`, an unnecessary dependency, in favor of Dart-maintained `convert`

### DIFF
--- a/lib/core/recoverbull/data/repository/recoverbull_repository.dart
+++ b/lib/core/recoverbull/data/repository/recoverbull_repository.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
 import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:hex/hex.dart';
+import 'package:convert/convert.dart' as convert;
 import 'package:recoverbull/recoverbull.dart' as recoverbull;
 
 /// Data boundary for the RecoverBull key server and vault crypto. Catches the
@@ -37,7 +37,7 @@ class RecoverBullRepository {
     try {
       final encryptedBackup = RecoverBullDatasource.create(
         utf8.encode(plaintext),
-        HEX.decode(vaultKey),
+        convert.hex.decode(_normalizeHex(vaultKey)),
       );
       final mapBackup = json.decode(encryptedBackup) as Map<String, dynamic>;
       mapBackup['path'] = derivationPath;
@@ -57,7 +57,7 @@ class RecoverBullRepository {
     try {
       final decryptedBytes = RecoverBullDatasource.restore(
         vault.toFile(),
-        HEX.decode(vaultKey),
+        convert.hex.decode(_normalizeHex(vaultKey)),
       );
       final plaintext = utf8.decode(decryptedBytes);
       final decoded = json.decode(plaintext) as Map<String, dynamic>;
@@ -77,10 +77,10 @@ class RecoverBullRepository {
     try {
       final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
       await remoteDatasource.store(
-        HEX.decode(identifier),
+        convert.hex.decode(_normalizeHex(identifier)),
         utf8.encode(password),
-        HEX.decode(salt),
-        HEX.decode(vaultKey),
+        convert.hex.decode(_normalizeHex(salt)),
+        convert.hex.decode(_normalizeHex(vaultKey)),
         externalProxy: externalProxy,
       );
       return const Ok(null);
@@ -101,12 +101,12 @@ class RecoverBullRepository {
     try {
       final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
       final vaultKey = await remoteDatasource.fetch(
-        HEX.decode(identifier),
+        convert.hex.decode(_normalizeHex(identifier)),
         utf8.encode(password),
-        HEX.decode(salt),
+        convert.hex.decode(_normalizeHex(salt)),
         externalProxy: externalProxy,
       );
-      return Ok(HEX.encode(vaultKey));
+      return Ok(convert.hex.encode(vaultKey));
     } on recoverbull.KeyServerException catch (e, st) {
       log.severe(message: 'fetchVaultKey failed', error: e, trace: st);
       return Err(_mapKeyServer(e));
@@ -123,9 +123,9 @@ class RecoverBullRepository {
   ) async {
     final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
     await remoteDatasource.trash(
-      HEX.decode(identifier),
+      convert.hex.decode(_normalizeHex(identifier)),
       utf8.encode(password),
-      HEX.decode(salt),
+      convert.hex.decode(_normalizeHex(salt)),
       externalProxy: externalProxy,
     );
   }
@@ -177,4 +177,10 @@ class RecoverBullRepository {
     }
     return KeyServerUnavailableFailure(e.toString());
   }
+
+  /// Vault keys and server identifiers reach us as raw user input (typed or
+  /// pasted — the recovery screen has no input formatter). Strip formatting
+  /// whitespace before decoding so a spaced or newline-terminated key (the
+  /// reveal screen shows the key in 4-char groups) still decodes. 
+  String _normalizeHex(String input) => input.replaceAll(RegExp(r'\s'), '');
 }

--- a/lib/core/recoverbull/data/repository/recoverbull_repository.dart
+++ b/lib/core/recoverbull/data/repository/recoverbull_repository.dart
@@ -181,6 +181,6 @@ class RecoverBullRepository {
   /// Vault keys and server identifiers reach us as raw user input (typed or
   /// pasted — the recovery screen has no input formatter). Strip formatting
   /// whitespace before decoding so a spaced or newline-terminated key (the
-  /// reveal screen shows the key in 4-char groups) still decodes. 
+  /// reveal screen shows the key in 4-char groups) still decodes.
   String _normalizeHex(String input) => input.replaceAll(RegExp(r'\s'), '');
 }

--- a/lib/core/recoverbull/domain/entity/encrypted_vault.dart
+++ b/lib/core/recoverbull/domain/entity/encrypted_vault.dart
@@ -1,5 +1,5 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
-import 'package:hex/hex.dart';
+import 'package:convert/convert.dart' as convert;
 import 'package:recoverbull/recoverbull.dart' as recoverbull;
 
 class EncryptedVault {
@@ -13,14 +13,14 @@ class EncryptedVault {
 
   static bool isValid(String file) => recoverbull.BullBackup.isValid(file);
 
-  String get salt => HEX.encode(backup.salt);
+  String get salt => convert.hex.encode(backup.salt);
 
   String get derivationPath {
     if (backup.path == null) throw EncryptedVaultMissingPath();
     return backup.path!;
   }
 
-  String get id => HEX.encode(backup.id);
+  String get id => convert.hex.encode(backup.id);
 
   DateTime get createdAt =>
       DateTime.fromMillisecondsSinceEpoch(backup.createdAt);

--- a/lib/core/utils/recoverbull_bip85.dart
+++ b/lib/core/utils/recoverbull_bip85.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:bip85_entropy/bip85_entropy.dart';
-import 'package:hex/hex.dart';
+import 'package:convert/convert.dart' as convert;
 
 class RecoverbullBip85Utils {
   static final CustomApplication recoverbullApplication =
@@ -43,7 +43,7 @@ class RecoverbullBip85Utils {
       path: clearedPath,
     );
     final octets32 = derivation.sublist(0, 32);
-    return HEX.encode(octets32);
+    return convert.hex.encode(octets32);
   }
 
   static int _getRandomIndex() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1056,7 +1056,7 @@ packages:
     source: hosted
     version: "2.0.0"
   hex:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: hex
       sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,6 @@ dependencies:
       ref: 3dcd008d1ca5233a65f2f354c03b3975e2ab33f7
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
-  hex: ^0.2.0
   auto_size_text: ^3.0.0
   no_screenshot: ^1.1.0
   freezed_annotation: ^3.1.0

--- a/test/core_test/recoverbull/recoverbull_repository_test.dart
+++ b/test/core_test/recoverbull/recoverbull_repository_test.dart
@@ -149,4 +149,98 @@ void main() {
     expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
     expect((result as Ok<String, RecoverBullCoreFailure>).value, 'abcd');
   });
+
+  // Guards the package:hex -> package:convert codec swap and the
+  // `_normalizeHex` input handling. The repository HEX-decodes `identifier`
+  // and `salt` before the network call, so `fetchVaultKey` is the observable
+  // seam: a decodable input reaches the mocked `remote.fetch`, a malformed one
+  // is rejected before any network I/O.
+  group('hex input normalization and strict decoding (identifier/salt)', () {
+    void stubFetchOk() {
+      when(
+        () => remote.fetch(
+          any(),
+          any(),
+          any(),
+          externalProxy: any(named: 'externalProxy'),
+        ),
+      ).thenAnswer((_) async => [0xab, 0xcd]);
+    }
+
+    test('whitespace-formatted input still decodes (normalized, not '
+        'rejected)', () async {
+      stubFetchOk();
+
+      // The reveal screen groups the key into space-separated 4-char chunks;
+      // a user may retype it that way. Normalization must strip the spaces so
+      // the value still decodes, preserving the tolerance package:hex gave
+      // implicitly.
+      final result = await repository.fetchVaultKey(
+        'de ad be ef',
+        'password',
+        '00 11',
+      );
+
+      expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
+      verify(
+        () => remote.fetch(
+          any(),
+          any(),
+          any(),
+          externalProxy: any(named: 'externalProxy'),
+        ),
+      ).called(1);
+    });
+
+    test('uppercase input still decodes', () async {
+      stubFetchOk();
+
+      final result = await repository.fetchVaultKey('ABCD', 'password', 'EF01');
+
+      expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
+    });
+
+    test('odd-length input is rejected before any network call '
+        '(no silent zero-padding)', () async {
+      stubFetchOk();
+
+      // Under package:hex "abc" was silently decoded as "0abc" -> a different,
+      // wrong key, and the request proceeded. Under package:convert it throws,
+      // is caught, and mapped to a failure *before* remote.fetch is reached.
+      final result = await repository.fetchVaultKey('abc', 'password', '00');
+
+      expect(result, isA<Err<String, RecoverBullCoreFailure>>());
+      expect(
+        (result as Err<String, RecoverBullCoreFailure>).failure,
+        isA<RecoverBullUnexpectedCoreFailure>(),
+      );
+      verifyNever(
+        () => remote.fetch(
+          any(),
+          any(),
+          any(),
+          externalProxy: any(named: 'externalProxy'),
+        ),
+      );
+    });
+
+    test('non-hex input is rejected before any network call', () async {
+      stubFetchOk();
+
+      final result = await repository.fetchVaultKey('zz', 'password', '00');
+
+      expect(
+        (result as Err<String, RecoverBullCoreFailure>).failure,
+        isA<RecoverBullUnexpectedCoreFailure>(),
+      );
+      verifyNever(
+        () => remote.fetch(
+          any(),
+          any(),
+          any(),
+          externalProxy: any(named: 'externalProxy'),
+        ),
+      );
+    });
+  });
 }

--- a/test/core_test/recoverbull/recoverbull_repository_test.dart
+++ b/test/core_test/recoverbull/recoverbull_repository_test.dart
@@ -182,14 +182,20 @@ void main() {
       );
 
       expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
-      verify(
+      // Pin the decoded bytes, not just that the call happened: proves the
+      // spaces were stripped and the codec produced the right bytes, rather
+      // than merely not throwing. fetch(identifier, password, salt) — the two
+      // captureAny() slots yield [identifier, salt] in order.
+      final captured = verify(
         () => remote.fetch(
+          captureAny(),
           any(),
-          any(),
-          any(),
+          captureAny(),
           externalProxy: any(named: 'externalProxy'),
         ),
-      ).called(1);
+      ).captured;
+      expect(captured[0], [0xde, 0xad, 0xbe, 0xef]);
+      expect(captured[1], [0x00, 0x11]);
     });
 
     test('uppercase input still decodes', () async {
@@ -198,6 +204,18 @@ void main() {
       final result = await repository.fetchVaultKey('ABCD', 'password', 'EF01');
 
       expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
+      // Proves convert case-folds (RFC 4648): 'ABCD'/'EF01' decode to the same
+      // bytes as lowercase, with no manual .toLowerCase() in _normalizeHex.
+      final captured = verify(
+        () => remote.fetch(
+          captureAny(),
+          any(),
+          captureAny(),
+          externalProxy: any(named: 'externalProxy'),
+        ),
+      ).captured;
+      expect(captured[0], [0xab, 0xcd]);
+      expect(captured[1], [0xef, 0x01]);
     });
 
     test('odd-length input is rejected before any network call '


### PR DESCRIPTION
We were carrying two dependencies that do exactly the same thing - `hex` and `convert`, both hex codecs. They were even being used side by side inside core/recoverbull.

This PR removes `hex` and standardizes on `convert`, because:
- It's maintained by the Dart team
- `hex` 0.2.0 was last published around 2019 and offers nothing `convert` doesn't already do
- `convert` was already the choice in the codebase - 13 files use it, versus 3 for `hex`.