### PR TITLE
feat(core): replace the OS keyboard in favor of an in-app keyboard on seed entry

### DIFF
--- a/lib/core/utils/bip39.dart
+++ b/lib/core/utils/bip39.dart
@@ -23,4 +23,36 @@ class Bip39WordList {
       return null;
     }
   }
+
+  /// The letters that can extend [prefix] toward at least one word of
+  /// [language].
+  ///
+  /// This is what lets the in-app keyboard shrink to only the keys that keep a
+  /// word possible: an empty prefix yields every letter some word begins with
+  /// (so a letter no word starts with is never offered), and a prefix like
+  /// `'a'` excludes `'a'` itself because no wordlist word starts with `'aa'`.
+  /// A prefix that is already a complete word with no longer word extending it
+  /// yields the empty set — the keyboard then offers backspace only.
+  ///
+  /// Deliberately answered against the **whole** wordlist even when used on the
+  /// last field: narrowing to the checksum candidates would let an earlier typo
+  /// that happens to be another valid word hide the real last word, turning the
+  /// one error the checksum exists to catch into a silently restored wrong
+  /// wallet. The candidate narrowing stays a guidance-only concern of the
+  /// suggestion chips.
+  ///
+  /// A linear scan of the 2048-word list per keystroke is negligible, so no
+  /// trie is warranted.
+  static Set<String> allowedNextLetters({
+    required String prefix,
+    bip39.Language language = bip39.Language.english,
+  }) {
+    final letters = <String>{};
+    for (final word in language.list) {
+      if (word.length > prefix.length && word.startsWith(prefix)) {
+        letters.add(word[prefix.length]);
+      }
+    }
+    return letters;
+  }
 }

--- a/lib/core/widgets/inputs/labeled_text_input.dart
+++ b/lib/core/widgets/inputs/labeled_text_input.dart
@@ -10,6 +10,11 @@ class LabeledTextInput extends StatelessWidget {
   final Function(String)? onChanged;
   final int? maxLines;
 
+  /// Both default to true. Set them false for secrets: the IME's suggestion
+  /// and autocorrect caches must never see the value.
+  final bool enableSuggestions;
+  final bool autocorrect;
+
   const LabeledTextInput({
     super.key,
     required this.label,
@@ -17,6 +22,8 @@ class LabeledTextInput extends StatelessWidget {
     required this.onChanged,
     this.hint = '',
     this.maxLines,
+    this.enableSuggestions = true,
+    this.autocorrect = true,
   });
 
   @override
@@ -63,6 +70,8 @@ class LabeledTextInput extends StatelessWidget {
             hint: hint,
             hideBorder: true,
             maxLines: maxLines,
+            enableSuggestions: enableSuggestions,
+            autocorrect: autocorrect,
           ),
         ),
       ],

--- a/lib/core/widgets/mnemonic_keyboard.dart
+++ b/lib/core/widgets/mnemonic_keyboard.dart
@@ -1,0 +1,301 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:flutter/material.dart';
+
+/// Letters-only keyboard for mnemonic entry.
+///
+/// It exists to keep the recovery phrase off the platform IME: on the seed
+/// entry screen the word fields are read-only, and this widget is the only
+/// path from a tap to a character. A third-party keyboard, the OS
+/// autocorrect cache, and any accessibility keylogger therefore never see a
+/// keystroke of the seed.
+///
+/// Deliberately dumb: it knows nothing about BIP39. It renders the 26 letters
+/// of [layout] in three rows, enables a key only when its letter is in
+/// [enabledLetters], and reports taps through [onLetter] / [onBackspace]. All
+/// the wordlist intelligence — which letters keep a word possible, auto fill,
+/// focus advance — stays with the owner that computes [enabledLetters].
+///
+/// [layout] is just the display order: pass [qwerty] for a familiar keyboard,
+/// or a shuffled alphabet for the paranoid mode, where randomised key
+/// positions defeat shoulder-surfing and tap-position inference.
+class MnemonicKeyboard extends StatelessWidget {
+  /// A familiar QWERTY order, split 10 / 9 / 7 across the three rows.
+  static const List<String> qwerty = [
+    'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', //
+    'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', //
+    'z', 'x', 'c', 'v', 'b', 'n', 'm', //
+  ];
+
+  /// The 26 lowercase letters in display order. Split 10 / 9 / 7 into rows.
+  final List<String> layout;
+
+  /// The lowercase letters a tap may currently produce. A key outside this set
+  /// is shown disabled: the owner has determined it cannot extend the word.
+  final Set<String> enabledLetters;
+
+  /// Whether the backspace key is active — false only when the focused field
+  /// is already empty, so there is nothing to delete.
+  final bool canBackspace;
+
+  final void Function(String letter) onLetter;
+  final VoidCallback onBackspace;
+
+  /// Paranoid mode toggle, shown as a key next to backspace.
+  final bool shuffleActive;
+  final VoidCallback onToggleShuffle;
+
+  /// Tooltip for the shuffle key. Passed in so this widget stays free of
+  /// localization.
+  final String shuffleHint;
+
+  const MnemonicKeyboard({
+    super.key,
+    required this.enabledLetters,
+    required this.canBackspace,
+    required this.onLetter,
+    required this.onBackspace,
+    required this.shuffleActive,
+    required this.onToggleShuffle,
+    required this.shuffleHint,
+    this.layout = qwerty,
+  }) : assert(
+         layout.length == 26,
+         'The keyboard lays out exactly 26 keys in three rows (10/9/7); '
+         'any other length throws a RangeError at build time.',
+       );
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: context.appColors.surfaceContainer,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _LetterRow(
+                letters: layout.sublist(0, 10),
+                enabledLetters: enabledLetters,
+                onLetter: onLetter,
+                paranoid: shuffleActive,
+              ),
+              _LetterRow(
+                letters: layout.sublist(10, 19),
+                enabledLetters: enabledLetters,
+                onLetter: onLetter,
+                paranoid: shuffleActive,
+              ),
+              _LetterRow(
+                letters: layout.sublist(19, 26),
+                enabledLetters: enabledLetters,
+                onLetter: onLetter,
+                paranoid: shuffleActive,
+                // Backspace shares its slot with the shuffle toggle
+                trailing: Row(
+                  children: [
+                    Expanded(
+                      child: _BackspaceKey(
+                        enabled: canBackspace,
+                        onTap: onBackspace,
+                      ),
+                    ),
+                    Expanded(
+                      child: _ShuffleKey(
+                        active: shuffleActive,
+                        hint: shuffleHint,
+                        onTap: onToggleShuffle,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LetterRow extends StatelessWidget {
+  final List<String> letters;
+  final Set<String> enabledLetters;
+  final void Function(String letter) onLetter;
+  final bool paranoid;
+  final Widget? trailing;
+
+  const _LetterRow({
+    required this.letters,
+    required this.enabledLetters,
+    required this.onLetter,
+    required this.paranoid,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          for (final letter in letters)
+            Expanded(
+              child: _LetterKey(
+                letter: letter,
+                enabled: enabledLetters.contains(letter),
+                paranoid: paranoid,
+                onTap: () => onLetter(letter),
+              ),
+            ),
+          if (trailing != null) Expanded(flex: 2, child: trailing!),
+        ],
+      ),
+    );
+  }
+}
+
+class _LetterKey extends StatelessWidget {
+  final String letter;
+  final bool enabled;
+  final bool paranoid;
+  final VoidCallback onTap;
+
+  const _LetterKey({
+    required this.letter,
+    required this.enabled,
+    required this.paranoid,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // ExcludeSemantics: the key's letter must not reach the accessibility tree,
+    // where a malicious accessibility service would read the seed letter by
+    // letter as it is typed. This makes the keyboard unusable with a screen
+    // reader by design — the recovery phrase is too sensitive to narrate.
+    return ExcludeSemantics(
+      child: _KeyCap(
+        enabled: enabled,
+        onTap: onTap,
+        suppressAnimation: paranoid,
+        child: BBText(
+          letter,
+          style: context.font.headlineLarge,
+          color: enabled
+              ? context.appColors.onSurface
+              : context.appColors.textMuted,
+        ),
+      ),
+    );
+  }
+}
+
+class _BackspaceKey extends StatelessWidget {
+  final bool enabled;
+  final VoidCallback onTap;
+
+  const _BackspaceKey({required this.enabled, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return _KeyCap(
+      enabled: enabled,
+      onTap: onTap,
+      child: Icon(
+        Icons.backspace_outlined,
+        size: 20,
+        color: enabled
+            ? context.appColors.onSurface
+            : context.appColors.textMuted,
+      ),
+    );
+  }
+}
+
+/// Toggles the paranoid, randomised-layout mode. Accent-coloured while active.
+class _ShuffleKey extends StatelessWidget {
+  final bool active;
+  final String hint;
+  final VoidCallback onTap;
+
+  const _ShuffleKey({
+    required this.active,
+    required this.hint,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: hint,
+      child: _KeyCap(
+        key: const Key('mnemonicParanoidToggle'),
+        enabled: true,
+        onTap: onTap,
+        child: Icon(
+          Icons.shuffle,
+          size: 20,
+          color: active
+              ? context.appColors.primary
+              : context.appColors.onSurface,
+        ),
+      ),
+    );
+  }
+}
+
+/// The shared key shell: sizing, colour, and tap surface. A disabled key has
+/// no tap handler at all, so it cannot fire even through automation.
+class _KeyCap extends StatelessWidget {
+  final bool enabled;
+  final VoidCallback onTap;
+  final Widget child;
+
+  /// When true, the key changes appearance as an instant cut with no ink
+  /// splash. Used while the layout is reshuffling on every tap: an animated
+  /// colour fade or a splash that outlives the reshuffle would mark, for a
+  /// frame, which slot was just pressed — letting an observer follow a letter
+  /// across the shuffle and defeating it.
+  final bool suppressAnimation;
+
+  const _KeyCap({
+    super.key,
+    required this.enabled,
+    required this.onTap,
+    required this.child,
+    this.suppressAnimation = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      child: Material(
+        // Zero duration: even in basic mode an enable/disable colour tween is
+        // an extra frame of state history for a camera; there is no reason to
+        // animate a key cap.
+        animationDuration: Duration.zero,
+        color: enabled
+            ? context.appColors.surface
+            : context.appColors.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+        child: InkWell(
+          // A key must never take focus from the word field being typed into.
+          canRequestFocus: false,
+          borderRadius: BorderRadius.circular(6),
+          splashFactory: suppressAnimation ? NoSplash.splashFactory : null,
+          highlightColor: suppressAnimation ? Colors.transparent : null,
+          onTap: enabled ? onTap : null,
+          child: Container(
+            height: 44,
+            alignment: Alignment.center,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -1,16 +1,18 @@
+import 'dart:math';
+
 import 'package:bb_mobile/core/failures/mnemonic_entry_failure.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/bip39.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/inputs/labeled_text_input.dart';
+import 'package:bb_mobile/core/widgets/mnemonic_keyboard.dart';
 import 'package:bb_mobile/core/widgets/mnemonic_entry_failure_l10n.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 typedef Mnemonic = ({
   String label,
@@ -27,6 +29,10 @@ typedef Mnemonic = ({
 typedef _HintQuery = ({int index, String prefix, int revision});
 
 class MnemonicWidget extends StatefulWidget {
+  /// Only English is supported: the in-app keyboard is fixed to the 26 Latin
+  /// letters, so a language with accented or non-Latin words (French, Spanish,
+  /// Japanese, …) would leave most of its wordlist untypeable and the wallet
+  /// impossible to import. Guarded by an assert rather than silently accepted.
   final bip39.Language language;
   final bip39.MnemonicLength initialLength;
   final Function(Mnemonic) onSubmit;
@@ -49,7 +55,11 @@ class MnemonicWidget extends StatefulWidget {
     this.allowMultipleMnemonicLength = true,
     this.allowAutoFillWords = true,
     this.externalError,
-  });
+  }) : assert(
+         language == bip39.Language.english,
+         'The in-app keyboard is Latin a–z only; non-English wordlists cannot '
+         'be typed and would produce an un-importable wallet.',
+       );
 
   @override
   State<MnemonicWidget> createState() => _MnemonicWidgetState();
@@ -77,14 +87,6 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
     super.initState();
     length = widget.initialLength;
     _controllers = _newControllers(length.words);
-  }
-
-  @override
-  void dispose() {
-    for (final controller in _controllers) {
-      controller.dispose();
-    }
-    super.dispose();
   }
 
   List<TextEditingController> _newControllers(int count) =>
@@ -153,68 +155,112 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
   }
 
   @override
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+    _keyboardBarSlot.dispose();
+    super.dispose();
+  }
+
+  /// The docked keyboard bar is rendered here, below the scroll area, but its
+  /// state lives in the sentence widget. The sentence registers a builder into
+  /// this slot once mounted; this widget renders it. Docking (rather than
+  /// floating in an overlay) means the scrollable fields occupy exactly the
+  /// space above the keyboard, so a focused field is always reachable — the
+  /// scroll simply flexes, which is what keeps small screens (iPhone mini,
+  /// landscape) working without overflow.
+  final ValueNotifier<WidgetBuilder?> _keyboardBarSlot = ValueNotifier(null);
+
+  @override
   Widget build(BuildContext context) {
     final errorMessage =
         _failure?.toTranslated(context) ?? widget.externalError;
 
-    return Padding(
-      padding: const EdgeInsets.only(left: 16, right: 16),
-      child: Column(
-        children: [
-          if (widget.allowMultipleMnemonicLength) ...[
-            MnemonicLengthDropdown(
-              value: length,
-              onChanged: changeMnemonicLength,
-            ),
-            const Gap(16),
-          ],
+    return Column(
+      children: [
+        Expanded(
+          // Tapping empty page space dismisses the keyboard. A word field taps
+          // wins the gesture arena and keeps its focus, so only taps that land
+          // on nothing reach this handler and unfocus.
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => FocusScope.of(context).unfocus(),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(left: 16, right: 16),
+              child: Column(
+                children: [
+                  if (widget.allowMultipleMnemonicLength) ...[
+                    MnemonicLengthDropdown(
+                      value: length,
+                      onChanged: changeMnemonicLength,
+                    ),
+                    const Gap(16),
+                  ],
 
-          MnemonicSentenceWidget(
-            controllers: _controllers,
-            language: widget.language,
-            allowAutoFillWords: widget.allowAutoFillWords,
+                  MnemonicSentenceWidget(
+                    controllers: _controllers,
+                    language: widget.language,
+                    allowAutoFillWords: widget.allowAutoFillWords,
+                    keyboardBarSlot: _keyboardBarSlot,
+                  ),
+
+                  if (widget.allowPassphrase) ...[
+                    const Gap(16),
+                    LabeledTextInput(
+                      label: 'Passphrase',
+                      hint: 'Optional Passphrase',
+                      value: passphrase,
+                      onChanged: updatePassphrase,
+                      maxLines: 1,
+                      // A passphrase is key material too: keep it out of the
+                      // IME's suggestion and autocorrect caches.
+                      enableSuggestions: false,
+                      autocorrect: false,
+                    ),
+                  ],
+
+                  if (widget.allowLabel) ...[
+                    const Gap(16),
+                    LabeledTextInput(
+                      label: 'Label',
+                      hint: 'Required',
+                      value: label,
+                      onChanged: updateLabel,
+                      maxLines: 1,
+                    ),
+                  ],
+
+                  if (errorMessage != null) ...[
+                    const Gap(16),
+                    BBText(
+                      errorMessage,
+                      style: context.font.bodyMedium,
+                      color: context.appColors.error,
+                    ),
+                  ],
+
+                  const Gap(16),
+                  BBButton.big(
+                    label: widget.submitLabel,
+                    onPressed: onSubmit,
+                    bgColor: context.appColors.onSurface,
+                    textColor: context.appColors.surface,
+                  ),
+                  const Gap(16),
+                ],
+              ),
+            ),
           ),
-
-          if (widget.allowPassphrase) ...[
-            const Gap(16),
-            LabeledTextInput(
-              label: 'Passphrase',
-              hint: 'Optional Passphrase',
-              value: passphrase,
-              onChanged: updatePassphrase,
-              maxLines: 1,
-            ),
-          ],
-
-          if (widget.allowLabel) ...[
-            const Gap(16),
-            LabeledTextInput(
-              label: 'Label',
-              hint: 'Required',
-              value: label,
-              onChanged: updateLabel,
-              maxLines: 1,
-            ),
-          ],
-
-          if (errorMessage != null) ...[
-            const Gap(16),
-            BBText(
-              errorMessage,
-              style: context.font.bodyMedium,
-              color: context.appColors.error,
-            ),
-          ],
-
-          const Gap(16),
-          BBButton.big(
-            label: widget.submitLabel,
-            onPressed: onSubmit,
-            bgColor: context.appColors.onSurface,
-            textColor: context.appColors.surface,
-          ),
-        ],
-      ),
+        ),
+        // The docked keyboard, drawn below the scroll area. Empty until a word
+        // field is focused.
+        ValueListenableBuilder<WidgetBuilder?>(
+          valueListenable: _keyboardBarSlot,
+          builder: (context, barBuilder, _) =>
+              barBuilder?.call(context) ?? const SizedBox.shrink(),
+        ),
+      ],
     );
   }
 }
@@ -223,19 +269,17 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
 ///
 /// Stateless on purpose: the [TextField] is never rebuilt by a keystroke.
 /// Only the index badge and the clear button depend on the typed text, and
-/// each subscribes on its own; the field itself rebuilds once per auto fill,
-/// when [fieldLock] starts swallowing its edits.
+/// each subscribes on its own.
+///
+/// The field is **read-only**: it never opens the platform keyboard and
+/// refuses paste and the selection toolbar. Its controller is written only by
+/// the in-app [MnemonicKeyboard], so the recovery phrase never travels through
+/// a third-party IME. The field is purely a display of that controller.
 class MnemonicWord extends StatelessWidget {
   final bip39.Language language;
   final int index;
   final TextEditingController controller;
   final FocusNode focusNode;
-  final VoidCallback onComplete;
-
-  /// Set by the auto fill once it completes the word: the field keeps focus
-  /// and the keyboard, but swallows any further edit until it is emptied, so
-  /// a stray keystroke cannot break a word that was the only possibility left.
-  final ValueListenable<bool> fieldLock;
 
   /// Non-null on the last field only: the checksum candidates, derived from
   /// every other word. The badge then answers "is this word acceptable", not
@@ -249,8 +293,6 @@ class MnemonicWord extends StatelessWidget {
     required this.index,
     required this.controller,
     required this.focusNode,
-    required this.onComplete,
-    required this.fieldLock,
     this.candidates,
   });
 
@@ -306,59 +348,35 @@ class MnemonicWord extends StatelessWidget {
           ),
           const Gap(4),
           Expanded(
-            child: ValueListenableBuilder<bool>(
-              valueListenable: fieldLock,
-              builder: (context, locked, _) {
-                return TextField(
-                  enableSuggestions: false,
-                  autocorrect: false,
-                  controller: controller,
-                  inputFormatters: [
-                    // A locked word was the only possibility left: swallow any
-                    // further typing instead of closing the keyboard - the
-                    // field stays focused and editable, but the word cannot be
-                    // broken. A deletion empties the field instead, which
-                    // unlocks it: backspace is the user's undo instinct, and
-                    // the clear icon remains the explicit way out.
-                    TextInputFormatter.withFunction((oldValue, newValue) {
-                      if (!locked) return newValue;
-                      final isDeletion =
-                          newValue.text.length < oldValue.text.length;
-                      return isDeletion ? TextEditingValue.empty : oldValue;
-                    }),
-                    // Keeps the previous behaviour of lowercasing as you type.
-                    // Same length in and out, so the caret position stays valid.
-                    TextInputFormatter.withFunction(
-                      (_, value) =>
-                          value.copyWith(text: value.text.toLowerCase()),
-                    ),
-                  ],
-                  style: context.font.bodyMedium?.copyWith(
-                    color: context.appColors.text,
-                  ),
-                  focusNode: focusNode,
-                  clipBehavior: .antiAliasWithSaveLayer,
-                  onEditingComplete: onComplete,
-                  decoration: InputDecoration(
-                    contentPadding: const EdgeInsets.only(right: 8),
-                    border: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: context.appColors.transparent,
-                      ),
-                    ),
-                    enabledBorder: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: context.appColors.transparent,
-                      ),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: context.appColors.transparent,
-                      ),
-                    ),
-                  ),
-                );
-              },
+            // Read-only: the platform keyboard never opens, paste and the
+            // selection toolbar are suppressed. The only writer of this
+            // controller is the in-app MnemonicKeyboard, so no keystroke of
+            // the seed leaves the app process.
+            child: TextField(
+              readOnly: true,
+              showCursor: true,
+              enableInteractiveSelection: false,
+              contextMenuBuilder: (_, _) => const SizedBox.shrink(),
+              enableSuggestions: false,
+              autocorrect: false,
+              controller: controller,
+              style: context.font.bodyMedium?.copyWith(
+                color: context.appColors.text,
+              ),
+              focusNode: focusNode,
+              clipBehavior: .antiAliasWithSaveLayer,
+              decoration: InputDecoration(
+                contentPadding: const EdgeInsets.only(right: 8),
+                border: OutlineInputBorder(
+                  borderSide: BorderSide(color: context.appColors.transparent),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: context.appColors.transparent),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: context.appColors.transparent),
+                ),
+              ),
             ),
           ),
           ValueListenableBuilder<TextEditingValue>(
@@ -388,11 +406,18 @@ class MnemonicSentenceWidget extends StatefulWidget {
   final bip39.Language language;
   final bool allowAutoFillWords;
 
+  /// A slot, owned by the parent, into which this widget publishes its docked
+  /// keyboard bar builder. The parent renders it below the scroll area so the
+  /// keyboard is docked rather than floating, and the fields scroll in exactly
+  /// the space that remains above it.
+  final ValueNotifier<WidgetBuilder?>? keyboardBarSlot;
+
   const MnemonicSentenceWidget({
     super.key,
     required this.controllers,
     required this.language,
     this.allowAutoFillWords = true,
+    this.keyboardBarSlot,
   });
 
   @override
@@ -409,10 +434,25 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
   final List<VoidCallback> _textListeners = [];
   List<FocusNode> _focusNodes = [];
 
-  /// One lock per field, set by the auto fill: a completed word was the only
-  /// possibility left, so further typing could only break it. Emptied fields
-  /// are editable again, whatever emptied them.
-  List<ValueNotifier<bool>> _fieldLocks = [];
+  /// The word field the in-app keyboard currently types into, or null when no
+  /// word field is focused. Drives both the keyboard's visibility and which
+  /// controller a key tap writes to.
+  final ValueNotifier<int?> _activeField = ValueNotifier(null);
+
+  /// Paranoid mode: the keyboard shows a randomised letter layout instead of
+  /// QWERTY. Toggled by the shuffle button.
+  final ValueNotifier<bool> _paranoid = ValueNotifier(false);
+
+  /// The current randomised order, regenerated on every key tap while paranoid
+  /// so a key never sits in the same place twice — nothing can be learned from
+  /// watching finger positions or a screen recording.
+  List<String> _shuffledLayout = MnemonicKeyboard.qwerty;
+  final Random _random = Random.secure();
+
+  /// Caches the shuffled suggestion order for one _hint query, so the chips
+  /// reshuffle once per keystroke rather than on every rebuild.
+  _HintQuery? _shuffledHintsFor;
+  List<String>? _shuffledHintsOrder;
 
   /// The last field's checksum candidates, mirrored as a listenable so the
   /// last badge can judge acceptability against the pool - and refresh when
@@ -425,6 +465,13 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
   void initState() {
     super.initState();
     _attach();
+    // Publish the docked keyboard builder to the parent once mounted. Deferred
+    // to a post-frame callback so the parent is not marked dirty during its own
+    // build; the keyboard is hidden until a field is focused, so the one-frame
+    // delay is invisible.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.keyboardBarSlot?.value = _buildKeyboardBar;
+    });
   }
 
   @override
@@ -432,21 +479,25 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.controllers, widget.controllers)) {
       final retiredNodes = _focusNodes;
-      final retiredLocks = _fieldLocks;
       _detach(oldWidget.controllers);
       _attach();
       _candidatesKey = null;
-      _candidatePool.value = null;
-      _hint.value = (index: 0, prefix: '', revision: ++_revision);
-      // The old fields still reference these until they rebuild later in
-      // this frame: dispose only once the tree no longer holds them, the
-      // same courtesy the parent extends to the old controllers.
+      // Every notifier mutation is deferred to a post-frame callback: firing
+      // them here, mid-build, would mark the listening keyboard bar and the
+      // last field's badge dirty during the build phase, which is illegal —
+      // the bar is rendered by the parent, not by this subtree. A length
+      // change rebuilds every field: no field is focused any more, so the
+      // keyboard has nothing to type into.
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _activeField.value = null;
+        _candidatePool.value = null;
+        _hint.value = (index: 0, prefix: '', revision: ++_revision);
+        // The old fields still referenced these until they rebuilt earlier in
+        // this frame: dispose only once the tree no longer holds them, the
+        // same courtesy the parent extends to the old controllers.
         for (final node in retiredNodes) {
           node.dispose();
-        }
-        for (final lock in retiredLocks) {
-          lock.dispose();
         }
       });
     }
@@ -458,26 +509,19 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
     for (final node in _focusNodes) {
       node.dispose();
     }
-    for (final lock in _fieldLocks) {
-      lock.dispose();
-    }
     _hint.dispose();
+    _activeField.dispose();
+    _paranoid.dispose();
     _candidatePool.dispose();
     super.dispose();
   }
 
   void _attach() {
-    _focusNodes = List.generate(widget.controllers.length, (index) {
+    _focusNodes = List.generate(widget.controllers.length, (_) {
       final node = FocusNode();
-      node.addListener(() {
-        if (node.hasFocus) _refreshHint(index);
-      });
+      node.addListener(_onFocusChanged);
       return node;
     });
-    _fieldLocks = List.generate(
-      widget.controllers.length,
-      (_) => ValueNotifier(false),
-    );
     for (var index = 0; index < widget.controllers.length; index++) {
       final position = index;
       void listener() => _onTextChanged(position);
@@ -493,13 +537,49 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
     _textListeners.clear();
   }
 
-  void _onTextChanged(int index) {
-    // A locked field can only be emptied - by the clear icon, or by the
-    // parent clearing the last word on a checksum failure - and an emptied
-    // field is editable again.
-    if (widget.controllers[index].text.isEmpty) {
-      _fieldLocks[index].value = false;
+  /// Focus is the single source of truth for the active field: whichever node
+  /// currently holds it decides where a key tap goes and keeps the keyboard
+  /// up; when none does, the keyboard leaves. Reading the live focus state
+  /// (rather than the node that fired) is robust to the brief moment during a
+  /// field-to-field move when the losing node reports first.
+  void _onFocusChanged() {
+    final index = _focusNodes.indexWhere((node) => node.hasFocus);
+    if (index >= 0) {
+      _activeField.value = index;
+      _refreshHint(index);
+      _ensureFieldVisible(index);
+    } else {
+      _activeField.value = null;
     }
+  }
+
+  /// Scrolls the focused field into the area left above the docked keyboard.
+  ///
+  /// Deferred to after the frame: focusing a field grows the keyboard bar,
+  /// which shrinks the scroll viewport, so the target position is only known
+  /// once that layout has settled. Centering keeps the field clear of both the
+  /// keyboard below and the top edge on small screens.
+  void _ensureFieldVisible(int index) {
+    // Capture the node, not the index: a length change can replace
+    // [_focusNodes] with a shorter list before the callback runs, and
+    // dereferencing the stale index there would throw a RangeError.
+    final node = _focusNodes[index];
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // The captured node was retired by a length change: nothing to scroll to.
+      if (!_focusNodes.contains(node)) return;
+      final context = node.context;
+      if (context == null) return;
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  void _onTextChanged(int index) {
     // The pool is derived from every word but the last; the cached answer is
     // a new instance only when it actually changed.
     final pool = _lastWordCandidates();
@@ -562,10 +642,12 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
   /// Runs on the text-change notification rather than during build, where the
   /// previous implementation scheduled it as a post-frame side effect.
   ///
-  /// The completed field locks: the match was the only one left, so another
-  /// keystroke could only break a certain word. Focus stays put and the
-  /// keyboard stays up - except on the last word, where a completed sentence
-  /// is the natural moment to dismiss it. The clear icon unlocks the field.
+  /// Once the field holds the only word left, the in-app keyboard has no
+  /// letter to offer anyway (no wordlist word extends a uniquely-determined
+  /// one), so the word cannot be broken by a further tap - the old edit "lock"
+  /// is redundant under keyboard-only input. Focus stays put, except on the
+  /// last word, where a completed sentence is the natural moment to dismiss
+  /// the keyboard.
   void _maybeAutoFill(int index) {
     if (!widget.allowAutoFillWords) return;
     final prefix = widget.controllers[index].text.trim();
@@ -577,12 +659,160 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
         .take(2)
         .toList();
     if (matches.length == 1 && matches.first != prefix) {
-      widget.controllers[index].text = matches.first;
-      _fieldLocks[index].value = true;
+      _setWord(index, matches.first);
       if (index == widget.controllers.length - 1) {
         _focusNodes[index].unfocus();
       }
     }
+  }
+
+  /// Writes [word] to field [index], caret at the end so the visible text
+  /// tracks what was typed. The controller listener does the rest (candidate
+  /// refresh, hint, auto fill).
+  void _setWord(int index, String word) {
+    widget.controllers[index].value = TextEditingValue(
+      text: word,
+      selection: TextSelection.collapsed(offset: word.length),
+    );
+  }
+
+  /// Appends a letter to the active field. Routed here from the in-app
+  /// keyboard, the only writer of the word fields' text.
+  ///
+  /// The model, not the key widget, is authoritative: a key's `enabled` flag is
+  /// captured at build time, so a second tap fired in the same frame as the
+  /// first still runs the stale (enabled) handler. Re-checking the letter
+  /// against the live prefix here drops that racing tap, so a burst of taps can
+  /// never append a letter that cannot begin a wordlist word (e.g. `aa`).
+  void _onKeyLetter(String letter) {
+    final index = _activeField.value;
+    if (index == null) return;
+    final prefix = widget.controllers[index].text;
+    final allowed = Bip39WordList.allowedNextLetters(
+      prefix: prefix,
+      language: widget.language,
+    );
+    if (!allowed.contains(letter)) return;
+    _reshuffleIfParanoid();
+    _setWord(index, prefix + letter);
+  }
+
+  /// Clears the whole active field. A word is entered as one unit against the
+  /// wordlist, so it is deleted as one unit too: backspace wipes the field
+  /// rather than trimming a letter. The emptied field re-enables every letter
+  /// on the next build.
+  void _onKeyBackspace() {
+    final index = _activeField.value;
+    if (index == null) return;
+    if (widget.controllers[index].text.isEmpty) return;
+    _reshuffleIfParanoid();
+    _setWord(index, '');
+  }
+
+  /// Toggles paranoid mode. Enabling it shuffles the layout immediately so the
+  /// very first key is already in a random place.
+  void _toggleParanoid() {
+    final enabling = !_paranoid.value;
+    if (enabling) _shuffle();
+    _paranoid.value = enabling;
+  }
+
+  /// Reshuffles before each key tap while paranoid, so the next repaint of the
+  /// keyboard (driven by the resulting text change) lands on a fresh layout.
+  void _reshuffleIfParanoid() {
+    if (_paranoid.value) _shuffle();
+  }
+
+  void _shuffle() {
+    // Reject an arrangement too close to the current one: a shuffle that leaves
+    // most letters in place looks like nothing changed and invites a mistap
+    // from muscle memory. Require at least 20 of 26 positions to move.
+    final previous = _shuffledLayout;
+    List<String> next;
+    do {
+      next = List.of(MnemonicKeyboard.qwerty)..shuffle(_random);
+    } while (_samePositions(next, previous) > 6);
+    _shuffledLayout = next;
+  }
+
+  int _samePositions(List<String> a, List<String> b) {
+    var same = 0;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] == b[i]) same++;
+    }
+    return same;
+  }
+
+  /// The docked bottom bar: the suggestion chips sit directly above the keys,
+  /// like a system keyboard's suggestion strip, so neither the chips nor a
+  /// focused field is ever hidden behind the keyboard. Empty until a word
+  /// field is focused. Rendered by the parent below the scroll area (via
+  /// [MnemonicSentenceWidget.keyboardBarSlot]).
+  ///
+  /// [ExcludeFocus] keeps every tap target here out of focus traversal: the
+  /// keys and chips must never steal focus from the word field being typed
+  /// into.
+  Widget _buildKeyboardBar(BuildContext context) {
+    return ListenableBuilder(
+      listenable: Listenable.merge([_activeField, _paranoid]),
+      builder: (context, _) {
+        if (_activeField.value == null) return const SizedBox.shrink();
+        final paranoid = _paranoid.value;
+        return ExcludeFocus(
+          child: Material(
+            color: context.appColors.surfaceContainer,
+            child: SafeArea(
+              top: false,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                    // Suggestions stay visible in paranoid mode; they are only
+                    // shuffled (see _buildHintsList), so an onlooker cannot map
+                    // a chip position to a word either. ExcludeSemantics: the
+                    // chips are plain-text word candidates — an accessibility
+                    // service must not read them any more than the keys.
+                    child: ExcludeSemantics(
+                      child: _buildHintsList(paranoid: paranoid),
+                    ),
+                  ),
+                  _buildKeyboard(),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildKeyboard() {
+    // Driven by _hint, which already carries the focused field's live prefix
+    // and is refreshed on every focus change and keystroke. Using it (rather
+    // than the controllers) keeps the keyboard independent of the controller
+    // list, so it survives a length change without re-subscribing. Reading the
+    // layout inside the builder means each keystroke picks up the freshly
+    // reshuffled order while paranoid.
+    return ValueListenableBuilder<_HintQuery>(
+      valueListenable: _hint,
+      builder: (context, query, _) {
+        final prefix = query.prefix;
+        return MnemonicKeyboard(
+          layout: _paranoid.value ? _shuffledLayout : MnemonicKeyboard.qwerty,
+          enabledLetters: Bip39WordList.allowedNextLetters(
+            prefix: prefix,
+            language: widget.language,
+          ),
+          canBackspace: prefix.isNotEmpty,
+          onLetter: _onKeyLetter,
+          onBackspace: _onKeyBackspace,
+          shuffleActive: _paranoid.value,
+          onToggleShuffle: _toggleParanoid,
+          shuffleHint: context.loc.mnemonicShuffleKeyboardHint,
+        );
+      },
+    );
   }
 
   void _focusNext(int nextIndex) {
@@ -592,7 +822,7 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
   }
 
   void _onHintTap(int index, String word) {
-    widget.controllers[index].text = word;
+    _setWord(index, word);
     // Like the auto fill, a tapped chip completes the sentence on the last
     // field: the same natural moment to dismiss the keyboard.
     if (index == widget.controllers.length - 1) {
@@ -602,7 +832,7 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
     }
   }
 
-  Widget _buildHintsList() {
+  Widget _buildHintsList({required bool paranoid}) {
     const height = 50.0;
     return ValueListenableBuilder<_HintQuery>(
       valueListenable: _hint,
@@ -619,6 +849,22 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
         final hints = pool
             .where((word) => word.startsWith(query.prefix))
             .toList();
+
+        // Paranoid mode randomises the chip order so a chip's position leaks
+        // nothing about which word it is. Cached per _hint query (which bumps
+        // once per keystroke) so the order is stable across unrelated rebuilds
+        // — otherwise the chips would jitter on every repaint.
+        if (paranoid) {
+          if (query != _shuffledHintsFor) {
+            hints.shuffle(_random);
+            _shuffledHintsFor = query;
+            _shuffledHintsOrder = hints;
+          } else {
+            hints
+              ..clear()
+              ..addAll(_shuffledHintsOrder!);
+          }
+        }
 
         // The field already holds the single matching word: the question is
         // answered, so both the chips and the count label leave.
@@ -671,26 +917,26 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
             controller: widget.controllers[index],
             language: widget.language,
             focusNode: _focusNodes[index],
-            onComplete: () => _focusNext(index + 1),
-            fieldLock: _fieldLocks[index],
             candidates: index == count - 1 ? _candidatePool : null,
           ),
       ],
     );
 
-    return Column(
-      children: [
-        Row(
-          crossAxisAlignment: .start,
-          spacing: 16,
-          children: [
-            Expanded(child: column(0, splitIndex)),
-            Expanded(child: column(splitIndex, count)),
-          ],
-        ),
-        const Gap(16),
-        _buildHintsList(),
-      ],
+    // ExcludeSemantics: a TextField publishes its text as its semantics
+    // value, so without this the fields would narrate the seed letter by
+    // letter to any accessibility service — the very attacker the read-only
+    // fields and the excluded keyboard keys are meant to defeat. The badges
+    // and clear icons go with them: this screen is unusable with a screen
+    // reader by design, the recovery phrase is too sensitive to narrate.
+    return ExcludeSemantics(
+      child: Row(
+        crossAxisAlignment: .start,
+        spacing: 16,
+        children: [
+          Expanded(child: column(0, splitIndex)),
+          Expanded(child: column(splitIndex, count)),
+        ],
+      ),
     );
   }
 }
@@ -744,6 +990,8 @@ class _HintChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
+      // A suggestion must never take focus from the word field being typed into.
+      canRequestFocus: false,
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/lib/features/import_mnemonic/ui/mnemonic_page.dart
+++ b/lib/features/import_mnemonic/ui/mnemonic_page.dart
@@ -55,21 +55,18 @@ class _MnemonicPageState extends State<MnemonicPage> with PrivacyScreen {
         builder: (context, state) {
           return Stack(
             children: [
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      MnemonicWidget(
-                        initialLength: bip39.MnemonicLength.words12,
-                        onSubmit: context
-                            .read<ImportMnemonicCubit>()
-                            .updateMnemonic,
-                        submitLabel: context.loc.importMnemonicContinue,
-                        externalError: state.failure?.toTranslated(context),
-                      ),
-                    ],
+              // MnemonicWidget owns its own scroll and docks the in-app
+              // keyboard at the bottom, so it must fill the available height.
+              Positioned.fill(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: MnemonicWidget(
+                    initialLength: bip39.MnemonicLength.words12,
+                    onSubmit: context
+                        .read<ImportMnemonicCubit>()
+                        .updateMnemonic,
+                    submitLabel: context.loc.importMnemonicContinue,
+                    externalError: state.failure?.toTranslated(context),
                   ),
                 ),
               ),

--- a/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
@@ -59,41 +59,31 @@ class _OnboardingPhysicalRecoveryState extends State<OnboardingPhysicalRecovery>
                     ),
                     Expanded(
                       child: SafeArea(
-                        child: Padding(
-                          padding: const EdgeInsets.only(bottom: 16),
-                          child: SingleChildScrollView(
-                            child: Column(
-                              crossAxisAlignment: .stretch,
-                              children: [
-                                IgnorePointer(
-                                  ignoring:
-                                      state.onboardingStepStatus ==
-                                      OnboardingStepStatus.loading,
-                                  child: Opacity(
-                                    opacity:
-                                        state.onboardingStepStatus ==
-                                            OnboardingStepStatus.loading
-                                        ? 0.5
-                                        : 1.0,
-                                    child: MnemonicWidget(
-                                      initialLength:
-                                          bip39.MnemonicLength.words12,
-                                      allowMultipleMnemonicLength: true,
-                                      allowLabel: false,
-                                      allowPassphrase: false,
-                                      submitLabel:
-                                          context.loc.onboardingRecover,
-                                      onSubmit: (mnemonic) {
-                                        context.read<OnboardingBloc>().add(
-                                          OnboardingRecoverWalletClicked(
-                                            mnemonic: mnemonic,
-                                          ),
-                                        );
-                                      },
-                                    ),
+                        // MnemonicWidget owns its own scroll and docks the
+                        // in-app keyboard at the bottom, so it fills the space.
+                        child: IgnorePointer(
+                          ignoring:
+                              state.onboardingStepStatus ==
+                              OnboardingStepStatus.loading,
+                          child: Opacity(
+                            opacity:
+                                state.onboardingStepStatus ==
+                                    OnboardingStepStatus.loading
+                                ? 0.5
+                                : 1.0,
+                            child: MnemonicWidget(
+                              initialLength: bip39.MnemonicLength.words12,
+                              allowMultipleMnemonicLength: true,
+                              allowLabel: false,
+                              allowPassphrase: false,
+                              submitLabel: context.loc.onboardingRecover,
+                              onSubmit: (mnemonic) {
+                                context.read<OnboardingBloc>().add(
+                                  OnboardingRecoverWalletClicked(
+                                    mnemonic: mnemonic,
                                   ),
-                                ),
-                              ],
+                                );
+                              },
                             ),
                           ),
                         ),

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14668,5 +14668,9 @@
   "swapErrorRouteUnavailableGeneric": "This swap is not available.",
   "@swapErrorRouteUnavailableGeneric": {
     "description": "Fallback for ERR_ORD_PO404 when the source or destination network is unknown."
+  },
+  "mnemonicShuffleKeyboardHint": "Scramble the keys and suggestions on every tap",
+  "@mnemonicShuffleKeyboardHint": {
+    "description": "Tooltip on the in-app keyboard toggle that turns on the privacy mode: the letter keys and word suggestions are randomised after each key press so their positions cannot be read by an onlooker"
   }
 }

--- a/packages/bull_ui/lib/src/inputs/bull_input_text.dart
+++ b/packages/bull_ui/lib/src/inputs/bull_input_text.dart
@@ -28,6 +28,8 @@ class BullInputText extends StatefulWidget {
     this.onlyPaste = false,
     this.onlyNumbers = false,
     this.obscure = false,
+    this.enableSuggestions = true,
+    this.autocorrect = true,
     this.style,
     this.hideBorder = false,
     this.maxLines,
@@ -82,6 +84,11 @@ class BullInputText extends StatefulWidget {
 
   /// Obscures the text (e.g. for secrets).
   final bool obscure;
+
+  /// Both default to true. Set them false for secrets (a BIP39 passphrase):
+  /// the IME's suggestion and autocorrect caches must never see the value.
+  final bool enableSuggestions;
+  final bool autocorrect;
 
   /// Maximum lines.
   final int? maxLines;
@@ -173,6 +180,8 @@ class _BullInputTextState extends State<BullInputText> {
       obscureText: widget.obscure,
       obscuringCharacter: widget.onlyNumbers ? 'x' : '*',
       enableIMEPersonalizedLearning: false,
+      enableSuggestions: widget.enableSuggestions,
+      autocorrect: widget.autocorrect,
       maxLength: widget.maxLength,
       minLines: widget.minLines ?? 1,
       maxLines: effectiveMaxLines,

--- a/test/core_test/utils/bip39_test.dart
+++ b/test/core_test/utils/bip39_test.dart
@@ -1,0 +1,60 @@
+import 'package:bb_mobile/core/utils/bip39.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Bip39WordList.allowedNextLetters', () {
+    final list = bip39.Language.english.list;
+
+    test(
+      'an empty prefix offers exactly the letters some word begins with',
+      () {
+        final firstLetters = {for (final word in list) word[0]};
+
+        expect(
+          Bip39WordList.allowedNextLetters(prefix: ''),
+          equals(firstLetters),
+        );
+        // 'x' begins no english wordlist word, so it is never offered up front.
+        expect(firstLetters, isNot(contains('x')));
+      },
+    );
+
+    test("'a' cannot be followed by 'a' \u2014 no word starts with 'aa'", () {
+      expect(
+        Bip39WordList.allowedNextLetters(prefix: 'a'),
+        isNot(contains('a')),
+      );
+      // But 'b' is fine: 'abandon', 'ability', ...
+      expect(Bip39WordList.allowedNextLetters(prefix: 'a'), contains('b'));
+    });
+
+    test('every offered letter actually extends the prefix to a real word', () {
+      const prefix = 'ab';
+      final allowed = Bip39WordList.allowedNextLetters(prefix: prefix);
+      for (final letter in allowed) {
+        expect(
+          list.any((word) => word.startsWith('$prefix$letter')),
+          isTrue,
+          reason: "'$prefix$letter' should be the start of some word",
+        );
+      }
+    });
+
+    test('a uniquely-determined word offers nothing more (backspace only)', () {
+      // 'abandon' is the only word starting with 'aba', and no longer word
+      // extends it: once complete, no letter can be added.
+      expect(list.where((w) => w.startsWith('aba')), equals(['abandon']));
+      expect(Bip39WordList.allowedNextLetters(prefix: 'abandon'), isEmpty);
+    });
+
+    test('a word that is a prefix of a longer word still offers letters', () {
+      // 'act' is a word, but 'action'/'actor'/'actress'/'actual' extend it.
+      expect(Bip39WordList.allowedNextLetters(prefix: 'act'), isNotEmpty);
+    });
+
+    test('an impossible prefix offers no letters', () {
+      expect(Bip39WordList.allowedNextLetters(prefix: 'zzz'), isEmpty);
+    });
+  });
+}

--- a/test/core_test/widgets/mnemonic_keyboard_test.dart
+++ b/test/core_test/widgets/mnemonic_keyboard_test.dart
@@ -1,0 +1,96 @@
+import 'package:bb_mobile/core/widgets/mnemonic_keyboard.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> pumpKeyboard(
+  WidgetTester tester, {
+  required Set<String> enabledLetters,
+  bool canBackspace = true,
+  void Function(String)? onLetter,
+  VoidCallback? onBackspace,
+  VoidCallback? onToggleShuffle,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: MnemonicKeyboard(
+          enabledLetters: enabledLetters,
+          canBackspace: canBackspace,
+          onLetter: onLetter ?? (_) {},
+          onBackspace: onBackspace ?? () {},
+          shuffleActive: false,
+          onToggleShuffle: onToggleShuffle ?? () {},
+          shuffleHint: 'shuffle',
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MnemonicKeyboard', () {
+    testWidgets('renders every letter of the alphabet as a key', (
+      tester,
+    ) async {
+      await pumpKeyboard(tester, enabledLetters: const {});
+      for (final letter in 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+        expect(find.text(letter), findsOneWidget, reason: 'missing $letter');
+      }
+    });
+
+    testWidgets('an enabled key reports its letter', (tester) async {
+      String? tapped;
+      await pumpKeyboard(
+        tester,
+        enabledLetters: const {'a'},
+        onLetter: (l) => tapped = l,
+      );
+
+      await tester.tap(find.text('a'));
+      expect(tapped, equals('a'));
+    });
+
+    testWidgets('a disabled key does nothing when tapped', (tester) async {
+      var fired = false;
+      await pumpKeyboard(
+        tester,
+        enabledLetters: const {'a'}, // 'b' is disabled
+        onLetter: (_) => fired = true,
+      );
+
+      await tester.tap(find.text('b'), warnIfMissed: false);
+      expect(fired, isFalse);
+    });
+
+    testWidgets('backspace reports when enabled', (tester) async {
+      var fired = false;
+      await pumpKeyboard(
+        tester,
+        enabledLetters: const {},
+        onBackspace: () => fired = true,
+      );
+
+      await tester.tap(find.byIcon(Icons.backspace_outlined));
+      expect(fired, isTrue);
+    });
+
+    testWidgets('backspace does nothing when disabled', (tester) async {
+      var fired = false;
+      await pumpKeyboard(
+        tester,
+        enabledLetters: const {},
+        canBackspace: false,
+        onBackspace: () => fired = true,
+      );
+
+      await tester.tap(
+        find.byIcon(Icons.backspace_outlined),
+        warnIfMissed: false,
+      );
+      expect(fired, isFalse);
+    });
+  });
+}

--- a/test/core_test/widgets/mnemonic_widget_test.dart
+++ b/test/core_test/widgets/mnemonic_widget_test.dart
@@ -1,6 +1,9 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/mnemonic_keyboard.dart';
 import 'package:bb_mobile/core/widgets/mnemonic_widget.dart';
 import 'package:bb_mobile/generated/l10n/localization.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -25,24 +28,28 @@ Future<void> pumpWidget(
   bip39.MnemonicLength length = bip39.MnemonicLength.words12,
   bool allowAutoFillWords = false,
   bool allowMultipleMnemonicLength = true,
+  bool allowPassphrase = false,
   String? externalError,
   required void Function(Mnemonic) onSubmit,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
+      // The passphrase field renders BullInputText, which reads the BullTheme
+      // extension off the ambient ThemeData and throws without it.
+      theme: AppTheme.themeData(AppThemeType.light),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: SingleChildScrollView(
-          child: MnemonicWidget(
-            initialLength: length,
-            onSubmit: onSubmit,
-            allowAutoFillWords: allowAutoFillWords,
-            allowMultipleMnemonicLength: allowMultipleMnemonicLength,
-            allowLabel: false,
-            allowPassphrase: false,
-            externalError: externalError,
-          ),
+        // MnemonicWidget owns its own scroll and docks the keyboard, so it is
+        // given bounded height (the test surface) rather than an outer scroll.
+        body: MnemonicWidget(
+          initialLength: length,
+          onSubmit: onSubmit,
+          allowAutoFillWords: allowAutoFillWords,
+          allowMultipleMnemonicLength: allowMultipleMnemonicLength,
+          allowLabel: false,
+          allowPassphrase: allowPassphrase,
+          externalError: externalError,
         ),
       ),
     ),
@@ -51,10 +58,92 @@ Future<void> pumpWidget(
 
 Finder wordField(int index) => find.byType(TextField).at(index);
 
+/// A key on the in-app keyboard, scoped so the letter is matched on the
+/// keyboard and not in a field or a suggestion chip.
+Finder keyboardKey(String letter) => find.descendant(
+  of: find.byType(MnemonicKeyboard),
+  matching: find.text(letter),
+);
+
+String fieldText(WidgetTester tester, int index) =>
+    tester.widget<TextField>(wordField(index)).controller!.text;
+
+bool fieldHasFocus(WidgetTester tester, int index) =>
+    tester.widget<TextField>(wordField(index)).focusNode!.hasFocus;
+
+/// Focuses a field. Read-only fields raise no OS keyboard; tapping them only
+/// moves focus and reveals the docked in-app keyboard. A no-op when the field
+/// already holds focus.
+///
+/// `pumpAndSettle` after each step because focusing a field triggers an
+/// animated scroll (the widget keeps the focused field above the keyboard);
+/// tapping before it settles would land on a moving target.
+Future<void> focusField(WidgetTester tester, int index) async {
+  if (fieldHasFocus(tester, index)) return;
+  await tester.ensureVisible(wordField(index));
+  await tester.pumpAndSettle();
+  await tester.tap(wordField(index), warnIfMissed: false);
+  await tester.pumpAndSettle();
+}
+
+Future<void> tapKey(WidgetTester tester, String letter) async {
+  await tester.tap(keyboardKey(letter));
+  await tester.pump();
+}
+
+Finder _backspaceKey() => find.descendant(
+  of: find.byType(MnemonicKeyboard),
+  matching: find.byIcon(Icons.backspace_outlined),
+);
+
+Finder shuffleToggle() => find.byKey(const Key('mnemonicParanoidToggle'));
+
+/// The on-screen centre of every letter key currently rendered, keyed by
+/// letter — used to detect that the layout changed (reshuffled) or held still.
+Map<String, Offset> keyPositions(WidgetTester tester) {
+  final positions = <String, Offset>{};
+  for (final letter in 'abcdefghijklmnopqrstuvwxyz'.split('')) {
+    final finder = keyboardKey(letter);
+    if (finder.evaluate().isNotEmpty) {
+      positions[letter] = tester.getCenter(finder);
+    }
+  }
+  return positions;
+}
+
+/// Empties a field through the keyboard's backspace, one character at a time.
+Future<void> clearField(WidgetTester tester, int index) async {
+  await focusField(tester, index);
+  while (fieldText(tester, index).isNotEmpty) {
+    await tester.tap(_backspaceKey());
+    await tester.pump();
+  }
+}
+
+/// Types [word] into field [index] through the in-app keyboard, one key tap
+/// per letter — the only input path now.
+Future<void> typeWord(WidgetTester tester, int index, String word) async {
+  await focusField(tester, index);
+  for (final letter in word.split('')) {
+    await tapKey(tester, letter);
+  }
+}
+
 Future<void> fillAll(WidgetTester tester, List<String> words) async {
   for (var i = 0; i < words.length; i++) {
-    await tester.enterText(wordField(i), words[i]);
+    if (words[i].isEmpty) continue;
+    await typeWord(tester, i, words[i]);
   }
+  await tester.pump();
+}
+
+/// Dismisses the keyboard (so the submit button is no longer covered by the
+/// bottom overlay) and taps it.
+Future<void> submit(WidgetTester tester) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pumpAndSettle();
+  await tester.ensureVisible(find.text('Submit'));
+  await tester.tap(find.text('Submit'));
   await tester.pump();
 }
 
@@ -95,34 +184,72 @@ void main() {
       expect(find.byType(TextField), findsNWidgets(24));
     });
 
-    testWidgets('submits the typed sentence', (tester) async {
+    test('rejects a non-English language — the keyboard is a-z only', () {
+      expect(
+        () => MnemonicWidget(
+          initialLength: bip39.MnemonicLength.words12,
+          onSubmit: (_) {},
+          language: bip39.Language.french,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    testWidgets('word fields are read-only so no OS keyboard can open', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      for (var i = 0; i < 12; i++) {
+        expect(
+          tester.widget<TextField>(wordField(i)).readOnly,
+          isTrue,
+          reason: 'field $i must be read-only',
+        );
+      }
+    });
+
+    testWidgets('the in-app keyboard appears only while a field is focused', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      expect(find.byType(MnemonicKeyboard), findsNothing);
+
+      await focusField(tester, 0);
+      expect(find.byType(MnemonicKeyboard), findsOneWidget);
+
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pumpAndSettle();
+      expect(find.byType(MnemonicKeyboard), findsNothing);
+    });
+
+    testWidgets('tapping empty page space dismisses the keyboard', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await focusField(tester, 0);
+      expect(find.byType(MnemonicKeyboard), findsOneWidget);
+
+      // Tap the gap between the two columns, level with the first field — a
+      // point that lands on no field.
+      final row = tester.getRect(wordField(0));
+      await tester.tapAt(Offset(400, row.center.dy));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MnemonicKeyboard), findsNothing);
+      expect(fieldHasFocus(tester, 0), isFalse);
+    });
+
+    testWidgets('submits the sentence typed on the in-app keyboard', (
+      tester,
+    ) async {
       Mnemonic? submitted;
       await pumpWidget(tester, onSubmit: (m) => submitted = m);
 
       await fillAll(tester, validWords);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
 
       expect(submitted, isNotNull);
       expect(submitted!.words, equals(validWords));
-    });
-
-    testWidgets('lowercases as the user types', (tester) async {
-      Mnemonic? submitted;
-      await pumpWidget(tester, onSubmit: (m) => submitted = m);
-
-      await fillAll(tester, [
-        validWords.first.toUpperCase(),
-        ...validWords.skip(1),
-      ]);
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('raise'),
-      );
-
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
-      expect(submitted!.words.first, equals('raise'));
     });
 
     testWidgets('clears the last word when the checksum is invalid', (
@@ -133,11 +260,10 @@ void main() {
 
       // 'zoo' is a valid word but breaks the checksum of this sentence.
       await fillAll(tester, [...validWords.take(11), 'zoo']);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
 
       expect(submitted, isFalse);
-      expect(tester.widget<TextField>(wordField(11)).controller!.text, isEmpty);
+      expect(fieldText(tester, 11), isEmpty);
     });
 
     testWidgets('refuses to submit an incomplete sentence', (tester) async {
@@ -145,8 +271,7 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) => submitted = true);
 
       await fillAll(tester, [...validWords.take(11), '']);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
 
       expect(submitted, isFalse);
       expect(find.text('Enter all words of your mnemonic'), findsOneWidget);
@@ -161,8 +286,6 @@ void main() {
         externalError: 'A label is required to import a mnemonic',
       );
 
-      // Shown without any submit, and stays put (persisted by the caller),
-      // unlike a one-shot snackbar.
       expect(
         find.text('A label is required to import a mnemonic'),
         findsOneWidget,
@@ -178,11 +301,8 @@ void main() {
         externalError: 'external error message',
       );
 
-      // Submitting an incomplete sentence raises a local entry error, which is
-      // the more relevant message and must win.
       await fillAll(tester, [...validWords.take(11), '']);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
 
       expect(find.text('Enter all words of your mnemonic'), findsOneWidget);
       expect(find.text('external error message'), findsNothing);
@@ -194,8 +314,7 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) {});
 
       await fillAll(tester, [...validWords.take(11), 'zoo']);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
 
       expect(
         find.text(
@@ -204,18 +323,19 @@ void main() {
         ),
         findsOneWidget,
       );
-      // bip39_mnemonic raises 'Mnemonic checksum zoo is invalid'. That message
-      // carries a word of the user's seed, so none of it may reach the screen.
       expect(find.textContaining('checksum'), findsNothing);
     });
 
-    testWidgets('reports an unknown word without echoing it', (tester) async {
+    testWidgets('reports an incomplete word without echoing it', (
+      tester,
+    ) async {
       await pumpWidget(tester, onSubmit: (_) {});
 
-      // 'zzzz' is not in the english wordlist.
-      await fillAll(tester, [...validWords.take(11), 'zzzz']);
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      // 'aban' is a valid prefix the keyboard allows, but not a wordlist word:
+      // the seed cannot be typed off-list, yet a half-typed word is still
+      // caught as unknown on submit.
+      await fillAll(tester, [...validWords.take(11), 'aban']);
+      await submit(tester);
 
       expect(
         find.text(
@@ -224,11 +344,9 @@ void main() {
         ),
         findsOneWidget,
       );
-      // The typed field legitimately shows 'zzzz'; the failure message must
-      // not. Only plain Text widgets are checked, not the EditableText inputs.
       expect(
         find.byWidgetPredicate(
-          (widget) => widget is Text && widget.data?.contains('zzzz') == true,
+          (widget) => widget is Text && widget.data?.contains('aban') == true,
         ),
         findsNothing,
       );
@@ -238,6 +356,9 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) {});
       await fillAll(tester, validWords);
 
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pumpAndSettle();
+
       await tester.tap(find.byType(DropdownButton<bip39.MnemonicLength>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('24 words').last);
@@ -246,10 +367,231 @@ void main() {
       expect(find.byType(TextField), findsNWidgets(24));
       for (var i = 0; i < 24; i++) {
         expect(
-          tester.widget<TextField>(wordField(i)).controller!.text,
+          fieldText(tester, i),
           isEmpty,
           reason: 'field $i should be empty after a length change',
         );
+      }
+    });
+
+    testWidgets(
+      'shrinking the length with a late field focused does not crash',
+      (tester) async {
+        await pumpWidget(
+          tester,
+          length: bip39.MnemonicLength.words24,
+          onSubmit: (_) {},
+        );
+        await focusField(tester, 23);
+
+        // The crash interleaving, driven deterministically: the refocus of
+        // field 23 and the length change land in the same frame. The focus
+        // notification fires first, while the old 24-node list is still
+        // installed, and schedules a post-frame scroll for index 23; the build
+        // then replaces the list with 12 entries, and the scroll callback runs
+        // after it. On device this interleaving comes from the dropdown popup
+        // restoring focus to the word field in the same frame onChanged
+        // rebuilds. The pump after the unfocus is required: without it the
+        // unfocus and refocus coalesce into no notification at all.
+        final node23 = tester.widget<TextField>(wordField(23)).focusNode!;
+        final dropdown = tester.widget<DropdownButton<bip39.MnemonicLength>>(
+          find.byType(DropdownButton<bip39.MnemonicLength>),
+        );
+        FocusManager.instance.primaryFocus?.unfocus();
+        await tester.pump();
+        node23.requestFocus();
+        dropdown.onChanged!(bip39.MnemonicLength.words12);
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(TextField), findsNWidgets(12));
+      },
+    );
+  });
+
+  group('MnemonicWidget keyboard', () {
+    testWidgets('offers no key that cannot continue a wordlist word', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'a');
+
+      // No english word starts with 'aa', so 'a' must be disabled after 'a'.
+      final aKey = tester.widget<InkWell>(
+        find.ancestor(of: keyboardKey('a'), matching: find.byType(InkWell)),
+      );
+      expect(aKey.onTap, isNull);
+    });
+
+    testWidgets('tapping a disabled key does not change the field', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'a');
+
+      await tester.tap(keyboardKey('a'), warnIfMissed: false);
+      await tester.pump();
+      expect(fieldText(tester, 0), equals('a'));
+    });
+
+    testWidgets('backspace clears the whole field', (tester) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'abo'); // prefix of 'about'/'above'
+
+      await tester.tap(_backspaceKey());
+      await tester.pump();
+      expect(fieldText(tester, 0), isEmpty);
+    });
+
+    testWidgets('a rapid double-tap cannot append a disabled letter', (
+      tester,
+    ) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await focusField(tester, 0);
+
+      // Two taps on 'a' with no frame between them: the second races the
+      // rebuild that disables the key. No word starts with 'aa', so the model
+      // must drop the racing tap rather than produce 'aa'.
+      await tester.tap(keyboardKey('a'), warnIfMissed: false);
+      await tester.tap(keyboardKey('a'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 0), equals('a'));
+    });
+
+    testWidgets('key letters are hidden from the accessibility tree', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpWidget(tester, onSubmit: (_) {});
+      await focusField(tester, 0);
+
+      // A malicious accessibility service must not be able to read the letters:
+      // the keys are wrapped in ExcludeSemantics.
+      expect(find.bySemanticsLabel('a'), findsNothing);
+      expect(find.bySemanticsLabel('e'), findsNothing);
+      handle.dispose();
+    });
+
+    testWidgets('word fields are hidden from the accessibility tree', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'zone');
+
+      // Excluding the keys is not enough: a TextField publishes its text as
+      // its semantics value, so the whole word grid is excluded too — the
+      // typed word must not be readable back from the field.
+      expect(
+        find.ancestor(
+          of: wordField(0),
+          matching: find.byType(ExcludeSemantics),
+        ),
+        findsWidgets,
+      );
+      expect(find.bySemanticsLabel('zone'), findsNothing);
+      handle.dispose();
+    });
+
+    testWidgets('suggestions are hidden from the accessibility tree', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'zo');
+
+      // The chips are visible on screen…
+      expect(find.text('zone'), findsOneWidget);
+      expect(find.text('zoo'), findsOneWidget);
+      // …but an accessibility service must not read the candidate words.
+      expect(find.bySemanticsLabel('zone'), findsNothing);
+      expect(find.bySemanticsLabel('zoo'), findsNothing);
+      handle.dispose();
+    });
+
+    testWidgets('the passphrase field stays out of the IME suggestion caches', (
+      tester,
+    ) async {
+      await pumpWidget(tester, allowPassphrase: true, onSubmit: (_) {});
+
+      // The passphrase is key material too: the OS keyboard may serve it, but
+      // its autocorrect and prediction caches must never see the value.
+      final field = tester.widget<TextField>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is TextField &&
+              widget.decoration?.hintText == 'Optional Passphrase',
+        ),
+      );
+      expect(field.enableSuggestions, isFalse);
+      expect(field.autocorrect, isFalse);
+    });
+  });
+
+  group('MnemonicWidget paranoid mode', () {
+    testWidgets('suggestions stay visible in paranoid mode', (tester) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await typeWord(tester, 0, 'zo');
+      expect(find.text('zone'), findsOneWidget);
+      expect(find.text('zoo'), findsOneWidget);
+
+      await tester.tap(shuffleToggle());
+      await tester.pumpAndSettle();
+
+      // Still offered — paranoid mode randomises their order, it does not
+      // remove them.
+      expect(find.text('zone'), findsOneWidget);
+      expect(find.text('zoo'), findsOneWidget);
+    });
+
+    testWidgets('a word can still be typed with a shuffled layout', (
+      tester,
+    ) async {
+      Mnemonic? submitted;
+      await pumpWidget(tester, onSubmit: (m) => submitted = m);
+
+      await focusField(tester, 0);
+      await tester.tap(shuffleToggle());
+      await tester.pumpAndSettle();
+
+      // Keys are found by their letter, not their position, so a shuffled
+      // layout does not change what can be typed.
+      await fillAll(tester, validWords);
+      await submit(tester);
+
+      expect(submitted, isNotNull);
+      expect(submitted!.words, equals(validWords));
+    });
+
+    testWidgets('the layout reshuffles after each key tap', (tester) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await focusField(tester, 0);
+      await tester.tap(shuffleToggle());
+      await tester.pumpAndSettle();
+
+      final before = keyPositions(tester);
+      await tapKey(tester, 'a'); // a valid first letter, so enabled
+      final after = keyPositions(tester);
+
+      // A full reshuffle: the odds of an identical 26-letter arrangement are
+      // vanishing, so the positions must differ.
+      expect(mapEquals(before, after), isFalse);
+    });
+
+    testWidgets('basic mode keeps a stable layout across taps', (tester) async {
+      await pumpWidget(tester, onSubmit: (_) {});
+      await focusField(tester, 0);
+
+      final before = keyPositions(tester);
+      await tapKey(tester, 'a');
+      final after = keyPositions(tester);
+
+      // No shuffle in basic mode: every key still shown sits where it was.
+      for (final letter in after.keys) {
+        if (before.containsKey(letter)) {
+          expect(after[letter], equals(before[letter]), reason: letter);
+        }
       }
     });
   });
@@ -259,11 +601,7 @@ void main() {
       tester,
     ) async {
       await pumpWidget(tester, onSubmit: (_) {});
-
-      await tester.tap(wordField(0));
-      await tester.pump();
-      await tester.enterText(wordField(0), 'zo');
-      await tester.pump();
+      await typeWord(tester, 0, 'zo');
 
       // 'zone' and 'zoo' are the only english words starting with 'zo'.
       expect(find.text('zone'), findsOneWidget);
@@ -272,18 +610,11 @@ void main() {
 
     testWidgets('tapping a suggestion fills the focused field', (tester) async {
       await pumpWidget(tester, onSubmit: (_) {});
-
-      await tester.tap(wordField(0));
-      await tester.pump();
-      await tester.enterText(wordField(0), 'zo');
-      await tester.pump();
+      await typeWord(tester, 0, 'zo');
       await tester.tap(find.text('zone'));
       await tester.pump();
 
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('zone'),
-      );
+      expect(fieldText(tester, 0), equals('zone'));
     });
 
     testWidgets('offers only checksum valid words on the last field', (
@@ -292,18 +623,12 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) {});
       await fillAll(tester, [...validWords.take(11), '']);
 
-      await tester.tap(wordField(11));
-      await tester.pump();
-
       final valid = bip39.Mnemonic.lastWordCandidates(
         words: validWords.take(11).toList(),
       );
       expect(valid, hasLength(128));
 
-      // Narrow to a prefix so the chips fit on screen: the list is lazy and
-      // only builds what is visible.
-      await tester.enterText(wordField(11), 'sen');
-      await tester.pump();
+      await typeWord(tester, 11, 'sen');
 
       // the real last word is offered
       expect(find.text('senior'), findsOneWidget);
@@ -322,29 +647,9 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) {});
       await fillAll(tester, [...validWords.take(11), '']);
 
-      await tester.tap(wordField(11));
-      await tester.pump();
+      await focusField(tester, 11);
 
       expect(find.text('128 possible last words'), findsOneWidget);
-    });
-
-    testWidgets('hides the count once the last word is complete', (
-      tester,
-    ) async {
-      await pumpWidget(tester, onSubmit: (_) {});
-      await fillAll(tester, [...validWords.take(11), '']);
-
-      await tester.tap(wordField(11));
-      await tester.pump();
-      expect(find.text('128 possible last words'), findsOneWidget);
-
-      await tester.enterText(wordField(11), 'sen');
-      await tester.pump();
-      await tester.tap(find.text('senior'));
-      await tester.pump();
-
-      // The question is answered: like the chips, the label leaves.
-      expect(find.textContaining('possible last words'), findsNothing);
     });
 
     testWidgets('tapping a chip on the last field dismisses the keyboard', (
@@ -353,44 +658,18 @@ void main() {
       await pumpWidget(tester, onSubmit: (_) {});
       await fillAll(tester, [...validWords.take(11), '']);
 
-      await tester.tap(wordField(11));
-      await tester.pump();
-      await tester.enterText(wordField(11), 'sen');
-      await tester.pump();
+      await typeWord(tester, 11, 'sen');
       await tester.tap(find.text('senior'));
       await tester.pump();
 
-      expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
-        equals('senior'),
-      );
-      // A tapped chip completes the sentence, like the auto fill: the same
-      // natural moment to dismiss the keyboard.
-      expect(
-        tester.widget<TextField>(wordField(11)).focusNode!.hasFocus,
-        isFalse,
-      );
-    });
-
-    testWidgets('falls back to the full list while earlier words are missing', (
-      tester,
-    ) async {
-      await pumpWidget(tester, onSubmit: (_) {});
-      await fillAll(tester, [...validWords.take(10), '', '']);
-
-      await tester.tap(wordField(11));
-      await tester.pump();
-
-      expect(find.textContaining('possible last words'), findsNothing);
+      expect(fieldText(tester, 11), equals('senior'));
+      expect(fieldHasFocus(tester, 11), isFalse);
     });
 
     testWidgets('does not auto fill the last field from the candidates', (
       tester,
     ) async {
       // A transcription error that is itself a valid word: shell -> sell.
-      // The real last word 'senior' is then not a candidate, but 'se' singles
-      // out exactly one candidate. Completing to it would produce a sentence
-      // with a valid checksum, silently accepting the wrong mnemonic.
       final typed = [...validWords.take(11)];
       typed[3] = 'sell';
       final candidates = bip39.Mnemonic.lastWordCandidates(words: typed);
@@ -405,29 +684,18 @@ void main() {
         allowAutoFillWords: true,
       );
       await fillAll(tester, [...typed, '']);
-      await tester.tap(wordField(11));
-      await tester.pump();
-      await tester.enterText(wordField(11), 'se');
-      await tester.pump();
+      await typeWord(tester, 11, 'se');
 
       // the field keeps what the user typed
-      expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
-        equals('se'),
-      );
+      expect(fieldText(tester, 11), equals('se'));
 
-      // and the wrong sentence is never submitted
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
       expect(submitted, isNull);
     });
 
     testWidgets('still completes the real last word, then fails the checksum', (
       tester,
     ) async {
-      // Same typo as above. 'seni' is unique in the wordlist ('senior') but
-      // matches no candidate, so the user must still get their word - and the
-      // checksum must then surface the typo instead of absorbing it.
       final typed = [...validWords.take(11)];
       typed[3] = 'sell';
 
@@ -438,41 +706,17 @@ void main() {
         allowAutoFillWords: true,
       );
       await fillAll(tester, [...typed, '']);
-      await tester.tap(wordField(11));
-      await tester.pump();
-      await tester.enterText(wordField(11), 'seni');
-      await tester.pump();
+      await typeWord(tester, 11, 'seni');
 
-      expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
-        equals('senior'),
-      );
+      expect(fieldText(tester, 11), equals('senior'));
 
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
+      await submit(tester);
       expect(submitted, isFalse);
       expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
+        fieldText(tester, 11),
         isEmpty,
         reason: 'an invalid checksum clears the last word',
       );
-    });
-
-    testWidgets('refreshes the candidates when another field is cleared', (
-      tester,
-    ) async {
-      await pumpWidget(tester, onSubmit: (_) {});
-      await fillAll(tester, [...validWords.take(11), '']);
-      await tester.tap(wordField(11));
-      await tester.pump();
-      expect(find.text('128 possible last words'), findsOneWidget);
-
-      // Clearing an earlier word does not move focus, yet it invalidates the
-      // candidate pool: the label must fall back, not keep a stale count.
-      await tester.tap(find.byIcon(Icons.close).first);
-      await tester.pump();
-
-      expect(find.textContaining('possible last words'), findsNothing);
     });
 
     testWidgets('auto fills once the prefix leaves a single candidate', (
@@ -480,156 +724,78 @@ void main() {
     ) async {
       await pumpWidget(tester, onSubmit: (_) {}, allowAutoFillWords: true);
 
-      await tester.tap(wordField(0));
-      await tester.pump();
       // 'aba' can only be 'abandon'.
-      await tester.enterText(wordField(0), 'aba');
-      await tester.pump();
+      await typeWord(tester, 0, 'aba');
 
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('abandon'),
-      );
-      // The completion was the only possibility left: the field locks, but
-      // focus stays put and the keyboard stays up - no automatic advance.
-      expect(
-        tester.widget<TextField>(wordField(0)).focusNode!.hasFocus,
-        isTrue,
-      );
+      expect(fieldText(tester, 0), equals('abandon'));
+      // The completion was the only possibility left: focus stays put.
+      expect(fieldHasFocus(tester, 0), isTrue);
 
-      // A stray keystroke is swallowed instead of breaking the word.
-      await tester.enterText(wordField(0), 'abandonx');
+      // Every letter key is now disabled: a completed unique word cannot be
+      // extended, so a stray tap cannot break it.
+      await tester.tap(keyboardKey('a'), warnIfMissed: false);
       await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('abandon'),
-      );
+      expect(fieldText(tester, 0), equals('abandon'));
     });
 
-    testWidgets('the clear icon unlocks an auto-filled field', (tester) async {
+    testWidgets('the clear icon empties an auto-filled field', (tester) async {
       await pumpWidget(tester, onSubmit: (_) {}, allowAutoFillWords: true);
 
-      await tester.tap(wordField(0));
-      await tester.pump();
-      await tester.enterText(wordField(0), 'aba');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('abandon'),
-      );
+      await typeWord(tester, 0, 'aba');
+      expect(fieldText(tester, 0), equals('abandon'));
 
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pump();
-      expect(tester.widget<TextField>(wordField(0)).controller!.text, isEmpty);
+      expect(fieldText(tester, 0), isEmpty);
 
       // Editable again right away, focus never left: 'abi' -> 'ability'.
-      await tester.enterText(wordField(0), 'abi');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('ability'),
-      );
-      expect(
-        tester.widget<TextField>(wordField(0)).focusNode!.hasFocus,
-        isTrue,
-      );
+      await tapKey(tester, 'a');
+      await tapKey(tester, 'b');
+      await tapKey(tester, 'i');
+      expect(fieldText(tester, 0), equals('ability'));
+      expect(fieldHasFocus(tester, 0), isTrue);
     });
 
-    testWidgets('backspace on an auto-filled word empties and unlocks it', (
+    testWidgets('backspace clears the whole word, not one character', (
       tester,
     ) async {
       await pumpWidget(tester, onSubmit: (_) {}, allowAutoFillWords: true);
 
-      await tester.tap(wordField(0));
-      await tester.pump();
-      await tester.enterText(wordField(0), 'aba');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('abandon'),
-      );
+      await typeWord(tester, 0, 'aba');
+      expect(fieldText(tester, 0), equals('abandon'));
 
-      // A deletion is the user's undo instinct: the field empties (as the
-      // clear icon would) instead of ignoring the keystroke.
-      await tester.enterText(wordField(0), 'abando');
+      // A word is entered as a unit and deleted as a unit: one backspace wipes
+      // the field rather than trimming to 'abando'.
+      await tester.tap(_backspaceKey());
       await tester.pump();
-      expect(tester.widget<TextField>(wordField(0)).controller!.text, isEmpty);
-      expect(
-        tester.widget<TextField>(wordField(0)).focusNode!.hasFocus,
-        isTrue,
-      );
-
-      // Unlocked: typing completes again.
-      await tester.enterText(wordField(0), 'abi');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(0)).controller!.text,
-        equals('ability'),
-      );
+      expect(fieldText(tester, 0), isEmpty);
     });
 
     testWidgets('marks a last word that cannot close the checksum as wrong', (
       tester,
     ) async {
       await pumpWidget(tester, onSubmit: (_) {});
-      await fillAll(tester, [...validWords.take(11), '']);
 
-      // Reference colors from the first field: unknown word, then valid word.
-      await tester.enterText(wordField(0), 'zzzz');
-      await tester.pump();
+      // Reference colours from the first field: a non-word prefix (invalid),
+      // then a valid wordlist word.
+      await typeWord(tester, 0, 'aban');
       final invalidColor = badgeColor(tester, 0);
-      await tester.enterText(wordField(0), validWords.first);
-      await tester.pump();
+      await clearField(tester, 0);
+      await typeWord(tester, 0, validWords.first);
       final validColor = badgeColor(tester, 0);
 
-      await tester.tap(wordField(11));
-      await tester.pump();
+      // Complete the first eleven words so the last field has a candidate pool.
+      for (var i = 1; i < 11; i++) {
+        await typeWord(tester, i, validWords[i]);
+      }
 
-      // 'zoo' is a wordlist word, but not one of this sentence's checksum
-      // candidates: on the last field that makes it the wrong word.
-      await tester.enterText(wordField(11), 'zoo');
-      await tester.pump();
+      // 'zoo' is a wordlist word but not a checksum candidate here: wrong word.
+      await typeWord(tester, 11, 'zoo');
       expect(badgeColor(tester, 11), equals(invalidColor));
 
-      // The real last word is both a wordlist word and a candidate.
-      await tester.enterText(wordField(11), 'senior');
-      await tester.pump();
+      await clearField(tester, 11);
+      await typeWord(tester, 11, 'senior');
       expect(badgeColor(tester, 11), equals(validColor));
-    });
-
-    testWidgets('only the last word dismisses the keyboard', (tester) async {
-      // shell -> sell keeps every word valid but moves the checksum.
-      final typed = [...validWords.take(11)];
-      typed[3] = 'sell';
-
-      await pumpWidget(tester, onSubmit: (_) {}, allowAutoFillWords: true);
-      await fillAll(tester, [...typed, '']);
-      await tester.tap(wordField(11));
-      await tester.pump();
-      await tester.enterText(wordField(11), 'seni');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
-        equals('senior'),
-      );
-      // The sentence is complete: the one place the keyboard may go.
-      expect(
-        tester.widget<TextField>(wordField(11)).focusNode!.hasFocus,
-        isFalse,
-      );
-
-      await tester.tap(find.text('Submit'));
-      await tester.pump();
-
-      // Cleared by the parent on the checksum failure: editable again, so
-      // the word can be retyped.
-      expect(tester.widget<TextField>(wordField(11)).controller!.text, isEmpty);
-      await tester.enterText(wordField(11), 'seni');
-      await tester.pump();
-      expect(
-        tester.widget<TextField>(wordField(11)).controller!.text,
-        equals('senior'),
-      );
     });
   });
 }


### PR DESCRIPTION
Seed words were typed into ordinary text fields, so every keystroke passed through the platform IME - a third-party keyboard, the autocorrect/prediction cache, or a malicious accessibility service could read the recovery phrase as it was typed.

**Changes:**

- Word fields on import/onboarding are now read-only displays: no platform keyboard, no paste, no selection toolbar.
- New mnemonic keyboard - letters-only, docked at the bottom with suggestions above. 
- Only letters that keep at least one wordlist word possible are enabled, so a typo can't be typed.
- Paranoid mode - optional shuffle randomises the layout and reshuffles on every tap (`Random.secure()`, rejecting arrangements where >6 of 26 keys stay put).


https://github.com/user-attachments/assets/ab2e4512-54f3-42d5-9fac-81fd6fd24f24

