### PR TITLE
refactor: add Gap to bull_ui and drop gap dependency

### DIFF
--- a/lib/core/screens/app_init_error_screen.dart
+++ b/lib/core/screens/app_init_error_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/generated/l10n/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/core/screens/send_confirm_screen.dart
+++ b/lib/core/screens/send_confirm_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 enum SendType { send, swap }
 

--- a/lib/core/widgets/address_viewer.dart
+++ b/lib/core/widgets/address_viewer.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/core/widgets/viewer_action_button.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:satoshifier/satoshifier.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/core/widgets/advanced_options_bottom_sheet.dart
+++ b/lib/core/widgets/advanced_options_bottom_sheet.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
 import 'package:bb_mobile/features/send/ui/widgets/coin_selection_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class AdvancedOptionsBottomSheet extends StatelessWidget {

--- a/lib/core/widgets/backup_success_screen.dart
+++ b/lib/core/widgets/backup_success_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/core/widgets/bottom_sheet/disclosure_bottom_sheet.dart
+++ b/lib/core/widgets/bottom_sheet/disclosure_bottom_sheet.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DisclosureLink extends StatelessWidget {
   const DisclosureLink({

--- a/lib/core/widgets/bottom_sheet/instructions_bottom_sheet.dart
+++ b/lib/core/widgets/bottom_sheet/instructions_bottom_sheet.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class InstructionsBottomSheet extends StatelessWidget {
   final String title;

--- a/lib/core/widgets/bottom_sheet/picker_sheet.dart
+++ b/lib/core/widgets/bottom_sheet/picker_sheet.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Generic single-selection bottom-sheet picker.
 ///

--- a/lib/core/widgets/buttons/button.dart
+++ b/lib/core/widgets/buttons/button.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 enum ButtonSize { small, large }
 

--- a/lib/core/widgets/cards/action_card.dart
+++ b/lib/core/widgets/cards/action_card.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/swap/ui/swap_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 enum _ButtonPosition { first, last, middle }

--- a/lib/core/widgets/cards/autoswap_warning_card.dart
+++ b/lib/core/widgets/cards/autoswap_warning_card.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AutoSwapWarningCard extends StatelessWidget {
   const AutoSwapWarningCard({

--- a/lib/core/widgets/cards/backup_card.dart
+++ b/lib/core/widgets/cards/backup_card.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BackupCard extends StatelessWidget {
   const BackupCard({super.key, required this.onTap});

--- a/lib/core/widgets/cards/backup_option_card.dart
+++ b/lib/core/widgets/cards/backup_option_card.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/cards/tag_card.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BackupOptionCard extends StatelessWidget {
   final Widget icon;

--- a/lib/core/widgets/cards/balance_card.dart
+++ b/lib/core/widgets/cards/balance_card.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/exchange/domain/entity/user_summary.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BalanceCard extends StatelessWidget {
   const BalanceCard({super.key, required this.balance, required this.onTap});

--- a/lib/core/widgets/cards/consolidation_required_card.dart
+++ b/lib/core/widgets/cards/consolidation_required_card.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ConsolidationRequiredCard extends StatelessWidget {
   const ConsolidationRequiredCard({

--- a/lib/core/widgets/cards/info_card.dart
+++ b/lib/core/widgets/cards/info_card.dart
@@ -1,6 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class InfoCard extends StatelessWidget {
   const InfoCard({

--- a/lib/core/widgets/cards/provider_cart.dart
+++ b/lib/core/widgets/cards/provider_cart.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/cards/tag_card.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ProviderCard extends StatefulWidget {
   final VaultProvider provider;

--- a/lib/core/widgets/cards/wallet_card.dart
+++ b/lib/core/widgets/cards/wallet_card.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class WalletCard extends StatelessWidget {
   const WalletCard({

--- a/lib/core/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/core/widgets/coin_selection_bottom_sheet.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class CommonCoinSelectionBottomSheet extends StatefulWidget {

--- a/lib/core/widgets/dropdown/selectable_list.dart
+++ b/lib/core/widgets/dropdown/selectable_list.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SelectableListItem {
   final String? iconPath;

--- a/lib/core/widgets/fees/custom_fee_list_item.dart
+++ b/lib/core/widgets/fees/custom_fee_list_item.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Reusable "Custom Fee" tile used inside the fee-selection modal of both
 /// Send and Swap, and as the inline custom-rate tile in RBF. Owns the

--- a/lib/core/widgets/fees/fee_options_modal.dart
+++ b/lib/core/widgets/fees/fee_options_modal.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/core/widgets/fees/fee_modal_controller.dart';
 import 'package:bb_mobile/core/widgets/inputs/bb_keyboard_actions.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Shared fee-selection bottom sheet — mounted by both the Bitcoin send
 /// confirm screen and the swap confirm page. The widget depends only on

--- a/lib/core/widgets/inputs/copy_input.dart
+++ b/lib/core/widgets/inputs/copy_input.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class CopyInput extends StatelessWidget {
   const CopyInput({

--- a/lib/core/widgets/inputs/paste_input.dart
+++ b/lib/core/widgets/inputs/paste_input.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PasteInput extends StatelessWidget {
   const PasteInput({

--- a/lib/core/widgets/invoice_viewer.dart
+++ b/lib/core/widgets/invoice_viewer.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/core/widgets/viewer_action_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Displays a Lightning invoice truncated to fit the available width.
 ///

--- a/lib/core/widgets/lists/transactions_by_day_list.dart
+++ b/lib/core/widgets/lists/transactions_by_day_list.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart
 import 'package:bb_mobile/features/transactions/ui/widgets/ongoing_swaps.dart';
 import 'package:bb_mobile/features/transactions/ui/widgets/tx_list_item.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class TransactionsByDayList extends StatelessWidget {

--- a/lib/core/widgets/loading/progress_screen.dart
+++ b/lib/core/widgets/loading/progress_screen.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart' show Assets;
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart' show Autostart, Gif;
 
 class ProgressScreen extends StatelessWidget {

--- a/lib/core/widgets/loading/status_screen.dart
+++ b/lib/core/widgets/loading/status_screen.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/loading/progress_screen.dart';
 import 'package:bb_mobile/core/widgets/template/screen_template.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// A screen that handles three states: loading, success, and error
 class StatusScreen extends StatelessWidget {

--- a/lib/core/widgets/log_viewer_widget.dart
+++ b/lib/core/widgets/log_viewer_widget.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class LogsViewerWidget extends StatefulWidget {

--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/labels/ui/labeled_text_input.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 typedef Mnemonic = ({
   String label,

--- a/lib/core/widgets/navbar/top_bar.dart
+++ b/lib/core/widgets/navbar/top_bar.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class TopBar extends StatelessWidget {
   const TopBar({

--- a/lib/core/widgets/price_input/balance_row.dart
+++ b/lib/core/widgets/price_input/balance_row.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/switch/bb_switch.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BalanceRow extends StatelessWidget {
   final String title;

--- a/lib/core/widgets/price_input/price_input.dart
+++ b/lib/core/widgets/price_input/price_input.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/inputs/amount_input_formatter.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PriceInput extends StatelessWidget {
   const PriceInput({

--- a/lib/core/widgets/selectors/recoverbull_vault_provider_selector.dart
+++ b/lib/core/widgets/selectors/recoverbull_vault_provider_selector.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/cards/provider_cart.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class RecoverbullVaultProviderSelector extends StatelessWidget {
   final void Function(VaultProvider provider) onProviderSelected;

--- a/lib/core/widgets/share_logs_widget.dart
+++ b/lib/core/widgets/share_logs_widget.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/widgets/share_logs_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ShareLogsWidget extends StatelessWidget {
   const ShareLogsWidget({super.key});

--- a/lib/core/widgets/tab_menu_vertical_button.dart
+++ b/lib/core/widgets/tab_menu_vertical_button.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class TabMenuVerticalButton extends StatelessWidget {
   final Widget? icon;

--- a/lib/core/widgets/tables/details_table_item.dart
+++ b/lib/core/widgets/tables/details_table_item.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DetailsTableItem extends StatefulWidget {
   const DetailsTableItem({

--- a/lib/core/widgets/transaction_viewer.dart
+++ b/lib/core/widgets/transaction_viewer.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/core/widgets/viewer_action_button.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:url_launcher/url_launcher.dart';
 
 enum _TransactionNetwork { bitcoin, liquid, ark }

--- a/lib/core/widgets/viewer_action_button.dart
+++ b/lib/core/widgets/viewer_action_button.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Standard action row used inside address / transaction / invoice detail
 /// dialogs (Copy, Copy link, Open in explorer).

--- a/lib/core/widgets/warning_bottom_sheet.dart
+++ b/lib/core/widgets/warning_bottom_sheet.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WarningBottomSheet extends StatelessWidget {

--- a/lib/features/address_view/ui/screens/addresses_screen.dart
+++ b/lib/features/address_view/ui/screens/addresses_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/address_view/presentation/address_view_failur
 import 'package:bb_mobile/features/settings/ui/widgets/address_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AddressesScreen extends StatefulWidget {
   const AddressesScreen({super.key, required this.walletId});

--- a/lib/features/app_startup/ui/app_startup_widget.dart
+++ b/lib/features/app_startup/ui/app_startup_widget.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/onboarding/ui/screens/onboarding_splash.dart'
 import 'package:bb_mobile/router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:url_launcher/url_launcher.dart';
 
 class AppStartupWidget extends StatefulWidget {

--- a/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
+++ b/lib/features/app_unlock/ui/pin_code_unlock_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PinCodeUnlockScreen extends StatelessWidget {

--- a/lib/features/ark/ui/ark_about_page.dart
+++ b/lib/features/ark/ui/ark_about_page.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ArkAboutPage extends StatelessWidget {

--- a/lib/features/ark/ui/ark_balance_detail_widget.dart
+++ b/lib/features/ark/ui/ark_balance_detail_widget.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/wallet/ui/widgets/eye_toggle.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/home_fiat_balance.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ArkBalanceDetailWidget extends StatelessWidget {
   const ArkBalanceDetailWidget({super.key, required this.arkBalance});

--- a/lib/features/ark/ui/ark_transaction_details_page.dart
+++ b/lib/features/ark/ui/ark_transaction_details_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/core/widgets/tables/details_table_item.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/features/ark/ui/ark_tx_widget.dart
+++ b/lib/features/ark/ui/ark_tx_widget.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/ark/router.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:timeago/timeago.dart' as timeago;
 

--- a/lib/features/ark/ui/ark_wallet_detail_page.dart
+++ b/lib/features/ark/ui/ark_wallet_detail_page.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ArkWalletDetailPage extends StatelessWidget {

--- a/lib/features/ark/ui/collaborative_redeem_bottom_sheet.dart
+++ b/lib/features/ark/ui/collaborative_redeem_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:bb_mobile/features/ark/presentation/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class CollaborativeRedeemBottomSheet extends StatelessWidget {
   const CollaborativeRedeemBottomSheet({

--- a/lib/features/ark/ui/receive_page.dart
+++ b/lib/features/ark/ui/receive_page.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ReceivePage extends StatefulWidget {
   const ReceivePage({super.key});

--- a/lib/features/ark/ui/send_confirm_page.dart
+++ b/lib/features/ark/ui/send_confirm_page.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/core/widgets/scrollable_column.dart';
 import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SendConfirmPage extends StatelessWidget {
   const SendConfirmPage({super.key});

--- a/lib/features/ark/ui/send_recipient_page.dart
+++ b/lib/features/ark/ui/send_recipient_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/send/ui/screens/open_the_camera_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SendRecipientPage extends StatefulWidget {

--- a/lib/features/ark/ui/settle_bottom_sheet.dart
+++ b/lib/features/ark/ui/settle_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/ark/presentation/cubit.dart';
 import 'package:bb_mobile/features/ark/presentation/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SettleBottomSheet extends StatelessWidget {
   const SettleBottomSheet({super.key, required this.cubit});

--- a/lib/features/ark/ui/transaction_history_widget.dart
+++ b/lib/features/ark/ui/transaction_history_widget.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/themes/fonts.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/ark/ui/ark_tx_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class TransactionHistoryWidget extends StatelessWidget {

--- a/lib/features/ark_setup/setup_page.dart
+++ b/lib/features/ark_setup/setup_page.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/ark_setup/presentation/state.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ArkSetupPage extends StatelessWidget {
   const ArkSetupPage({super.key});

--- a/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
+++ b/lib/features/autoswap/ui/screens/autoswap_settings_screen.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/autoswap/presentation/autoswap_settings_cubit
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AutoSwapSettingsScreen extends StatefulWidget {
   const AutoSwapSettingsScreen({super.key});

--- a/lib/features/autoswap/ui/widgets/autoswap_settings.dart
+++ b/lib/features/autoswap/ui/widgets/autoswap_settings.dart
@@ -15,7 +15,7 @@ import 'package:bb_mobile/features/autoswap/presentation/autoswap_settings_cubit
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AutoSwapSettingsBottomSheet extends StatelessWidget {
   const AutoSwapSettingsBottomSheet({super.key});

--- a/lib/features/backup_settings/ui/screens/backup_options_screen.dart
+++ b/lib/features/backup_settings/ui/screens/backup_options_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:bb_mobile/features/test_wallet_backup/ui/test_wallet_backup_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class BackupOptionsScreen extends StatefulWidget {

--- a/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
+++ b/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
@@ -14,7 +14,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class BackupSettingsScreen extends StatefulWidget {

--- a/lib/features/backup_settings/ui/widgets/how_to_decide.dart
+++ b/lib/features/backup_settings/ui/widgets/how_to_decide.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class HowToDecideBackupOption extends StatelessWidget {
   const HowToDecideBackupOption({super.key});

--- a/lib/features/backup_settings/ui/widgets/view_vault_key_warning_bottom_sheet.dart
+++ b/lib/features/backup_settings/ui/widgets/view_vault_key_warning_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ViewVaultKeyWarningBottomSheet extends StatelessWidget {

--- a/lib/features/bip85_entropy/bip85_home_page.dart
+++ b/lib/features/bip85_entropy/bip85_home_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/bip85_entropy/presentation/cubit.dart';
 import 'package:bb_mobile/features/bip85_entropy/presentation/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class Bip85HomePage extends StatelessWidget {
   const Bip85HomePage({super.key});

--- a/lib/features/bitbox/ui/screens/bitbox_action_screen.dart
+++ b/lib/features/bitbox/ui/screens/bitbox_action_screen.dart
@@ -31,7 +31,7 @@ import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_en
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 

--- a/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
+++ b/lib/features/broadcast_signed_tx/presentation/pages/broadcast_signed_tx_page.dart
@@ -19,7 +19,7 @@ import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/broadcast_signed_tx/ui/transaction_review_view.dart
+++ b/lib/features/broadcast_signed_tx/ui/transaction_review_view.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/broadcast_signed_tx/presentation/transaction_
 import 'package:bb_mobile/features/broadcast_signed_tx/presentation/transaction_review_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// A reusable transaction confirm/review screen that displays transaction
 /// details before broadcasting.

--- a/lib/features/buy/ui/screens/buy_accelerate_screen.dart
+++ b/lib/features/buy/ui/screens/buy_accelerate_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/buy/ui/widgets/buy_confirm_detail_row.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BuyAccelerateScreen extends StatelessWidget {
   const BuyAccelerateScreen({super.key});

--- a/lib/features/buy/ui/screens/buy_confirm_screen.dart
+++ b/lib/features/buy/ui/screens/buy_confirm_screen.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dar
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BuyConfirmScreen extends StatelessWidget {
   const BuyConfirmScreen({super.key});

--- a/lib/features/buy/ui/screens/buy_input_screen.dart
+++ b/lib/features/buy/ui/screens/buy_input_screen.dart
@@ -14,7 +14,7 @@ import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class BuyInputScreen extends StatefulWidget {

--- a/lib/features/buy/ui/screens/buy_success_screen.dart
+++ b/lib/features/buy/ui/screens/buy_success_screen.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class BuySuccessScreen extends StatelessWidget {

--- a/lib/features/buy/ui/widgets/buy_amount_input_fields.dart
+++ b/lib/features/buy/ui/widgets/buy_amount_input_fields.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/buy/presentation/buy_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class BuyAmountInputFields extends StatefulWidget {

--- a/lib/features/buy/ui/widgets/buy_destination_input_fields.dart
+++ b/lib/features/buy/ui/widgets/buy_destination_input_fields.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/buy/presentation/buy_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BuyDestinationInputFields extends StatefulWidget {
   const BuyDestinationInputFields({super.key});

--- a/lib/features/consolidation/ui/screens/consolidation_screen.dart
+++ b/lib/features/consolidation/ui/screens/consolidation_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/consolidation/presentation/consolidation_stat
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Confirmation + progress screen for consolidating a Liquid wallet. Styled to
 /// match the Send confirm screen (top bar, header, info rows, primary button).

--- a/lib/features/dca/ui/screens/dca_confirmation_screen.dart
+++ b/lib/features/dca/ui/screens/dca_confirmation_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/dca/presentation/dca_bloc.dart';
 import 'package:bb_mobile/features/dca/ui/widgets/dca_confirmation_detail_row.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DcaConfirmationScreen extends StatelessWidget {
   const DcaConfirmationScreen({super.key});

--- a/lib/features/dca/ui/screens/dca_screen.dart
+++ b/lib/features/dca/ui/screens/dca_screen.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/dca/ui/widgets/dca_frequency_radio_list.dart'
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class DcaScreen extends StatefulWidget {

--- a/lib/features/dca/ui/screens/dca_success_screen.dart
+++ b/lib/features/dca/ui/screens/dca_success_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/dca/presentation/dca_bloc.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class DcaSuccessScreen extends StatelessWidget {

--- a/lib/features/dca/ui/screens/dca_wallet_selection_screen.dart
+++ b/lib/features/dca/ui/screens/dca_wallet_selection_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/dca/ui/widgets/dca_wallet_radio_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DcaWalletSelectionScreen extends StatefulWidget {
   const DcaWalletSelectionScreen({super.key});

--- a/lib/features/dca/ui/widgets/dca_amount_input_fields.dart
+++ b/lib/features/dca/ui/widgets/dca_amount_input_fields.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/exchange/ui/widgets/exchange_amount_currency_
 import 'package:bb_mobile/features/exchange/ui/widgets/exchange_amount_input_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DcaAmountInputFields extends StatelessWidget {
   const DcaAmountInputFields({

--- a/lib/features/dca/ui/widgets/dca_frequency_radio_list.dart
+++ b/lib/features/dca/ui/widgets/dca_frequency_radio_list.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/dca/domain/dca.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DcaFrequencyRadioList extends StatelessWidget {
   const DcaFrequencyRadioList({

--- a/lib/features/dca/ui/widgets/dca_wallet_radio_list.dart
+++ b/lib/features/dca/ui/widgets/dca_wallet_radio_list.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/dca/domain/dca.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DcaWalletRadioList extends StatelessWidget {
   const DcaWalletRadioList({

--- a/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
+++ b/lib/features/electrum_settings/frameworks/ui/screens/electrum_settings_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/electrum_settings/frameworks/ui/widgets/tor_p
 import 'package:bb_mobile/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ElectrumSettingsScreen extends StatelessWidget {
   const ElectrumSettingsScreen({super.key});

--- a/lib/features/electrum_settings/frameworks/ui/widgets/add_custom_server_bottom_sheet.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/add_custom_server_bottom_sheet.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/electrum_settings/interface_adapters/presente
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class CustomServerInput {
   final String url;

--- a/lib/features/electrum_settings/frameworks/ui/widgets/delete_custom_server_dialog.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/delete_custom_server_dialog.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/dialog/blurred_dialog.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DeleteCustomServerDialog {
   static Future<bool?> show(

--- a/lib/features/electrum_settings/frameworks/ui/widgets/draggable_server_list.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/draggable_server_list.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/electrum_settings/interface_adapters/presente
 import 'package:bb_mobile/features/electrum_settings/presentation/electrum_settings_failure_l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class DraggableServerList extends StatelessWidget {
   const DraggableServerList({super.key});

--- a/lib/features/electrum_settings/frameworks/ui/widgets/privacy_notice.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/privacy_notice.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PrivacyNoticeBottomSheet extends StatelessWidget {
   const PrivacyNoticeBottomSheet({super.key});

--- a/lib/features/exchange/ui/screens/exchange_home_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_home_screen.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/features/withdraw/ui/withdraw_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 

--- a/lib/features/exchange/ui/screens/exchange_landing_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_landing_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ExchangeLandingScreen extends StatelessWidget {

--- a/lib/features/exchange/ui/screens/exchange_landing_screen_v2.dart
+++ b/lib/features/exchange/ui/screens/exchange_landing_screen_v2.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/features/exchange/ui/screens/exchange_support_login_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_support_login_screen.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ExchangeSupportLoginScreen extends StatelessWidget {

--- a/lib/features/exchange/ui/widgets/announcement_banner.dart
+++ b/lib/features/exchange/ui/widgets/announcement_banner.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AnnouncementBanner extends StatelessWidget {
   const AnnouncementBanner({super.key});

--- a/lib/features/exchange/ui/widgets/dca_list_tile.dart
+++ b/lib/features/exchange/ui/widgets/dca_list_tile.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/dca/ui/dca_router.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class DcaListTile extends StatefulWidget {

--- a/lib/features/exchange/ui/widgets/exchange_amount_currency_dropdown.dart
+++ b/lib/features/exchange/ui/widgets/exchange_amount_currency_dropdown.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ExchangeAmountCurrencyDropdown extends StatelessWidget {
   const ExchangeAmountCurrencyDropdown({

--- a/lib/features/exchange/ui/widgets/exchange_amount_input_field.dart
+++ b/lib/features/exchange/ui/widgets/exchange_amount_input_field.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/inputs/amount_input_formatter.dart';
 import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class ExchangeAmountInputField extends StatelessWidget {

--- a/lib/features/exchange/ui/widgets/exchange_home_kyc_card.dart
+++ b/lib/features/exchange/ui/widgets/exchange_home_kyc_card.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ExchangeHomeKycCard extends StatelessWidget {

--- a/lib/features/exchange/ui/widgets/exchange_home_top_section.dart
+++ b/lib/features/exchange/ui/widgets/exchange_home_top_section.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/bitcoin_price/ui/price_chart_widget.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ExchangeHomeTopSection extends StatelessWidget {
   const ExchangeHomeTopSection({super.key});

--- a/lib/features/exchange_support_chat/ui/screens/exchange_support_chat_screen.dart
+++ b/lib/features/exchange_support_chat/ui/screens/exchange_support_chat_screen.dart
@@ -20,7 +20,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class ExchangeSupportChatScreen extends StatelessWidget {

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_ars_bank_transfer_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_ars_bank_transfer_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeArsBankTransferScreen extends StatelessWidget {
   const FundExchangeArsBankTransferScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_bank_transfer_wire_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_bank_transfer_wire_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeBankTransferWireScreen extends StatelessWidget {
   const FundExchangeBankTransferWireScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_canada_post_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_canada_post_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCanadaPostScreen extends StatelessWidget {
   const FundExchangeCanadaPostScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_cop_bank_transfer_input_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_cop_bank_transfer_input_screen.dart
@@ -15,7 +15,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/fund_exchange_pres
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCopBankTransferInputScreen extends StatefulWidget {
   const FundExchangeCopBankTransferInputScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_cop_bank_transfer_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_cop_bank_transfer_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCopBankTransferScreen extends StatelessWidget {
   const FundExchangeCopBankTransferScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_cr_iban_crc_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_cr_iban_crc_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCrIbanCrcScreen extends StatelessWidget {
   const FundExchangeCrIbanCrcScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_cr_iban_usd_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_cr_iban_usd_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCrIbanUsdScreen extends StatelessWidget {
   const FundExchangeCrIbanUsdScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_email_e_transfer_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_email_e_transfer_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeEmailETransferScreen extends StatelessWidget {
   const FundExchangeEmailETransferScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_instant_sepa_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_instant_sepa_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeInstantSepaScreen extends StatelessWidget {
   const FundExchangeInstantSepaScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_method_selection_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_method_selection_screen.dart
@@ -19,7 +19,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_restricted_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeMethodSelectionScreen extends StatefulWidget {
   const FundExchangeMethodSelectionScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_online_bill_payment_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_online_bill_payment_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeOnlineBillPaymentScreen extends StatelessWidget {
   const FundExchangeOnlineBillPaymentScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_regular_sepa_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_regular_sepa_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeRegularSepaScreen extends StatelessWidget {
   const FundExchangeRegularSepaScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_sinpe_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_sinpe_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeSinpeScreen extends StatelessWidget {
   const FundExchangeSinpeScreen({super.key});

--- a/lib/features/fund_exchange/presentation/screens/fund_exchange_spei_transfer_screen.dart
+++ b/lib/features/fund_exchange/presentation/screens/fund_exchange_spei_transfer_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_done_bottom_navigation_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeSpeiTransferScreen extends StatelessWidget {
   const FundExchangeSpeiTransferScreen({super.key});

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_canada_methods.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_canada_methods.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCanadaMethods extends StatelessWidget {
   const FundExchangeCanadaMethods({super.key});

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_costa_rica_methods.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_costa_rica_methods.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeCostaRicaMethods extends StatelessWidget {
   const FundExchangeCostaRicaMethods({super.key});

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_detail.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_detail.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeDetail extends StatelessWidget {
   const FundExchangeDetail({

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_europe_methods.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_europe_methods.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_excha
 import 'package:bb_mobile/features/fund_exchange/presentation/bloc/fund_exchange_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeEuropeMethods extends StatelessWidget {
   const FundExchangeEuropeMethods({super.key});

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_scam_warning_card.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_scam_warning_card.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeScamWarningCard extends StatelessWidget {
   const FundExchangeScamWarningCard({super.key});

--- a/lib/features/fund_exchange/presentation/widgets/fund_exchange_warning_bottom_sheet.dart
+++ b/lib/features/fund_exchange/presentation/widgets/fund_exchange_warning_bottom_sheet.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/fund_exchange/presentation/fund_exchange_pres
 import 'package:bb_mobile/features/fund_exchange/presentation/widgets/fund_exchange_scam_warning_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class FundExchangeWarningBottomSheet extends StatefulWidget {
   const FundExchangeWarningBottomSheet({super.key});

--- a/lib/features/import_coldcard/import_coldcard_page.dart
+++ b/lib/features/import_coldcard/import_coldcard_page.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_ro
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ImportColdcardPage extends StatelessWidget {

--- a/lib/features/import_mnemonic/ui/select_purpose_page.dart
+++ b/lib/features/import_mnemonic/ui/select_purpose_page.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SelectScriptTypePage extends StatelessWidget {

--- a/lib/features/import_qr_device/import_qr_device_page.dart
+++ b/lib/features/import_qr_device/import_qr_device_page.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/import_qr_device/device_instructions_bottom_s
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ImportQrDevicePage extends StatelessWidget {

--- a/lib/features/import_wallet/import_wallet_page.dart
+++ b/lib/features/import_wallet/import_wallet_page.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/import_qr_device/router.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_router.dart';
 import 'package:bb_mobile/features/ledger/ui/ledger_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ImportWalletPage extends StatelessWidget {

--- a/lib/features/import_watch_only_wallet/presentation/import_method_widget.dart
+++ b/lib/features/import_watch_only_wallet/presentation/import_method_widget.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ImportMethodWidget extends StatelessWidget {

--- a/lib/features/import_watch_only_wallet/presentation/import_watch_only_screen.dart
+++ b/lib/features/import_watch_only_wallet/presentation/import_watch_only_screen.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ImportWatchOnlyScreen extends StatelessWidget {

--- a/lib/features/import_watch_only_wallet/presentation/watch_only_details_widget.dart
+++ b/lib/features/import_watch_only_wallet/presentation/watch_only_details_widget.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/import_watch_only_wallet/presentation/cubit/i
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:satoshifier/enums/derivation.dart' as satoshifier;
 
 class WatchOnlyDetailsWidget extends StatelessWidget {

--- a/lib/features/labels/ui/label_entry_bottom_sheet.dart
+++ b/lib/features/labels/ui/label_entry_bottom_sheet.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/core/widgets/tiles/bordered_tappable_tile.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 /// Shared bottom-sheet editor for user-entered annotations on payment

--- a/lib/features/labels/ui/labeled_text_input.dart
+++ b/lib/features/labels/ui/labeled_text_input.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/inputs/text_input.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LabeledTextInput extends StatelessWidget {
   final String label;

--- a/lib/features/labels/ui/page.dart
+++ b/lib/features/labels/ui/page.dart
@@ -17,7 +17,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class Bip329LabelsPage extends StatelessWidget {

--- a/lib/features/ledger/ui/screens/ledger_action_screen.dart
+++ b/lib/features/ledger/ui/screens/ledger_action_screen.dart
@@ -27,7 +27,7 @@ import 'package:bb_mobile/features/ledger/presentation/cubit/ledger_operation_st
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 

--- a/lib/features/mempool_settings/ui/mempool_settings_screen.dart
+++ b/lib/features/mempool_settings/ui/mempool_settings_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/mempool_settings/presentation/mempool_setting
 import 'package:bb_mobile/features/mempool_settings/ui/widgets/mempool_server_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class MempoolSettingsScreen extends StatefulWidget {
   const MempoolSettingsScreen({super.key});

--- a/lib/features/mempool_settings/ui/widgets/mempool_server_list.dart
+++ b/lib/features/mempool_settings/ui/widgets/mempool_server_list.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/mempool_settings/ui/widgets/mempool_server_it
 import 'package:bb_mobile/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class MempoolServerList extends StatelessWidget {
   const MempoolServerList({super.key});

--- a/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
+++ b/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/mempool_settings/presentation/mempool_setting
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SetCustomServerBottomSheet extends StatefulWidget {
   final String? initialUrl;

--- a/lib/features/onboarding/ui/screens/advanced_options.dart
+++ b/lib/features/onboarding/ui/screens/advanced_options.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/tor_settings/presentation/bloc/tor_settings_c
 import 'package:bb_mobile/features/tor_settings/ui/widgets/tor_proxy_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class AdvancedOptions extends StatefulWidget {

--- a/lib/features/onboarding/ui/screens/onboarding_splash.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_splash.dart
@@ -14,7 +14,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class OnboardingSplash extends StatelessWidget {
   const OnboardingSplash({super.key, this.loading = false});

--- a/lib/features/onboarding/ui/screens/recover_options.dart
+++ b/lib/features/onboarding/ui/screens/recover_options.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class OnboardingRecoverOptions extends StatefulWidget {

--- a/lib/features/pay/ui/screens/pay_amount_screen.dart
+++ b/lib/features/pay/ui/screens/pay_amount_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
 import 'package:bb_mobile/features/pay/ui/widgets/pay_amount_input_fields.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PayAmountScreen extends StatefulWidget {

--- a/lib/features/pay/ui/screens/pay_external_wallet_network_selection_screen.dart
+++ b/lib/features/pay/ui/screens/pay_external_wallet_network_selection_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/scrollable_column.dart';
 import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PayExternalWalletNetworkSelectionScreen extends StatelessWidget {
   const PayExternalWalletNetworkSelectionScreen({super.key});

--- a/lib/features/pay/ui/screens/pay_in_progress_screen.dart
+++ b/lib/features/pay/ui/screens/pay_in_progress_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/pay/ui/screens/pay_receive_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_receive_payment_screen.dart
@@ -20,7 +20,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PayReceivePaymentScreen extends StatelessWidget {

--- a/lib/features/pay/ui/screens/pay_send_payment_screen.dart
+++ b/lib/features/pay/ui/screens/pay_send_payment_screen.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PaySendPaymentScreen extends StatelessWidget {
   const PaySendPaymentScreen({super.key});

--- a/lib/features/pay/ui/screens/pay_sinpe_success_screen.dart
+++ b/lib/features/pay/ui/screens/pay_sinpe_success_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
 import 'package:bb_mobile/features/pay/ui/widgets/sinpe_receipt_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PaySinpeSuccessScreen extends StatefulWidget {

--- a/lib/features/pay/ui/screens/pay_success_screen.dart
+++ b/lib/features/pay/ui/screens/pay_success_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/pay/ui/screens/pay_wallet_selection_screen.dart
+++ b/lib/features/pay/ui/screens/pay_wallet_selection_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/pay/ui/pay_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_cards.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PayWalletSelectionScreen extends StatelessWidget {

--- a/lib/features/pay/ui/widgets/pay_advanced_options_bottom_sheet.dart
+++ b/lib/features/pay/ui/widgets/pay_advanced_options_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/pay/presentation/pay_bloc.dart';
 import 'package:bb_mobile/features/pay/ui/widgets/pay_coin_selection_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PayAdvancedOptionsBottomSheet extends StatelessWidget {

--- a/lib/features/pay/ui/widgets/pay_amount_input_fields.dart
+++ b/lib/features/pay/ui/widgets/pay_amount_input_fields.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/features/exchange/ui/widgets/exchange_amount_currency_dropdown.dart';
 import 'package:bb_mobile/features/exchange/ui/widgets/exchange_amount_input_field.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PayAmountInputFields extends StatelessWidget {
   const PayAmountInputFields({

--- a/lib/features/pay/ui/widgets/pay_qr_bottom_sheet.dart
+++ b/lib/features/pay/ui/widgets/pay_qr_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class PayQrBottomSheet extends StatelessWidget {
   const PayQrBottomSheet({super.key, required this.bip21InvoiceData});

--- a/lib/features/pay/ui/widgets/sinpe_receipt_bottom_sheet.dart
+++ b/lib/features/pay/ui/widgets/sinpe_receipt_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/bottom_sheet/x.dart';
 import 'package:bb_mobile/features/pay/ui/widgets/sinpe_receipt_card.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 Future<void> showSinpeReceiptBottomSheet(

--- a/lib/features/pay/ui/widgets/sinpe_receipt_card.dart
+++ b/lib/features/pay/ui/widgets/sinpe_receipt_card.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 
 String formatSinpePhoneNumber(String? phoneNumber, String fallback) {

--- a/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/choose_pin_code_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ChoosePinCodeScreen extends StatelessWidget {

--- a/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
+++ b/lib/features/pin_code/ui/screens/confirm_pin_code_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ConfirmPinCodeScreen extends StatelessWidget {
   const ConfirmPinCodeScreen({super.key});

--- a/lib/features/pin_code/ui/screens/pin_settings_screen.dart
+++ b/lib/features/pin_code/ui/screens/pin_settings_screen.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/features/pin_code/presentation/bloc/pin_code_setting_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class PinSettingsScreen extends StatelessWidget {

--- a/lib/features/psbt_flow/show_animated_qr/show_animated_qr_widget.dart
+++ b/lib/features/psbt_flow/show_animated_qr/show_animated_qr_widget.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/psbt_flow/show_animated_qr/show_animated_qr_c
 import 'package:bb_mobile/features/psbt_flow/show_animated_qr/show_animated_qr_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ShowAnimatedQrWidget extends StatelessWidget {
   final String psbt;

--- a/lib/features/psbt_flow/show_psbt/show_psbt_screen.dart
+++ b/lib/features/psbt_flow/show_psbt/show_psbt_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/broadcast_signed_tx/router.dart';
 import 'package:bb_mobile/features/psbt_flow/show_animated_qr/show_animated_qr_widget.dart';
 import 'package:bb_mobile/features/psbt_flow/show_psbt/device_instructions.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ShowPsbtScreen extends StatelessWidget {

--- a/lib/features/receive/ui/screens/receive_amount_screen.dart
+++ b/lib/features/receive/ui/screens/receive_amount_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/features/receive/ui/widgets/receive_amount_input.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ReceiveAmountScreen extends StatefulWidget {

--- a/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payjoin_in_progress_screen.dart
@@ -17,7 +17,7 @@ import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ReceivePayjoinInProgressScreen extends StatelessWidget {

--- a/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_in_progress_screen.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/receive/presentation/bloc/receive_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ReceivePaymentInProgressScreen extends StatelessWidget {

--- a/lib/features/receive/ui/screens/receive_payment_received_screen.dart
+++ b/lib/features/receive/ui/screens/receive_payment_received_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/receive/ui/screens/receive_qr_screen.dart
+++ b/lib/features/receive/ui/screens/receive_qr_screen.dart
@@ -27,7 +27,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 

--- a/lib/features/receive/ui/screens/receive_scaffold.dart
+++ b/lib/features/receive/ui/screens/receive_scaffold.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/navbar/top_bar.dart';
 import 'package:bb_mobile/features/receive/ui/widgets/receive_network_selection.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ReceiveScaffold extends StatelessWidget {

--- a/lib/features/recipients/frameworks/ui/screens/recipients_screen.dart
+++ b/lib/features/recipients/frameworks/ui/screens/recipients_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 enum RecipientsTab { newRecipient, recipientsList }
 

--- a/lib/features/recipients/frameworks/ui/tabs/new_recipient_tab.dart
+++ b/lib/features/recipients/frameworks/ui/tabs/new_recipient_tab.dart
@@ -21,7 +21,7 @@ import 'package:bb_mobile/features/recipients/frameworks/ui/widgets/recipient_ty
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc/recipients_bloc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class NewRecipientTab extends StatefulWidget {
   const NewRecipientTab({this.hookError, super.key});

--- a/lib/features/recipients/frameworks/ui/tabs/recipients_list_tab.dart
+++ b/lib/features/recipients/frameworks/ui/tabs/recipients_list_tab.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class RecipientsListTab extends StatefulWidget {
   const RecipientsListTab({this.hookError, super.key});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bank_account_cop_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bank_account_cop_form.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BankAccountCopForm extends StatefulWidget {
   const BankAccountCopForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bank_transfer_cad_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bank_transfer_cad_form.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BankTransferCadForm extends StatefulWidget {
   const BankTransferCadForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bill_payment_cad_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/bill_payment_cad_form.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BillPaymentCadForm extends StatefulWidget {
   const BillPaymentCadForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/cbu_cvu_argentina_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/cbu_cvu_argentina_form.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BankAccountArgentinaForm extends StatefulWidget {
   const BankAccountArgentinaForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/interac_email_cad_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/interac_email_cad_form.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class InteracEmailCadForm extends StatefulWidget {
   const InteracEmailCadForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/nequi_cop_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/nequi_cop_form.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/mode
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class NequiCopForm extends StatefulWidget {
   const NequiCopForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sepa_eur_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sepa_eur_form.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SepaEurForm extends StatefulWidget {
   const SepaEurForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sinpe_iban_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sinpe_iban_form.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SinpeIbanForm extends StatefulWidget {
   const SinpeIbanForm({super.key, this.recipientType, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sinpe_movil_crc_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/sinpe_movil_crc_form.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/generated/l10n/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 String? validateSinpeMovilPhone(String? value, AppLocalizations loc) {
   if (value == null || value.trim().isEmpty) {

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_card_mxn_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_card_mxn_form.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SpeiCardMxnForm extends StatefulWidget {
   const SpeiCardMxnForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_clabe_mxn_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_clabe_mxn_form.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SpeiClabeMxnForm extends StatefulWidget {
   const SpeiClabeMxnForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_sms_mxn_form.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/new_recipient_forms/spei_sms_mxn_form.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_form_data_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SpeiSmsMxnForm extends StatefulWidget {
   const SpeiSmsMxnForm({super.key, this.hookError});

--- a/lib/features/recipients/frameworks/ui/widgets/recipient_type_selector.dart
+++ b/lib/features/recipients/frameworks/ui/widgets/recipient_type_selector.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/recipients/frameworks/ui/widgets/recipient_ty
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/bloc/recipients_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class RecipientTypeSelector extends StatelessWidget {
   const RecipientTypeSelector({

--- a/lib/features/recoverbull/ui/pages/connecting_page.dart
+++ b/lib/features/recoverbull/ui/pages/connecting_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/recoverbull/ui/pages/vault_provider_selection
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/recoverbull/ui/pages/password_input_page.dart
+++ b/lib/features/recoverbull/ui/pages/password_input_page.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/recoverbull/ui/widgets/key_server_status_widg
 import 'package:bb_mobile/features/recoverbull/utils/password_validator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 enum InputType { pin, password, vaultKey }

--- a/lib/features/recoverbull/ui/pages/server_confirmation_page.dart
+++ b/lib/features/recoverbull/ui/pages/server_confirmation_page.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/features/recoverbull/ui/pages/settings_page.dart
+++ b/lib/features/recoverbull/ui/pages/settings_page.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/features/recoverbull/ui/pages/vault_provider_selection_page.dart
+++ b/lib/features/recoverbull/ui/pages/vault_provider_selection_page.dart
@@ -13,7 +13,7 @@ import 'package:bb_mobile/features/recoverbull/ui/pages/vault_selected_page.dart
 import 'package:bb_mobile/features/recoverbull/ui/widgets/key_server_status_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class VaultProviderSelectionPage extends StatelessWidget {

--- a/lib/features/recoverbull/ui/pages/vault_selected_page.dart
+++ b/lib/features/recoverbull/ui/pages/vault_selected_page.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:bb_mobile/features/recoverbull/ui/widgets/key_server_status_widget.dart';
 import 'package:bb_mobile/features/recoverbull_google_drive/router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/features/recoverbull_google_drive/ui/drive_vaults_list_page.dart
+++ b/lib/features/recoverbull_google_drive/ui/drive_vaults_list_page.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/recoverbull_google_drive/presentation/recover
 import 'package:bb_mobile/features/recoverbull_google_drive/presentation/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/features/replace_by_fee/ui/fee_selector_widget.dart
+++ b/lib/features/replace_by_fee/ui/fee_selector_widget.dart
@@ -5,7 +5,7 @@ import 'package:bb_mobile/core/widgets/fees/custom_fee_list_item.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/replace_by_fee/domain/fee_entity.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class BumpFeeSelectorWidget extends StatelessWidget {
   const BumpFeeSelectorWidget({

--- a/lib/features/replace_by_fee/ui/home_page.dart
+++ b/lib/features/replace_by_fee/ui/home_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/replace_by_fee/presentation/state.dart';
 import 'package:bb_mobile/features/replace_by_fee/ui/fee_selector_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ReplaceByFeeHomePage extends StatefulWidget {

--- a/lib/features/sell/ui/screens/sell_external_wallet_network_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_external_wallet_network_selection_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/scrollable_column.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SellExternalWalletNetworkSelectionScreen extends StatelessWidget {
   const SellExternalWalletNetworkSelectionScreen({super.key});

--- a/lib/features/sell/ui/screens/sell_receive_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_receive_payment_screen.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/features/sell/ui/widgets/sell_qr_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SellReceivePaymentScreen extends StatelessWidget {
   const SellReceivePaymentScreen({super.key});

--- a/lib/features/sell/ui/screens/sell_screen.dart
+++ b/lib/features/sell/ui/screens/sell_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/sell/ui/widgets/sell_amount_currency_dropdown
 import 'package:bb_mobile/features/sell/ui/widgets/sell_amount_input_bottom_buttons.dart';
 import 'package:bb_mobile/features/sell/ui/widgets/sell_amount_input_field.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SellScreen extends StatefulWidget {

--- a/lib/features/sell/ui/screens/sell_send_payment_screen.dart
+++ b/lib/features/sell/ui/screens/sell_send_payment_screen.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SellSendPaymentScreen extends StatelessWidget {
   const SellSendPaymentScreen({super.key});

--- a/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
+++ b/lib/features/sell/ui/screens/sell_wallet_selection_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/sell/ui/sell_router.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/wallet_cards.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SellWalletSelectionScreen extends StatelessWidget {

--- a/lib/features/sell/ui/widgets/sell_advanced_options_bottom_sheet.dart
+++ b/lib/features/sell/ui/widgets/sell_advanced_options_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:bb_mobile/features/sell/ui/widgets/sell_coin_selection_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SellAdvancedOptionsBottomSheet extends StatelessWidget {

--- a/lib/features/sell/ui/widgets/sell_amount_input_bottom_buttons.dart
+++ b/lib/features/sell/ui/widgets/sell_amount_input_bottom_buttons.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/sell/presentation/bloc/sell_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SellAmountInputBottomButtons extends StatefulWidget {

--- a/lib/features/sell/ui/widgets/sell_qr_bottom_sheet.dart
+++ b/lib/features/sell/ui/widgets/sell_qr_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SellQrBottomSheet extends StatelessWidget {
   const SellQrBottomSheet({super.key, required this.bip21InvoiceData});

--- a/lib/features/send/request_identifier/request_identifier_screen.dart
+++ b/lib/features/send/request_identifier/request_identifier_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/send/request_identifier/request_identifier_st
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class RequestIdentifierScreen extends StatelessWidget {

--- a/lib/features/send/ui/screens/open_the_camera_widget.dart
+++ b/lib/features/send/ui/screens/open_the_camera_widget.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/send/ui/screens/full_screen_scanner_page.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class OpenTheCameraWidget extends StatelessWidget {
   final OnScannedPaymentRequestCallback onScannedPaymentRequest;

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -45,7 +45,7 @@ import 'package:bitcoin_base/bitcoin_base.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/send/ui/widgets/advanced_options_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/advanced_options_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
 import 'package:bb_mobile/features/send/ui/widgets/coin_selection_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class AdvancedOptionsBottomSheet extends StatelessWidget {

--- a/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
 import 'package:bb_mobile/features/send/ui/widgets/coin_select_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class CoinSelectionBottomSheet extends StatelessWidget {

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -15,7 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/lib/features/settings/ui/screens/bitcoin/payjoin_advanced_settings_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/payjoin_advanced_settings_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Payjoin advanced settings, on their own page (product decision
 /// 2026-07-26 — not an expand/collapse section): the minimum-receive-amount

--- a/lib/features/settings/ui/screens/bitcoin/payjoin_settings_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/payjoin_settings_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/settings/presentation/settings_failure_l10n.d
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 /// Payjoin settings (product decision 2026-07-25/26): deliberately minimal —

--- a/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
@@ -10,7 +10,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class WalletDetailsScreen extends StatelessWidget {
   const WalletDetailsScreen({super.key, required this.walletId});

--- a/lib/features/settings/ui/widgets/address_card.dart
+++ b/lib/features/settings/ui/widgets/address_card.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/address_viewer.dart';
 import 'package:bb_mobile/features/bitcoin_price/ui/currency_text.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AddressCard extends StatelessWidget {
   const AddressCard({

--- a/lib/features/swap/ui/pages/swap_confirm_page.dart
+++ b/lib/features/swap/ui/pages/swap_confirm_page.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:bb_mobile/core/widgets/fees/fee_options_modal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapConfirmPage extends StatelessWidget {
   const SwapConfirmPage({super.key});

--- a/lib/features/swap/ui/pages/swap_in_progress_page.dart
+++ b/lib/features/swap/ui/pages/swap_in_progress_page.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/swap/ui/pages/swap_page.dart
+++ b/lib/features/swap/ui/pages/swap_page.dart
@@ -22,7 +22,7 @@ import 'package:bb_mobile/features/swap/ui/widgets/swap_to_wallet_dropdown.dart'
 import 'package:bb_mobile/features/swap/ui/widgets/swap_advanced_options_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapPage extends StatefulWidget {
   const SwapPage({super.key});

--- a/lib/features/swap/ui/widgets/swap_advanced_options_bottom_sheet.dart
+++ b/lib/features/swap/ui/widgets/swap_advanced_options_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:bb_mobile/features/swap/ui/widgets/swap_coin_selection_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SwapAdvancedOptionsBottomSheet extends StatelessWidget {

--- a/lib/features/swap/ui/widgets/swap_amount_input.dart
+++ b/lib/features/swap/ui/widgets/swap_amount_input.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapAmountInput extends StatelessWidget {
   const SwapAmountInput({

--- a/lib/features/swap/ui/widgets/swap_balance_row.dart
+++ b/lib/features/swap/ui/widgets/swap_balance_row.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapBalanceRow extends StatelessWidget {
   const SwapBalanceRow({super.key, required this.amountController});

--- a/lib/features/swap/ui/widgets/swap_external_address_input.dart
+++ b/lib/features/swap/ui/widgets/swap_external_address_input.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/swap/ui/swap_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class SwapExternalAddressInput extends StatelessWidget {

--- a/lib/features/swap/ui/widgets/swap_fees_row.dart
+++ b/lib/features/swap/ui/widgets/swap_fees_row.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapFeesRow extends StatelessWidget {
   const SwapFeesRow({super.key, required this.amountSat});

--- a/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_from_wallet_dropdown.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapFromWalletDropdown extends StatelessWidget {
   const SwapFromWalletDropdown();

--- a/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
+++ b/lib/features/swap/ui/widgets/swap_to_wallet_dropdown.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/loading/loading_line_content.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapToWalletDropdown extends StatelessWidget {
   const SwapToWalletDropdown();

--- a/lib/features/test_wallet_backup/ui/app_bar_widget.dart
+++ b/lib/features/test_wallet_backup/ui/app_bar_widget.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/test_wallet_backup/presentation/bloc/test_wal
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class AppBarWidget extends StatelessWidget {

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/test_wallet_backup/ui/screens/verify_mnemonic
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class ShowMnemonicScreen extends StatefulWidget {
   const ShowMnemonicScreen({super.key});

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/test_wallet_backup/ui/app_bar_widget.dart';
 import 'package:bb_mobile/features/test_wallet_backup/ui/screens/backup_test_success.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class VerifyMnemonicScreen extends StatefulWidget {
   const VerifyMnemonicScreen({super.key});

--- a/lib/features/tor_settings/ui/widgets/tor_connection_status_card.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_connection_status_card.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class TorConnectionStatusCard extends StatelessWidget {
   final TorStatus status;

--- a/lib/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/inputs/bb_keyboard_actions.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class TorPortInputBottomSheet extends StatefulWidget {

--- a/lib/features/tor_settings/ui/widgets/tor_proxy_widget.dart
+++ b/lib/features/tor_settings/ui/widgets/tor_proxy_widget.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/tor_settings/ui/widgets/tor_connection_status
 import 'package:bb_mobile/features/tor_settings/ui/widgets/tor_port_input_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class TorProxyWidget extends StatelessWidget {
   const TorProxyWidget({super.key});

--- a/lib/features/transactions/ui/screens/export_transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/export_transactions_screen.dart
@@ -9,7 +9,7 @@ import 'package:bb_mobile/features/transactions/presentation/blocs/export/export
 import 'package:bb_mobile/features/transactions/presentation/blocs/export/export_transactions_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class ExportTransactionsScreen extends StatefulWidget {

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -25,7 +25,7 @@ import 'package:bb_mobile/features/labels/ui/label_entry_bottom_sheet.dart';
 import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class TransactionDetailsScreen extends StatelessWidget {

--- a/lib/features/transactions/ui/screens/transactions_screen.dart
+++ b/lib/features/transactions/ui/screens/transactions_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/transactions/ui/widgets/txs_syncing_indicator
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class TransactionsScreen extends StatelessWidget {

--- a/lib/features/transactions/ui/widgets/ongoing_swaps.dart
+++ b/lib/features/transactions/ui/widgets/ongoing_swaps.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
 import 'package:bb_mobile/features/transactions/ui/widgets/tx_list_item.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class OngoingSwapsWidget extends StatelessWidget {
   const OngoingSwapsWidget({super.key, required this.ongoingSwaps});

--- a/lib/features/transactions/ui/widgets/sender_broadcast_payjoin_original_tx_button.dart
+++ b/lib/features/transactions/ui/widgets/sender_broadcast_payjoin_original_tx_button.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SenderBroadcastPayjoinOriginalTxButton extends StatelessWidget {
   const SenderBroadcastPayjoinOriginalTxButton({super.key});

--- a/lib/features/transactions/ui/widgets/swap_status_description.dart
+++ b/lib/features/transactions/ui/widgets/swap_status_description.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/cards/info_card.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class SwapStatusDescription extends StatelessWidget {
   const SwapStatusDescription({required this.swap});

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -18,7 +18,7 @@ import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_d
 import 'package:bb_mobile/features/transactions/ui/widgets/labels_table_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:intl/intl.dart';
 
 class TransactionDetailsTable extends StatelessWidget {

--- a/lib/features/transactions/ui/widgets/tx_list_item.dart
+++ b/lib/features/transactions/ui/widgets/tx_list_item.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
 import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:timeago/timeago.dart' as timeago;
 

--- a/lib/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart
+++ b/lib/features/wallet/ui/screens/legacy_storage_are_you_sure_screen.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LegacyStorageAreYouSureScreen extends StatefulWidget {
   const LegacyStorageAreYouSureScreen({

--- a/lib/features/wallet/ui/screens/legacy_storage_warning_screen.dart
+++ b/lib/features/wallet/ui/screens/legacy_storage_warning_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/wallet/ui/widgets/legacy_storage/legacy_stora
 import 'package:bb_mobile/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/legacy_storage/legacy_storage_step_row.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LegacyStorageWarningScreen extends StatelessWidget {
   const LegacyStorageWarningScreen({

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -21,7 +21,7 @@ import 'package:bb_mobile/locator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:bb_mobile/features/consolidation/public/consolidation_facade.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/features/wallet/ui/widgets/auto_swap_fee_warning.dart
+++ b/lib/features/wallet/ui/widgets/auto_swap_fee_warning.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AutoSwapFeeWarning extends StatelessWidget {
   const AutoSwapFeeWarning({super.key});

--- a/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
+++ b/lib/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class AutoSwapWarningBottomSheet extends StatelessWidget {

--- a/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
+++ b/lib/features/wallet/ui/widgets/backup_warning_overlay.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dar
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class BackupWarningOverlay extends StatelessWidget {

--- a/lib/features/wallet/ui/widgets/home_errors.dart
+++ b/lib/features/wallet/ui/widgets/home_errors.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/autoswap_warning_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class HomeWarnings extends StatelessWidget {

--- a/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_important_callout.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_important_callout.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LegacyStorageImportantCallout extends StatelessWidget {
   const LegacyStorageImportantCallout({

--- a/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_screen_scaffold.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/legacy_storage/legacy_storage_badge.dart';
 import 'package:bb_mobile/features/wizard/ui/widgets/wizard_dots.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LegacyStorageScreenScaffold extends StatelessWidget {
   const LegacyStorageScreenScaffold({

--- a/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_step_row.dart
+++ b/lib/features/wallet/ui/widgets/legacy_storage/legacy_storage_step_row.dart
@@ -1,7 +1,7 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class LegacyStorageStepRow extends StatelessWidget {
   const LegacyStorageStepRow({

--- a/lib/features/wallet/ui/widgets/wallet_bottom_buttons.dart
+++ b/lib/features/wallet/ui/widgets/wallet_bottom_buttons.dart
@@ -7,7 +7,7 @@ import 'package:bb_mobile/features/receive/domain/extensions/wallet_receive_exte
 import 'package:bb_mobile/features/receive/ui/receive_router.dart';
 import 'package:bb_mobile/features/send/ui/send_router.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WalletBottomButtons extends StatelessWidget {

--- a/lib/features/wallet/ui/widgets/wallet_cards.dart
+++ b/lib/features/wallet/ui/widgets/wallet_cards.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/ark/router.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WalletCards extends StatelessWidget {

--- a/lib/features/wallet/ui/widgets/wallet_detail_balance_card.dart
+++ b/lib/features/wallet/ui/widgets/wallet_detail_balance_card.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/wallet/ui/widgets/eye_toggle.dart';
 import 'package:bb_mobile/features/wallet/ui/widgets/home_fiat_balance.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class WalletDetailBalanceCard extends StatelessWidget {
   const WalletDetailBalanceCard({

--- a/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_app_bar.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WalletHomeAppBar extends StatefulWidget implements PreferredSizeWidget {

--- a/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
@@ -12,7 +12,7 @@ import 'package:bb_mobile/features/wallet/ui/widgets/home_fiat_balance.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 

--- a/lib/features/withdraw/ui/screens/withdraw_amount_screen.dart
+++ b/lib/features/withdraw/ui/screens/withdraw_amount_screen.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/withdraw/presentation/withdraw_bloc.dart';
 import 'package:bb_mobile/features/withdraw/ui/widgets/withdraw_amount_input_fields.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WithdrawAmountScreen extends StatefulWidget {

--- a/lib/features/withdraw/ui/screens/withdraw_confirmation_screen.dart
+++ b/lib/features/withdraw/ui/screens/withdraw_confirmation_screen.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/features/withdraw/presentation/withdraw_bloc.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class WithdrawConfirmationScreen extends StatelessWidget {
   const WithdrawConfirmationScreen({super.key});

--- a/lib/features/withdraw/ui/screens/withdraw_success_screen.dart
+++ b/lib/features/withdraw/ui/screens/withdraw_success_screen.dart
@@ -6,7 +6,7 @@ import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
 import 'package:bb_mobile/features/withdraw/presentation/withdraw_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
 class WithdrawSuccessScreen extends StatelessWidget {

--- a/lib/features/withdraw/ui/widgets/account_ownership_widget.dart
+++ b/lib/features/withdraw/ui/widgets/account_ownership_widget.dart
@@ -2,7 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart' show BBText;
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class AccountOwnershipWidget extends StatelessWidget {
   const AccountOwnershipWidget({

--- a/lib/features/withdraw/ui/widgets/withdraw_amount_input_fields.dart
+++ b/lib/features/withdraw/ui/widgets/withdraw_amount_input_fields.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/features/exchange/ui/widgets/exchange_amount_input_fie
 import 'package:bb_mobile/features/withdraw/presentation/withdraw_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class WithdrawAmountInputFields extends StatelessWidget {
   const WithdrawAmountInputFields({

--- a/lib/features/wizard/ui/widgets/welcome_step.dart
+++ b/lib/features/wizard/ui/widgets/welcome_step.dart
@@ -4,7 +4,7 @@ import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
 
 /// Page 1 of the wizard — splash-style welcome that mirrors
 /// `OnboardingSplash` visually. Renders only the centered content; the

--- a/packages/bull_ui/lib/bull_ui.dart
+++ b/packages/bull_ui/lib/bull_ui.dart
@@ -84,7 +84,7 @@ export 'package:flutter/material.dart'
 export 'package:flutter/services.dart' show TextInputFormatter;
 export 'package:flutter/widgets.dart' show FocusNode;
 
-export 'package:gap/gap.dart' show Gap;
+export 'src/layout/gap.dart' show Gap;
 
 // Theme.
 export 'src/theme/bull_icon.dart';

--- a/packages/bull_ui/lib/src/buttons/bull_button.dart
+++ b/packages/bull_ui/lib/src/buttons/bull_button.dart
@@ -1,7 +1,7 @@
 import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_tokens.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// Button size variants.
 enum BullButtonSize {

--- a/packages/bull_ui/lib/src/buttons/bull_tab_menu_vertical_button.dart
+++ b/packages/bull_ui/lib/src/buttons/bull_tab_menu_vertical_button.dart
@@ -1,7 +1,7 @@
 import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A bordered menu row with an optional leading icon and a title — duplicated
 /// from `core/widgets/navbar/tab_menu_vertical_button.dart`

--- a/packages/bull_ui/lib/src/buttons/bull_viewer_action_button.dart
+++ b/packages/bull_ui/lib/src/buttons/bull_viewer_action_button.dart
@@ -1,7 +1,7 @@
 import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// Compact icon+label action used inside detail dialogs (Copy, Open in
 /// explorer, …) — duplicated from `core/widgets/viewer_action_button.dart`

--- a/packages/bull_ui/lib/src/data_display/bull_backup_option_card.dart
+++ b/packages/bull_ui/lib/src/data_display/bull_backup_option_card.dart
@@ -3,7 +3,7 @@ import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:bull_ui/src/theme/bull_tokens.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A tappable option card with icon, title, description and optional tag —
 /// duplicated from `core/widgets/cards/backup_option_card.dart`.

--- a/packages/bull_ui/lib/src/data_display/bull_details_table.dart
+++ b/packages/bull_ui/lib/src/data_display/bull_details_table.dart
@@ -3,7 +3,7 @@ import 'package:bull_ui/src/feedback/bull_snack_bar.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A bordered, padded container that stacks [BullDetailsTableItem] rows with
 /// hairline dividers between them — duplicated from

--- a/packages/bull_ui/lib/src/data_display/bull_info_card.dart
+++ b/packages/bull_ui/lib/src/data_display/bull_info_card.dart
@@ -1,7 +1,7 @@
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:bull_ui/src/theme/bull_tokens.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A coloured info panel with a leading accent bar and info icon —
 /// duplicated from `core/widgets/cards/info_card.dart`.

--- a/packages/bull_ui/lib/src/inputs/bull_paste_input.dart
+++ b/packages/bull_ui/lib/src/inputs/bull_paste_input.dart
@@ -2,7 +2,7 @@ import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A read-only field with a paste button that fills it from the clipboard —
 /// duplicated from `core/widgets/inputs/paste_input.dart`.

--- a/packages/bull_ui/lib/src/inputs/bull_selectable_list.dart
+++ b/packages/bull_ui/lib/src/inputs/bull_selectable_list.dart
@@ -2,7 +2,7 @@ import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:bull_ui/src/theme/bull_tokens.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// One row of a [BullSelectableList].
 class BullSelectableListItem {

--- a/packages/bull_ui/lib/src/layout/gap.dart
+++ b/packages/bull_ui/lib/src/layout/gap.dart
@@ -1,0 +1,263 @@
+// Vendored from the `gap` package (https://pub.dev/packages/gap), v3.0.1.
+//
+// Copyright (c) 2020 Romain Rastel. Licensed under the MIT License.
+//
+// Reimplemented here so the design system owns its spacing primitive and the
+// app no longer depends on the external `gap` package. Only `Gap` is vendored
+// (the package's `MaxGap`/`SliverGap` are unused in this project). Behaviour is
+// identical to upstream: a fixed main-axis gap that reads its enclosing Flex
+// direction at layout time (with a `Scrollable` fallback). Constructors were
+// modernised to super-parameters to satisfy bull_ui's lint set; the layout and
+// paint logic is unchanged from upstream.
+
+// RenderGap takes public named parameters (e.g. `mainAxisExtent`) backed by
+// private fields with custom setters that call markNeedsLayout/Paint. An
+// initializing formal would require a private named parameter, which Dart
+// disallows, so the initializer-list assignment is intentional here.
+// ignore_for_file: prefer_initializing_formals
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// A widget that takes a fixed amount of space in the direction of its parent.
+///
+/// It only works in the following cases:
+/// - It is a descendant of a [Row], [Column], or [Flex], and the path from the
+///   [Gap] widget to its enclosing [Row], [Column], or [Flex] contains only
+///   [StatelessWidget]s or [StatefulWidget]s (not [RenderObjectWidget]s).
+/// - It is a descendant of a [Scrollable].
+class Gap extends StatelessWidget {
+  /// Creates a widget that takes a fixed [mainAxisExtent] of space in the
+  /// direction of its parent.
+  const Gap(this.mainAxisExtent, {super.key, this.crossAxisExtent, this.color})
+    : assert(mainAxisExtent >= 0 && mainAxisExtent < double.infinity),
+      assert(crossAxisExtent == null || crossAxisExtent >= 0);
+
+  /// Creates a widget that takes a fixed [mainAxisExtent] of space in the
+  /// direction of its parent and expands in the cross axis direction.
+  const Gap.expand(double mainAxisExtent, {Key? key, Color? color})
+    : this(
+        mainAxisExtent,
+        key: key,
+        crossAxisExtent: double.infinity,
+        color: color,
+      );
+
+  /// The amount of space this widget takes in the direction of its parent.
+  ///
+  /// If the parent is a [Column] this is the height; if a [Row], the width.
+  final double mainAxisExtent;
+
+  /// The amount of space this widget takes in the opposite direction of the
+  /// parent. Null (the default) means it matches the parent's cross-axis
+  /// constraint.
+  final double? crossAxisExtent;
+
+  /// The color used to fill the gap.
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final scrollableState = Scrollable.maybeOf(context);
+    final axisDirection = scrollableState?.axisDirection;
+    final fallbackDirection = axisDirection == null
+        ? null
+        : axisDirectionToAxis(axisDirection);
+
+    return _RawGap(
+      mainAxisExtent,
+      crossAxisExtent: crossAxisExtent,
+      color: color,
+      fallbackDirection: fallbackDirection,
+    );
+  }
+}
+
+class _RawGap extends LeafRenderObjectWidget {
+  const _RawGap(
+    this.mainAxisExtent, {
+    this.crossAxisExtent,
+    this.color,
+    this.fallbackDirection,
+  }) : assert(mainAxisExtent >= 0 && mainAxisExtent < double.infinity),
+       assert(crossAxisExtent == null || crossAxisExtent >= 0);
+
+  final double mainAxisExtent;
+  final double? crossAxisExtent;
+  final Color? color;
+  final Axis? fallbackDirection;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderGap(
+      mainAxisExtent: mainAxisExtent,
+      crossAxisExtent: crossAxisExtent ?? 0,
+      color: color,
+      fallbackDirection: fallbackDirection,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderGap renderObject) {
+    renderObject
+      ..mainAxisExtent = mainAxisExtent
+      ..crossAxisExtent = crossAxisExtent ?? 0
+      ..color = color
+      ..fallbackDirection = fallbackDirection;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('mainAxisExtent', mainAxisExtent));
+    properties.add(
+      DoubleProperty('crossAxisExtent', crossAxisExtent, defaultValue: 0),
+    );
+    properties.add(ColorProperty('color', color));
+    properties.add(EnumProperty<Axis>('fallbackDirection', fallbackDirection));
+  }
+}
+
+/// Render object backing [Gap]. Sizes itself along the enclosing [RenderFlex]'s
+/// direction (or [fallbackDirection] when inside a [Scrollable]).
+class RenderGap extends RenderBox {
+  RenderGap({
+    required double mainAxisExtent,
+    double? crossAxisExtent,
+    Axis? fallbackDirection,
+    Color? color,
+  }) : _mainAxisExtent = mainAxisExtent,
+       _crossAxisExtent = crossAxisExtent,
+       _color = color,
+       _fallbackDirection = fallbackDirection;
+
+  double get mainAxisExtent => _mainAxisExtent;
+  double _mainAxisExtent;
+  set mainAxisExtent(double value) {
+    if (_mainAxisExtent != value) {
+      _mainAxisExtent = value;
+      markNeedsLayout();
+    }
+  }
+
+  double? get crossAxisExtent => _crossAxisExtent;
+  double? _crossAxisExtent;
+  set crossAxisExtent(double? value) {
+    if (_crossAxisExtent != value) {
+      _crossAxisExtent = value;
+      markNeedsLayout();
+    }
+  }
+
+  Axis? get fallbackDirection => _fallbackDirection;
+  Axis? _fallbackDirection;
+  set fallbackDirection(Axis? value) {
+    if (_fallbackDirection != value) {
+      _fallbackDirection = value;
+      markNeedsLayout();
+    }
+  }
+
+  Axis? get _direction {
+    final parentNode = parent;
+    if (parentNode is RenderFlex) {
+      return parentNode.direction;
+    } else {
+      return fallbackDirection;
+    }
+  }
+
+  Color? get color => _color;
+  Color? _color;
+  set color(Color? value) {
+    if (_color != value) {
+      _color = value;
+      markNeedsPaint();
+    }
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    return _computeIntrinsicExtent(
+      Axis.horizontal,
+      () => super.computeMinIntrinsicWidth(height),
+    )!;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    return _computeIntrinsicExtent(
+      Axis.horizontal,
+      () => super.computeMaxIntrinsicWidth(height),
+    )!;
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    return _computeIntrinsicExtent(
+      Axis.vertical,
+      () => super.computeMinIntrinsicHeight(width),
+    )!;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    return _computeIntrinsicExtent(
+      Axis.vertical,
+      () => super.computeMaxIntrinsicHeight(width),
+    )!;
+  }
+
+  double? _computeIntrinsicExtent(Axis axis, double Function() compute) {
+    final direction = _direction;
+    if (direction == axis) {
+      return _mainAxisExtent;
+    } else {
+      if (_crossAxisExtent!.isFinite) {
+        return _crossAxisExtent;
+      } else {
+        return compute();
+      }
+    }
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final direction = _direction;
+
+    if (direction != null) {
+      if (direction == Axis.horizontal) {
+        return constraints.constrain(Size(mainAxisExtent, crossAxisExtent!));
+      } else {
+        return constraints.constrain(Size(crossAxisExtent!, mainAxisExtent));
+      }
+    } else {
+      throw FlutterError(
+        'A Gap widget must be placed directly inside a Flex widget '
+        'or its fallbackDirection must not be null',
+      );
+    }
+  }
+
+  @override
+  void performLayout() {
+    size = computeDryLayout(constraints);
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (color != null) {
+      final paint = Paint()..color = color!;
+      context.canvas.drawRect(offset & size, paint);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('mainAxisExtent', mainAxisExtent));
+    properties.add(DoubleProperty('crossAxisExtent', crossAxisExtent));
+    properties.add(ColorProperty('color', color));
+    properties.add(EnumProperty<Axis>('fallbackDirection', fallbackDirection));
+  }
+}

--- a/packages/bull_ui/lib/src/overlays/bull_instructions_sheet.dart
+++ b/packages/bull_ui/lib/src/overlays/bull_instructions_sheet.dart
@@ -2,7 +2,7 @@ import 'package:bull_ui/src/data_display/bull_text.dart';
 import 'package:bull_ui/src/overlays/bull_bottom_sheet.dart';
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// A bottom sheet that lists numbered instruction steps — duplicated from
 /// `core/widgets/bottom_sheet/instructions_bottom_sheet.dart`

--- a/packages/bull_ui/lib/src/overlays/bull_picker_sheet.dart
+++ b/packages/bull_ui/lib/src/overlays/bull_picker_sheet.dart
@@ -1,6 +1,6 @@
 import 'package:bull_ui/src/theme/bull_theme.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
+import 'package:bull_ui/src/layout/gap.dart';
 
 /// Generic single-selection bottom-sheet picker — duplicated from
 /// `core/widgets/bottom_sheet/picker_sheet.dart` (`BBPickerSheet`).

--- a/packages/bull_ui/pubspec.yaml
+++ b/packages/bull_ui/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  gap: ^3.0.1
   auto_size_text: ^3.0.0
   custom_sliding_segmented_control: ^1.8.5
   shimmer: ^3.0.0

--- a/packages/bull_ui/test/gap_test.dart
+++ b/packages/bull_ui/test/gap_test.dart
@@ -1,0 +1,66 @@
+import 'package:bull_ui/bull_ui.dart';
+import 'package:bull_ui/src/layout/gap.dart' show RenderGap;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Gap', () {
+    testWidgets('takes its mainAxisExtent as width inside a Row', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Row(children: [Gap(20)]),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(Gap)).width, 20);
+    });
+
+    testWidgets('takes its mainAxisExtent as height inside a Column', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Column(children: [Gap(24)]),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(Gap)).height, 24);
+    });
+
+    testWidgets('falls back to the Scrollable direction outside a Flex', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ListView(children: const [Gap(16)]),
+          ),
+        ),
+      );
+
+      // A vertical ListView resolves the fallback direction to the main axis,
+      // so the gap sizes along the scroll direction.
+      expect(tester.getSize(find.byType(Gap)).height, 16);
+    });
+
+    // The error branch is exercised on RenderGap directly: with no RenderFlex
+    // parent and no Scrollable fallback, the direction is unresolvable. Testing
+    // it through a widget pump would surface the layout error on every layout
+    // pass (flutter_test can only clear one), so the render object is checked
+    // in isolation instead.
+    test('RenderGap throws when no direction can be resolved', () {
+      final render = RenderGap(mainAxisExtent: 10);
+
+      expect(
+        () => render.computeDryLayout(const BoxConstraints()),
+        throwsA(isA<FlutterError>()),
+      );
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -927,14 +927,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  gap:
-    dependency: "direct main"
-    description:
-      name: gap
-      sha256: f19387d4e32f849394758b91377f9153a1b41d79513ef7668c088c77dbc6955d
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   get_it:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   get_it: ^9.1.1
   flutter_animate: ^4.5.2
   flutter_svg: ^2.2.4
-  gap: ^3.0.1
   go_router: ^17.0.0
   flutter_secure_storage:
     git:


### PR DESCRIPTION
Removes the external `gap` package from the project. 

`bull_ui` now ships its own `Gap` (vendored from `gap` 3.0.1), and every feature sources `Gap` through `bull_ui` instead of importing `package:gap`.