### PR TITLE
feat(storage): encrypt local sqlite databases

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -11,6 +11,20 @@ import workmanager_apple
     GeneratedPluginRegistrant.register(with: self)
     excludeSensitiveFilesFromBackup()
 
+    // The local SQLite databases are encrypted with a key held in the
+    // keychain under `first_unlock_this_device`, which is never restored
+    // onto a different device. An iCloud/iTunes backup that carried the
+    // databases but not the key would restore a database nothing can
+    // open, so the databases are marked "do not back up" instead. See
+    // `lib/core/storage/backup_exclusion.dart` for the full rationale.
+    //
+    // Registered only on the main engine: the workmanager background
+    // engine never needs it, and the sweep is driven from the
+    // foreground composition root.
+    if let controller = window?.rootViewController as? FlutterViewController {
+      BackupExclusion.register(messenger: controller.binaryMessenger)
+    }
+
     // workmanager_apple spawns a separate FlutterEngine per background task
     // (see BackgroundWorker.swift in workmanager_apple). Plugins registered
     // against `self` above only attach to the main app's engine — the BG
@@ -41,5 +55,71 @@ import workmanager_apple
     // `setResourceValues` is `mutating`, so it needs a `var` receiver.
     // URLResourceValues.isExcludedFromBackup sets NSURLIsExcludedFromBackupKey.
     try? documentsURL.setResourceValues(resourceValues)
+  }
+}
+
+/// Sets `URLResourceValues.isExcludedFromBackup` on the paths Dart hands
+/// us.
+///
+/// Lives in `AppDelegate.swift` rather than its own file on purpose:
+/// a new `.swift` file has to be added to `project.pbxproj` to be
+/// compiled, and a hand-edited pbxproj that silently drops the file
+/// would leave the exclusion a no-op with no build error to catch it.
+enum BackupExclusion {
+  static func register(messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(
+      name: "bullbitcoin.com/backup_exclusion",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { call, result in
+      guard call.method == "excludeFromBackup" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let paths = arguments["paths"] as? [String]
+      else {
+        result(
+          FlutterError(
+            code: "bad-arguments",
+            message: "excludeFromBackup expects a `paths` list of strings",
+            details: nil
+          )
+        )
+        return
+      }
+
+      var failures: [String] = []
+      for path in paths {
+        // Setting the flag on a file that doesn't exist throws, and Dart
+        // filters by existence before calling — but the two checks race
+        // across the channel hop, so re-check here.
+        guard FileManager.default.fileExists(atPath: path) else { continue }
+        var url = URL(fileURLWithPath: path)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        do {
+          try url.setResourceValues(values)
+        } catch {
+          // Report the failing basename only: the container path
+          // contains an install-scoped UUID and this string can end up
+          // in a log the user shares.
+          failures.append(url.lastPathComponent)
+        }
+      }
+
+      if failures.isEmpty {
+        result(nil)
+      } else {
+        result(
+          FlutterError(
+            code: "exclude-failed",
+            message: "Could not exclude: \(failures.joined(separator: ", "))",
+            details: nil
+          )
+        )
+      }
+    }
   }
 }

--- a/lib/core/background_tasks/handler.dart
+++ b/lib/core/background_tasks/handler.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/background_tasks/tasks.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
 import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
 import 'package:bb_mobile/core/utils/logger.dart' show log;
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -33,7 +34,21 @@ Future<bool> tasksHandler(String task) async {
   await Bull.initFlutterRustBridgeDependencies();
 
   try {
-    final databaseKey = await DatabaseEncryptionKeyStore.loadExisting();
+    // `loadExisting` never creates a key: a background task can fire
+    // before the user has ever opened the app on this install, and
+    // minting a key here would either race the foreground boot or
+    // write a key that doesn't match an existing encrypted database.
+    final String? databaseKey;
+    try {
+      databaseKey = await DatabaseEncryptionKeyStore.loadExisting();
+    } on KeychainLockedException {
+      // iOS can fire a BGTask before the device has been unlocked since
+      // boot, at which point a `first_unlock_this_device` item is
+      // unreadable. That is "come back later", not "the key is gone" —
+      // return false so workmanager reschedules, and touch nothing.
+      log.warning('Background task skipped: keychain locked, will retry');
+      return false;
+    }
     if (databaseKey == null) {
       log.warning('Background task skipped before database key initialization');
       return false;

--- a/lib/core/background_tasks/handler.dart
+++ b/lib/core/background_tasks/handler.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/background_tasks/tasks.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
 import 'package:bb_mobile/core/utils/logger.dart' show log;
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
@@ -32,7 +33,14 @@ Future<bool> tasksHandler(String task) async {
   await Bull.initFlutterRustBridgeDependencies();
 
   try {
-    final driftIsolate = await SqliteDatabase.createIsolateWithSpawn();
+    final databaseKey = await DatabaseEncryptionKeyStore.loadExisting();
+    if (databaseKey == null) {
+      log.warning('Background task skipped before database key initialization');
+      return false;
+    }
+    final driftIsolate = await SqliteDatabase.createIsolateWithSpawn(
+      databaseKey,
+    );
     final sqlite = SqliteDatabase(
       await driftIsolate.connect(singleClientMode: true),
     );
@@ -46,6 +54,7 @@ Future<bool> tasksHandler(String task) async {
     await AppLocator.setup(
       locator,
       sqlite,
+      databaseKey: databaseKey,
       startPayjoinRecovery: false,
       // No order-swap polling either: the watcher is lifecycle-gated to the
       // foreground app, and this isolate runs on a ~30s iOS background budget.

--- a/lib/core/screens/app_init_error_screen.dart
+++ b/lib/core/screens/app_init_error_screen.dart
@@ -1,28 +1,19 @@
-import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/screens/pre_init_scaffold.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/widgets/app_language_picker.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/share_logs_bottom_sheet.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/generated/l10n/localization.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
+import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class AppInitErrorScreen extends StatefulWidget {
+class AppInitErrorScreen extends StatelessWidget {
   const AppInitErrorScreen({super.key, required this.error});
 
   final Object error;
-
-  @override
-  State<AppInitErrorScreen> createState() => _AppInitErrorScreenState();
-}
-
-class _AppInitErrorScreenState extends State<AppInitErrorScreen> {
-  Language _language = Language.fromKeyboard();
 
   Future<void> _shareLogs(BuildContext context, AppLocalizations loc) async {
     try {
@@ -76,168 +67,87 @@ class _AppInitErrorScreenState extends State<AppInitErrorScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final loc = lookupAppLocalizations(_language.locale);
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.themeData(AppThemeType.dark),
-      locale: _language.locale,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Builder(
-        builder: (context) {
-          // Seed Device.screen so AppLanguagePicker / TranslationWarningBottomSheet
-          // (which read it synchronously) work on this pre-init screen.
-          Device.init(context);
-          return Scaffold(
-            body: SafeArea(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: Text(
-                            loc.appInitErrorTitle,
-                            style: Theme.of(context).textTheme.headlineSmall
-                                ?.copyWith(fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        AppLanguagePicker(
-                          value: _language,
-                          onChanged: (lang) => setState(() => _language = lang),
-                        ),
-                      ],
-                    ),
-                    const Gap(24),
-                    _BackupSection(
-                      asset: 'assets/misc/undraw_secure-usb-drive.svg',
-                      title: loc.appInitErrorHasBackupTitle,
-                      message: loc.appInitErrorHasBackupMessage,
-                    ),
-                    const Gap(32),
-                    Divider(color: context.appColors.border),
-                    const Gap(32),
-                    _BackupSection(
-                      asset: 'assets/misc/undraw_forgot-password.svg',
-                      title: loc.appInitErrorNoBackupTitle,
-                      message: loc.appInitErrorNoBackupMessage,
-                    ),
-                    const Gap(32),
-                    BBButton.big(
-                      label: loc.appInitErrorContactSupportButton,
-                      iconData: Icons.open_in_new,
-                      bgColor: context.appColors.primary,
-                      textColor: context.appColors.onPrimary,
-                      onPressed: _contactSupport,
-                    ),
-                    const Gap(12),
-                    BBButton.big(
-                      label: loc.appInitErrorShareLogsButton,
-                      iconData: Icons.share,
-                      iconFirst: true,
-                      bgColor: context.appColors.surface,
-                      textColor: context.appColors.text,
-                      borderColor: context.appColors.border,
-                      outlined: true,
-                      onPressed: () => _shareLogs(context, loc),
-                    ),
-                    const Gap(12),
-                    BBButton.big(
-                      label: loc.logsShareOptionExport,
-                      iconData: Icons.file_download_outlined,
-                      iconFirst: true,
-                      bgColor: context.appColors.surface,
-                      textColor: context.appColors.text,
-                      borderColor: context.appColors.border,
-                      outlined: true,
-                      onPressed: () => _exportLogs(context, loc),
-                    ),
-                    const Gap(12),
-                    BBButton.big(
-                      label: loc.deleteLogsTitle,
-                      iconData: Icons.delete_outline,
-                      iconFirst: true,
-                      bgColor: context.appColors.surface,
-                      textColor: context.appColors.error,
-                      borderColor: context.appColors.error,
-                      outlined: true,
-                      onPressed: () => _deleteLogs(context, loc),
-                    ),
-                    const Gap(16),
-                    _ErrorDetails(
-                      error: widget.error,
-                      label: loc.appInitErrorDetailsToggle,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _BackupSection extends StatelessWidget {
-  const _BackupSection({
-    required this.asset,
-    required this.title,
-    required this.message,
-  });
-
-  final String asset;
-  final String title;
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Center(
-          child: SvgPicture.asset(
-            asset,
-            height: 120,
-            fit: BoxFit.contain,
-            placeholderBuilder: (_) => const SizedBox(height: 120),
-          ),
+    return PreInitScaffold(
+      title: (loc) => loc.appInitErrorTitle,
+      builder: (context, loc) => [
+        PreInitIllustration(
+          asset: 'assets/misc/undraw_secure-usb-drive.svg',
+          title: loc.appInitErrorHasBackupTitle,
+          message: loc.appInitErrorHasBackupMessage,
+        ),
+        const Gap(32),
+        Divider(color: context.appColors.border),
+        const Gap(32),
+        PreInitIllustration(
+          asset: 'assets/misc/undraw_forgot-password.svg',
+          title: loc.appInitErrorNoBackupTitle,
+          message: loc.appInitErrorNoBackupMessage,
+        ),
+        const Gap(32),
+        BBButton.big(
+          label: loc.appInitErrorContactSupportButton,
+          iconData: Icons.open_in_new,
+          bgColor: context.appColors.primary,
+          textColor: context.appColors.onPrimary,
+          onPressed: _contactSupport,
+        ),
+        const Gap(12),
+        BBButton.big(
+          label: loc.appInitErrorShareLogsButton,
+          iconData: Icons.share,
+          iconFirst: true,
+          bgColor: context.appColors.surface,
+          textColor: context.appColors.text,
+          borderColor: context.appColors.border,
+          outlined: true,
+          onPressed: () => _shareLogs(context, loc),
+        ),
+        const Gap(12),
+        BBButton.big(
+          label: loc.logsShareOptionExport,
+          iconData: Icons.file_download_outlined,
+          iconFirst: true,
+          bgColor: context.appColors.surface,
+          textColor: context.appColors.text,
+          borderColor: context.appColors.border,
+          outlined: true,
+          onPressed: () => _exportLogs(context, loc),
+        ),
+        const Gap(12),
+        BBButton.big(
+          label: loc.deleteLogsTitle,
+          iconData: Icons.delete_outline,
+          iconFirst: true,
+          bgColor: context.appColors.surface,
+          textColor: context.appColors.error,
+          borderColor: context.appColors.error,
+          outlined: true,
+          onPressed: () => _deleteLogs(context, loc),
         ),
         const Gap(16),
-        Text(
-          title,
-          style: theme.textTheme.titleLarge?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
-          textAlign: TextAlign.center,
-        ),
-        const Gap(8),
-        Text(
-          message,
-          style: theme.textTheme.bodyMedium,
-          textAlign: TextAlign.center,
-        ),
+        ErrorDetailsPanel(error: error, label: loc.appInitErrorDetailsToggle),
       ],
     );
   }
 }
 
-class _ErrorDetails extends StatefulWidget {
-  const _ErrorDetails({required this.error, required this.label});
+/// Collapsible raw-error panel. Developer detail, shown only when the user
+/// opens it; the screens themselves lead with a localized message.
+class ErrorDetailsPanel extends StatefulWidget {
+  const ErrorDetailsPanel({
+    super.key,
+    required this.error,
+    required this.label,
+  });
 
   final Object error;
   final String label;
 
   @override
-  State<_ErrorDetails> createState() => _ErrorDetailsState();
+  State<ErrorDetailsPanel> createState() => _ErrorDetailsPanelState();
 }
 
-class _ErrorDetailsState extends State<_ErrorDetails> {
+class _ErrorDetailsPanelState extends State<ErrorDetailsPanel> {
   bool _expanded = false;
 
   @override

--- a/lib/core/screens/local_data_recovery_screen.dart
+++ b/lib/core/screens/local_data_recovery_screen.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/screens/app_init_error_screen.dart'
+    show ErrorDetailsPanel;
+import 'package:bb_mobile/core/screens/pre_init_scaffold.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/utils/logger.dart' show log;
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/dialog/blurred_dialog.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Shown when a local database exists but its encryption key does not,
+/// so the databases can never be opened again.
+///
+/// Replaces the generic init-error screen for this one case, which left
+/// the user staring at an app that would not start with nothing to do
+/// about it. There is exactly one way out of this state — delete the
+/// unreadable data — and the user has to be the one to choose it.
+///
+/// The ordering of the actions is deliberate. "Try again" comes first
+/// and free: if we ever misread a temporarily-unavailable key as a
+/// permanently-absent one, a retry costs nothing while a reset costs the
+/// user their local data. Reset is last, destructive-styled, and behind
+/// a confirmation dialog that names what is lost.
+class LocalDataRecoveryScreen extends StatefulWidget {
+  /// Performs the destructive reset. Injected rather than called
+  /// directly so this screen has no dependency on the storage layer and
+  /// so the confirmation gate can be tested without touching a disk.
+  final Future<void> Function() onReset;
+
+  /// Re-runs startup. Called after a successful reset and by "try
+  /// again"; on success it swaps in the real app.
+  final Future<void> Function() onRestart;
+
+  final Object error;
+
+  const LocalDataRecoveryScreen({
+    super.key,
+    required this.onReset,
+    required this.onRestart,
+    required this.error,
+  });
+
+  @override
+  State<LocalDataRecoveryScreen> createState() =>
+      _LocalDataRecoveryScreenState();
+}
+
+class _LocalDataRecoveryScreenState extends State<LocalDataRecoveryScreen> {
+  bool _busy = false;
+
+  Future<void> _restart() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      // On success this replaces the root widget and nothing below runs
+      // against a mounted state — hence the `mounted` guard rather than
+      // a `finally`.
+      await widget.onRestart();
+    } catch (_) {
+      // The guarded startup path reports its own failures and swaps in
+      // whichever screen matches the new outcome.
+    }
+    if (mounted) setState(() => _busy = false);
+  }
+
+  Future<void> _confirmAndReset(
+    BuildContext context,
+    AppLocalizations loc,
+  ) async {
+    if (_busy) return;
+    final confirmed = await BlurredDialog.show<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: context.appColors.background,
+        title: Text(loc.localDataRecoveryResetConfirmTitle),
+        content: Text(loc.localDataRecoveryResetConfirmMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(loc.localDataRecoveryCancelButton),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(
+              loc.localDataRecoveryResetConfirmButton,
+              style: TextStyle(color: context.appColors.error),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+
+    setState(() => _busy = true);
+    try {
+      await widget.onReset();
+    } catch (e, s) {
+      log.severe(message: 'Local data reset failed', error: e, trace: s);
+      if (!mounted) return;
+      setState(() => _busy = false);
+      SnackBarUtils.showSnackBar(
+        context,
+        loc.localDataRecoveryResetFailedMessage,
+      );
+      return;
+    }
+    if (mounted) setState(() => _busy = false);
+    await _restart();
+  }
+
+  Future<void> _contactSupport() async {
+    await launchUrl(
+      Uri.parse(SettingsConstants.webSupportLink),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PreInitScaffold(
+      builder: (context, loc) => [
+        PreInitIllustration(
+          asset: 'assets/misc/undraw_forgot-password.svg',
+          title: loc.localDataRecoveryTitle,
+          message: loc.localDataRecoveryMessage,
+        ),
+        const Gap(32),
+        BBButton.big(
+          label: loc.localDataRecoveryRetryButton,
+          iconData: Icons.refresh,
+          iconFirst: true,
+          bgColor: context.appColors.primary,
+          textColor: context.appColors.onPrimary,
+          disabled: _busy,
+          onPressed: _restart,
+        ),
+        const Gap(12),
+        BBButton.big(
+          label: loc.appInitErrorContactSupportButton,
+          iconData: Icons.open_in_new,
+          bgColor: context.appColors.surface,
+          textColor: context.appColors.text,
+          borderColor: context.appColors.border,
+          outlined: true,
+          disabled: _busy,
+          onPressed: _contactSupport,
+        ),
+        const Gap(32),
+        Divider(color: context.appColors.border),
+        const Gap(24),
+        Text(
+          loc.localDataRecoveryResetWarning,
+          style: Theme.of(context).textTheme.bodySmall,
+          textAlign: TextAlign.center,
+        ),
+        const Gap(12),
+        BBButton.big(
+          label: loc.localDataRecoveryResetButton,
+          iconData: Icons.delete_forever_outlined,
+          iconFirst: true,
+          bgColor: context.appColors.surface,
+          textColor: context.appColors.error,
+          borderColor: context.appColors.error,
+          outlined: true,
+          disabled: _busy,
+          onPressed: () => unawaited(_confirmAndReset(context, loc)),
+        ),
+        const Gap(16),
+        ErrorDetailsPanel(
+          error: widget.error,
+          label: loc.appInitErrorDetailsToggle,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/screens/pre_init_scaffold.dart
+++ b/lib/core/screens/pre_init_scaffold.dart
@@ -1,0 +1,139 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/constants.dart' show Device;
+import 'package:bb_mobile/core/widgets/app_language_picker.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Chrome for the screens that run *before* `Bull.init` has produced a
+/// locator, a router or a settings repository.
+///
+/// Those screens can't use the app shell — there is no `SettingsCubit`
+/// to read a language from and no `GoRouter` to sit inside — so each one
+/// has to raise its own [MaterialApp] and pick a locale from the
+/// keyboard. This is that boilerplate, in one place, so a new failure
+/// screen is a list of widgets rather than another copy of the shell.
+class PreInitScaffold extends StatefulWidget {
+  /// Optional heading rendered on the same row as the language picker.
+  final String Function(AppLocalizations loc)? title;
+
+  /// Body of the screen. Receives the localizations for the currently
+  /// picked language so callers never reach for `context.loc`, which
+  /// isn't wired up this early.
+  final List<Widget> Function(BuildContext context, AppLocalizations loc)
+  builder;
+
+  const PreInitScaffold({super.key, this.title, required this.builder});
+
+  @override
+  State<PreInitScaffold> createState() => _PreInitScaffoldState();
+}
+
+class _PreInitScaffoldState extends State<PreInitScaffold> {
+  Language _language = Language.fromKeyboard();
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = lookupAppLocalizations(_language.locale);
+    final title = widget.title?.call(loc);
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.themeData(AppThemeType.dark),
+      locale: _language.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) {
+          // Seed Device.screen so AppLanguagePicker /
+          // TranslationWarningBottomSheet (which read it synchronously)
+          // work on this pre-init screen.
+          Device.init(context);
+          return Scaffold(
+            body: SafeArea(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Expanded(
+                          child: title == null
+                              ? const SizedBox.shrink()
+                              : Text(
+                                  title,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .headlineSmall
+                                      ?.copyWith(fontWeight: FontWeight.bold),
+                                ),
+                        ),
+                        const SizedBox(width: 12),
+                        AppLanguagePicker(
+                          value: _language,
+                          onChanged: (lang) => setState(() => _language = lang),
+                        ),
+                      ],
+                    ),
+                    const Gap(24),
+                    ...widget.builder(context, loc),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Illustration + heading + body copy, the block every pre-init screen
+/// leads with.
+class PreInitIllustration extends StatelessWidget {
+  final String asset;
+  final String title;
+  final String message;
+
+  const PreInitIllustration({
+    super.key,
+    required this.asset,
+    required this.title,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Center(
+          child: SvgPicture.asset(
+            asset,
+            height: 120,
+            fit: BoxFit.contain,
+            placeholderBuilder: (_) => const SizedBox(height: 120),
+          ),
+        ),
+        const Gap(16),
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const Gap(8),
+        Text(
+          message,
+          style: theme.textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/screens/startup_keychain_locked_screen.dart
+++ b/lib/core/screens/startup_keychain_locked_screen.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/screens/pre_init_scaffold.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
+import 'package:flutter/material.dart';
+
+/// Shown when startup could not read the database encryption key because
+/// the keychain has not been unlocked since boot.
+///
+/// This is the *recoverable* half of the fail-closed path: nothing is
+/// wrong with the data, the OS just will not hand over a
+/// `first_unlock_this_device` item yet. So this screen offers exactly
+/// one thing — try again — and deliberately offers no way to reset
+/// anything. iOS reaches it when a launch (typically a background wake)
+/// beats the user's first unlock.
+///
+/// Retries automatically on resume, because the natural way out is for
+/// the user to unlock the device, which sends the app through
+/// `AppLifecycleState.resumed` anyway.
+class StartupKeychainLockedScreen extends StatefulWidget {
+  final Future<void> Function() onRetry;
+
+  const StartupKeychainLockedScreen({super.key, required this.onRetry});
+
+  @override
+  State<StartupKeychainLockedScreen> createState() =>
+      _StartupKeychainLockedScreenState();
+}
+
+class _StartupKeychainLockedScreenState
+    extends State<StartupKeychainLockedScreen>
+    with WidgetsBindingObserver {
+  bool _retrying = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) unawaited(_retry());
+  }
+
+  Future<void> _retry() async {
+    if (_retrying) return;
+    setState(() => _retrying = true);
+    try {
+      // On success this replaces the whole root widget, so there may be
+      // nothing left to call `setState` on afterwards — hence the
+      // `mounted` check below rather than a `finally`.
+      await widget.onRetry();
+    } catch (_) {
+      // `onRetry` runs the same guarded startup path that produced this
+      // screen; it reports its own failures and swaps in whichever
+      // screen matches the new outcome.
+    }
+    if (mounted) setState(() => _retrying = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PreInitScaffold(
+      builder: (context, loc) => [
+        PreInitIllustration(
+          asset: 'assets/misc/undraw_forgot-password.svg',
+          title: loc.startupKeychainLockedTitle,
+          message: loc.startupKeychainLockedMessage,
+        ),
+        const Gap(32),
+        BBButton.big(
+          label: loc.startupKeychainLockedRetryButton,
+          iconData: Icons.refresh,
+          iconFirst: true,
+          bgColor: context.appColors.primary,
+          textColor: context.appColors.onPrimary,
+          disabled: _retrying,
+          onPressed: _retry,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/storage/backup_exclusion.dart
+++ b/lib/core/storage/backup_exclusion.dart
@@ -1,0 +1,66 @@
+import 'dart:io' show File, Platform;
+
+import 'package:bb_mobile/core/utils/logger.dart' show log;
+import 'package:flutter/services.dart'
+    show MethodChannel, MissingPluginException, PlatformException;
+import 'package:meta/meta.dart';
+
+/// Marks the local databases as "do not back up" on iOS.
+///
+/// Why this exists: the databases live in `NSDocumentDirectory`, which
+/// iCloud and iTunes back up, while their encryption key lives in the
+/// keychain under `first_unlock_this_device`, which is *not* restored
+/// onto a different device. Restoring a backup onto a new phone would
+/// therefore reproduce an encrypted database with no key to open it,
+/// and the fail-closed path would stop the app from starting.
+///
+/// Excluding the databases loses nothing that was previously
+/// recoverable: wallet seeds already use `first_unlock_this_device`, so
+/// a device-to-device restore never carried working wallets. It only
+/// stops the restore from carrying a database that can't be read.
+///
+/// Best effort by design. If the platform channel fails the app must
+/// still start — a database that is backed up is a future migration
+/// problem, a startup that throws here is an outage now.
+abstract final class BackupExclusion {
+  static const _channel = MethodChannel('bullbitcoin.com/backup_exclusion');
+
+  /// Sidecars SQLite creates next to a database file. They hold the
+  /// same (encrypted) pages, and an orphaned `-wal` restored without
+  /// its database is at best useless, so they get the same treatment.
+  static const _sidecarSuffixes = ['', '-wal', '-shm'];
+
+  /// Excludes [databasePaths] and their SQLite sidecars from device
+  /// backups. Paths that don't exist yet are skipped — call this again
+  /// once they do (see the app-lifecycle sweep in `main.dart`).
+  static Future<void> excludeDatabases(Iterable<String> databasePaths) async {
+    if (!Platform.isIOS) return;
+
+    final paths = resolvePaths(databasePaths);
+    if (paths.isEmpty) return;
+
+    try {
+      await _channel.invokeMethod<void>('excludeFromBackup', {'paths': paths});
+    } on PlatformException catch (e) {
+      log.warning('Could not exclude databases from backup: ${e.code}');
+    } on MissingPluginException {
+      // An older Runner without the handler. Not fatal, and not worth a
+      // warning on every launch of a build that simply predates it.
+      log.fine('Backup-exclusion channel unavailable');
+    }
+  }
+
+  /// Expands each database path into the set of files that actually
+  /// exist right now.
+  ///
+  /// Filtering here rather than natively keeps the channel payload
+  /// honest: `setResourceValues` throws on a missing file, and a launch
+  /// where the payjoin database has not been opened yet would otherwise
+  /// report a failure for a file that is simply not there yet.
+  @visibleForTesting
+  static List<String> resolvePaths(Iterable<String> databasePaths) => [
+    for (final path in databasePaths)
+      for (final suffix in _sidecarSuffixes)
+        if (File('$path$suffix').existsSync()) '$path$suffix',
+  ];
+}

--- a/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_data_source_impl.dart
+++ b/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_data_source_impl.dart
@@ -11,13 +11,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// `PlatformException` types and share no code).
 enum _Operation { read, write, delete, contains, readAll, deleteAll }
 
-/// iOS keychain `OSStatus` for `errSecInteractionNotAllowed`. Returned
-/// by `SecItemCopyMatching` / `SecItemAdd` when the item's accessibility
-/// class requires the device to be unlocked (or to have been unlocked
-/// since boot) and the current state doesn't satisfy that. See
-/// [KeychainLockedException].
-const int _errSecInteractionNotAllowed = -25308;
-
 class SecureStorageDatasourceImpl implements KeyValueStorageDatasource<String> {
   final FlutterSecureStorage _storage;
 
@@ -35,13 +28,7 @@ class SecureStorageDatasourceImpl implements KeyValueStorageDatasource<String> {
     try {
       return await body();
     } on PlatformException catch (e) {
-      // Belt-and-suspenders: across `flutter_secure_storage` releases,
-      // the OSStatus has historically appeared in `details` (current
-      // fork), `code` (older versions, as a string), or embedded in
-      // `message`. Match all three so a future fork bump that shifts
-      // the field doesn't silently regress this whole class of
-      // handling without a compile error.
-      if (_isLocked(e)) {
+      if (isKeychainLocked(e)) {
         final target = key != null ? ' "$key"' : '';
         log.warning(
           'Device not unlocked since boot (${operation.name}$target)',
@@ -51,11 +38,6 @@ class SecureStorageDatasourceImpl implements KeyValueStorageDatasource<String> {
       rethrow;
     }
   }
-
-  bool _isLocked(PlatformException e) =>
-      e.details == _errSecInteractionNotAllowed ||
-      e.code == '$_errSecInteractionNotAllowed' ||
-      (e.message ?? '').contains('$_errSecInteractionNotAllowed');
 
   @override
   Future<void> saveValue({required String key, required String value}) {

--- a/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_legacy_datasource_impl.dart
+++ b/lib/core/storage/data/datasources/key_value_storage/impl/secure_storage_legacy_datasource_impl.dart
@@ -10,12 +10,6 @@ import 'package:flutter_secure_storage_legacy/flutter_secure_storage.dart';
 /// and the two impls share no code.
 enum _Operation { read, write, delete, contains, readAll, deleteAll }
 
-/// See [_errSecInteractionNotAllowed] in
-/// `secure_storage_data_source_impl.dart`. Duplicated here because the
-/// fss9 and fss10 plugins expose distinct `PlatformException` types and
-/// can't share a single wrapper without coupling the impls.
-const int _errSecInteractionNotAllowed = -25308;
-
 class SecureStorageLegacyDatasourceImpl
     implements KeyValueStorageDatasource<String> {
   final FlutterSecureStorage _storage;
@@ -30,10 +24,7 @@ class SecureStorageLegacyDatasourceImpl
     try {
       return await body();
     } on PlatformException catch (e) {
-      // See note in `secure_storage_data_source_impl.dart` `_isLocked`
-      // — the OSStatus field has shifted across fss releases, so we
-      // check `details` / `code` / `message` all three.
-      if (_isLocked(e)) {
+      if (isKeychainLocked(e)) {
         final target = key != null ? ' "$key"' : '';
         log.warning(
           'Device not unlocked since boot '
@@ -44,11 +35,6 @@ class SecureStorageLegacyDatasourceImpl
       rethrow;
     }
   }
-
-  bool _isLocked(PlatformException e) =>
-      e.details == _errSecInteractionNotAllowed ||
-      e.code == '$_errSecInteractionNotAllowed' ||
-      (e.message ?? '').contains('$_errSecInteractionNotAllowed');
 
   @override
   Future<void> saveValue({required String key, required String value}) {

--- a/lib/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart
+++ b/lib/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/services.dart' show PlatformException;
+
 /// Thrown by secure-storage datasources when the underlying OS keychain
 /// refuses an operation because the device is in a state where keychain
 /// items aren't currently readable.
@@ -34,3 +36,30 @@ class KeychainLockedException implements Exception {
   String toString() =>
       'KeychainLockedException: device not unlocked since boot';
 }
+
+/// iOS keychain `OSStatus` for `errSecInteractionNotAllowed`. Returned
+/// by `SecItemCopyMatching` / `SecItemAdd` when the item's accessibility
+/// class requires the device to be unlocked (or to have been unlocked
+/// since boot) and the current state doesn't satisfy that.
+const int errSecInteractionNotAllowed = -25308;
+
+/// Whether [e] is the keychain telling us "not now, the device has not
+/// been unlocked since boot" rather than "no such item" or a real
+/// failure.
+///
+/// Belt-and-suspenders: across `flutter_secure_storage` releases the
+/// OSStatus has historically appeared in `details` (current fork), in
+/// `code` (older versions, as a string), or embedded in `message`.
+/// Match all three so a future fork bump that shifts the field doesn't
+/// silently regress this whole class of handling without a compile
+/// error.
+///
+/// Shared by every caller that talks to the keychain — the fss9 and
+/// fss10 datasource impls can't share their `_wrap` (the two plugins
+/// expose distinct types) but this predicate only touches
+/// `PlatformException`, which they do share, and duplicating a
+/// security-critical constant is how one copy silently drifts.
+bool isKeychainLocked(PlatformException e) =>
+    e.details == errSecInteractionNotAllowed ||
+    e.code == '$errSecInteractionNotAllowed' ||
+    (e.message ?? '').contains('$errSecInteractionNotAllowed');

--- a/lib/core/storage/database_encryption_key_store.dart
+++ b/lib/core/storage/database_encryption_key_store.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:meta/meta.dart';
+
+abstract final class DatabaseEncryptionKeyStore {
+  static const _key = 'databaseEncryptionKeyV1';
+
+  static Future<String> loadOrCreate({
+    required bool hasExistingDatabase,
+  }) async {
+    final storage = _openStorage();
+    final existing = await storage.read(key: _key);
+    if (existing != null) {
+      _validate(existing);
+      return existing;
+    }
+    ensureKeyCanBeCreated(hasExistingDatabase: hasExistingDatabase);
+
+    final random = Random.secure();
+    final generated = base64UrlEncode(
+      List<int>.generate(32, (_) => random.nextInt(256)),
+    );
+    await storage.write(key: _key, value: generated);
+    final persisted = await storage.read(key: _key);
+    if (persisted == null) {
+      throw StateError('Database encryption key was not persisted');
+    }
+    _validate(persisted);
+    return persisted;
+  }
+
+  static Future<String?> loadExisting() async {
+    final key = await _openStorage().read(key: _key);
+    if (key != null) _validate(key);
+    return key;
+  }
+
+  @visibleForTesting
+  static void ensureKeyCanBeCreated({required bool hasExistingDatabase}) {
+    if (hasExistingDatabase) {
+      throw StateError('Database encryption key is unavailable');
+    }
+  }
+
+  static FlutterSecureStorage _openStorage() => const FlutterSecureStorage(
+    aOptions: AndroidOptions(
+      resetOnError: false,
+      migrateOnAlgorithmChange: false,
+    ),
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
+
+  static void _validate(String key) {
+    if (base64Url.decode(base64Url.normalize(key)).length != 32) {
+      throw StateError('Invalid database encryption key');
+    }
+  }
+}

--- a/lib/core/storage/database_encryption_key_store.dart
+++ b/lib/core/storage/database_encryption_key_store.dart
@@ -1,47 +1,138 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
+import 'package:bb_mobile/core/storage/database_key_unavailable_exception.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:meta/meta.dart';
 
 abstract final class DatabaseEncryptionKeyStore {
   static const _key = 'databaseEncryptionKeyV1';
 
+  /// Reads the per-installation database key, creating one only when it
+  /// is safe to do so.
+  ///
+  /// Three outcomes, and keeping them apart is the whole point of this
+  /// method:
+  ///
+  /// - key present → return it;
+  /// - keychain temporarily locked → throw [KeychainLockedException]
+  ///   **before** the creation path is reachable, so a boot that
+  ///   happens before first unlock can never mint a replacement key
+  ///   over an existing encrypted database;
+  /// - key genuinely absent while a database exists → throw
+  ///   [DatabaseKeyUnavailableException] (fail closed).
+  ///
+  /// Only the third case is a permanent condition, and even then this
+  /// method never deletes anything — the user is asked first.
   static Future<String> loadOrCreate({
-    required bool hasExistingDatabase,
+    required bool hasDatabaseRequiringExistingKey,
   }) async {
     final storage = _openStorage();
-    final existing = await storage.read(key: _key);
+    final existing = await _read(storage);
     if (existing != null) {
       _validate(existing);
       return existing;
     }
-    ensureKeyCanBeCreated(hasExistingDatabase: hasExistingDatabase);
+    // Reached only when the keychain answered "no such item" — a locked
+    // keychain has already thrown above.
+    ensureKeyCanBeCreated(
+      hasDatabaseRequiringExistingKey: hasDatabaseRequiringExistingKey,
+    );
 
     final random = Random.secure();
     final generated = base64UrlEncode(
       List<int>.generate(32, (_) => random.nextInt(256)),
     );
-    await storage.write(key: _key, value: generated);
-    final persisted = await storage.read(key: _key);
+    await _guardKeychain(() => storage.write(key: _key, value: generated));
+    final persisted = await _read(storage);
     if (persisted == null) {
-      throw StateError('Database encryption key was not persisted');
+      throw const DatabaseKeyUnavailableException(
+        'database encryption key was not persisted',
+      );
     }
     _validate(persisted);
     return persisted;
   }
 
+  /// Read-only variant for callers that must never create a key — the
+  /// workmanager background isolate above all, which can run before the
+  /// user has ever unlocked the device.
+  ///
+  /// Returns null only for a genuinely absent key. A locked keychain
+  /// throws [KeychainLockedException] so the caller can retry later
+  /// instead of reading the absence as "no database yet".
   static Future<String?> loadExisting() async {
-    final key = await _openStorage().read(key: _key);
+    final key = await _read(_openStorage());
     if (key != null) _validate(key);
     return key;
   }
 
-  @visibleForTesting
-  static void ensureKeyCanBeCreated({required bool hasExistingDatabase}) {
-    if (hasExistingDatabase) {
-      throw StateError('Database encryption key is unavailable');
+  /// Drops the stored key so the next [loadOrCreate] mints a fresh one.
+  ///
+  /// Only ever called as part of an explicit, user-confirmed local-data
+  /// reset, and only *after* the encrypted databases it opens have been
+  /// deleted — dropping the key while the databases are still on disk
+  /// is exactly the unreadable-database state this whole area exists to
+  /// avoid. See `LocalDatabaseReset`.
+  static Future<void> delete() =>
+      _guardKeychain(() => _openStorage().delete(key: _key));
+
+  static Future<String?> _read(FlutterSecureStorage storage) =>
+      _guardKeychain(() => storage.read(key: _key));
+
+  /// Maps the iOS "device not unlocked since boot" `OSStatus` onto
+  /// [KeychainLockedException]. Every other [PlatformException] rethrows
+  /// unchanged: an unknown keychain failure is not something we want to
+  /// quietly interpret as either "locked" or "absent".
+  static Future<T> _guardKeychain<T>(Future<T> Function() body) async {
+    try {
+      return await body();
+    } on PlatformException catch (e) {
+      if (isKeychainLocked(e)) throw const KeychainLockedException();
+      rethrow;
     }
+  }
+
+  @visibleForTesting
+  static void ensureKeyCanBeCreated({
+    required bool hasDatabaseRequiringExistingKey,
+  }) {
+    if (hasDatabaseRequiringExistingKey) {
+      throw const DatabaseKeyUnavailableException(
+        'a database exists but its encryption key is gone',
+      );
+    }
+  }
+
+  /// Whether any existing database already needs the stored encryption
+  /// key to be opened.
+  ///
+  /// A plaintext SQLite database is the expected upgrade input and is
+  /// safe to pair with a newly-generated key: the storage layer will
+  /// immediately migrate it in place. An encrypted file (or a file with
+  /// an unknown/truncated header) is not safe to re-key, so it keeps the
+  /// fail-closed behavior.
+  static Future<bool> hasDatabaseRequiringExistingKey(
+    Iterable<File> databases,
+  ) async {
+    for (final database in databases) {
+      if (!await database.exists()) continue;
+      final handle = await database.open();
+      try {
+        final header = await handle.read(16);
+        if (header.length != 16 ||
+            utf8.decode(header, allowMalformed: true) !=
+                'SQLite format 3\u0000') {
+          return true;
+        }
+      } finally {
+        await handle.close();
+      }
+    }
+    return false;
   }
 
   static FlutterSecureStorage _openStorage() => const FlutterSecureStorage(
@@ -55,8 +146,18 @@ abstract final class DatabaseEncryptionKeyStore {
   );
 
   static void _validate(String key) {
-    if (base64Url.decode(base64Url.normalize(key)).length != 32) {
-      throw StateError('Invalid database encryption key');
+    final List<int> decoded;
+    try {
+      decoded = base64Url.decode(base64Url.normalize(key));
+    } on FormatException {
+      throw const DatabaseKeyUnavailableException(
+        'stored database encryption key is not valid base64url',
+      );
+    }
+    if (decoded.length != 32) {
+      throw const DatabaseKeyUnavailableException(
+        'stored database encryption key has the wrong length',
+      );
     }
   }
 }

--- a/lib/core/storage/database_key_unavailable_exception.dart
+++ b/lib/core/storage/database_key_unavailable_exception.dart
@@ -1,0 +1,35 @@
+/// Thrown when a local database file exists but its encryption key can
+/// not be obtained from secure storage, and the key's absence is
+/// *permanent* rather than temporary.
+///
+/// This is the fail-closed path: the databases on disk are encrypted
+/// with a key we no longer have, so there is nothing to read and
+/// generating a replacement key would only produce a second, equally
+/// unreadable database on top of the user's data.
+///
+/// Deliberately distinct from `KeychainLockedException`, which means
+/// "the key is very probably there, the device just hasn't been
+/// unlocked since boot". Conflating the two is what turns a five-second
+/// wait into a data wipe, so the two never share a catch clause:
+///
+/// - `KeychainLockedException` → wait, retry after unlock, change nothing.
+/// - [DatabaseKeyUnavailableException] → offer the user an explicit,
+///   confirmed local-data reset. Never reset without asking.
+///
+/// The realistic way to reach this on iOS is restoring an iCloud/iTunes
+/// backup onto a *different* device: the databases come back but the
+/// key, stored with `first_unlock_this_device`, does not. Excluding the
+/// databases from backup (see `BackupExclusion`) is what stops that
+/// combination from occurring in the first place; this exception is the
+/// safety net for every case it doesn't cover (Keychain reset, partial
+/// restore, an OS bug).
+class DatabaseKeyUnavailableException implements Exception {
+  /// Developer-facing detail. Logged, never rendered to the user — the
+  /// recovery screen shows a localized message instead.
+  final String reason;
+
+  const DatabaseKeyUnavailableException(this.reason);
+
+  @override
+  String toString() => 'DatabaseKeyUnavailableException: $reason';
+}

--- a/lib/core/storage/local_database_reset.dart
+++ b/lib/core/storage/local_database_reset.dart
@@ -1,0 +1,79 @@
+import 'dart:io' show File;
+
+import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
+import 'package:bb_mobile/core/utils/logger.dart' show log;
+import 'package:bb_mobile/core/utils/report.dart' show ReportCategory;
+import 'package:meta/meta.dart';
+
+/// Deletes the local databases and the key that opens them, so the next
+/// launch starts from an empty install.
+///
+/// This is the only escape from the fail-closed path: when a database
+/// exists whose encryption key is gone, nothing can read it and no
+/// amount of retrying will change that. It is destructive and
+/// unrecoverable without the user's own wallet backup, so it must never
+/// run on its own — only behind an explicit, confirmed user action (see
+/// `LocalDataRecoveryScreen`).
+///
+/// Deliberately *not* a wipe of secure storage: wallet seeds live there,
+/// and destroying them turns "your local cache is unreadable" into
+/// "your funds are gone". Orphaned seeds are re-associated when the user
+/// restores from their backup.
+abstract final class LocalDatabaseReset {
+  /// Suffixes of every file the storage layer can leave next to a
+  /// database. The last two are the crash-safe encryption migration's
+  /// scratch and rollback copies — a reset that left a
+  /// `.plaintext-backup` behind would resurrect the very database it
+  /// was asked to remove on the next launch's recovery pass.
+  static const _suffixes = [
+    '',
+    '-wal',
+    '-shm',
+    '.encryption-tmp',
+    '.plaintext-backup',
+  ];
+
+  /// Deletes [databasePaths] with all their sidecars, then the
+  /// encryption key.
+  ///
+  /// Order is load-bearing: the key goes last, and is deleted only if
+  /// every database file was removed. An interruption or deletion
+  /// failure therefore leaves the key available for any database that
+  /// remains rather than manufacturing a keyless encrypted database.
+  static Future<void> run(
+    Iterable<String> databasePaths, {
+    @visibleForTesting Future<void> Function(File file)? deleteFile,
+  }) async {
+    log.warning('Resetting local databases at the user request');
+
+    Object? firstFailure;
+    StackTrace? firstFailureTrace;
+
+    for (final path in databasePaths) {
+      for (final suffix in _suffixes) {
+        final file = File('$path$suffix');
+        try {
+          if (await file.exists()) {
+            await (deleteFile?.call(file) ?? file.delete());
+          }
+        } catch (e, s) {
+          // Try every file so one failure doesn't leave avoidable
+          // leftovers, but retain the key if any deletion failed.
+          firstFailure ??= e;
+          firstFailureTrace ??= s;
+          log.severe(
+            message: 'Could not delete local database file',
+            error: e,
+            trace: s,
+            category: ReportCategory.migration,
+          );
+        }
+      }
+    }
+
+    if (firstFailure != null) {
+      Error.throwWithStackTrace(firstFailure, firstFailureTrace!);
+    }
+    await DatabaseEncryptionKeyStore.delete();
+  }
+}

--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
@@ -30,6 +31,7 @@ import 'package:drift_flutter/drift_flutter.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
 
 part 'sqlite_database.g.dart';
 
@@ -58,7 +60,7 @@ part 'sqlite_database.g.dart';
 class SqliteDatabase extends _$SqliteDatabase {
   static const name = 'bullbitcoin_sqlite';
 
-  static Future<DriftIsolate> createIsolateWithSpawn() async {
+  static Future<DriftIsolate> createIsolateWithSpawn(String key) async {
     final token = RootIsolateToken.instance!;
     return await DriftIsolate.spawn(() {
       BackgroundIsolateBinaryMessenger.ensureInitialized(token);
@@ -69,6 +71,7 @@ class SqliteDatabase extends _$SqliteDatabase {
         return NativeDatabase(
           File(dbPath),
           setup: (database) {
+            _setupEncryptedConnection(database, key);
             // busy_timeout MUST be set FIRST so the subsequent
             // `journal_mode = WAL` switch retries (instead of
             // returning `database is locked, errno=261` —
@@ -96,8 +99,19 @@ class SqliteDatabase extends _$SqliteDatabase {
     });
   }
 
-  SqliteDatabase([QueryExecutor? executor])
-    : super(executor ?? _openConnection());
+  /// Takes an already-built [executor]. There is deliberately no constructor
+  /// that opens the on-disk database without a key, so no call site can end
+  /// up on a plaintext file.
+  SqliteDatabase(super.executor);
+
+  SqliteDatabase.encrypted(String key) : super(_openConnection(key));
+
+  static Future<SqliteDatabase> openEncrypted(String key) async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final databaseFile = File(p.join(dbFolder.path, '$name.sqlite'));
+    await _encryptExistingDatabase(databaseFile, key);
+    return SqliteDatabase.encrypted(key);
+  }
 
   /// Current drift schema version. Bump in lockstep with adding a new
   /// `Schema<N-1>To<N>.migrate` step in [migration] and regenerating the
@@ -107,7 +121,7 @@ class SqliteDatabase extends _$SqliteDatabase {
   @override
   int get schemaVersion => currentSchemaVersion;
 
-  static QueryExecutor _openConnection() {
+  static QueryExecutor _openConnection(String key) {
     return driftDatabase(
       name: name,
       native: DriftNativeOptions(
@@ -118,6 +132,8 @@ class SqliteDatabase extends _$SqliteDatabase {
         /// preventing "database is locked" errors due to concurrent transactions.
         shareAcrossIsolates: true,
         setup: (database) {
+          // Keying runs before every other statement on this connection.
+          _setupEncryptedConnection(database as sqlite.Database, key);
           // busy_timeout MUST be set FIRST so subsequent PRAGMA
           // writes that require an exclusive lock (notably
           // `journal_mode = WAL`) retry instead of returning
@@ -140,6 +156,143 @@ class SqliteDatabase extends _$SqliteDatabase {
       ),
     );
   }
+
+  static void _setupEncryptedConnection(sqlite.Database database, String key) {
+    if (database.select('PRAGMA cipher;').isEmpty) {
+      throw StateError('Encrypted SQLite binary is unavailable');
+    }
+    database.execute("PRAGMA key = '${_escape(key)}';");
+  }
+
+  static Future<void> _encryptExistingDatabase(
+    File databaseFile,
+    String key,
+  ) async {
+    final temporary = File('${databaseFile.path}.encryption-tmp');
+    final backup = File('${databaseFile.path}.plaintext-backup');
+    await _recoverEncryptionMigration(
+      databaseFile: databaseFile,
+      temporary: temporary,
+      backup: backup,
+      key: key,
+    );
+
+    if (!await databaseFile.exists() ||
+        !await _hasPlaintextSqliteHeader(databaseFile)) {
+      return;
+    }
+
+    final plaintext = sqlite.sqlite3.open(databaseFile.path);
+    try {
+      plaintext.execute('PRAGMA busy_timeout = 2000;');
+      plaintext.execute('PRAGMA wal_checkpoint(TRUNCATE);');
+      plaintext.execute("VACUUM INTO '${_escape(temporary.path)}';");
+    } finally {
+      plaintext.close();
+    }
+
+    final encrypted = sqlite.sqlite3.open(temporary.path);
+    try {
+      if (encrypted.select('PRAGMA cipher;').isEmpty) {
+        throw StateError('Encrypted SQLite binary is unavailable');
+      }
+      encrypted.execute("PRAGMA rekey = '${_escape(key)}';");
+    } finally {
+      encrypted.close();
+    }
+
+    await _verifyEncryptedDatabase(temporary, key);
+    for (final suffix in ['-wal', '-shm']) {
+      final sidecar = File('${databaseFile.path}$suffix');
+      if (await sidecar.exists()) await sidecar.delete();
+    }
+    await databaseFile.rename(backup.path);
+    try {
+      await temporary.rename(databaseFile.path);
+      await _verifyEncryptedDatabase(databaseFile, key);
+    } catch (_) {
+      if (await databaseFile.exists()) {
+        await databaseFile.delete();
+      }
+      if (await backup.exists()) {
+        await backup.rename(databaseFile.path);
+      }
+      rethrow;
+    }
+    await backup.delete();
+  }
+
+  static Future<void> _recoverEncryptionMigration({
+    required File databaseFile,
+    required File temporary,
+    required File backup,
+    required String key,
+  }) async {
+    final databaseExists = await databaseFile.exists();
+    final temporaryExists = await temporary.exists();
+    final backupExists = await backup.exists();
+
+    if (!backupExists) {
+      if (temporaryExists) {
+        if (!databaseExists) {
+          throw StateError('Incomplete database encryption migration');
+        }
+        await temporary.delete();
+      }
+      return;
+    }
+
+    if (databaseExists) {
+      if (await _hasPlaintextSqliteHeader(databaseFile)) {
+        throw StateError('Incomplete database encryption migration');
+      }
+      await _verifyEncryptedDatabase(databaseFile, key);
+      if (temporaryExists) await temporary.delete();
+      await backup.delete();
+      return;
+    }
+
+    if (temporaryExists) {
+      try {
+        await _verifyEncryptedDatabase(temporary, key);
+        await temporary.rename(databaseFile.path);
+        await _verifyEncryptedDatabase(databaseFile, key);
+        await backup.delete();
+        return;
+      } catch (_) {
+        if (await databaseFile.exists()) await databaseFile.delete();
+        if (await temporary.exists()) await temporary.delete();
+      }
+    }
+
+    await backup.rename(databaseFile.path);
+  }
+
+  static Future<void> _verifyEncryptedDatabase(File file, String key) async {
+    final database = sqlite.sqlite3.open(file.path);
+    try {
+      _setupEncryptedConnection(database, key);
+      final result = database.select('PRAGMA quick_check;');
+      if (result.length != 1 || result.single.values.single != 'ok') {
+        throw StateError('Encrypted database integrity check failed');
+      }
+    } finally {
+      database.close();
+    }
+  }
+
+  static Future<bool> _hasPlaintextSqliteHeader(File file) async {
+    final handle = await file.open();
+    try {
+      final header = await handle.read(16);
+      return utf8.decode(header, allowMalformed: true) ==
+          'SQLite format 3\u0000';
+    } finally {
+      await handle.close();
+    }
+  }
+
+  static String _escape(String value) => value.replaceAll("'", "''");
 
   @override
   MigrationStrategy get migration {

--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -109,7 +109,7 @@ class SqliteDatabase extends _$SqliteDatabase {
   static Future<SqliteDatabase> openEncrypted(String key) async {
     final dbFolder = await getApplicationDocumentsDirectory();
     final databaseFile = File(p.join(dbFolder.path, '$name.sqlite'));
-    await _encryptExistingDatabase(databaseFile, key);
+    await encryptExistingDatabase(databaseFile, key);
     return SqliteDatabase.encrypted(key);
   }
 
@@ -164,7 +164,11 @@ class SqliteDatabase extends _$SqliteDatabase {
     database.execute("PRAGMA key = '${_escape(key)}';");
   }
 
-  static Future<void> _encryptExistingDatabase(
+  /// Encrypts an existing plaintext SQLite database in place.
+  ///
+  /// Public so the Payjoin database follows the exact same crash-safe
+  /// migration before its encrypted connection is opened.
+  static Future<void> encryptExistingDatabase(
     File databaseFile,
     String key,
   ) async {

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -59,6 +59,7 @@ class AppLocator {
   static Future<void> setup(
     GetIt locator,
     SqliteDatabase database, {
+    required String databaseKey,
     String? payjoinDatabasePath,
     bool startPayjoinRecovery = true,
     bool startOrderSwapWatcher = true,
@@ -82,6 +83,7 @@ class AppLocator {
     PayjoinSetup.setup(
       locator,
       database,
+      databaseKey: databaseKey,
       databasePath: payjoinDatabasePath,
       startRecovery: startPayjoinRecovery,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,8 +6,14 @@ import 'package:bb_mobile/core/background_tasks/handler.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/screens/app_init_error_screen.dart';
+import 'package:bb_mobile/core/screens/local_data_recovery_screen.dart';
+import 'package:bb_mobile/core/screens/startup_keychain_locked_screen.dart';
+import 'package:bb_mobile/core/storage/backup_exclusion.dart';
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
+import 'package:bb_mobile/core/storage/database_key_unavailable_exception.dart';
+import 'package:bb_mobile/core/storage/local_database_reset.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
@@ -64,19 +70,43 @@ void resumePayjoinsOnAppResume(
 }
 
 class Bull {
+  /// Guards the process-wide, one-shot half of [init].
+  ///
+  /// [init] is re-entrant now: a boot that hits a locked keychain, or
+  /// one the user resolves by resetting local data, runs it again.
+  /// Everything below this flag installs a process-level singleton —
+  /// `SentryFlutter.init` re-registers the native crash handler,
+  /// `BullSdk.init` and `BitBoxApi.initialize` bind flutter_rust_bridge
+  /// — and running any of them twice is at best wasteful and at worst
+  /// corrupting. The locator setup below the flag *is* safe to redo,
+  /// because a retry only ever happens on a path that failed before
+  /// reaching it.
+  static bool _oneTimeInitDone = false;
+
+  /// Absolute paths of the local databases, sidecar suffixes excluded.
+  /// Cached at [initLocator] so the lifecycle sweep and the recovery
+  /// screen don't each have to re-derive them.
+  static List<String> _databasePaths = const [];
+
+  /// Empty until [initLocator] has run far enough to derive them.
+  static List<String> get databasePaths => _databasePaths;
+
   static Future<void> init({String? payjoinDatabasePath}) async {
-    await initLogs();
-    // The pre-init wizard writes consent to prefs via the bloc's
-    // `SavePendingWizardChoicesUsecase` right before this runs. Pull
-    // it so Sentry initializes with the user's freshest answer rather
-    // than a stale mirror, and so migration errors that happen on this
-    // very boot are captured if the user just opted in.
-    final preInitRepo = _buildPreInitWizardRepository();
-    final pending = await ReadPendingWizardChoicesUsecase(
-      repository: preInitRepo,
-    ).execute();
-    await Report.init(wizardConsent: pending?.reportingConsent);
-    await initFlutterRustBridgeDependencies();
+    if (!_oneTimeInitDone) {
+      await initLogs();
+      // The pre-init wizard writes consent to prefs via the bloc's
+      // `SavePendingWizardChoicesUsecase` right before this runs. Pull
+      // it so Sentry initializes with the user's freshest answer rather
+      // than a stale mirror, and so migration errors that happen on this
+      // very boot are captured if the user just opted in.
+      final preInitRepo = _buildPreInitWizardRepository();
+      final pending = await ReadPendingWizardChoicesUsecase(
+        repository: preInitRepo,
+      ).execute();
+      await Report.init(wizardConsent: pending?.reportingConsent);
+      await initFlutterRustBridgeDependencies();
+      _oneTimeInitDone = true;
+    }
     // The Locator setup might depend on the initialization of the libraries above
     //  so it's important to call it after the initialization
     await initLocator(payjoinDatabasePath: payjoinDatabasePath);
@@ -139,16 +169,23 @@ class Bull {
 
   static Future<void> initLocator({String? payjoinDatabasePath}) async {
     final databaseDirectory = await getApplicationDocumentsDirectory();
-    final hasExistingDatabase = await Future.wait([
-      File(
-        p.join(databaseDirectory.path, '${SqliteDatabase.name}.sqlite'),
-      ).exists(),
-      File(
-        payjoinDatabasePath ?? p.join(databaseDirectory.path, 'payjoin.sqlite'),
-      ).exists(),
-    ]).then((exists) => exists.any((value) => value));
+    _databasePaths = [
+      p.join(databaseDirectory.path, '${SqliteDatabase.name}.sqlite'),
+      payjoinDatabasePath ?? p.join(databaseDirectory.path, 'payjoin.sqlite'),
+    ];
+    final hasDatabaseRequiringExistingKey =
+        await DatabaseEncryptionKeyStore.hasDatabaseRequiringExistingKey(
+          _databasePaths.map(File.new),
+        );
     final databaseKey = await DatabaseEncryptionKeyStore.loadOrCreate(
-      hasExistingDatabase: hasExistingDatabase,
+      hasDatabaseRequiringExistingKey: hasDatabaseRequiringExistingKey,
+    );
+    // Payjoin existed as plaintext on source-built `develop` installs.
+    // Migrate it synchronously so startup does not report success while
+    // an unawaited recovery task is still changing its storage format.
+    await SqliteDatabase.encryptExistingDatabase(
+      File(_databasePaths[1]),
+      databaseKey,
     );
     await AppLocator.setup(
       locator,
@@ -156,8 +193,20 @@ class Bull {
       databaseKey: databaseKey,
       payjoinDatabasePath: payjoinDatabasePath,
     );
+    // First pass, so a fresh install is protected from the very first
+    // backup window. `payjoin.sqlite` is opened lazily by the payjoin
+    // runtime and the `-wal`/`-shm` sidecars only appear on first write,
+    // so this can't catch everything — `_excludeDatabasesFromBackup` runs
+    // again when the app goes to the background, which is the state a
+    // device is in when iCloud actually backs it up.
+    await excludeDatabasesFromBackup();
     Bloc.observer = AppBlocObserver();
   }
+
+  /// Re-marks the local databases as "do not back up". Cheap, idempotent
+  /// and a no-op off iOS.
+  static Future<void> excludeDatabasesFromBackup() =>
+      BackupExclusion.excludeDatabases(_databasePaths);
 
   static Future<void> initWorkmanager() async {
     await Workmanager().initialize(backgroundTasksHandler);
@@ -166,6 +215,58 @@ class Bull {
     // remove those persisted native tasks.
     await Workmanager().cancelAll();
   }
+}
+
+/// Runs `Bull.init` and puts on screen whichever of the four outcomes it
+/// produced.
+///
+/// Split out of [main] because two of those outcomes are recoverable and
+/// their screens call straight back into it: unlocking the device, or
+/// resetting local data, re-runs startup in place rather than asking the
+/// user to kill and relaunch the app.
+Future<void> startApp() async {
+  try {
+    await Bull.init();
+  } on KeychainLockedException catch (error) {
+    // Not an error: the device simply has not been unlocked since boot,
+    // so a `first_unlock_this_device` keychain item is unreadable. The
+    // data is intact and nothing must be created, deleted or migrated —
+    // the user just has to unlock. Logged at warning, never severe, so
+    // it doesn't drown the real failures in a shared log.
+    log.warning('App init deferred: $error');
+    await log.flush();
+    runApp(StartupKeychainLockedScreen(onRetry: startApp));
+    return;
+  } on DatabaseKeyUnavailableException catch (error, stackTrace) {
+    // Fail closed: a database exists that nothing can open. The generic
+    // error screen would leave the user with no action here, so this one
+    // offers the only real one — a confirmed local-data reset.
+    log.severe(
+      message: 'App init failed closed: local database key unavailable',
+      error: error,
+      trace: stackTrace,
+    );
+    await log.flush();
+    runApp(
+      LocalDataRecoveryScreen(
+        onReset: () => LocalDatabaseReset.run(Bull.databasePaths),
+        onRestart: startApp,
+        error: error,
+      ),
+    );
+    return;
+  } catch (error, stackTrace) {
+    log.severe(message: 'App Init Error', error: error, trace: stackTrace);
+    // Make sure the just-logged severe line is on disk before we
+    // render AppInitErrorScreen — the user typically shares logs
+    // from that screen to support, and the buffered severe write
+    // would otherwise still be pending in the IOSink.
+    await log.flush();
+    runApp(AppInitErrorScreen(error: error));
+    return;
+  }
+  await log.flush();
+  runApp(const BullBitcoinWalletApp());
 }
 
 Future main() async {
@@ -187,19 +288,13 @@ Future main() async {
           runApp(WizardApp(onDone: (_) => completer.complete()));
           await completer.future;
         }
-        await Bull.init();
       } catch (error, stackTrace) {
         log.severe(message: 'App Init Error', error: error, trace: stackTrace);
+        await log.flush();
         runApp(AppInitErrorScreen(error: error));
         return;
-      } finally {
-        // Make sure the just-logged severe line is on disk before we
-        // render AppInitErrorScreen — the user typically shares logs
-        // from that screen to support, and the buffered severe write
-        // would otherwise still be pending in the IOSink.
-        await log.flush();
       }
-      runApp(const BullBitcoinWalletApp());
+      await startApp();
     },
     (error, stackTrace) {
       // Use try-catch to prevent cascading crashes if logging itself fails
@@ -273,6 +368,14 @@ class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.paused) {
       log.flush();
+    }
+    if (state == AppLifecycleState.paused) {
+      // Backgrounding is the last moment we control before iOS may back
+      // the container up (backups run while the device is locked and
+      // charging, with the app not in the foreground). By now the
+      // lazily-opened payjoin database and the `-wal`/`-shm` sidecars
+      // exist, which the pass during `initLocator` could not assume.
+      unawaited(Bull.excludeDatabasesFromBackup());
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show Platform;
+import 'dart:io' show File, Platform;
 
 import 'package:bb_mobile/bloc_observer.dart';
 import 'package:bb_mobile/core/background_tasks/handler.dart';
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/screens/app_init_error_screen.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
@@ -37,6 +38,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show appFlavor;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
 import 'package:bull_tor/tor_adapter.dart' as tor;
 import 'package:workmanager/workmanager.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
@@ -136,9 +138,22 @@ class Bull {
   }
 
   static Future<void> initLocator({String? payjoinDatabasePath}) async {
+    final databaseDirectory = await getApplicationDocumentsDirectory();
+    final hasExistingDatabase = await Future.wait([
+      File(
+        p.join(databaseDirectory.path, '${SqliteDatabase.name}.sqlite'),
+      ).exists(),
+      File(
+        payjoinDatabasePath ?? p.join(databaseDirectory.path, 'payjoin.sqlite'),
+      ).exists(),
+    ]).then((exists) => exists.any((value) => value));
+    final databaseKey = await DatabaseEncryptionKeyStore.loadOrCreate(
+      hasExistingDatabase: hasExistingDatabase,
+    );
     await AppLocator.setup(
       locator,
-      SqliteDatabase(),
+      await SqliteDatabase.openEncrypted(databaseKey),
+      databaseKey: databaseKey,
       payjoinDatabasePath: payjoinDatabasePath,
     );
     Bloc.observer = AppBlocObserver();

--- a/lib/payjoin_setup.dart
+++ b/lib/payjoin_setup.dart
@@ -23,6 +23,7 @@ abstract final class PayjoinSetup {
   static void setup(
     GetIt locator,
     SqliteDatabase database, {
+    required String databaseKey,
     String? databasePath,
     bool startRecovery = true,
   }) {
@@ -35,6 +36,7 @@ abstract final class PayjoinSetup {
           );
       return openPayjoin(
         databasePath: path,
+        databaseKey: databaseKey,
         wallet: PayjoinWalletAdapter(
           locator<SeedDatasource>(),
           locator<BdkWalletDatasource>(),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -10,7 +10,6 @@
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <no_screenshot/no_screenshot_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -26,9 +25,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
   sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -7,7 +7,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
   no_screenshot
   sentry_flutter
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14672,5 +14672,57 @@
   "mnemonicShuffleKeyboardHint": "Scramble the keys and suggestions on every tap",
   "@mnemonicShuffleKeyboardHint": {
     "description": "Tooltip on the in-app keyboard toggle that turns on the privacy mode: the letter keys and word suggestions are randomised after each key press so their positions cannot be read by an onlooker"
+  },
+  "startupKeychainLockedTitle": "Unlock your device to continue",
+  "@startupKeychainLockedTitle": {
+    "description": "Title of the pre-init screen shown when the keychain is still locked after boot."
+  },
+  "startupKeychainLockedMessage": "Your local data is encrypted with a key that becomes available only after this device has been unlocked once since it started. Unlock the device, then try again.",
+  "@startupKeychainLockedMessage": {
+    "description": "Explanation on the keychain-locked startup screen."
+  },
+  "startupKeychainLockedRetryButton": "Try again",
+  "@startupKeychainLockedRetryButton": {
+    "description": "Retry button on the keychain-locked startup screen."
+  },
+  "localDataRecoveryTitle": "Local data cannot be opened",
+  "@localDataRecoveryTitle": {
+    "description": "Title of the screen shown when the local database exists but its encryption key is gone."
+  },
+  "localDataRecoveryMessage": "The data stored on this device is encrypted with a key that is no longer in the keychain, so it cannot be read. This usually happens after a backup was restored onto a different device.",
+  "@localDataRecoveryMessage": {
+    "description": "Explanation on the local-data recovery screen."
+  },
+  "localDataRecoveryRetryButton": "Try again",
+  "@localDataRecoveryRetryButton": {
+    "description": "Retry button on the local-data recovery screen."
+  },
+  "localDataRecoveryResetButton": "Reset local data",
+  "@localDataRecoveryResetButton": {
+    "description": "Destructive action on the local-data recovery screen."
+  },
+  "localDataRecoveryResetWarning": "Resetting deletes the data this app stores on this device: wallets, labels, transaction history and settings. Your bitcoin is not stored in the app, so you can restore your wallets from your backup afterwards. This cannot be undone.",
+  "@localDataRecoveryResetWarning": {
+    "description": "Warning shown above the reset action on the local-data recovery screen."
+  },
+  "localDataRecoveryResetConfirmTitle": "Reset local data?",
+  "@localDataRecoveryResetConfirmTitle": {
+    "description": "Title of the confirmation dialog for the local-data reset."
+  },
+  "localDataRecoveryResetConfirmMessage": "This permanently deletes the app data on this device. Make sure you have your wallet backup before continuing.",
+  "@localDataRecoveryResetConfirmMessage": {
+    "description": "Body of the confirmation dialog for the local-data reset."
+  },
+  "localDataRecoveryResetConfirmButton": "Reset",
+  "@localDataRecoveryResetConfirmButton": {
+    "description": "Confirm button of the local-data reset dialog."
+  },
+  "localDataRecoveryCancelButton": "Cancel",
+  "@localDataRecoveryCancelButton": {
+    "description": "Cancel button of the local-data reset dialog."
+  },
+  "localDataRecoveryResetFailedMessage": "Could not reset local data",
+  "@localDataRecoveryResetFailedMessage": {
+    "description": "Snackbar shown when the local-data reset itself fails."
   }
 }

--- a/packages/bull_payjoin/lib/src/data/payjoin_database.dart
+++ b/packages/bull_payjoin/lib/src/data/payjoin_database.dart
@@ -87,11 +87,21 @@ final class PayjoinDatabase extends _$PayjoinDatabase {
 
   PayjoinDatabase._(super.executor);
 
-  factory PayjoinDatabase.open(String path) {
+  /// The Payjoin database is always encrypted. There is deliberately no
+  /// unkeyed variant of this factory, so no call site — production or test —
+  /// can produce a plaintext file holding original PSBTs, proposals and
+  /// session metadata.
+  factory PayjoinDatabase.open(String path, {required String encryptionKey}) {
     return PayjoinDatabase._(
       NativeDatabase.createInBackground(
         File(path),
         setup: (database) {
+          // Keying runs first: it must precede every other pragma, query and
+          // schema migration issued on this connection.
+          if (database.select('PRAGMA cipher;').isEmpty) {
+            throw StateError('Encrypted SQLite binary is unavailable');
+          }
+          database.execute("PRAGMA key = '${_escape(encryptionKey)}';");
           database.execute('PRAGMA busy_timeout = 2000;');
           database.execute('PRAGMA journal_mode = WAL;');
           database.execute('PRAGMA synchronous = FULL;');
@@ -102,6 +112,8 @@ final class PayjoinDatabase extends _$PayjoinDatabase {
 
   factory PayjoinDatabase.forTesting(QueryExecutor executor) =
       PayjoinDatabase._;
+
+  static String _escape(String value) => value.replaceAll("'", "''");
 
   @override
   int get schemaVersion => schema;

--- a/packages/bull_payjoin/lib/src/engine/payjoin_runtime.dart
+++ b/packages/bull_payjoin/lib/src/engine/payjoin_runtime.dart
@@ -23,6 +23,9 @@ import 'package:synchronized/synchronized.dart';
 
 Future<Result<PayjoinLifecycle, PayjoinFailure>> openPayjoin({
   required String databasePath,
+
+  /// Payjoin storage is always encrypted; there is no unkeyed path.
+  required String databaseKey,
   required PayjoinWalletPort wallet,
   required PayjoinBlockchainPort blockchain,
   required PayjoinFeesPort fees,
@@ -36,7 +39,7 @@ Future<Result<PayjoinLifecycle, PayjoinFailure>> openPayjoin({
   // other's destination, and the order of `openPayjoin` calls would silently
   // decide where a session's failures are reported.
   final payjoinLog = logger.PayjoinLogger(log);
-  var database = await _tryOpenDatabase(databasePath, payjoinLog);
+  var database = await _tryOpenDatabase(databasePath, databaseKey, payjoinLog);
   if (database == null) {
     // Self-heal: a corrupt database file or a schema downgrade would
     // otherwise fail every open retry identically — and because
@@ -47,7 +50,11 @@ Future<Result<PayjoinLifecycle, PayjoinFailure>> openPayjoin({
     // created after that import are lost, but their funds are not: a
     // sender's counterparty still holds the original and can broadcast it,
     // and a receiver's sender owns their own fallback.
-    database = await _quarantineAndReopenDatabase(databasePath, payjoinLog);
+    database = await _quarantineAndReopenDatabase(
+      databasePath,
+      databaseKey,
+      payjoinLog,
+    );
     if (database == null) {
       return const Err(
         PayjoinMigrationFailure('Could not open or migrate Payjoin storage'),
@@ -101,10 +108,14 @@ Future<Result<PayjoinLifecycle, PayjoinFailure>> openPayjoin({
 
 Future<PayjoinDatabase?> _tryOpenDatabase(
   String databasePath,
+  String databaseKey,
   logger.PayjoinLogger payjoinLog,
 ) async {
   try {
-    final database = PayjoinDatabase.open(databasePath);
+    final database = PayjoinDatabase.open(
+      databasePath,
+      encryptionKey: databaseKey,
+    );
     // Force the lazy open NOW: drift spawns the background isolate, opens
     // the file and runs schema migrations on the first statement, so a
     // corrupt file or a schema downgrade surfaces here rather than
@@ -124,6 +135,7 @@ Future<PayjoinDatabase?> _tryOpenDatabase(
 
 Future<PayjoinDatabase?> _quarantineAndReopenDatabase(
   String databasePath,
+  String databaseKey,
   logger.PayjoinLogger payjoinLog,
 ) async {
   try {
@@ -157,7 +169,7 @@ Future<PayjoinDatabase?> _quarantineAndReopenDatabase(
       'sessions created after the legacy import were lost',
     ),
   );
-  return _tryOpenDatabase(databasePath, payjoinLog);
+  return _tryOpenDatabase(databasePath, databaseKey, payjoinLog);
 }
 
 final class _PayjoinLifecycle implements PayjoinLifecycle {

--- a/packages/bull_payjoin/pubspec.yaml
+++ b/packages/bull_payjoin/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
       path: packages/bull_sdk
   crypto: ^3.0.7
   dio: ^5.9.0
-  drift: ^2.29.0
+  drift: 2.34.0
   freezed_annotation: ^3.1.0
   meta: ^1.17.0
   payjoin:
@@ -25,14 +25,14 @@ dependencies:
       ref: 51da8ed79ee57536f4be223a01e6ecb163986f28
       path: payjoin-ffi/dart
   primitives:
-  sqlite3: ^2.9.4
   synchronized: ^3.4.0
 
 dev_dependencies:
   build_runner: ^2.7.1
-  drift_dev: ^2.29.0
+  drift_dev: 2.34.0
   fake_async: ^1.3.3
   freezed: ^3.2.3
   lints: ^6.0.0
   mocktail: ^1.0.4
+  sqlite3: ^3.5.1
   test: ^1.26.3

--- a/packages/bull_payjoin/test/payjoin_encrypted_storage_test.dart
+++ b/packages/bull_payjoin/test/payjoin_encrypted_storage_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bull_payjoin/src/data/payjoin_database.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:test/test.dart';
+
+/// `payjoin.sqlite` ships encrypted from its first byte: the package is
+/// unreleased, so there is no plaintext population to migrate and no unkeyed
+/// way to open it.
+void main() {
+  late Directory directory;
+  late File databaseFile;
+
+  const key = 'test-only-payjoin-key';
+  const marker = 'payjoin-original-psbt-marker';
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('payjoin-encrypted-');
+    databaseFile = File('${directory.path}/payjoin.sqlite');
+  });
+
+  tearDown(() => directory.delete(recursive: true));
+
+  Future<void> writeMarker() async {
+    final database = PayjoinDatabase.open(
+      databaseFile.path,
+      encryptionKey: key,
+    );
+    try {
+      await database.customStatement(
+        'CREATE TABLE encryption_probe (value TEXT NOT NULL);',
+      );
+      await database.customStatement(
+        "INSERT INTO encryption_probe VALUES ('$marker');",
+      );
+    } finally {
+      await database.close();
+    }
+  }
+
+  test('a freshly created Payjoin database is encrypted on disk', () async {
+    await writeMarker();
+
+    final contents = latin1.decode(await databaseFile.readAsBytes());
+    expect(contents, isNot(contains('SQLite format 3')));
+    expect(contents, isNot(contains(marker)));
+  });
+
+  test('the Payjoin database reopens with its key', () async {
+    await writeMarker();
+
+    final database = PayjoinDatabase.open(
+      databaseFile.path,
+      encryptionKey: key,
+    );
+    try {
+      final row =
+          (await database
+                  .customSelect('SELECT value FROM encryption_probe;')
+                  .get())
+              .single;
+      expect(row.data['value'], marker);
+    } finally {
+      await database.close();
+    }
+  });
+
+  test('the Payjoin database cannot be read without its key', () async {
+    await writeMarker();
+
+    final database = sqlite3.open(databaseFile.path);
+    try {
+      expect(
+        () => database.select('SELECT value FROM encryption_probe;'),
+        throwsA(isA<Exception>()),
+      );
+    } finally {
+      database.close();
+    }
+  });
+}

--- a/packages/bull_payjoin/test/payjoin_runtime_test.dart
+++ b/packages/bull_payjoin/test/payjoin_runtime_test.dart
@@ -115,6 +115,7 @@ void main() {
   Future<Result<PayjoinLifecycle, PayjoinFailure>> open({PayjoinLogPort? log}) {
     return openPayjoin(
       databasePath: '${directory.path}/payjoin.sqlite',
+      databaseKey: 'test-only-payjoin-key',
       wallet: _WalletPort(),
       blockchain: _BlockchainPort(),
       fees: _FeesPort(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -586,26 +586,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.3.1"
   extension_google_sign_in_as_googleapis_auth:
     dependency: "direct main"
     description:
@@ -1919,30 +1919,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
-  sqlite3:
+  sqlcipher_flutter_libs:
     dependency: transitive
     description:
-      name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "0.7.0+eol"
+  sqlite3:
+    dependency: "direct main"
+    description:
+      name: sqlite3
+      sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.1"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,11 @@ workspace:
   - packages/primitives
   - packages/bull_tor
 
+hooks:
+  user_defines:
+    sqlite3:
+      source: sqlite3mc
+
 dependencies:
   flutter:
     sdk: flutter
@@ -103,8 +108,9 @@ dependencies:
   webview_flutter_android: ^4.10.10
   webview_flutter_wkwebview: ^3.23.4
   async: ^2.11.0
-  drift: ^2.29.0
-  drift_flutter: ^0.2.7
+  drift: 2.34.0
+  drift_flutter: ^0.3.1
+  sqlite3: ^3.5.1
   package_info_plus: ^9.0.0
   share_plus: ^12.0.1
   bolt11_decoder:
@@ -157,7 +163,7 @@ dev_dependencies:
   path_provider_platform_interface: ^2.1.2
   test: ^1.26.3
   flutter_gen_runner: any
-  drift_dev: ^2.29.0
+  drift_dev: 2.34.0
   melos: ^7.8.1
 
 # Melos monorepo workspace. The Flutter app remains at the root

--- a/test/core_test/recoverbull/recoverbull_locator_test.dart
+++ b/test/core_test/recoverbull/recoverbull_locator_test.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_remote_d
 import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
 import 'package:bb_mobile/core/recoverbull/recoverbull_locator.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:bull_tor/tor.dart';
@@ -9,7 +10,9 @@ import 'package:bull_tor/tor.dart';
 void main() {
   test('registers synchronous RecoverBull dependencies without waiting', () {
     final locator = GetIt.asNewInstance()
-      ..registerLazySingleton<SqliteDatabase>(SqliteDatabase.new)
+      ..registerLazySingleton<SqliteDatabase>(
+        () => SqliteDatabase(NativeDatabase.memory()),
+      )
       ..registerLazySingleton<TorHttpClientFactory>(TorHttpClientFactory.new);
 
     RecoverbullLocator.registerDatasources(locator);

--- a/test/core_test/screens/local_data_recovery_screen_test.dart
+++ b/test/core_test/screens/local_data_recovery_screen_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io' show FileSystemException;
+
+import 'package:bb_mobile/core/screens/local_data_recovery_screen.dart';
+import 'package:bb_mobile/core/storage/database_key_unavailable_exception.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The gate in front of the only destructive action in the app that a
+/// user can reach without ever having unlocked it. What is being pinned
+/// here is not the layout — it is that nothing is deleted until the user
+/// has said yes twice, and that the free, non-destructive option is the
+/// one on offer first.
+void main() {
+  late List<String> actions;
+
+  setUp(() => actions = []);
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    Future<void> Function()? onReset,
+  }) async {
+    // The screen is a tall scrolling column; the default 800x600 test
+    // surface leaves the reset action below the fold and taps miss it.
+    await tester.binding.setSurfaceSize(const Size(1000, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      LocalDataRecoveryScreen(
+        onReset:
+            onReset ??
+            () async {
+              actions.add('reset');
+            },
+        onRestart: () async {
+          actions.add('restart');
+        },
+        error: const DatabaseKeyUnavailableException('test'),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('retrying does not reset anything', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    expect(actions, ['restart']);
+  });
+
+  testWidgets('asks for confirmation before resetting', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Reset local data'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Reset local data?'), findsOneWidget);
+    expect(actions, isEmpty);
+  });
+
+  testWidgets('cancelling the confirmation resets nothing', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Reset local data'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(actions, isEmpty);
+  });
+
+  testWidgets('confirming resets, then restarts', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Reset local data'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset'));
+    await tester.pumpAndSettle();
+
+    // Order matters: restarting before the reset finished would re-open
+    // the database we are in the middle of deleting.
+    expect(actions, ['reset', 'restart']);
+  });
+
+  testWidgets('a failed reset does not restart into the same wall', (
+    tester,
+  ) async {
+    await pumpScreen(
+      tester,
+      onReset: () async => throw const FileSystemException('file is locked'),
+    );
+
+    await tester.tap(find.text('Reset local data'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset'));
+    await tester.pumpAndSettle();
+
+    expect(actions, isEmpty);
+    expect(find.text('Could not reset local data'), findsOneWidget);
+
+    // The snackbar holds a static auto-dismiss timer that outlives the
+    // widget tree; leaving it pending fails the test's own invariants.
+    SnackBarUtils.dismiss();
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/core_test/storage/backup_exclusion_test.dart
+++ b/test/core_test/storage/backup_exclusion_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/storage/backup_exclusion.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+const _channel = MethodChannel('bullbitcoin.com/backup_exclusion');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late Directory directory;
+
+  setUp(() {
+    directory = Directory.systemTemp.createTempSync('backup_exclusion');
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(_channel, null);
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+  });
+
+  String touch(String name) {
+    final file = File(p.join(directory.path, name))..writeAsStringSync('x');
+    return file.path;
+  }
+
+  group('resolvePaths', () {
+    test('expands a database path into its existing sidecars', () {
+      final main = touch('bullbitcoin_sqlite.sqlite');
+      touch('bullbitcoin_sqlite.sqlite-wal');
+      touch('bullbitcoin_sqlite.sqlite-shm');
+
+      expect(BackupExclusion.resolvePaths([main]), [
+        main,
+        '$main-wal',
+        '$main-shm',
+      ]);
+    });
+
+    test('skips files that do not exist yet', () {
+      // The realistic first-launch shape: the main database is open but
+      // has not been written to, and the payjoin database is opened
+      // lazily. Handing a missing path to the native side would throw.
+      final main = touch('bullbitcoin_sqlite.sqlite');
+      final payjoin = p.join(directory.path, 'payjoin.sqlite');
+
+      expect(BackupExclusion.resolvePaths([main, payjoin]), [main]);
+    });
+
+    test('returns nothing when no database exists', () {
+      expect(
+        BackupExclusion.resolvePaths([p.join(directory.path, 'absent.sqlite')]),
+        isEmpty,
+      );
+    });
+  });
+
+  group('excludeDatabases', () {
+    test('does not touch the channel off iOS', () async {
+      // Android has no equivalent flag — `android:allowBackup` and the
+      // data-extraction rules cover it at the manifest level — so this
+      // must stay a silent no-op rather than a per-launch warning.
+      var invoked = false;
+      messenger.setMockMethodCallHandler(_channel, (call) async {
+        invoked = true;
+        return null;
+      });
+
+      await BackupExclusion.excludeDatabases([touch('a.sqlite')]);
+
+      expect(invoked, Platform.isIOS);
+    });
+
+    test('a failing channel never breaks startup', () async {
+      messenger.setMockMethodCallHandler(_channel, (call) async {
+        throw PlatformException(code: 'exclude-failed');
+      });
+
+      await expectLater(
+        BackupExclusion.excludeDatabases([touch('a.sqlite')]),
+        completes,
+      );
+    });
+  });
+}

--- a/test/core_test/storage/database_encryption_key_store_test.dart
+++ b/test/core_test/storage/database_encryption_key_store_test.dart
@@ -1,22 +1,281 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
 import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
+import 'package:bb_mobile/core/storage/database_key_unavailable_exception.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// The channel `flutter_secure_storage` talks over. Mocking it lets these
+/// tests drive the exact keychain answers an iOS device gives — "not
+/// unlocked since boot" versus "no such item" — which is the distinction
+/// the whole store exists to preserve.
+const _channel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+/// `errSecInteractionNotAllowed`, as the plugin surfaces it.
+PlatformException _lockedKeychain() =>
+    PlatformException(code: 'Unexpected security result code', details: -25308);
+
 void main() {
-  test('refuses to replace a missing key when a database exists', () {
-    expect(
-      () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
-        hasExistingDatabase: true,
-      ),
-      throwsA(isA<StateError>()),
-    );
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  /// Records every call so a test can assert on what was *not* done —
+  /// the security-relevant assertion here is almost always "no write".
+  late List<MethodCall> calls;
+
+  void mockKeychain({
+    String? storedValue,
+    bool locked = false,
+    bool captureWrites = true,
+  }) {
+    calls = [];
+    messenger.setMockMethodCallHandler(_channel, (call) async {
+      calls.add(call);
+      if (locked) throw _lockedKeychain();
+      switch (call.method) {
+        case 'read':
+          return storedValue;
+        case 'write':
+          if (captureWrites) storedValue = call.arguments['value'] as String;
+          return null;
+        case 'delete':
+          storedValue = null;
+          return null;
+      }
+      return null;
+    });
+  }
+
+  tearDown(() => messenger.setMockMethodCallHandler(_channel, null));
+
+  String validKey() => base64UrlEncode(List<int>.filled(32, 7));
+
+  group('loadOrCreate', () {
+    test('returns the stored key when there is one', () async {
+      final key = validKey();
+      mockKeychain(storedValue: key);
+
+      expect(
+        await DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        key,
+      );
+      expect(calls.map((c) => c.method), isNot(contains('write')));
+    });
+
+    test('creates a key for a fresh install', () async {
+      mockKeychain();
+
+      final key = await DatabaseEncryptionKeyStore.loadOrCreate(
+        hasDatabaseRequiringExistingKey: false,
+      );
+
+      expect(base64Url.decode(base64Url.normalize(key)), hasLength(32));
+      expect(calls.map((c) => c.method), contains('write'));
+    });
+
+    test('fails closed rather than re-keying an existing database', () async {
+      mockKeychain();
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        throwsA(isA<DatabaseKeyUnavailableException>()),
+      );
+      expect(calls.map((c) => c.method), isNot(contains('write')));
+    });
+
+    test('a locked keychain is not mistaken for a missing key, and writes '
+        'nothing even on a fresh install', () async {
+      // The dangerous case: the keychain refuses to answer *and* we
+      // believe there is no database yet (the databases could be there
+      // but unopened, or a background wake could beat the first
+      // unlock). Creating a key here is what silently orphans an
+      // existing encrypted database, so the read must throw before the
+      // creation path is ever reachable.
+      mockKeychain(locked: true);
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: false,
+        ),
+        throwsA(isA<KeychainLockedException>()),
+      );
+      expect(calls.map((c) => c.method), isNot(contains('write')));
+    });
+
+    test('a locked keychain throws even when a database exists', () async {
+      // Must be `KeychainLockedException`, not
+      // `DatabaseKeyUnavailableException`: the first sends the user to a
+      // retry screen, the second offers to delete their data.
+      mockKeychain(locked: true);
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        throwsA(isA<KeychainLockedException>()),
+      );
+    });
+
+    test('an unrelated keychain failure is not swallowed', () async {
+      calls = [];
+      messenger.setMockMethodCallHandler(_channel, (call) async {
+        throw PlatformException(code: 'some-other-failure');
+      });
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: false,
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'some-other-failure',
+          ),
+        ),
+      );
+    });
+
+    test('rejects a stored key of the wrong length', () async {
+      mockKeychain(storedValue: base64UrlEncode(List<int>.filled(16, 1)));
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        throwsA(isA<DatabaseKeyUnavailableException>()),
+      );
+    });
+
+    test('rejects a stored key that is not base64url', () async {
+      mockKeychain(storedValue: 'not base64!!');
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadOrCreate(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        throwsA(isA<DatabaseKeyUnavailableException>()),
+      );
+    });
   });
 
-  test('allows a key to be created for a new installation', () {
-    expect(
-      () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
-        hasExistingDatabase: false,
-      ),
-      returnsNormally,
-    );
+  group('loadExisting', () {
+    test('returns null for a genuinely absent key', () async {
+      mockKeychain();
+      expect(await DatabaseEncryptionKeyStore.loadExisting(), isNull);
+    });
+
+    test('throws rather than reporting a locked keychain as absent', () async {
+      // A background task reading null would conclude "no database yet"
+      // and carry on; it has to know to come back later instead.
+      mockKeychain(locked: true);
+
+      await expectLater(
+        DatabaseEncryptionKeyStore.loadExisting(),
+        throwsA(isA<KeychainLockedException>()),
+      );
+    });
+
+    test('never writes', () async {
+      mockKeychain();
+      await DatabaseEncryptionKeyStore.loadExisting();
+      expect(calls.map((c) => c.method), isNot(contains('write')));
+    });
+  });
+
+  group('ensureKeyCanBeCreated', () {
+    test('refuses to replace a missing key when a database exists', () {
+      expect(
+        () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
+          hasDatabaseRequiringExistingKey: true,
+        ),
+        throwsA(isA<DatabaseKeyUnavailableException>()),
+      );
+    });
+
+    test('allows a key to be created for a new installation', () {
+      expect(
+        () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
+          hasDatabaseRequiringExistingKey: false,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('hasDatabaseRequiringExistingKey', () {
+    late Directory directory;
+
+    setUp(() {
+      directory = Directory.systemTemp.createTempSync('database-key-policy');
+    });
+
+    tearDown(() {
+      directory.deleteSync(recursive: true);
+    });
+
+    File file(String name, List<int> bytes) =>
+        File('${directory.path}/$name')..writeAsBytesSync(bytes);
+
+    test('allows the first key to be created for plaintext upgrades', () async {
+      final main = file('bullbitcoin_sqlite.sqlite', [
+        ...utf8.encode('SQLite format 3\u0000'),
+        ...List<int>.filled(32, 0),
+      ]);
+      final payjoin = file('payjoin.sqlite', [
+        ...utf8.encode('SQLite format 3\u0000'),
+        ...List<int>.filled(32, 0),
+      ]);
+
+      expect(
+        await DatabaseEncryptionKeyStore.hasDatabaseRequiringExistingKey([
+          main,
+          payjoin,
+        ]),
+        isFalse,
+      );
+    });
+
+    test('requires the old key for an encrypted database', () async {
+      final encrypted = file(
+        'bullbitcoin_sqlite.sqlite',
+        List<int>.generate(48, (index) => index + 1),
+      );
+
+      expect(
+        await DatabaseEncryptionKeyStore.hasDatabaseRequiringExistingKey([
+          encrypted,
+        ]),
+        isTrue,
+      );
+    });
+
+    test('fails closed for a corrupt or truncated database', () async {
+      final corrupt = file('bullbitcoin_sqlite.sqlite', [1, 2, 3]);
+
+      expect(
+        await DatabaseEncryptionKeyStore.hasDatabaseRequiringExistingKey([
+          corrupt,
+        ]),
+        isTrue,
+      );
+    });
+
+    test('ignores database paths that do not exist', () async {
+      expect(
+        await DatabaseEncryptionKeyStore.hasDatabaseRequiringExistingKey([
+          File('${directory.path}/absent.sqlite'),
+        ]),
+        isFalse,
+      );
+    });
   });
 }

--- a/test/core_test/storage/database_encryption_key_store_test.dart
+++ b/test/core_test/storage/database_encryption_key_store_test.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/storage/database_encryption_key_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('refuses to replace a missing key when a database exists', () {
+    expect(
+      () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
+        hasExistingDatabase: true,
+      ),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('allows a key to be created for a new installation', () {
+    expect(
+      () => DatabaseEncryptionKeyStore.ensureKeyCanBeCreated(
+        hasExistingDatabase: false,
+      ),
+      returnsNormally,
+    );
+  });
+}

--- a/test/core_test/storage/keychain_locked_exception_test.dart
+++ b/test/core_test/storage/keychain_locked_exception_test.dart
@@ -1,0 +1,40 @@
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isKeychainLocked', () {
+    // The OSStatus has moved between fields across flutter_secure_storage
+    // releases, and every caller that gets this wrong degrades into
+    // "the key is gone" — which is the branch that offers to delete the
+    // user's data. So all three shapes are pinned here.
+    test('matches the status in `details`', () {
+      expect(
+        isKeychainLocked(PlatformException(code: 'x', details: -25308)),
+        isTrue,
+      );
+    });
+
+    test('matches the status in `code`', () {
+      expect(isKeychainLocked(PlatformException(code: '-25308')), isTrue);
+    });
+
+    test('matches the status embedded in `message`', () {
+      expect(
+        isKeychainLocked(
+          PlatformException(code: 'x', message: 'OSStatus -25308 returned'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not match an unrelated failure', () {
+      expect(
+        isKeychainLocked(
+          PlatformException(code: 'x', message: 'item not found', details: -1),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/core_test/storage/local_database_reset_test.dart
+++ b/test/core_test/storage/local_database_reset_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/storage/local_database_reset.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+const _keychain = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late Directory directory;
+  late List<MethodCall> keychainCalls;
+
+  setUp(() {
+    directory = Directory.systemTemp.createTempSync('local_database_reset');
+    keychainCalls = [];
+    messenger.setMockMethodCallHandler(_keychain, (call) async {
+      keychainCalls.add(call);
+      return null;
+    });
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(_keychain, null);
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+  });
+
+  File touch(String name) =>
+      File(p.join(directory.path, name))..writeAsStringSync('x');
+
+  test('removes every database file, sidecar and migration leftover', () async {
+    final main = p.join(directory.path, 'bullbitcoin_sqlite.sqlite');
+    final payjoin = p.join(directory.path, 'payjoin.sqlite');
+    final created = [
+      touch('bullbitcoin_sqlite.sqlite'),
+      touch('bullbitcoin_sqlite.sqlite-wal'),
+      touch('bullbitcoin_sqlite.sqlite-shm'),
+      // A crashed encryption migration leaves these behind. Missing them
+      // would resurrect the unreadable database on the next launch,
+      // because the recovery pass restores `.plaintext-backup`.
+      touch('bullbitcoin_sqlite.sqlite.encryption-tmp'),
+      touch('bullbitcoin_sqlite.sqlite.plaintext-backup'),
+      touch('payjoin.sqlite'),
+      touch('payjoin.sqlite-wal'),
+      touch('payjoin.sqlite-shm'),
+    ];
+
+    await LocalDatabaseReset.run([main, payjoin]);
+
+    for (final file in created) {
+      expect(file.existsSync(), isFalse, reason: file.path);
+    }
+  });
+
+  test('deletes the encryption key last, and only once', () async {
+    final main = p.join(directory.path, 'bullbitcoin_sqlite.sqlite');
+    touch('bullbitcoin_sqlite.sqlite');
+
+    await LocalDatabaseReset.run([main]);
+
+    expect(keychainCalls.map((c) => c.method), ['delete']);
+    expect(File(main).existsSync(), isFalse);
+  });
+
+  test('leaves unrelated files in the directory alone', () async {
+    final main = p.join(directory.path, 'bullbitcoin_sqlite.sqlite');
+    touch('bullbitcoin_sqlite.sqlite');
+    // Seeds and logs are not ours to delete: wiping secure storage here
+    // would turn "your local cache is unreadable" into "your funds are
+    // gone".
+    final logs = touch('bull_logs.tsv');
+
+    await LocalDatabaseReset.run([main]);
+
+    expect(logs.existsSync(), isTrue);
+  });
+
+  test(
+    'retains the encryption key when a database cannot be deleted',
+    () async {
+      final main = p.join(directory.path, 'bullbitcoin_sqlite.sqlite');
+      touch('bullbitcoin_sqlite.sqlite');
+
+      await expectLater(
+        LocalDatabaseReset.run([
+          main,
+        ], deleteFile: (_) async => throw const FileSystemException('locked')),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(keychainCalls, isEmpty);
+    },
+  );
+
+  test('is a no-op when there is nothing on disk', () async {
+    await LocalDatabaseReset.run([p.join(directory.path, 'absent.sqlite')]);
+    expect(keychainCalls.map((c) => c.method), ['delete']);
+  });
+}

--- a/test/experiments/sqlite_encryption_spike_test.dart
+++ b/test/experiments/sqlite_encryption_spike_test.dart
@@ -71,6 +71,43 @@ void main() {
     }
   });
 
+  test('shared migration encrypts a plaintext Payjoin database', () async {
+    final directory = await Directory.systemTemp.createTemp('payjoin-migrate-');
+    addTearDown(() => directory.delete(recursive: true));
+
+    final payjoin = File('${directory.path}/payjoin.sqlite');
+    const key = 'test-only-payjoin-key';
+    const marker = 'persisted-payjoin-session';
+
+    final plaintext = sqlite3.open(payjoin.path);
+    try {
+      plaintext.execute('CREATE TABLE sessions (payload TEXT NOT NULL);');
+      plaintext.execute("INSERT INTO sessions VALUES ('$marker');");
+    } finally {
+      plaintext.close();
+    }
+
+    await SqliteDatabase.encryptExistingDatabase(payjoin, key);
+
+    expect(
+      utf8.decode(
+        await payjoin.openRead(0, 16).fold(<int>[], (a, b) => a..addAll(b)),
+        allowMalformed: true,
+      ),
+      isNot('SQLite format 3\u0000'),
+    );
+    final encrypted = sqlite3.open(payjoin.path);
+    try {
+      encrypted.execute("PRAGMA key = '${_escape(key)}';");
+      expect(
+        encrypted.select('SELECT payload FROM sessions;').single['payload'],
+        marker,
+      );
+    } finally {
+      encrypted.close();
+    }
+  });
+
   test('drift_flutter applies the key in its database isolate', () async {
     TestWidgetsFlutterBinding.ensureInitialized();
     final directory = await Directory.systemTemp.createTemp('drift-spike-');

--- a/test/experiments/sqlite_encryption_spike_test.dart
+++ b/test/experiments/sqlite_encryption_spike_test.dart
@@ -1,0 +1,262 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:drift/isolate.dart';
+import 'package:drift/native.dart';
+import 'package:drift_flutter/drift_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  test('SQLite3MultipleCiphers encrypts a migrated WAL database', () async {
+    final directory = await Directory.systemTemp.createTemp('sqlite-spike-');
+    addTearDown(() => directory.delete(recursive: true));
+
+    final plaintext = File('${directory.path}/plaintext.sqlite');
+    final encrypted = File('${directory.path}/encrypted.sqlite');
+    final temporary = File('${encrypted.path}.tmp');
+    const key = 'test-only-database-key';
+    const marker = 'secret-swap-preimage-marker';
+
+    final plaintextDb = sqlite3.open(plaintext.path);
+    try {
+      _requireCipherSupport(plaintextDb);
+      plaintextDb.execute('PRAGMA journal_mode = WAL;');
+      plaintextDb.execute('CREATE TABLE swaps (preimage TEXT NOT NULL);');
+      plaintextDb.execute("INSERT INTO swaps VALUES ('$marker');");
+      plaintextDb.execute('PRAGMA wal_checkpoint(TRUNCATE);');
+      plaintextDb.execute("VACUUM INTO '${_escape(temporary.path)}';");
+    } finally {
+      plaintextDb.close();
+    }
+
+    final copyDb = sqlite3.open(temporary.path);
+    try {
+      _requireCipherSupport(copyDb);
+      copyDb.execute("PRAGMA rekey = '${_escape(key)}';");
+    } finally {
+      copyDb.close();
+    }
+    await temporary.rename(encrypted.path);
+
+    final unkeyedDb = sqlite3.open(encrypted.path);
+    try {
+      expect(
+        () => unkeyedDb.select('SELECT preimage FROM swaps;'),
+        throwsA(isA<Exception>()),
+      );
+    } finally {
+      unkeyedDb.close();
+    }
+
+    final encryptedDb = sqlite3.open(encrypted.path);
+    try {
+      _requireCipherSupport(encryptedDb);
+      encryptedDb.execute("PRAGMA key = '${_escape(key)}';");
+      expect(
+        encryptedDb.select('SELECT preimage FROM swaps;').single['preimage'],
+        marker,
+      );
+      encryptedDb.execute('PRAGMA journal_mode = WAL;');
+      encryptedDb.execute("INSERT INTO swaps VALUES ('$marker-wal');");
+    } finally {
+      encryptedDb.close();
+    }
+
+    await _expectNoPlaintextMarker(encrypted, marker);
+    final wal = File('${encrypted.path}-wal');
+    if (await wal.exists()) {
+      await _expectNoPlaintextMarker(wal, marker);
+    }
+  });
+
+  test('drift_flutter applies the key in its database isolate', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final directory = await Directory.systemTemp.createTemp('drift-spike-');
+    addTearDown(() => directory.delete(recursive: true));
+
+    final databaseFile = File('${directory.path}/bullbitcoin_sqlite.sqlite');
+    const key = 'test-only-drift-key';
+
+    final database = SqliteDatabase(
+      driftDatabase(
+        name: 'encrypted-drift-spike',
+        native: DriftNativeOptions(
+          databasePath: () async => databaseFile.path,
+          tempDirectoryPath: () async => directory.path,
+          shareAcrossIsolates: true,
+          setup: (rawDb) {
+            final nativeDb = rawDb as Database;
+            _requireCipherSupport(nativeDb);
+            nativeDb.execute("PRAGMA key = '${_escape(key)}';");
+          },
+        ),
+      ),
+    );
+    try {
+      expect((await database.customSelect('SELECT 1;').get()).single.data, {
+        '1': 1,
+      });
+    } finally {
+      await database.close();
+    }
+
+    final encryptedDb = sqlite3.open(databaseFile.path);
+    try {
+      _requireCipherSupport(encryptedDb);
+      encryptedDb.execute("PRAGMA key = '${_escape(key)}';");
+      expect(
+        encryptedDb
+            .select("SELECT name FROM sqlite_master WHERE name = 'settings';")
+            .single['name'],
+        'settings',
+      );
+    } finally {
+      encryptedDb.close();
+    }
+    await _expectNoPlaintextMarker(databaseFile, 'SQLite format 3');
+  });
+
+  test(
+    'manually spawned Drift isolate applies the key before opening',
+    () async {
+      final directory = await Directory.systemTemp.createTemp('spawned-spike-');
+      addTearDown(() => directory.delete(recursive: true));
+
+      final databaseFile = File('${directory.path}/bullbitcoin_sqlite.sqlite');
+      const key = 'test-only-spawned-isolate-key';
+
+      final isolate = await DriftIsolate.spawn(() {
+        return NativeDatabase(
+          databaseFile,
+          setup: (rawDb) {
+            _requireCipherSupport(rawDb);
+            rawDb.execute("PRAGMA key = '${_escape(key)}';");
+          },
+        );
+      });
+      final database = SqliteDatabase(
+        await isolate.connect(singleClientMode: true),
+      );
+      try {
+        expect(await database.customSelect('SELECT 1;').get(), hasLength(1));
+      } finally {
+        await database.close();
+      }
+
+      final encryptedDb = sqlite3.open(databaseFile.path);
+      try {
+        _requireCipherSupport(encryptedDb);
+        encryptedDb.execute("PRAGMA key = '${_escape(key)}';");
+        expect(
+          encryptedDb
+              .select("SELECT name FROM sqlite_master WHERE name = 'settings';")
+              .single['name'],
+          'settings',
+        );
+      } finally {
+        encryptedDb.close();
+      }
+    },
+  );
+
+  test(
+    'migrates the current Drift schema and its data to encryption',
+    () async {
+      final directory = await Directory.systemTemp.createTemp('schema-spike-');
+      addTearDown(() => directory.delete(recursive: true));
+
+      final plaintext = File('${directory.path}/plaintext.sqlite');
+      final encrypted = File('${directory.path}/encrypted.sqlite');
+      const key = 'test-only-schema-key';
+      const marker = 'schema-data-survives-encryption';
+
+      final plaintextDb = SqliteDatabase(
+        NativeDatabase.createInBackground(
+          plaintext,
+          setup: (rawDb) {
+            rawDb.execute('PRAGMA journal_mode = WAL;');
+          },
+        ),
+      );
+      try {
+        await plaintextDb.customStatement(
+          'CREATE TABLE encryption_spike (value TEXT NOT NULL);',
+        );
+        await plaintextDb.customStatement(
+          "INSERT INTO encryption_spike VALUES ('$marker');",
+        );
+      } finally {
+        await plaintextDb.close();
+      }
+
+      await _encryptPlaintextDatabase(
+        plaintext: plaintext,
+        encrypted: encrypted,
+        key: key,
+      );
+
+      final encryptedDb = SqliteDatabase(
+        NativeDatabase.createInBackground(
+          encrypted,
+          setup: (rawDb) {
+            _requireCipherSupport(rawDb);
+            rawDb.execute("PRAGMA key = '${_escape(key)}';");
+          },
+        ),
+      );
+      try {
+        final row =
+            (await encryptedDb
+                    .customSelect('SELECT value FROM encryption_spike;')
+                    .get())
+                .single;
+        expect(row.data['value'], marker);
+      } finally {
+        await encryptedDb.close();
+      }
+      await _expectNoPlaintextMarker(encrypted, marker);
+    },
+  );
+}
+
+void _requireCipherSupport(Database database) {
+  if (database.select('PRAGMA cipher;').isEmpty) {
+    throw StateError(
+      'The sqlite3mc build hook did not load an encrypted SQLite',
+    );
+  }
+}
+
+Future<void> _expectNoPlaintextMarker(File file, String marker) async {
+  final contents = latin1.decode(await file.readAsBytes());
+  expect(contents, isNot(contains(marker)));
+  expect(contents, isNot(contains('SQLite format 3')));
+}
+
+Future<void> _encryptPlaintextDatabase({
+  required File plaintext,
+  required File encrypted,
+  required String key,
+}) async {
+  final temporary = File('${encrypted.path}.tmp');
+  final plaintextDb = sqlite3.open(plaintext.path);
+  try {
+    plaintextDb.execute('PRAGMA wal_checkpoint(TRUNCATE);');
+    plaintextDb.execute("VACUUM INTO '${_escape(temporary.path)}';");
+  } finally {
+    plaintextDb.close();
+  }
+
+  final copyDb = sqlite3.open(temporary.path);
+  try {
+    _requireCipherSupport(copyDb);
+    copyDb.execute("PRAGMA rekey = '${_escape(key)}';");
+  } finally {
+    copyDb.close();
+  }
+  await temporary.rename(encrypted.path);
+}
+
+String _escape(String value) => value.replaceAll("'", "''");


### PR DESCRIPTION
- Encrypt `bullbitcoin_sqlite.sqlite` with SQLite3MultipleCiphers, migrating existing plaintext installs.
- Create `payjoin.sqlite` encrypted from the start. The package is unreleased, so it carries no plaintext population and needs no file migration.
- Store one random per-installation database key in FSS10 and pass it to foreground and Workmanager database connections.
- Fail closed when a database exists but its secure-storage key is unavailable — never generate a replacement key over existing data.

## Design notes

- No API can open a local database unencrypted. `PayjoinDatabase.open` and `openPayjoin` take a non-nullable `required` key, and `SqliteDatabase` no longer exposes a constructor that opens the on-disk file without one. Tests exercise the same encrypted path as production.
- The main-database migration is crash-safe: WAL checkpoint, `VACUUM INTO`, `PRAGMA rekey`, verification, then atomic rename with backup, and a resumable recovery path on the next launch.
- This is a storage-engine change, not a Drift schema change: the schema version is untouched.

## Validation

- `make analyze`, `make unit-test`, `make format-check`, `make bull-ui-check`, `fvm dart fix --dry-run`
- Pixel 5 arm64 upgrade from plaintext `develop`: wallet, synchronized testnet transaction, and label remained available after migration and repeated forced restarts; both files stopped starting with `SQLite format 3`; no migration leftovers.

## Remaining work before this ships on iOS — @wired-pasteque

Not deferred: the first item is a data-loss regression introduced by this PR and blocks an iOS release.

1. **Backup and restore policy.** On iOS the databases live in `NSDocumentDirectory`, which is included in iCloud/iTunes backups, while the key is stored with `first_unlock_this_device` and is not restored onto another device. A restored install therefore holds an encrypted database with no key, and the fail-closed path stops the app from starting. Before this PR the restored database was plaintext and still readable. Proposed fix: exclude both databases from backup (`NSURLIsExcludedFromBackupKey`, or move them to Application Support). Note that seeds already use `first_unlock_this_device`, so wallets already do not survive a device restore — excluding the databases loses nothing that was previously recoverable.
2. **Local-data recovery screen.** The fail-closed path currently surfaces through the generic init error screen, which leaves the user with no action. It needs an explicit screen offering to reset local data.
3. **Keychain-locked startup validation.** Startup and background tasks must distinguish "keychain temporarily locked, retry later" from "key genuinely absent, fail closed", and must never create a replacement key in the first case.

Items 1–3 are implementable and unit-testable without an iOS device. Their final validation is not: it needs real hardware for a backup-and-restore cycle onto a second device, a background task firing before first unlock, and a Keychain reset. An iOS simulator cannot reproduce any of these.

## iOS test request

Install the debug build over a plaintext `develop` install holding a **non-sensitive testnet wallet only**, then confirm:

1. The app opens after upgrade and after a forced restart.
2. Wallets, labels, transactions, settings, and Payjoin data remain available.
3. Both files in `app_flutter/` no longer begin with `SQLite format 3`.
