### PR TITLE
feat(recoverbull): isolate key-server Tor sessions

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,13 +9,13 @@ This diagram shows the dependencies between features in the Bull Bitcoin Mobile 
 ```mermaid
 graph TB
     %% Core infrastructure
-    CORE[Core<br/>---<br/>Database, Secure Storage,<br/>API Clients, Tor HTTP Client, UI Kit,<br/>DI & Router setup,<br/>PIN encrypted storage,<br/>Domain Primitives/Value Objects]
+    CORE[Core<br/>---<br/>Database, Secure Storage,<br/>API Clients, Tor Adapters, UI Kit,<br/>DI & Router setup,<br/>PIN encrypted storage,<br/>Domain Primitives/Value Objects]
     PRIMITIVES[Primitives Package]
     BULL_PAYJOIN[Bull Payjoin Package<br/>Public contract]
 
     %% Feature modules
     SETTINGS[Settings]
-    TOR[Tor]
+    TOR[Tor<br/>Workspace Package]
     PIN_CODE[Pin Code]
     LABELS[Labels]
     SECRETS[Secrets]
@@ -66,6 +66,8 @@ graph TB
     ANNOUNCEMENTS --> SWAPS
     APP_STARTUP --> WALLETS
     AUTOSWAP --> SWAPS
+    APP_STARTUP --> TOR
+    AUTOSWAPS --> TRANSFER
     BIP85 --> SECRETS
     BIP85 --> SETTINGS
     BACKUPS --> BIP85
@@ -108,11 +110,12 @@ graph TB
     SETTINGS --> CORE
     SETTINGS --> BULL_PAYJOIN
     STATUS --> BULL_PAYJOIN
+    STATUS --> TOR
     SWAPS --> BULL_PAYJOIN
     SWAPS --> EXCHANGE
     SWAPS --> LABELS
     SWAPS --> UTXO_MGMT
-    TOR --> CORE
+    CORE --> TOR
     TRANSFER --> CONSOLIDATION
     TRANSFER --> SEND
     TRANSFER --> RECEIVE
@@ -136,7 +139,8 @@ graph TB
     classDef featureStyle fill:#1a202c,stroke:#2d3748,stroke-width:2px,color:#e2e8f0
 
     class CORE coreStyle
-    class PRIMITIVES,BULL_PAYJOIN packageStyle
+    class PRIMITIVES,BULL_PAYJOIN,TOR packageStyle
+    class SETTINGS,PIN_CODE,LABELS,SECRETS,HW_WALLETS,BTC_PRICE,NETWORK,BIP85,FEES,WALLETS,EXCHANGE,APP_STARTUP,UTXO_MGMT,ADDRESS_MGMT,RECIPIENTS,FUNDING,BACKUPS,SWAPS,WITHDRAWAL,STATUS,SEND,RECEIVE,TRANSFER,TX_HISTORY,BG_TASKS,AUTOSWAPS,DCA,SELL,PAY,BUY,COINS,ANNOUNCEMENTS,CONSOLIDATION,ALL_SEED_VIEW,APP_UNLOCK featureStyle
 ```
 
 ## About Package Dependency Diagrams
@@ -175,7 +179,8 @@ graph TB
    - Database (Drift/SQLite)
    - Secure Storage instance (Flutter Secure Storage)
    - API Clients (REST/GraphQL clients)
-   - Factory for a HTTP client to connect to Tor
+   - Embedded Onion adapter with isolated RecoverBull and Bitcoin Electrum `.onion` sessions
+   - Explicit Orbot SOCKS override for Bitcoin Electrum `.onion` servers
    - UI Kit (shared widgets, theme)
    - DI setup and interfaces (Service Locator pattern)
    - Router setup and interfaces (Navigation)
@@ -194,6 +199,7 @@ graph TB
 ### Central Features (Highly Depended Upon)
 
 - **Core**: Foundation for all features
+- **Tor**: `packages/tor` — embedded Onion lifecycle with isolated RecoverBull and Bitcoin Electrum `.onion` sessions, plus external SOCKS verification for the explicit Electrum Orbot override. Depends on Flutter: it owns a platform plugin and app-directory storage, which is the infrastructure-package exception in AGENTS.md
 - **Wallets**: Used by Send, UTXO Management, Transaction History, Backups, App Startup
 - **Secrets**: Used by Wallets, BIP85
 - **Settings**: Used by Wallets, Exchange, BIP85, Bitcoin Price

--- a/integration_test/recoverbull_test.dart
+++ b/integration_test/recoverbull_test.dart
@@ -7,7 +7,6 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/utils/recoverbull_bip85.dart';
@@ -18,12 +17,13 @@ import 'package:bb_mobile/main.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_tor/tor.dart';
 
 Future<void> main({bool isInitialized = false}) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   if (!isInitialized) await Bull.init();
 
-  final initializeTorUsecase = locator<InitTorUsecase>();
+  final ensureTorReadyUsecase = locator<EnsureTorReadyUsecase>();
   final restoreVaultUsecase = locator<RestoreVaultUsecase>();
   final decryptVaultUsecase = locator<DecryptVaultUsecase>();
   final fetchVaultKeyFromServerUsecase =
@@ -65,7 +65,10 @@ Future<void> main({bool isInitialized = false}) async {
     Network.bitcoinMainnet,
   );
 
-  setUpAll(() async => await initializeTorUsecase.execute());
+  setUpAll(() async {
+    final state = await ensureTorReadyUsecase.execute();
+    expect(state, isA<TorReady>());
+  });
 
   group('Recoverbull', () {
     // Fetches the vault key over Tor from the RecoverBull key server. Tor can

--- a/lib/core/core_locator.dart
+++ b/lib/core/core_locator.dart
@@ -14,7 +14,9 @@ import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/storage/storage_locator.dart';
 import 'package:bb_mobile/core/swaps/swaps_locator.dart';
 import 'package:bb_mobile/core/tor/tor_locator.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/wallet_locator.dart';
+import 'package:bull_tor/tor_adapter.dart' as bull_tor;
 import 'package:get_it/get_it.dart';
 
 class CoreLocator {
@@ -23,13 +25,21 @@ class CoreLocator {
   }
 
   static Future<void> registerDatasources(GetIt locator) async {
+    await bull_tor.TorLocator.registerDatasources(
+      locator,
+      logger: bull_tor.TorLogger(
+        configCallback: log.config,
+        fineCallback: log.fine,
+        warningCallback: log.warning,
+      ),
+    );
     await TorLocator.registerDatasources(locator);
     BlockchainLocator.registerDatasources(locator);
     await ElectrumLocator.registerDatasources(locator);
     ExchangeLocator.registerDatasources(locator);
     FeesLocator.registerDatasources(locator);
     await MempoolLocator.registerDatasources(locator);
-    await RecoverbullLocator.registerDatasources(locator);
+    RecoverbullLocator.registerDatasources(locator);
     await StorageLocator.registerDatasources(locator);
     SeedLocator.registerDatasources(locator);
     await SwapsLocator.registerDatasources(locator);
@@ -47,6 +57,7 @@ class CoreLocator {
   }
 
   static Future<void> registerRepositories(GetIt locator) async {
+    bull_tor.TorLocator.registerRepositories(locator);
     await TorLocator.registerRepositories(locator);
     BlockchainLocator.registerRepositories(locator);
     ElectrumLocator.registerRepositories(locator);
@@ -55,7 +66,7 @@ class CoreLocator {
     MempoolLocator.registerRepositories(locator);
     await SettingsLocator.registerRepositories(locator);
     SeedLocator.registerRepositories(locator);
-    await RecoverbullLocator.registerRepositories(locator);
+    RecoverbullLocator.registerRepositories(locator);
     SwapsLocator.registerRepositories(locator);
     WalletLocator.registerRepositories(locator);
     Bip85DerivationsLocator.registerRepositories(locator);
@@ -70,6 +81,7 @@ class CoreLocator {
   }
 
   static void registerUsecases(GetIt locator) {
+    bull_tor.TorLocator.registerUsecases(locator);
     LabelsLocator.registerUseCases(locator);
     ElectrumLocator.registerUsecases(locator);
     BlockchainLocator.registerUsecases(locator);

--- a/lib/core/recoverbull/data/datasources/recoverbull_remote_datasource.dart
+++ b/lib/core/recoverbull/data/datasources/recoverbull_remote_datasource.dart
@@ -1,21 +1,19 @@
 import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_settings_datasource.dart';
-import 'package:bb_mobile/core/tor/data/datasources/tor_datasource.dart';
-import 'package:bb_mobile/core/tor/domain/value_objects/tor_proxy_config.dart';
-import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:recoverbull/recoverbull.dart';
+import 'package:bull_tor/tor.dart';
 
 class RecoverBullRemoteDatasource {
   final RecoverbullSettingsDatasource _recoverbullSettingsDatasource;
-  final TorDatasource _torDatasource;
+  final TorHttpClientFactory _torHttpClientFactory;
 
   RecoverBullRemoteDatasource({
     required this._recoverbullSettingsDatasource,
-    required this._torDatasource,
+    required this._torHttpClientFactory,
   });
 
-  Future<void> info({TorProxyConfig? externalProxy}) async {
-    final client = _torDatasource.httpClient(externalProxy: externalProxy);
+  Future<void> info(TorProxyEndpoint endpoint) async {
+    final client = _torHttpClientFactory.create(endpoint);
     final url = await _recoverbullSettingsDatasource.fetch();
     try {
       final info = await KeyServer(address: url, client: client).infos();
@@ -23,6 +21,8 @@ class RecoverBullRemoteDatasource {
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
       rethrow;
+    } finally {
+      client.close(force: true);
     }
   }
 
@@ -31,10 +31,10 @@ class RecoverBullRemoteDatasource {
     List<int> password,
     List<int> salt,
     List<int> backupKey, {
-    TorProxyConfig? externalProxy,
+    required TorProxyEndpoint endpoint,
   }) async {
+    final client = _torHttpClientFactory.create(endpoint);
     try {
-      final client = _torDatasource.httpClient(externalProxy: externalProxy);
       final url = await _recoverbullSettingsDatasource.fetch();
       await KeyServer(address: url, client: client).storeBackupKey(
         backupId: backupId,
@@ -49,6 +49,8 @@ class RecoverBullRemoteDatasource {
         trace: StackTrace.current,
       );
       rethrow;
+    } finally {
+      client.close(force: true);
     }
   }
 
@@ -56,10 +58,10 @@ class RecoverBullRemoteDatasource {
     List<int> backupId,
     List<int> password,
     List<int> salt, {
-    TorProxyConfig? externalProxy,
+    required TorProxyEndpoint endpoint,
   }) async {
+    final client = _torHttpClientFactory.create(endpoint);
     try {
-      final client = _torDatasource.httpClient(externalProxy: externalProxy);
       final url = await _recoverbullSettingsDatasource.fetch();
       return await KeyServer(
         address: url,
@@ -72,6 +74,8 @@ class RecoverBullRemoteDatasource {
         trace: StackTrace.current,
       );
       rethrow;
+    } finally {
+      client.close(force: true);
     }
   }
 
@@ -79,10 +83,10 @@ class RecoverBullRemoteDatasource {
     List<int> backupId,
     List<int> password,
     List<int> salt, {
-    TorProxyConfig? externalProxy,
+    required TorProxyEndpoint endpoint,
   }) async {
+    final client = _torHttpClientFactory.create(endpoint);
     try {
-      final client = _torDatasource.httpClient(externalProxy: externalProxy);
       final url = await _recoverbullSettingsDatasource.fetch();
       await KeyServer(
         address: url,
@@ -95,16 +99,14 @@ class RecoverBullRemoteDatasource {
         trace: StackTrace.current,
       );
       rethrow;
+    } finally {
+      client.close(force: true);
     }
   }
 
-  Future<void> checkConnection({TorProxyConfig? externalProxy}) async {
+  Future<void> checkConnection(TorProxyEndpoint endpoint) async {
+    final client = _torHttpClientFactory.create(endpoint);
     try {
-      if (externalProxy == null) {
-        await _waitForInternalTor();
-      }
-
-      final client = _torDatasource.httpClient(externalProxy: externalProxy);
       final url = await _recoverbullSettingsDatasource.fetch();
       await KeyServer(address: url, client: client).infos();
     } catch (e) {
@@ -114,19 +116,8 @@ class RecoverBullRemoteDatasource {
         trace: StackTrace.current,
       );
       rethrow;
-    }
-  }
-
-  Future<void> _waitForInternalTor() async {
-    const maxWaitTime = Duration(minutes: 2);
-    final startTime = DateTime.now();
-
-    while (_torDatasource.status == TorStatus.connecting) {
-      if (DateTime.now().difference(startTime) > maxWaitTime) {
-        throw Exception('Timeout waiting for Tor to be ready');
-      }
-      log.info('Waiting for Tor to be ready...');
-      await Future.delayed(const Duration(seconds: 3));
+    } finally {
+      client.close(force: true);
     }
   }
 }

--- a/lib/core/recoverbull/data/repository/recoverbull_repository.dart
+++ b/lib/core/recoverbull/data/repository/recoverbull_repository.dart
@@ -6,11 +6,11 @@ import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_settings
 import 'package:bb_mobile/core/recoverbull/domain/entity/decrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/encrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:convert/convert.dart' as convert;
 import 'package:recoverbull/recoverbull.dart' as recoverbull;
+import 'package:bull_tor/tor.dart';
 
 /// Data boundary for the RecoverBull key server and vault crypto. Catches the
 /// foreign exceptions the datasources/SDK throw, logs the raw reason, and
@@ -18,12 +18,10 @@ import 'package:recoverbull/recoverbull.dart' as recoverbull;
 class RecoverBullRepository {
   final RecoverBullRemoteDatasource remoteDatasource;
   final RecoverbullSettingsDatasource recoverbullSettingsDatasource;
-  final TorConfigPort torConfigPort;
 
   RecoverBullRepository({
     required this.remoteDatasource,
     required this.recoverbullSettingsDatasource,
-    required this.torConfigPort,
   });
 
   /// Builds an encrypted vault file for [plaintext] under [vaultKey] and stamps
@@ -85,15 +83,15 @@ class RecoverBullRepository {
     String password,
     String salt,
     String vaultKey,
+    TorProxyEndpoint endpoint,
   ) async {
     try {
-      final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
       await remoteDatasource.store(
         convert.hex.decode(_normalizeHex(identifier)),
         utf8.encode(password),
         convert.hex.decode(_normalizeHex(salt)),
         convert.hex.decode(_normalizeHex(vaultKey)),
-        externalProxy: externalProxy,
+        endpoint: endpoint,
       );
       return const Ok(null);
     } on recoverbull.KeyServerException catch (e, st) {
@@ -119,14 +117,14 @@ class RecoverBullRepository {
     String identifier,
     String password,
     String salt,
+    TorProxyEndpoint endpoint,
   ) async {
     try {
-      final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
       final vaultKey = await remoteDatasource.fetch(
         convert.hex.decode(_normalizeHex(identifier)),
         utf8.encode(password),
         convert.hex.decode(_normalizeHex(salt)),
-        externalProxy: externalProxy,
+        endpoint: endpoint,
       );
       return Ok(convert.hex.encode(vaultKey));
     } on recoverbull.KeyServerException catch (e, st) {
@@ -152,13 +150,13 @@ class RecoverBullRepository {
     String identifier,
     String password,
     String salt,
+    TorProxyEndpoint endpoint,
   ) async {
-    final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
     await remoteDatasource.trash(
       convert.hex.decode(_normalizeHex(identifier)),
       utf8.encode(password),
       convert.hex.decode(_normalizeHex(salt)),
-      externalProxy: externalProxy,
+      endpoint: endpoint,
     );
   }
 
@@ -166,9 +164,8 @@ class RecoverBullRepository {
   /// otherwise. Kept throwing (not Result) on purpose so the shared status
   /// checker — `CheckServerConnectionUsecase`, which turns the throw/return
   /// into the bool — is unaffected by the Result migration.
-  Future<void> checkConnection() async {
-    final externalProxy = await torConfigPort.getAvailableExternalTorConfig();
-    await remoteDatasource.checkConnection(externalProxy: externalProxy);
+  Future<void> checkConnection(TorProxyEndpoint endpoint) async {
+    await remoteDatasource.checkConnection(endpoint);
   }
 
   Future<Uri> fetchUrl() async {

--- a/lib/core/recoverbull/domain/recoverbull_tor_route.dart
+++ b/lib/core/recoverbull/domain/recoverbull_tor_route.dart
@@ -1,0 +1,19 @@
+import 'package:bull_tor/tor.dart';
+
+/// The SOCKS route one key-server call travels through.
+///
+/// Deliberately not a [TorSession]: that type carries a [TorTransport], which
+/// only describes how *embedded* Tor reached the network. An external proxy such
+/// as Orbot has no transport we know of, and inventing one would be a lie the
+/// UI could read back. Mirrors `ElectrumTorRoute`, which draws the same line for
+/// the same reason.
+final class RecoverBullTorRoute {
+  final TorProxyEndpoint endpoint;
+  final Future<void> Function() _onClose;
+  Future<void>? _closing;
+
+  RecoverBullTorRoute(this.endpoint, this._onClose);
+
+  /// Idempotent: callers close in a `finally`, and a retry path may close twice.
+  Future<void> close() => _closing ??= _onClose();
+}

--- a/lib/core/recoverbull/domain/usecases/check_server_connection_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/check_server_connection_usecase.dart
@@ -1,15 +1,47 @@
 import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 
 class CheckServerConnectionUsecase {
   final RecoverBullRepository _recoverBullRepository;
+  final EnsureRecoverBullTorSessionUsecase _ensureTorSessionUsecase;
 
-  CheckServerConnectionUsecase({required this._recoverBullRepository});
+  CheckServerConnectionUsecase(
+    this._recoverBullRepository,
+    this._ensureTorSessionUsecase,
+  );
 
+  /// `false` rather than a failure: this only answers "is the server
+  /// reachable right now", and every caller retries on its own schedule.
+  ///
+  /// Every `await` stays inside the `try`. Returning the repository call as a
+  /// future instead would chain it *outside* this block — an `async` function
+  /// completes a returned future after leaving the `try`, so the throw would
+  /// escape to the caller rather than become `false`.
   Future<bool> execute() async {
     try {
-      await _recoverBullRepository.checkConnection();
-      return true;
-    } catch (e) {
+      final result = await _ensureTorSessionUsecase.execute();
+      if (result case Ok(:final value)) {
+        try {
+          await _recoverBullRepository.checkConnection(value.endpoint);
+          return true;
+        } finally {
+          // Without this the outer catch would turn a *successful* check into
+          // `false` just because tearing the session down failed.
+          try {
+            await value.close();
+          } catch (e, st) {
+            log.warning(
+              'closing the RecoverBull Tor session failed',
+              error: e,
+              trace: st,
+            );
+          }
+        }
+      }
+      return false;
+    } catch (_) {
       return false;
     }
   }

--- a/lib/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_tor_route.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bull_tor/tor.dart';
+
+/// Opens the route RecoverBull reaches the key server through, behind its own
+/// failure boundary.
+///
+/// The external proxy wins when the user enabled it. That is not only what the
+/// app promised before embedded Tor existed — it is the only thing that works
+/// for an Orbot user: Orbot's "Full Device VPN" mode puts every socket this app
+/// opens inside its own Tor tunnel, and embedded Tor cannot bootstrap through
+/// another Tor. Measured on a Pixel 5: 51s to ready without the VPN, versus
+/// stuck at 8% and then a Snowflake attempt that never completed with it.
+/// Loopback is the way out — a connection to 127.0.0.1 does not traverse the tun
+/// interface, so the proxy hop stays local and only Orbot's Tor carries the
+/// traffic. One circuit instead of two nested ones.
+class EnsureRecoverBullTorSessionUsecase {
+  final EmbeddedTor _embeddedTor;
+  final SettingsRepository _settingsRepository;
+
+  const EnsureRecoverBullTorSessionUsecase(
+    this._embeddedTor,
+    this._settingsRepository,
+  );
+
+  Future<Result<RecoverBullTorRoute, RecoverBullCoreFailure>> execute() async {
+    try {
+      final settings = await _settingsRepository.fetch();
+      if (settings.useTorProxy) return _external(settings.torProxyPort);
+
+      return switch (await _embeddedTor.ensureReady()) {
+        TorReady(:final route) when route.source == TorSource.embedded =>
+          _openSession(),
+        TorUnavailable(:final failure) => Err(
+          KeyServerUnavailableFailure(failure.logMessage),
+        ),
+        final state => Err(
+          KeyServerUnavailableFailure(
+            'Tor did not reach a terminal ready state: ${state.runtimeType}',
+          ),
+        ),
+      };
+    } on TorBackendException catch (error) {
+      return Err(KeyServerUnavailableFailure(error.failure.logMessage));
+    } on Exception catch (error) {
+      return Err(KeyServerUnavailableFailure(error.toString()));
+    }
+  }
+
+  /// No circuit isolation to release, hence the no-op close: the proxy is not
+  /// ours to start or stop, and stopping it would break every other consumer.
+  Future<Result<RecoverBullTorRoute, RecoverBullCoreFailure>> _external(
+    int port,
+  ) async {
+    try {
+      return Ok(
+        RecoverBullTorRoute(
+          TorProxyEndpoint(
+            host: InternetAddress.loopbackIPv4.address,
+            port: port,
+          ),
+          () async {},
+        ),
+      );
+    } on ArgumentError catch (error) {
+      // A port persisted outside 1-65535 would otherwise throw out of a
+      // Result-returning use case. `RangeError` is an `ArgumentError`, so this
+      // single clause covers the endpoint's two validation failures.
+      return Err(KeyServerUnavailableFailure(error.toString()));
+    }
+  }
+
+  Future<Result<RecoverBullTorRoute, RecoverBullCoreFailure>>
+  _openSession() async {
+    try {
+      final session = await _embeddedTor.sessions.open();
+      return Ok(RecoverBullTorRoute(session.endpoint, session.close));
+    } on TorBackendException catch (error) {
+      return Err(KeyServerUnavailableFailure(error.failure.logMessage));
+    } catch (error) {
+      return Err(KeyServerUnavailableFailure(error.toString()));
+    }
+  }
+}

--- a/lib/core/recoverbull/domain/usecases/fetch_vault_key_from_server_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/fetch_vault_key_from_server_usecase.dart
@@ -1,17 +1,56 @@
 import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/encrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_tor_route.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 
 class FetchVaultKeyFromServerUsecase {
-  final RecoverBullRepository recoverBullRepository;
+  final RecoverBullRepository _recoverBullRepository;
+  final EnsureRecoverBullTorSessionUsecase _ensureTorSessionUsecase;
 
-  FetchVaultKeyFromServerUsecase({required this.recoverBullRepository});
+  FetchVaultKeyFromServerUsecase(
+    this._recoverBullRepository,
+    this._ensureTorSessionUsecase,
+  );
 
   Future<Result<String, RecoverBullCoreFailure>> execute({
     required EncryptedVault vault,
     required String password,
-  }) {
-    return recoverBullRepository.fetchVaultKey(vault.id, password, vault.salt);
+  }) async {
+    final session = await _ensureTorSessionUsecase.execute();
+    return switch (session) {
+      Ok(:final value) => _fetch(vault, password, value),
+      Err(:final failure) => Err(failure),
+    };
+  }
+
+  Future<Result<String, RecoverBullCoreFailure>> _fetch(
+    EncryptedVault vault,
+    String password,
+    RecoverBullTorRoute session,
+  ) async {
+    try {
+      return await _recoverBullRepository.fetchVaultKey(
+        vault.id,
+        password,
+        vault.salt,
+        session.endpoint,
+      );
+    } finally {
+      // Closing forwards to a native session stop, which can throw. Letting it
+      // escape a `finally` would break the `Result` contract and, worse, discard
+      // a vault key this call already retrieved.
+      try {
+        await session.close();
+      } catch (e, st) {
+        log.warning(
+          'closing the RecoverBull Tor session failed',
+          error: e,
+          trace: st,
+        );
+      }
+    }
   }
 }

--- a/lib/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart
@@ -1,24 +1,59 @@
 import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/encrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_tor_route.dart';
 
 /// Stores a backup key on the server with password protection
 class StoreVaultKeyIntoServerUsecase {
   final RecoverBullRepository _recoverBullRepository;
+  final EnsureRecoverBullTorSessionUsecase _ensureTorSessionUsecase;
 
-  StoreVaultKeyIntoServerUsecase({required this._recoverBullRepository});
+  StoreVaultKeyIntoServerUsecase(
+    this._recoverBullRepository,
+    this._ensureTorSessionUsecase,
+  );
 
   Future<Result<Null, RecoverBullCoreFailure>> execute({
     required String password,
     required EncryptedVault vault,
     required String vaultKey,
-  }) {
-    return _recoverBullRepository.storeVaultKey(
-      vault.id,
-      password,
-      vault.salt,
-      vaultKey,
-    );
+  }) async {
+    final session = await _ensureTorSessionUsecase.execute();
+    return switch (session) {
+      Ok(:final value) => _store(password, vault, vaultKey, value),
+      Err(:final failure) => Err(failure),
+    };
+  }
+
+  Future<Result<Null, RecoverBullCoreFailure>> _store(
+    String password,
+    EncryptedVault vault,
+    String vaultKey,
+    RecoverBullTorRoute session,
+  ) async {
+    try {
+      return await _recoverBullRepository.storeVaultKey(
+        vault.id,
+        password,
+        vault.salt,
+        vaultKey,
+        session.endpoint,
+      );
+    } finally {
+      // A throw here would escape after the key was already stored, leaving the
+      // flow half-completed with no typed failure for the caller to act on.
+      try {
+        await session.close();
+      } catch (e, st) {
+        log.warning(
+          'closing the RecoverBull Tor session failed',
+          error: e,
+          trace: st,
+        );
+      }
+    }
   }
 }

--- a/lib/core/recoverbull/recoverbull_locator.dart
+++ b/lib/core/recoverbull/recoverbull_locator.dart
@@ -9,6 +9,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/allow_permission_usec
 import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/create_encrypted_vault_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/decrypt_vault_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/fetch_permission_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/fetch_recoverbull_url_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/fetch_vault_key_from_server_usecase.dart';
@@ -28,40 +29,34 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/update_latest_encrypt
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
-import 'package:bb_mobile/core/tor/data/datasources/tor_datasource.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
-import 'package:bb_mobile/core/tor/infrastructure/services/tor_connectivity_service.dart';
-import 'package:bb_mobile/core/tor/interface_adapters/adapters/tor_config_adapter.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_usecase.dart';
 import 'package:get_it/get_it.dart';
+import 'package:bull_tor/tor.dart';
 
 class RecoverbullLocator {
-  static Future<void> registerDatasources(GetIt locator) async {
+  static void registerDatasources(GetIt locator) {
     locator.registerLazySingleton<GoogleDriveAppDatasource>(
-      () => GoogleDriveAppDatasource(),
+      GoogleDriveAppDatasource.new,
     );
 
     locator.registerLazySingleton<RecoverbullSettingsDatasource>(
       () => RecoverbullSettingsDatasource(sqlite: locator<SqliteDatabase>()),
     );
 
-    locator.registerSingletonWithDependencies<RecoverBullRemoteDatasource>(
+    locator.registerLazySingleton<RecoverBullRemoteDatasource>(
       () => RecoverBullRemoteDatasource(
         recoverbullSettingsDatasource: locator<RecoverbullSettingsDatasource>(),
-        torDatasource: locator<TorDatasource>(),
+        torHttpClientFactory: locator<TorHttpClientFactory>(),
       ),
-      dependsOn: [TorDatasource],
     );
 
     locator.registerLazySingleton<FileStorageDatasource>(
       () => FileStorageDatasource(),
     );
-
-    await locator.isReady<RecoverBullRemoteDatasource>();
   }
 
-  static Future<void> registerRepositories(GetIt locator) async {
+  static void registerRepositories(GetIt locator) {
     locator.registerLazySingleton<GoogleDriveRepository>(
       () => GoogleDriveRepository(
         datasource: locator<GoogleDriveAppDatasource>(),
@@ -72,26 +67,21 @@ class RecoverbullLocator {
       () => FileSystemRepository(datasource: locator<FileStorageDatasource>()),
     );
 
-    locator.registerLazySingleton<TorConfigPort>(
-      () => TorConfigAdapter(
-        settingsRepository: locator<SettingsRepository>(),
-        torConnectivityService: locator<TorConnectivityService>(),
-      ),
-    );
-
-    locator.registerSingletonWithDependencies<RecoverBullRepository>(
+    locator.registerLazySingleton<RecoverBullRepository>(
       () => RecoverBullRepository(
         remoteDatasource: locator<RecoverBullRemoteDatasource>(),
         recoverbullSettingsDatasource: locator<RecoverbullSettingsDatasource>(),
-        torConfigPort: locator<TorConfigPort>(),
       ),
-      dependsOn: [RecoverBullRemoteDatasource],
     );
-
-    await locator.isReady<RecoverBullRepository>();
   }
 
   static void registerUsecases(GetIt locator) {
+    locator.registerFactory<EnsureRecoverBullTorSessionUsecase>(
+      () => EnsureRecoverBullTorSessionUsecase(
+        locator<Tor>().embedded,
+        locator<SettingsRepository>(),
+      ),
+    );
     locator.registerFactory<CreateEncryptedVaultUsecase>(
       () => CreateEncryptedVaultUsecase(
         seedRepository: locator<SeedRepository>(),
@@ -149,19 +139,22 @@ class RecoverbullLocator {
 
     locator.registerFactory<StoreVaultKeyIntoServerUsecase>(
       () => StoreVaultKeyIntoServerUsecase(
-        recoverBullRepository: locator<RecoverBullRepository>(),
+        locator<RecoverBullRepository>(),
+        locator<EnsureRecoverBullTorSessionUsecase>(),
       ),
     );
 
     locator.registerFactory<CheckServerConnectionUsecase>(
       () => CheckServerConnectionUsecase(
-        recoverBullRepository: locator<RecoverBullRepository>(),
+        locator<RecoverBullRepository>(),
+        locator<EnsureRecoverBullTorSessionUsecase>(),
       ),
     );
 
     locator.registerFactory<FetchVaultKeyFromServerUsecase>(
       () => FetchVaultKeyFromServerUsecase(
-        recoverBullRepository: locator<RecoverBullRepository>(),
+        locator<RecoverBullRepository>(),
+        locator<EnsureRecoverBullTorSessionUsecase>(),
       ),
     );
     locator.registerFactory<SaveVaultToGoogleDriveUsecase>(

--- a/lib/core/status/domain/usecases/check_all_service_status_usecase.dart
+++ b/lib/core/status/domain/usecases/check_all_service_status_usecase.dart
@@ -2,26 +2,31 @@ import 'dart:io';
 
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_rate_repository.dart';
 import 'package:bb_mobile/core/fees/domain/repositories/fees_repository.dart';
-import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
 import 'package:bb_mobile/core/status/domain/entity/service_status.dart';
 import 'package:bb_mobile/core/status/domain/ports/electrum_connectivity_port.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
-import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:bull_tor/tor.dart';
 import 'package:primitives/primitives.dart' show Err, Ok;
 
 class CheckAllServiceStatusUsecase {
+  /// Ceiling for the two Tor-backed rows, which can otherwise start a bootstrap
+  /// and hold the whole screen. Generous enough for a warm client to answer and
+  /// for a cold direct bootstrap to usually finish, short enough that a blocked
+  /// network reports `offline` instead of hanging.
+  static const _torStatusTimeout = Duration(seconds: 20);
+
   final ElectrumConnectivityPort _electrumConnectivityPort;
   final ExchangeRateRepository _exchangeRateRepository;
   final PayjoinPolicyAccess _payjoinPolicy;
   final PayjoinDiagnostics _payjoinDiagnostics;
   final FeesRepository _feesRepository;
-  final RecoverBullRepository _recoverBullRepository;
   final WalletRepository _walletRepository;
-  final TorStatusUsecase _torStatusUsecase;
+  final EnsureTorReadyUsecase _ensureTorReadyUsecase;
+  final CheckServerConnectionUsecase _checkServerConnectionUsecase;
 
   CheckAllServiceStatusUsecase({
     required this._electrumConnectivityPort,
@@ -29,9 +34,9 @@ class CheckAllServiceStatusUsecase {
     required this._payjoinPolicy,
     required this._payjoinDiagnostics,
     required this._feesRepository,
-    required this._recoverBullRepository,
     required this._walletRepository,
-    required this._torStatusUsecase,
+    required this._ensureTorReadyUsecase,
+    required this._checkServerConnectionUsecase,
   });
 
   Future<AllServicesStatus> execute({required Network network}) async {
@@ -221,44 +226,61 @@ class CheckAllServiceStatusUsecase {
     }
   }
 
+  /// `unknown` — not `offline` — when this wallet has no encrypted backup:
+  /// Tor is then unused, so there is nothing to report either way.
+  ///
+  /// For a wallet that does use it, answering means starting the client. That
+  /// is the point of a connectivity screen, and it costs nothing in practice:
+  /// app startup already warms Tor for exactly these wallets, so this adopts
+  /// the running client instead of booting a second one.
   Future<ServiceStatusInfo> _checkTorConnection() async {
-    var status = ServiceStatusInfo(
+    final status = ServiceStatusInfo(
       status: ServiceStatus.unknown,
       name: 'Tor',
       lastChecked: DateTime.now(),
     );
 
-    final torStatus = await _torStatusUsecase.execute();
-    switch (torStatus) {
-      case TorStatus.online:
-        status = status.copyWith(status: ServiceStatus.online);
-      case TorStatus.offline:
-        status = status.copyWith(status: ServiceStatus.offline);
-      default:
-        status = status.copyWith(status: ServiceStatus.unknown);
-    }
-    return status;
+    if (!await _walletRepository.isTorRequired()) return status;
+
+    // Bounded on purpose. Adopting a warm client answers immediately, but when
+    // the startup warm-up failed — launched offline, or Tor blocked — this call
+    // starts a fresh bootstrap, and every other row on the screen waits on it
+    // through the single `Future.wait`. A censored network can spend the whole
+    // direct budget and then the Snowflake one, so an unbounded wait here means
+    // minutes of a blank connectivity screen.
+    return status.copyWith(
+      status: switch (await _ensureTorReadyUsecase.execute().timeout(
+        _torStatusTimeout,
+        onTimeout: () => const TorUninitialized(),
+      )) {
+        TorReady(:final route) when route.source == TorSource.embedded =>
+          ServiceStatus.online,
+        _ => ServiceStatus.offline,
+      },
+    );
   }
 
   Future<ServiceStatusInfo> _checkRecoverbullConnection() async {
-    var status = ServiceStatusInfo(
+    final status = ServiceStatusInfo(
       status: ServiceStatus.unknown,
       name: 'Recoverbull',
       lastChecked: DateTime.now(),
     );
 
-    final isTorRequired = await _walletRepository.isTorRequired();
-    final torStatus = await _torStatusUsecase.execute();
-    if (isTorRequired && torStatus == TorStatus.online) {
-      try {
-        await _recoverBullRepository.checkConnection();
-        status = status.copyWith(status: ServiceStatus.online);
-      } catch (e) {
-        status = status.copyWith(status: ServiceStatus.offline);
-      }
-    }
+    if (!await _walletRepository.isTorRequired()) return status;
 
-    return status;
+    // Delegated rather than reimplemented: this is the same "can we reach the
+    // key server over Tor" question the RecoverBull flow asks, and one answer
+    // for both keeps the screen and the flow from disagreeing.
+    return status.copyWith(
+      status:
+          await _checkServerConnectionUsecase.execute().timeout(
+            _torStatusTimeout,
+            onTimeout: () => false,
+          )
+          ? ServiceStatus.online
+          : ServiceStatus.offline,
+    );
   }
 
   AllServicesStatus _createUnknownStatus(DateTime now) {

--- a/lib/core/status/status_locator.dart
+++ b/lib/core/status/status_locator.dart
@@ -3,13 +3,13 @@ import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repo
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_rate_repository.dart';
 import 'package:bb_mobile/core/fees/domain/repositories/fees_repository.dart';
-import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
 import 'package:bb_mobile/core/status/domain/ports/electrum_connectivity_port.dart';
 import 'package:bb_mobile/core/status/domain/usecases/check_all_service_status_usecase.dart';
 import 'package:bb_mobile/core/status/interface_adapters/adapter/electrum_connectivity_adapter.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:bull_tor/tor.dart';
 import 'package:get_it/get_it.dart';
 
 class StatusLocator {
@@ -33,9 +33,9 @@ class StatusLocator {
         payjoinDiagnostics: locator<PayjoinDiagnostics>(),
         feesRepository: locator<FeesRepository>(),
         electrumConnectivityPort: locator<ElectrumConnectivityPort>(),
-        recoverBullRepository: locator<RecoverBullRepository>(),
         walletRepository: locator<WalletRepository>(),
-        torStatusUsecase: locator<TorStatusUsecase>(),
+        ensureTorReadyUsecase: locator<EnsureTorReadyUsecase>(),
+        checkServerConnectionUsecase: locator<CheckServerConnectionUsecase>(),
       ),
     );
   }

--- a/lib/features/app_startup/app_startup_locator.dart
+++ b/lib/features/app_startup/app_startup_locator.dart
@@ -3,22 +3,28 @@ import 'dart:io' show Platform;
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/features/app_startup/data/wallet_startup_adapter.dart';
+import 'package:bb_mobile/features/app_startup/domain/app_startup_wallet_port.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_legacy_install_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/get_legacy_seeds_usecase.dart';
+import 'package:bb_mobile/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/reset_app_data_usecase.dart';
 import 'package:bb_mobile/features/app_startup/presentation/bloc/app_startup_bloc.dart';
 import 'package:bb_mobile/features/app_unlock/domain/usecases/check_pin_code_exists_usecase.dart';
 import 'package:bb_mobile/features/pin_code/data/repositories/pin_code_repository.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_backup_usecase.dart';
 import 'package:get_it/get_it.dart';
+import 'package:bull_tor/tor.dart';
 
 class AppStartupLocator {
   static void setup(GetIt locator) {
+    locator.registerLazySingleton<AppStartupWalletPort>(
+      () => WalletStartupAdapter(locator<WalletRepository>()),
+    );
+
     // Use cases
     locator.registerFactory<ResetAppDataUsecase>(
       () =>
@@ -46,6 +52,12 @@ class AppStartupLocator {
         seedRepository: locator<SeedRepository>(),
       ),
     );
+    locator.registerFactory<InitializeRequiredTorUsecase>(
+      () => InitializeRequiredTorUsecase(
+        locator<AppStartupWalletPort>(),
+        locator<EnsureTorReadyUsecase>(),
+      ),
+    );
 
     // Bloc
     locator.registerFactory<AppStartupBloc>(
@@ -56,8 +68,7 @@ class AppStartupLocator {
             locator<CheckForExistingDefaultWalletsUsecase>(),
         checkLegacyInstallUsecase: locator<CheckLegacyInstallUsecase>(),
         checkBackupUsecase: locator<CheckBackupUsecase>(),
-        isTorRequiredUsecase: locator<IsTorRequiredUsecase>(),
-        initTorUsecase: locator<InitTorUsecase>(),
+        initializeRequiredTorUsecase: locator<InitializeRequiredTorUsecase>(),
       ),
     );
   }

--- a/lib/features/app_startup/data/wallet_startup_adapter.dart
+++ b/lib/features/app_startup/data/wallet_startup_adapter.dart
@@ -1,0 +1,19 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/features/app_startup/domain/app_startup_wallet_port.dart';
+
+final class WalletStartupAdapter implements AppStartupWalletPort {
+  final WalletRepository _walletRepository;
+
+  const WalletStartupAdapter(this._walletRepository);
+
+  @override
+  Future<bool> hasMainnetBitcoinEncryptedBackup() async {
+    final wallets = await _walletRepository.getWallets(
+      onlyDefaults: true,
+      onlyBitcoin: true,
+      environment: Environment.mainnet,
+    );
+    return wallets.isNotEmpty && wallets.first.latestEncryptedBackup != null;
+  }
+}

--- a/lib/features/app_startup/domain/app_startup_wallet_port.dart
+++ b/lib/features/app_startup/domain/app_startup_wallet_port.dart
@@ -1,0 +1,3 @@
+abstract interface class AppStartupWalletPort {
+  Future<bool> hasMainnetBitcoinEncryptedBackup();
+}

--- a/lib/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart
+++ b/lib/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/features/app_startup/domain/app_startup_wallet_port.dart';
+import 'package:bull_tor/tor.dart';
+
+/// Eagerly warms Tor only for an existing RecoverBull backup.
+class InitializeRequiredTorUsecase {
+  final AppStartupWalletPort _walletPort;
+  final EnsureTorReadyUsecase _ensureTorReadyUsecase;
+
+  const InitializeRequiredTorUsecase(
+    this._walletPort,
+    this._ensureTorReadyUsecase,
+  );
+
+  Future<TorConnectionState?> execute() async {
+    if (!await _walletPort.hasMainnetBitcoinEncryptedBackup()) {
+      return null;
+    }
+    return _ensureTorReadyUsecase.execute();
+  }
+}

--- a/lib/features/app_startup/presentation/bloc/app_startup_bloc.dart
+++ b/lib/features/app_startup/presentation/bloc/app_startup_bloc.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/keychain_locked_exception.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_legacy_install_usecase.dart';
+import 'package:bb_mobile/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/reset_app_data_usecase.dart';
 import 'package:bb_mobile/features/app_unlock/domain/app_unlock_failure.dart';
 import 'package:bb_mobile/features/app_unlock/domain/usecases/check_pin_code_exists_usecase.dart';
@@ -30,8 +29,7 @@ class AppStartupBloc extends Bloc<AppStartupEvent, AppStartupState>
     required this._checkForExistingDefaultWalletsUsecase,
     required this._checkLegacyInstallUsecase,
     required this._checkBackupUsecase,
-    required this._isTorRequiredUsecase,
-    required this._initTorUsecase,
+    required this._initializeRequiredTorUsecase,
   }) : super(const AppStartupState.initial()) {
     on<AppStartupStarted>(_onAppStartupStarted);
     WidgetsBinding.instance.addObserver(this);
@@ -43,8 +41,7 @@ class AppStartupBloc extends Bloc<AppStartupEvent, AppStartupState>
   _checkForExistingDefaultWalletsUsecase;
   final CheckLegacyInstallUsecase _checkLegacyInstallUsecase;
   final CheckBackupUsecase _checkBackupUsecase;
-  final IsTorRequiredUsecase _isTorRequiredUsecase;
-  final InitTorUsecase _initTorUsecase;
+  final InitializeRequiredTorUsecase _initializeRequiredTorUsecase;
 
   /// True while we're sitting on the splash because a startup step
   /// threw `KeychainLockedException` (iOS pre-first-unlock pre-warm).
@@ -116,17 +113,9 @@ class AppStartupBloc extends Bloc<AppStartupEvent, AppStartupState>
         await _resetAppDataUsecase.execute();
       }
 
-      // Run Tor initialization in background
-      try {
-        final isTorRequired = await _isTorRequiredUsecase.execute();
-        if (isTorRequired) unawaited(_initTorUsecase.execute());
-      } catch (e) {
-        log.severe(
-          message: 'Tor initialization check failed',
-          error: e,
-          trace: StackTrace.current,
-        );
-      }
+      // Warm the embedded client without delaying the startup screen. The
+      // coordinator makes this single-flight with any concurrent consumer.
+      unawaited(_initializeTorInBackground());
 
       emit(
         AppStartupState.success(
@@ -172,5 +161,17 @@ class AppStartupBloc extends Bloc<AppStartupEvent, AppStartupState>
       'App startup blocked on keychain (device not unlocked since '
       'boot) — staying on splash, will retry on lifecycle resumed',
     );
+  }
+
+  Future<void> _initializeTorInBackground() async {
+    try {
+      await _initializeRequiredTorUsecase.execute();
+    } catch (error, stackTrace) {
+      log.severe(
+        message: 'Required Tor initialization failed',
+        error: error,
+        trace: stackTrace,
+      );
+    }
   }
 }

--- a/lib/features/recoverbull/domain/connect_to_key_server_usecase.dart
+++ b/lib/features/recoverbull/domain/connect_to_key_server_usecase.dart
@@ -1,0 +1,38 @@
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
+
+/// Reaches the key server, retrying on a backoff.
+///
+/// Reaching it is an onion-service lookup — a descriptor fetch, then a
+/// rendezvous — which routinely needs more than one try just after a cold
+/// bootstrap. The schedule and the attempt accounting live here so the screen
+/// only renders what an attempt reports.
+class ConnectToKeyServerUsecase {
+  /// How many times the server is contacted before giving up. Published
+  /// because the screen shows the attempt out of this total.
+  static const int maxAttempts = 3;
+
+  final CheckServerConnectionUsecase _checkServerConnectionUsecase;
+
+  /// Injected so a test does not have to spend the backoff in real time.
+  final Future<void> Function(Duration) _wait;
+
+  ConnectToKeyServerUsecase(
+    this._checkServerConnectionUsecase, {
+    Future<void> Function(Duration)? wait,
+  }) : _wait = wait ?? Future<void>.delayed;
+
+  /// [onAttempt] fires before each call with a 1-based attempt number, so the
+  /// caller can show which attempt is in flight rather than which one failed.
+  ///
+  /// The first attempt is immediate. Tor readiness is already awaited before
+  /// this runs, so delaying it only added a second to every start, including
+  /// the common case where the server answers at once.
+  Future<bool> execute({required void Function(int attempt) onAttempt}) async {
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (attempt > 1) await _wait(Duration(seconds: attempt - 1));
+      onAttempt(attempt);
+      if (await _checkServerConnectionUsecase.execute()) return true;
+    }
+    return false;
+  }
+}

--- a/lib/features/recoverbull/flow.dart
+++ b/lib/features/recoverbull/flow.dart
@@ -20,6 +20,9 @@ class _RecoverBullFlowNavigatorState extends State<RecoverBullFlowNavigator> {
   final _navigatorKey = GlobalKey<NavigatorState>();
   final _fetchPermissionUsecase = locator<FetchPermissionUsecase>();
 
+  /// Guards the one-shot connection kickoff below.
+  bool _connectionRequested = false;
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<bool>(
@@ -41,9 +44,22 @@ class _RecoverBullFlowNavigatorState extends State<RecoverBullFlowNavigator> {
         final hasPermission = snapshot.data ?? false;
         if (!hasPermission) {
           page = const RequestPermissionPage();
-        } else {
-          context.read<RecoverBullBloc>().add(const OnTorInitialization());
-          context.read<RecoverBullBloc>().add(const OnServerCheck());
+        } else if (!_connectionRequested) {
+          // Dispatched once, and after the frame rather than during it.
+          //
+          // This used to fire on every rebuild of the FutureBuilder, which
+          // started a second key-server check on top of the one already in
+          // flight — the duplicated "waiting for Tor" traces came from here, not
+          // from two isolates. Repeated dispatch also makes any Tor restart
+          // unsafe: a rebuild storm would tear the client down mid-bootstrap.
+          //
+          // `OnServerCheck` is not dispatched here: `OnTorInitialization`
+          // already chains to it once Tor is up, so sending both raced them.
+          _connectionRequested = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            context.read<RecoverBullBloc>().add(const OnTorInitialization());
+          });
         }
 
         return PopScope(

--- a/lib/features/recoverbull/presentation/bloc.dart
+++ b/lib/features/recoverbull/presentation/bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/recoverbull/domain/entity/decrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/encrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/vault_provider.dart';
@@ -14,16 +16,15 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/update_latest_encrypted_backup_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
-import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/recoverbull/domain/connect_to_key_server_usecase.dart';
 import 'package:bb_mobile/features/recoverbull/domain/recoverbull_failure.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:bull_tor/tor.dart' as tor;
 
 part 'bloc.freezed.dart';
 part 'event.dart';
@@ -36,17 +37,26 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
   final SaveVaultToGoogleDriveUsecase _saveToGoogleDriveUsecase;
   final CreateEncryptedVaultUsecase _createEncryptedVaultUsecase;
   final StoreVaultKeyIntoServerUsecase _storeVaultKeyIntoServerUsecase;
+
+  /// Single-shot: the pre-flight check before storing a vault key, where the
+  /// user is already committed and a retry budget would only delay the error.
   final CheckServerConnectionUsecase _checkKeyServerConnectionUsecase;
+
+  /// Retrying: the connecting screen, where a cold onion lookup is expected to
+  /// need more than one try.
+  final ConnectToKeyServerUsecase _connectToKeyServerUsecase;
   final FetchVaultKeyFromServerUsecase _fetchVaultKeyFromServerUsecase;
   final DecryptVaultUsecase _decryptVaultUsecase;
   final RestoreVaultUsecase _restoreVaultUsecase;
-  final InitTorUsecase _initializeTorUsecase;
+  final tor.EnsureTorReadyUsecase _ensureTorReadyUsecase;
+  final tor.RetryTorConnectionUsecase _retryTorConnectionUsecase;
   final WalletBloc _walletBloc;
   final FetchLatestGoogleDriveVaultUsecase _fetchLatestGoogleDriveVaultUsecase;
   final UpdateLatestEncryptedVaultTestUsecase
   _updateLatestEncryptedVaultTestUsecase;
-  final TorStatusUsecase _torStatusUsecase;
-  final TorConfigPort _torConfigPort;
+  final tor.WatchTorConnectionUsecase _watchTorConnectionUsecase;
+
+  StreamSubscription<tor.TorConnectionState>? _torSubscription;
 
   RecoverBullBloc({
     required RecoverBullFlow flow,
@@ -56,52 +66,106 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
     required this._createEncryptedVaultUsecase,
     required this._storeVaultKeyIntoServerUsecase,
     required this._checkKeyServerConnectionUsecase,
+    required this._connectToKeyServerUsecase,
     required this._fetchVaultKeyFromServerUsecase,
     required this._decryptVaultUsecase,
     required this._restoreVaultUsecase,
     required this._connectToGoogleDriveUsecase,
     required this._saveToGoogleDriveUsecase,
-    required this._initializeTorUsecase,
+    required this._ensureTorReadyUsecase,
+    required this._retryTorConnectionUsecase,
     required this._walletBloc,
     required this._fetchLatestGoogleDriveVaultUsecase,
     required this._updateLatestEncryptedVaultTestUsecase,
-    required this._torStatusUsecase,
-    required this._torConfigPort,
+    required this._watchTorConnectionUsecase,
   }) : super(RecoverBullState(flow: flow, vault: preSelectedVault)) {
     on<OnVaultProviderSelection>(_onVaultProviderSelection);
     on<OnVaultSelection>(_onVaultSelection);
     on<OnVaultPasswordSet>(_onVaultPasswordSet);
     on<OnVaultCreation>(_onVaultCreation);
     on<OnVaultDecryption>(_onVaultDecryption);
-    on<OnServerCheck>(_onServerCheck);
-    on<OnTorInitialization>(_onTorInitialization);
+    on<OnServerCheck>(_onServerCheck, transformer: droppable());
+    on<OnTorInitialization>(_onTorInitialization, transformer: droppable());
     on<OnClearError>(_onClearError);
+    on<_OnTorConnectionChanged>(_onTorConnectionChanged);
+
+    // Tor readiness is pushed, so follow it for as long as this flow is open.
+    // Taking a single snapshot in `_onServerCheck` reported whatever the status
+    // happened to be at T=0 — during a cold start that is "not ready", which
+    // the UI rendered as a Tor failure while bootstrap was still running, and
+    // it never updated once Tor came up.
+    _torSubscription = _watchTorConnectionUsecase.execute().listen(
+      (state) => add(_OnTorConnectionChanged(state)),
+    );
+  }
+
+  @override
+  Future<void> close() async {
+    await _torSubscription?.cancel();
+    return super.close();
+  }
+
+  Future<void> _onTorConnectionChanged(
+    _OnTorConnectionChanged event,
+    Emitter<RecoverBullState> emit,
+  ) async {
+    // Arti's directory fraction is not monotonic after traffic becomes usable:
+    // a background refresh can report Connecting again while the established
+    // SOCKS route remains valid. RecoverBull only needs that route, so keep its
+    // local readiness latched until Tor reports an actual blockage or a
+    // terminal state. A diagnostic means this is not a benign refresh.
+    final next = event.state;
+    if (state.torConnection is tor.TorReady &&
+        next is tor.TorConnecting &&
+        next.diagnostic == null) {
+      return;
+    }
+    emit(state.copyWith(torConnection: next));
+
+    // The stale-generation arm of `_onTorInitialization` returns without
+    // dispatching a server check, so readiness that arrives through this stream
+    // instead of through that call would otherwise never trigger one — leaving
+    // the screen on "waiting" with no failure and no retry. Picking it up here
+    // is what closes that dead end.
+    if (next is tor.TorReady &&
+        state.keyServerStatus == KeyServerStatus.unknown) {
+      add(const OnServerCheck());
+    }
   }
 
   Future<void> _onTorInitialization(
     OnTorInitialization event,
     Emitter<RecoverBullState> emit,
   ) async {
-    // Tor is a separate core domain that still throws; the bloc is its boundary.
-    try {
-      final externalTorConfig = await _torConfigPort
-          .getAvailableExternalTorConfig();
-
-      if (externalTorConfig == null) {
-        await _initializeTorUsecase.execute();
-      } else {
-        log.info('Using external Tor proxy on port ${externalTorConfig.port}');
-      }
-
-      add(const OnServerCheck());
-    } catch (e) {
-      log.severe(error: e, trace: StackTrace.current);
-      emit(
-        state.copyWith(
-          failure: const TorNotStartedFailure(),
-          keyServerStatus: KeyServerStatus.offline,
-        ),
-      );
+    emit(
+      state.copyWith(failure: null, keyServerStatus: KeyServerStatus.unknown),
+    );
+    final connection = event.restart
+        ? await _retryTorConnectionUsecase.execute()
+        : await _ensureTorReadyUsecase.execute();
+    if (isClosed) return;
+    switch (connection) {
+      case tor.TorReady(:final route):
+        log.info(
+          'Using ${route.source.name} Tor on port ${route.endpoint.port}',
+        );
+        emit(state.copyWith(torConnection: connection));
+        add(const OnServerCheck());
+      case tor.TorUnavailable(:final failure):
+        log.severe(
+          error: failure.logMessage ?? failure.runtimeType.toString(),
+          trace: StackTrace.current,
+        );
+        emit(
+          state.copyWith(
+            failure: const TorNotStartedFailure(),
+            keyServerStatus: KeyServerStatus.offline,
+          ),
+        );
+      case tor.TorUninitialized() || tor.TorStopped() || tor.TorConnecting():
+        // A newer retry generation replaced this operation. Its stream owns the
+        // current state; the stale handler must not publish a failure.
+        return;
     }
   }
 
@@ -109,22 +173,29 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
     OnServerCheck event,
     Emitter<RecoverBullState> emit,
   ) async {
-    // _torStatusUsecase (tor domain) still throws; the bloc is its boundary.
     try {
-      final torStatus = await _torStatusUsecase.execute();
-      emit(state.copyWith(torStatus: torStatus));
+      // `torStatus` is not emitted here: it is driven by the subscription set
+      // up in the constructor. Emitting a snapshot at this point is what made a
+      // healthy cold start look like a Tor failure.
+      const retries = ConnectToKeyServerUsecase.maxAttempts;
+      emit(
+        state.copyWith(
+          failure: null,
+          keyServerStatus: KeyServerStatus.connecting,
+          keyServerAttempt: 0,
+          keyServerAttempts: retries,
+        ),
+      );
 
-      emit(state.copyWith(keyServerStatus: KeyServerStatus.connecting));
-
-      var isConnected = false;
-      const retries = 3;
-      int attempt = 1;
-      for (; attempt <= retries; attempt++) {
-        final delay = Duration(seconds: attempt);
-        await Future.delayed(delay);
-        isConnected = await _checkKeyServerConnectionUsecase.execute();
-        if (isConnected) break;
-      }
+      final isConnected = await _connectToKeyServerUsecase.execute(
+        // Published before the call, so the screen shows which attempt is
+        // actually in flight rather than which one already failed. Guarded:
+        // the backoff outlives the screen when the user navigates away.
+        onAttempt: (attempt) {
+          if (isClosed) return;
+          emit(state.copyWith(keyServerAttempt: attempt));
+        },
+      );
 
       if (!isConnected) {
         log.severe(
@@ -138,13 +209,14 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
           ),
         );
       } else {
-        log.fine('Recoverbull server ready after $attempt attempts');
-        emit(
-          state.copyWith(
-            keyServerStatus: KeyServerStatus.online,
-            torStatus: TorStatus.online,
-          ),
+        log.fine(
+          'Recoverbull server ready after ${state.keyServerAttempt} attempts',
         );
+        // Tor's status is not forced here. It used to be set to `online` on
+        // this path, which asserted Tor's health from the key server's reply;
+        // the readiness stream is the only thing that knows, and the screen
+        // latches it.
+        emit(state.copyWith(keyServerStatus: KeyServerStatus.online));
       }
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);

--- a/lib/features/recoverbull/presentation/event.dart
+++ b/lib/features/recoverbull/presentation/event.dart
@@ -41,7 +41,24 @@ class OnServerCheck extends RecoverBullEvent {
 }
 
 class OnTorInitialization extends RecoverBullEvent {
-  const OnTorInitialization();
+  /// Discard a client that is running but stuck, instead of adopting it.
+  ///
+  /// Only set from an explicit retry: restarting on a rebuild would tear down a
+  /// healthy bootstrap in progress.
+  final bool restart;
+
+  const OnTorInitialization({this.restart = false});
+}
+
+/// Carries a pushed Tor readiness change into the bloc.
+///
+/// Internal: emitted by the bloc's own subscription, never by the UI. A bloc
+/// may only `emit` from inside a handler, so an external stream has to be
+/// funnelled through an event rather than calling `emit` from the listener.
+class _OnTorConnectionChanged extends RecoverBullEvent {
+  final tor.TorConnectionState state;
+
+  const _OnTorConnectionChanged(this.state);
 }
 
 class OnClearError extends RecoverBullEvent {

--- a/lib/features/recoverbull/presentation/state.dart
+++ b/lib/features/recoverbull/presentation/state.dart
@@ -22,8 +22,23 @@ sealed class RecoverBullState with _$RecoverBullState {
     @Default(false) bool isLoading,
     @Default(null) RecoverBullFailure? failure,
     @Default(KeyServerStatus.unknown) KeyServerStatus keyServerStatus,
+
+    /// Which key-server attempt is in flight, and out of how many.
+    ///
+    /// Reaching the server is an onion-service lookup — a descriptor fetch then
+    /// a rendezvous — which routinely needs more than one try just after a cold
+    /// bootstrap. Showing the count is the difference between "it is retrying"
+    /// and "it is frozen".
+    @Default(0) int keyServerAttempt,
+    @Default(0) int keyServerAttempts,
     @Default(false) bool isFlowFinished,
-    @Default(TorStatus.unknown) TorStatus torStatus,
+
+    /// The full readiness snapshot, not just the coarse status.
+    ///
+    /// The screen needs `fraction` for progress and `blockage` to say *why*
+    /// Tor is stuck; deriving those from [TorStatus] is impossible because it
+    /// collapses all three into four values.
+    @Default(tor.TorUninitialized()) tor.TorConnectionState torConnection,
   }) = _RecoverBullState;
 
   const RecoverBullState._();

--- a/lib/features/recoverbull/router.dart
+++ b/lib/features/recoverbull/router.dart
@@ -11,14 +11,13 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/update_latest_encrypted_backup_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
+import 'package:bb_mobile/features/recoverbull/domain/connect_to_key_server_usecase.dart';
 import 'package:bb_mobile/features/recoverbull/flow.dart';
 import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:bull_tor/tor.dart';
 
 enum RecoverBullRoute {
   recoverbullFlows('/recoverbull-flows');
@@ -53,20 +52,26 @@ class RecoverBullRouter {
               locator<StoreVaultKeyIntoServerUsecase>(),
           checkKeyServerConnectionUsecase:
               locator<CheckServerConnectionUsecase>(),
+          // Composed here rather than registered: this feature has no locator
+          // of its own, and the use case is a thin retry policy over a core
+          // use case that is registered.
+          connectToKeyServerUsecase: ConnectToKeyServerUsecase(
+            locator<CheckServerConnectionUsecase>(),
+          ),
           fetchVaultKeyFromServerUsecase:
               locator<FetchVaultKeyFromServerUsecase>(),
           decryptVaultUsecase: locator<DecryptVaultUsecase>(),
           restoreVaultUsecase: locator<RestoreVaultUsecase>(),
           connectToGoogleDriveUsecase: locator<ConnectToGoogleDriveUsecase>(),
           saveToGoogleDriveUsecase: locator<SaveVaultToGoogleDriveUsecase>(),
-          initializeTorUsecase: locator<InitTorUsecase>(),
+          ensureTorReadyUsecase: locator<EnsureTorReadyUsecase>(),
+          retryTorConnectionUsecase: locator<RetryTorConnectionUsecase>(),
           walletBloc: context.read(),
           fetchLatestGoogleDriveVaultUsecase:
               locator<FetchLatestGoogleDriveVaultUsecase>(),
           updateLatestEncryptedVaultTestUsecase:
               locator<UpdateLatestEncryptedVaultTestUsecase>(),
-          torStatusUsecase: locator<TorStatusUsecase>(),
-          torConfigPort: locator<TorConfigPort>(),
+          watchTorConnectionUsecase: locator<WatchTorConnectionUsecase>(),
         ),
         child: const RecoverBullFlowNavigator(),
       );

--- a/lib/features/recoverbull/ui/pages/connecting_page.dart
+++ b/lib/features/recoverbull/ui/pages/connecting_page.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
-import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -8,6 +7,7 @@ import 'package:bb_mobile/features/recoverbull/presentation/recoverbull_failure_
 import 'package:bb_mobile/features/recoverbull/ui/pages/password_input_page.dart';
 import 'package:bb_mobile/features/recoverbull/ui/pages/vault_provider_selection_page.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
+import 'package:bull_tor/tor.dart' as tor;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
@@ -21,10 +21,10 @@ class ConnectingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocListener<RecoverBullBloc, RecoverBullState>(
       listenWhen: (previous, current) =>
-          previous.torStatus != current.torStatus ||
+          previous.torConnection != current.torConnection ||
           previous.keyServerStatus != current.keyServerStatus,
       listener: (context, state) {
-        if (state.torStatus == TorStatus.online &&
+        if (state.torConnection is tor.TorReady &&
             state.keyServerStatus == KeyServerStatus.online) {
           final flow = state.flow;
           final hasPreSelectedVault = state.vault != null;
@@ -54,11 +54,18 @@ class ConnectingPage extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: BlocBuilder<RecoverBullBloc, RecoverBullState>(
             builder: (context, state) {
-              final torOnline = state.torStatus == TorStatus.online;
+              final torStatus = switch (state.torConnection) {
+                tor.TorReady() => KeyServerStatus.online,
+                tor.TorUnavailable() => KeyServerStatus.offline,
+                tor.TorConnecting() => KeyServerStatus.connecting,
+                tor.TorUninitialized() ||
+                tor.TorStopped() => KeyServerStatus.unknown,
+              };
+              final torOnline = torStatus == KeyServerStatus.online;
               final serverOnline =
                   state.keyServerStatus == KeyServerStatus.online;
               final hasError =
-                  state.torStatus == TorStatus.offline ||
+                  torStatus == KeyServerStatus.offline ||
                   state.keyServerStatus == KeyServerStatus.offline;
 
               return Column(
@@ -85,14 +92,12 @@ class ConnectingPage extends StatelessWidget {
                   const Gap(24),
                   _StatusRow(
                     label: context.loc.recoverbullTorNetwork,
-                    status: state.torStatus,
-                    isKeyServer: false,
+                    status: torStatus,
                   ),
                   const Gap(12),
                   _StatusRow(
                     label: context.loc.recoverbullRecoverBullServer,
                     status: state.keyServerStatus,
-                    isKeyServer: true,
                   ),
                   const Gap(40),
                   if (hasError) ...[
@@ -112,9 +117,9 @@ class ConnectingPage extends StatelessWidget {
                       bgColor: context.appColors.onSurface,
                       textColor: context.appColors.surface,
                       onPressed: () {
-                        context.read<RecoverBullBloc>()
-                          ..add(const OnTorInitialization())
-                          ..add(const OnServerCheck());
+                        context.read<RecoverBullBloc>().add(
+                          const OnTorInitialization(restart: true),
+                        );
                       },
                     ),
                   ] else ...[
@@ -139,14 +144,9 @@ class ConnectingPage extends StatelessWidget {
 
 class _StatusRow extends StatelessWidget {
   final String label;
-  final dynamic status;
-  final bool isKeyServer;
+  final KeyServerStatus status;
 
-  const _StatusRow({
-    required this.label,
-    required this.status,
-    required this.isKeyServer,
-  });
+  const _StatusRow({required this.label, required this.status});
 
   @override
   Widget build(BuildContext context) {
@@ -185,46 +185,29 @@ class _StatusRow extends StatelessWidget {
   }
 
   String _getStatusText(BuildContext context) {
-    if (isKeyServer) {
-      return switch (status as KeyServerStatus) {
-        KeyServerStatus.unknown => context.loc.recoverbullWaiting,
-        KeyServerStatus.connecting => context.loc.recoverbullConnecting,
-        KeyServerStatus.online => context.loc.recoverbullConnected,
-        KeyServerStatus.offline => context.loc.recoverbullFailed,
-      };
-    } else {
-      return switch (status as TorStatus) {
-        TorStatus.unknown => context.loc.recoverbullWaiting,
-        TorStatus.connecting => context.loc.recoverbullConnecting,
-        TorStatus.online => context.loc.recoverbullConnected,
-        TorStatus.offline => context.loc.recoverbullFailed,
-      };
-    }
+    return switch (status) {
+      KeyServerStatus.unknown => context.loc.recoverbullWaiting,
+      KeyServerStatus.connecting => context.loc.recoverbullConnecting,
+      KeyServerStatus.online => context.loc.recoverbullConnected,
+      KeyServerStatus.offline => context.loc.recoverbullFailed,
+    };
   }
 
   Color _getStatusColor(BuildContext context) {
-    final statusEnum = isKeyServer
-        ? (status as KeyServerStatus)
-        : (status as TorStatus);
-
-    return switch (statusEnum.toString().split('.').last) {
-      'online' => context.appColors.success,
-      'offline' => context.appColors.error,
-      'connecting' => context.appColors.textMuted,
-      _ => context.appColors.textMuted,
+    return switch (status) {
+      KeyServerStatus.online => context.appColors.success,
+      KeyServerStatus.offline => context.appColors.error,
+      KeyServerStatus.connecting ||
+      KeyServerStatus.unknown => context.appColors.textMuted,
     };
   }
 
   IconData _getIcon() {
-    final statusEnum = isKeyServer
-        ? (status as KeyServerStatus)
-        : (status as TorStatus);
-
-    return switch (statusEnum.toString().split('.').last) {
-      'online' => Icons.check_circle,
-      'offline' => Icons.error,
-      'connecting' => Icons.hourglass_empty,
-      _ => Icons.circle_outlined,
+    return switch (status) {
+      KeyServerStatus.online => Icons.check_circle,
+      KeyServerStatus.offline => Icons.error,
+      KeyServerStatus.connecting => Icons.hourglass_empty,
+      KeyServerStatus.unknown => Icons.circle_outlined,
     };
   }
 }

--- a/lib/features/wallet/presentation/bloc/wallet_bloc.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_bloc.dart
@@ -4,8 +4,6 @@ import 'package:bb_mobile/core/seed/data/datasources/seed_store_type_datasource.
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_sync_result.dart';
 import 'package:bb_mobile/core/sync/sync_coordinator.dart';
 import 'package:bb_mobile/core/sync/sync_trigger.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
@@ -35,8 +33,6 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     required this._watchFinishedWalletSyncsUsecase,
     required this._watchElectrumSyncResultsUsecase,
     required this._syncCoordinator,
-    required this._initializeTorUsecase,
-    required this._checkForTorInitializationOnStartupUsecase,
     required this._getUnconfirmedIncomingBalanceUsecase,
     required this._deleteWalletUsecase,
     required this._seedStoreTypeDatasource,
@@ -47,7 +43,6 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
     on<WalletSyncStarted>(_onWalletSyncStarted);
     on<WalletSyncFinished>(_onWalletSyncFinished);
     on<ElectrumSyncResultChanged>(_onElectrumSyncResultChanged);
-    on<StartTorInitialization>(_onStartTorInitialization);
     on<WalletDeleted>(_onDeleted);
     on<DismissBackupWarning>(_onDismissBackupWarning);
     on<DismissLegacyStorageWarning>(_onDismissLegacyStorageWarning);
@@ -60,8 +55,6 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
   final WatchFinishedWalletSyncsUsecase _watchFinishedWalletSyncsUsecase;
   final WatchElectrumSyncResultsUsecase _watchElectrumSyncResultsUsecase;
   final SyncCoordinator _syncCoordinator;
-  final InitTorUsecase _initializeTorUsecase;
-  final IsTorRequiredUsecase _checkForTorInitializationOnStartupUsecase;
   final GetUnconfirmedIncomingBalanceUsecase
   _getUnconfirmedIncomingBalanceUsecase;
   final DeleteWalletUsecase _deleteWalletUsecase;
@@ -359,19 +352,6 @@ class WalletBloc extends Bloc<WalletEvent, WalletState> {
       );
     } finally {
       emit(state.copyWith(isDeletingWallet: false));
-    }
-  }
-
-  Future<void> _onStartTorInitialization(
-    StartTorInitialization event,
-    Emitter<WalletState> emit,
-  ) async {
-    emit(state.copyWith(status: WalletStatus.loading));
-    final isTorIniatizationEnabled =
-        await _checkForTorInitializationOnStartupUsecase.execute();
-
-    if (isTorIniatizationEnabled) {
-      await _initializeTorUsecase.execute();
     }
   }
 

--- a/lib/features/wallet/presentation/bloc/wallet_event.dart
+++ b/lib/features/wallet/presentation/bloc/wallet_event.dart
@@ -37,8 +37,16 @@ class WalletDeleted extends WalletEvent {
   const WalletDeleted(this.walletId);
 }
 
-class StartTorInitialization extends WalletEvent {
-  const StartTorInitialization();
+class BlockAutoSwapUntilNextExecution extends WalletEvent {
+  const BlockAutoSwapUntilNextExecution();
+}
+
+class ExecuteAutoSwap extends WalletEvent {
+  const ExecuteAutoSwap();
+}
+
+class ExecuteAutoSwapFeeOverride extends WalletEvent {
+  const ExecuteAutoSwapFeeOverride();
 }
 
 class ElectrumSyncResultChanged extends WalletEvent {

--- a/lib/features/wallet/wallet_locator.dart
+++ b/lib/features/wallet/wallet_locator.dart
@@ -1,8 +1,6 @@
 import 'package:bb_mobile/core/seed/data/datasources/seed_store_type_datasource.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
 import 'package:bb_mobile/core/sync/sync_coordinator.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
@@ -47,9 +45,6 @@ class WalletLocator {
         watchElectrumSyncResultsUsecase:
             locator<WatchElectrumSyncResultsUsecase>(),
         syncCoordinator: locator<SyncCoordinator>(),
-        initializeTorUsecase: locator<InitTorUsecase>(),
-        checkForTorInitializationOnStartupUsecase:
-            locator<IsTorRequiredUsecase>(),
         getUnconfirmedIncomingBalanceUsecase:
             locator<GetUnconfirmedIncomingBalanceUsecase>(),
         deleteWalletUsecase: locator<DeleteWalletUsecase>(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show appFlavor;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:bull_tor/tor_adapter.dart' as tor;
 import 'package:workmanager/workmanager.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
 
@@ -219,12 +220,14 @@ class BullBitcoinWalletApp extends StatefulWidget {
 
 class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
   late final AppLifecycleListener _listener;
+  late final tor.TorLifecycleController _torLifecycleController;
   // final router = AppRouter.router;
 
   @override
   void initState() {
     super.initState();
 
+    _torLifecycleController = locator<tor.TorLifecycleController>()..start();
     // Initialize the AppLifecycleListener class and pass callbacks
     _listener = AppLifecycleListener(onStateChange: _onStateChanged);
   }
@@ -236,6 +239,7 @@ class _BullBitcoinWalletAppState extends State<BullBitcoinWalletApp> {
     if (locator.isRegistered<PayjoinLifecycle>()) {
       unawaited(locator<PayjoinLifecycle>().dispose());
     }
+    _torLifecycleController.dispose();
 
     super.dispose();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   bull_payjoin:
   bull_ui:
   primitives:
+  bull_tor:
   flutter_bloc: ^9.1.1
   freezed: ^3.2.3
   get_it: ^9.1.1

--- a/test/core_test/recoverbull/check_server_connection_usecase_test.dart
+++ b/test/core_test/recoverbull/check_server_connection_usecase_test.dart
@@ -1,0 +1,78 @@
+import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_tor_route.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
+
+class _MockRepository extends Mock implements RecoverBullRepository {}
+
+class _MockEnsureSession extends Mock
+    implements EnsureRecoverBullTorSessionUsecase {}
+
+void main() {
+  late _MockRepository repository;
+  late _MockEnsureSession ensureSession;
+  late CheckServerConnectionUsecase usecase;
+
+  final endpoint = TorProxyEndpoint(host: '127.0.0.1', port: 19050);
+  var sessionClosed = false;
+  late RecoverBullTorRoute session;
+
+  setUp(() {
+    sessionClosed = false;
+    session = RecoverBullTorRoute(endpoint, () async => sessionClosed = true);
+  });
+
+  setUpAll(() => registerFallbackValue(endpoint));
+
+  setUp(() {
+    repository = _MockRepository();
+    ensureSession = _MockEnsureSession();
+    usecase = CheckServerConnectionUsecase(repository, ensureSession);
+  });
+
+  test('reachable server over the embedded route -> true', () async {
+    when(() => ensureSession.execute()).thenAnswer((_) async => Ok(session));
+    when(() => repository.checkConnection(any())).thenAnswer((_) async {});
+
+    expect(await usecase.execute(), isTrue);
+    verify(() => repository.checkConnection(endpoint)).called(1);
+    expect(sessionClosed, isTrue);
+  });
+
+  test('no Tor route -> false, server never contacted', () async {
+    when(() => ensureSession.execute()).thenAnswer(
+      (_) async => const Err(KeyServerUnavailableFailure('tor down')),
+    );
+
+    expect(await usecase.execute(), isFalse);
+    verifyNever(() => repository.checkConnection(any()));
+  });
+
+  // Regression pin: the check used to return the repository call as a future
+  // from inside its `try`, which chained the throw outside the block — the
+  // caller got an exception instead of `false`, aborting its retry loop.
+  test('throwing server check -> false, never rethrown', () async {
+    when(() => ensureSession.execute()).thenAnswer((_) async => Ok(session));
+    when(
+      () => repository.checkConnection(any()),
+    ).thenThrow(Exception('key server unreachable'));
+
+    expect(await usecase.execute(), isFalse);
+    expect(sessionClosed, isTrue);
+  });
+
+  test('server that rejects asynchronously -> false', () async {
+    when(() => ensureSession.execute()).thenAnswer((_) async => Ok(session));
+    when(
+      () => repository.checkConnection(any()),
+    ).thenAnswer((_) async => throw Exception('timeout'));
+
+    expect(await usecase.execute(), isFalse);
+    expect(sessionClosed, isTrue);
+  });
+}

--- a/test/core_test/recoverbull/ensure_recoverbull_tor_session_usecase_test.dart
+++ b/test/core_test/recoverbull/ensure_recoverbull_tor_session_usecase_test.dart
@@ -1,0 +1,142 @@
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_tor_route.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bull_tor/tor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockEmbeddedTor extends Mock implements EmbeddedTor {}
+
+class _MockTorSessions extends Mock implements TorSessions {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+SettingsEntity _settings({bool useTorProxy = false, int torProxyPort = 9050}) =>
+    SettingsEntity(
+      environment: Environment.mainnet,
+      bitcoinUnit: BitcoinUnit.btc,
+      currencyCode: 'CAD',
+      useTorProxy: useTorProxy,
+      torProxyPort: torProxyPort,
+    );
+
+void main() {
+  late _MockEmbeddedTor embeddedTor;
+  late _MockTorSessions sessions;
+  late _MockSettingsRepository settingsRepository;
+  late EnsureRecoverBullTorSessionUsecase usecase;
+
+  setUp(() {
+    embeddedTor = _MockEmbeddedTor();
+    sessions = _MockTorSessions();
+    settingsRepository = _MockSettingsRepository();
+    when(() => embeddedTor.sessions).thenReturn(sessions);
+    when(() => settingsRepository.fetch()).thenAnswer((_) async => _settings());
+    usecase = EnsureRecoverBullTorSessionUsecase(
+      embeddedTor,
+      settingsRepository,
+    );
+  });
+
+  test('accepts an embedded Onion route', () async {
+    final route = TorRoute(
+      source: TorSource.embedded,
+      endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 19050),
+      evidence: TorReadinessEvidence.embeddedBootstrap,
+      transport: TorTransport.direct,
+    );
+    final session = TorSession(
+      TorProxyEndpoint(host: '127.0.0.1', port: 19051),
+      TorTransport.direct,
+      () async {},
+    );
+    when(
+      () => embeddedTor.ensureReady(),
+    ).thenAnswer((_) async => TorReady(route));
+    when(() => sessions.open()).thenAnswer((_) async => session);
+
+    final result = await usecase.execute();
+
+    expect(result, isA<Ok<RecoverBullTorRoute, RecoverBullCoreFailure>>());
+  });
+
+  test('rejects an external SOCKS route', () async {
+    final route = TorRoute(
+      source: TorSource.external,
+      endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 9050),
+      evidence: TorReadinessEvidence.externalSocksHandshake,
+    );
+    when(
+      () => embeddedTor.ensureReady(),
+    ).thenAnswer((_) async => TorReady(route));
+
+    final result = await usecase.execute();
+
+    expect(result, isA<Err<RecoverBullTorRoute, RecoverBullCoreFailure>>());
+    verifyNever(() => sessions.open());
+  });
+
+  // Embedded Tor cannot bootstrap inside Orbot's device-wide tunnel, so an
+  // Orbot user has to reach the key server through Orbot's own SOCKS port.
+  // Loopback is what makes that work: it never traverses the tun interface.
+  test('routes through the external proxy when the user enabled it', () async {
+    when(
+      () => settingsRepository.fetch(),
+    ).thenAnswer((_) async => _settings(useTorProxy: true, torProxyPort: 9050));
+
+    final result = await usecase.execute();
+
+    expect(result, isA<Ok<RecoverBullTorRoute, RecoverBullCoreFailure>>());
+    final route =
+        (result as Ok<RecoverBullTorRoute, RecoverBullCoreFailure>).value;
+    expect(route.endpoint.host, '127.0.0.1');
+    expect(route.endpoint.port, 9050);
+    verifyNever(() => embeddedTor.ensureReady());
+    verifyNever(() => sessions.open());
+    // Closing must not tear down a proxy the app does not own.
+    await route.close();
+  });
+
+  test('honours a custom external proxy port', () async {
+    when(() => settingsRepository.fetch()).thenAnswer(
+      (_) async => _settings(useTorProxy: true, torProxyPort: 19050),
+    );
+
+    final result = await usecase.execute();
+
+    final route =
+        (result as Ok<RecoverBullTorRoute, RecoverBullCoreFailure>).value;
+    expect(route.endpoint.port, 19050);
+  });
+
+  test('maps settings fetch exceptions to a failure result', () async {
+    when(
+      () => settingsRepository.fetch(),
+    ).thenThrow(Exception('settings down'));
+
+    final result = await usecase.execute();
+
+    expect(result, isA<Err<RecoverBullTorRoute, RecoverBullCoreFailure>>());
+    expect(
+      (result as Err<RecoverBullTorRoute, RecoverBullCoreFailure>).failure,
+      isA<KeyServerUnavailableFailure>(),
+    );
+  });
+
+  test('maps Tor ensureReady exceptions to a failure result', () async {
+    when(() => embeddedTor.ensureReady()).thenThrow(
+      const TorBackendException(TorBootstrapFailure('bootstrap failed')),
+    );
+
+    final result = await usecase.execute();
+
+    expect(result, isA<Err<RecoverBullTorRoute, RecoverBullCoreFailure>>());
+    expect(
+      (result as Err<RecoverBullTorRoute, RecoverBullCoreFailure>).failure,
+      isA<KeyServerUnavailableFailure>(),
+    );
+  });
+}

--- a/test/core_test/recoverbull/recoverbull_locator_test.dart
+++ b/test/core_test/recoverbull/recoverbull_locator_test.dart
@@ -1,0 +1,21 @@
+import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_remote_datasource.dart';
+import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/recoverbull_locator.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:bull_tor/tor.dart';
+
+void main() {
+  test('registers synchronous RecoverBull dependencies without waiting', () {
+    final locator = GetIt.asNewInstance()
+      ..registerLazySingleton<SqliteDatabase>(SqliteDatabase.new)
+      ..registerLazySingleton<TorHttpClientFactory>(TorHttpClientFactory.new);
+
+    RecoverbullLocator.registerDatasources(locator);
+    RecoverbullLocator.registerRepositories(locator);
+
+    expect(locator.isRegistered<RecoverBullRemoteDatasource>(), isTrue);
+    expect(locator.isRegistered<RecoverBullRepository>(), isTrue);
+  });
+}

--- a/test/core_test/recoverbull/recoverbull_repository_test.dart
+++ b/test/core_test/recoverbull/recoverbull_repository_test.dart
@@ -2,23 +2,22 @@ import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_remote_d
 import 'package:bb_mobile/core/recoverbull/data/datasources/recoverbull_settings_datasource.dart';
 import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
 import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
-import 'package:bb_mobile/core/tor/domain/value_objects/tor_proxy_config.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:recoverbull/recoverbull.dart' as recoverbull;
+import 'package:bull_tor/tor.dart';
 
 class _MockRemote extends Mock implements RecoverBullRemoteDatasource {}
 
 class _MockSettings extends Mock implements RecoverbullSettingsDatasource {}
 
-class _MockTorConfig extends Mock implements TorConfigPort {}
-
 void main() {
+  final endpoint = TorProxyEndpoint(host: '127.0.0.1', port: 9050);
+
   setUpAll(() {
     registerFallbackValue(<int>[]);
-    registerFallbackValue(const TorProxyConfig(port: 0));
+    registerFallbackValue(endpoint);
   });
 
   late _MockRemote remote;
@@ -26,31 +25,21 @@ void main() {
 
   setUp(() {
     remote = _MockRemote();
-    final torConfig = _MockTorConfig();
-    when(
-      () => torConfig.getAvailableExternalTorConfig(),
-    ).thenAnswer((_) async => null);
     repository = RecoverBullRepository(
       remoteDatasource: remote,
       recoverbullSettingsDatasource: _MockSettings(),
-      torConfigPort: torConfig,
     );
   });
 
   void stubFetchThrows(Object error) {
     when(
-      () => remote.fetch(
-        any(),
-        any(),
-        any(),
-        externalProxy: any(named: 'externalProxy'),
-      ),
+      () => remote.fetch(any(), any(), any(), endpoint: any(named: 'endpoint')),
     ).thenThrow(error);
   }
 
   // identifier/salt must be valid hex (the repo HEX-decodes them).
   Future<Result<String, RecoverBullCoreFailure>> fetch() =>
-      repository.fetchVaultKey('00', 'password', '00');
+      repository.fetchVaultKey('00', 'password', '00', endpoint);
 
   group('RecoverBullRepository.fetchVaultKey maps KeyServerException', () {
     test('401 -> KeyServerInvalidCredentialsFailure (no raw leak)', () async {
@@ -136,12 +125,7 @@ void main() {
 
   test('success -> Ok with hex-encoded key', () async {
     when(
-      () => remote.fetch(
-        any(),
-        any(),
-        any(),
-        externalProxy: any(named: 'externalProxy'),
-      ),
+      () => remote.fetch(any(), any(), any(), endpoint: any(named: 'endpoint')),
     ).thenAnswer((_) async => [0xab, 0xcd]);
 
     final result = await fetch();
@@ -158,12 +142,8 @@ void main() {
   group('hex input normalization and strict decoding (identifier/salt)', () {
     void stubFetchOk() {
       when(
-        () => remote.fetch(
-          any(),
-          any(),
-          any(),
-          externalProxy: any(named: 'externalProxy'),
-        ),
+        () =>
+            remote.fetch(any(), any(), any(), endpoint: any(named: 'endpoint')),
       ).thenAnswer((_) async => [0xab, 0xcd]);
     }
 
@@ -179,6 +159,7 @@ void main() {
         'de ad be ef',
         'password',
         '00 11',
+        endpoint,
       );
 
       expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
@@ -191,7 +172,7 @@ void main() {
           captureAny(),
           any(),
           captureAny(),
-          externalProxy: any(named: 'externalProxy'),
+          endpoint: any(named: 'endpoint'),
         ),
       ).captured;
       expect(captured[0], [0xde, 0xad, 0xbe, 0xef]);
@@ -201,7 +182,12 @@ void main() {
     test('uppercase input still decodes', () async {
       stubFetchOk();
 
-      final result = await repository.fetchVaultKey('ABCD', 'password', 'EF01');
+      final result = await repository.fetchVaultKey(
+        'ABCD',
+        'password',
+        'EF01',
+        endpoint,
+      );
 
       expect(result, isA<Ok<String, RecoverBullCoreFailure>>());
       // Proves convert case-folds (RFC 4648): 'ABCD'/'EF01' decode to the same
@@ -211,7 +197,7 @@ void main() {
           captureAny(),
           any(),
           captureAny(),
-          externalProxy: any(named: 'externalProxy'),
+          endpoint: any(named: 'endpoint'),
         ),
       ).captured;
       expect(captured[0], [0xab, 0xcd]);
@@ -225,7 +211,12 @@ void main() {
       // Under package:hex "abc" was silently decoded as "0abc" -> a different,
       // wrong key, and the request proceeded. Under package:convert it throws,
       // is caught, and mapped to a failure *before* remote.fetch is reached.
-      final result = await repository.fetchVaultKey('abc', 'password', '00');
+      final result = await repository.fetchVaultKey(
+        'abc',
+        'password',
+        '00',
+        endpoint,
+      );
 
       expect(result, isA<Err<String, RecoverBullCoreFailure>>());
       expect(
@@ -233,31 +224,28 @@ void main() {
         isA<RecoverBullUnexpectedCoreFailure>(),
       );
       verifyNever(
-        () => remote.fetch(
-          any(),
-          any(),
-          any(),
-          externalProxy: any(named: 'externalProxy'),
-        ),
+        () =>
+            remote.fetch(any(), any(), any(), endpoint: any(named: 'endpoint')),
       );
     });
 
     test('non-hex input is rejected before any network call', () async {
       stubFetchOk();
 
-      final result = await repository.fetchVaultKey('zz', 'password', '00');
+      final result = await repository.fetchVaultKey(
+        'zz',
+        'password',
+        '00',
+        endpoint,
+      );
 
       expect(
         (result as Err<String, RecoverBullCoreFailure>).failure,
         isA<RecoverBullUnexpectedCoreFailure>(),
       );
       verifyNever(
-        () => remote.fetch(
-          any(),
-          any(),
-          any(),
-          externalProxy: any(named: 'externalProxy'),
-        ),
+        () =>
+            remote.fetch(any(), any(), any(), endpoint: any(named: 'endpoint')),
       );
     });
   });

--- a/test/core_test/status/check_all_service_status_usecase_test.dart
+++ b/test/core_test/status/check_all_service_status_usecase_test.dart
@@ -1,14 +1,13 @@
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_rate_repository.dart';
 import 'package:bb_mobile/core/fees/domain/repositories/fees_repository.dart';
-import 'package:bb_mobile/core/recoverbull/data/repository/recoverbull_repository.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
 import 'package:bb_mobile/core/status/domain/entity/service_status.dart';
 import 'package:bb_mobile/core/status/domain/ports/electrum_connectivity_port.dart';
 import 'package:bb_mobile/core/status/domain/usecases/check_all_service_status_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
-import 'package:bb_mobile/core/tor/tor_status.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:bull_tor/tor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:primitives/primitives.dart' show Ok;
@@ -25,21 +24,22 @@ class _MockPayjoinDiagnostics extends Mock implements PayjoinDiagnostics {}
 
 class _MockFeesRepository extends Mock implements FeesRepository {}
 
-class _MockRecoverBullRepository extends Mock
-    implements RecoverBullRepository {}
+class _MockCheckServerConnectionUsecase extends Mock
+    implements CheckServerConnectionUsecase {}
 
 class _MockWalletRepository extends Mock implements WalletRepository {}
 
-class _MockTorStatusUsecase extends Mock implements TorStatusUsecase {}
+class _MockEnsureTorReadyUsecase extends Mock
+    implements EnsureTorReadyUsecase {}
 
 void main() {
   test('disabled Payjoin is not probed or reported offline', () async {
     final payjoinPolicy = _MockPayjoinPolicyAccess();
     final payjoinDiagnostics = _MockPayjoinDiagnostics();
     final walletRepository = _MockWalletRepository();
-    final torStatusUsecase = _MockTorStatusUsecase();
+    // Tor is not required for this wallet, so neither the Tor nor the
+    // RecoverBull probe is reached — the point of the test is Payjoin.
     when(walletRepository.isTorRequired).thenAnswer((_) async => false);
-    when(torStatusUsecase.execute).thenAnswer((_) async => TorStatus.unknown);
     when(
       payjoinPolicy.load,
     ).thenAnswer((_) async => Ok(PayjoinPolicy.defaults()));
@@ -49,9 +49,9 @@ void main() {
       payjoinPolicy: payjoinPolicy,
       payjoinDiagnostics: payjoinDiagnostics,
       feesRepository: _MockFeesRepository(),
-      recoverBullRepository: _MockRecoverBullRepository(),
       walletRepository: walletRepository,
-      torStatusUsecase: torStatusUsecase,
+      ensureTorReadyUsecase: _MockEnsureTorReadyUsecase(),
+      checkServerConnectionUsecase: _MockCheckServerConnectionUsecase(),
     );
 
     final status = await usecase.execute(network: Network.bitcoinMainnet);

--- a/test/features/app_startup/app_startup_bloc_test.dart
+++ b/test/features/app_startup/app_startup_bloc_test.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/is_tor_required_usecase.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/check_legacy_install_usecase.dart';
+import 'package:bb_mobile/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart';
 import 'package:bb_mobile/features/app_startup/domain/usecases/reset_app_data_usecase.dart';
 import 'package:bb_mobile/features/app_startup/presentation/bloc/app_startup_bloc.dart';
 import 'package:bb_mobile/features/app_unlock/domain/app_unlock_failure.dart';
@@ -27,9 +26,8 @@ class _MockCheckLegacyInstallUsecase extends Mock
 
 class _MockCheckBackupUsecase extends Mock implements CheckBackupUsecase {}
 
-class _MockIsTorRequiredUsecase extends Mock implements IsTorRequiredUsecase {}
-
-class _MockInitTorUsecase extends Mock implements InitTorUsecase {}
+class _MockInitializeRequiredTorUsecase extends Mock
+    implements InitializeRequiredTorUsecase {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -45,7 +43,7 @@ void main() {
   late _MockCheckPinCodeExistsUsecase checkPinCodeExists;
   late _MockCheckForExistingDefaultWalletsUsecase checkDefaultWallets;
   late _MockCheckLegacyInstallUsecase checkLegacyInstall;
-  late _MockIsTorRequiredUsecase isTorRequired;
+  late _MockInitializeRequiredTorUsecase initializeRequiredTor;
 
   AppStartupBloc buildBloc() => AppStartupBloc(
     resetAppDataUsecase: resetAppData,
@@ -53,8 +51,7 @@ void main() {
     checkForExistingDefaultWalletsUsecase: checkDefaultWallets,
     checkLegacyInstallUsecase: checkLegacyInstall,
     checkBackupUsecase: _MockCheckBackupUsecase(),
-    isTorRequiredUsecase: isTorRequired,
-    initTorUsecase: _MockInitTorUsecase(),
+    initializeRequiredTorUsecase: initializeRequiredTor,
   );
 
   setUp(() {
@@ -62,10 +59,11 @@ void main() {
     checkPinCodeExists = _MockCheckPinCodeExistsUsecase();
     checkDefaultWallets = _MockCheckForExistingDefaultWalletsUsecase();
     checkLegacyInstall = _MockCheckLegacyInstallUsecase();
-    isTorRequired = _MockIsTorRequiredUsecase();
+    initializeRequiredTor = _MockInitializeRequiredTorUsecase();
 
     when(() => resetAppData.execute()).thenAnswer((_) async {});
-    when(() => isTorRequired.execute()).thenAnswer((_) async => false);
+    // No encrypted backup in these fixtures, so Tor is never warmed.
+    when(() => initializeRequiredTor.execute()).thenAnswer((_) async => null);
   });
 
   test(

--- a/test/features/app_startup/domain/initialize_required_tor_usecase_test.dart
+++ b/test/features/app_startup/domain/initialize_required_tor_usecase_test.dart
@@ -1,0 +1,47 @@
+import 'package:bb_mobile/features/app_startup/domain/app_startup_wallet_port.dart';
+import 'package:bb_mobile/features/app_startup/domain/usecases/initialize_required_tor_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
+
+class _MockAppStartupWalletPort extends Mock implements AppStartupWalletPort {}
+
+class _MockEnsureTorReadyUsecase extends Mock
+    implements EnsureTorReadyUsecase {}
+
+void main() {
+  late _MockAppStartupWalletPort walletPort;
+  late _MockEnsureTorReadyUsecase ensureTorReadyUsecase;
+  late InitializeRequiredTorUsecase usecase;
+
+  setUp(() {
+    walletPort = _MockAppStartupWalletPort();
+    ensureTorReadyUsecase = _MockEnsureTorReadyUsecase();
+    usecase = InitializeRequiredTorUsecase(walletPort, ensureTorReadyUsecase);
+  });
+
+  test('does not start embedded Tor without an encrypted backup', () async {
+    when(
+      () => walletPort.hasMainnetBitcoinEncryptedBackup(),
+    ).thenAnswer((_) async => false);
+
+    expect(await usecase.execute(), isNull);
+    verifyNever(() => ensureTorReadyUsecase.execute());
+  });
+
+  test('starts embedded Tor when an encrypted backup exists', () async {
+    final route = TorRoute(
+      source: TorSource.embedded,
+      endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 19050),
+      evidence: TorReadinessEvidence.embeddedBootstrap,
+    );
+    final ready = TorReady(route);
+    when(
+      () => walletPort.hasMainnetBitcoinEncryptedBackup(),
+    ).thenAnswer((_) async => true);
+    when(() => ensureTorReadyUsecase.execute()).thenAnswer((_) async => ready);
+
+    expect(await usecase.execute(), same(ready));
+    verify(() => ensureTorReadyUsecase.execute()).called(1);
+  });
+}

--- a/test/features/recoverbull/domain/connect_to_key_server_usecase_test.dart
+++ b/test/features/recoverbull/domain/connect_to_key_server_usecase_test.dart
@@ -1,0 +1,78 @@
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
+import 'package:bb_mobile/features/recoverbull/domain/connect_to_key_server_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockCheckServerConnection extends Mock
+    implements CheckServerConnectionUsecase {}
+
+void main() {
+  late _MockCheckServerConnection checkConnection;
+  late List<Duration> waited;
+  late List<int> attempts;
+  late ConnectToKeyServerUsecase usecase;
+
+  setUp(() {
+    checkConnection = _MockCheckServerConnection();
+    waited = [];
+    attempts = [];
+    usecase = ConnectToKeyServerUsecase(
+      checkConnection,
+      wait: (duration) async => waited.add(duration),
+    );
+  });
+
+  Future<bool> run() => usecase.execute(onAttempt: attempts.add);
+
+  test('stops at the first answer instead of exhausting the budget', () async {
+    when(() => checkConnection.execute()).thenAnswer((_) async => true);
+
+    expect(await run(), isTrue);
+    expect(attempts, [1]);
+    verify(() => checkConnection.execute()).called(1);
+  });
+
+  test('gives up after the attempt budget', () async {
+    when(() => checkConnection.execute()).thenAnswer((_) async => false);
+
+    expect(await run(), isFalse);
+    expect(attempts, [1, 2, 3]);
+    expect(attempts.length, ConnectToKeyServerUsecase.maxAttempts);
+    verify(
+      () => checkConnection.execute(),
+    ).called(ConnectToKeyServerUsecase.maxAttempts);
+  });
+
+  test(
+    'reports the attempt that is in flight, not the one that failed',
+    () async {
+      var calls = 0;
+      when(() => checkConnection.execute()).thenAnswer((_) async {
+        // The attempt must already be published when the call runs, otherwise
+        // the screen names the previous one.
+        expect(attempts.last, calls + 1);
+        calls++;
+        return calls == 2;
+      });
+
+      expect(await run(), isTrue);
+      expect(attempts, [1, 2]);
+    },
+  );
+
+  test('tries immediately, then backs off between retries', () async {
+    when(() => checkConnection.execute()).thenAnswer((_) async => false);
+
+    await run();
+
+    expect(waited, const [Duration(seconds: 1), Duration(seconds: 2)]);
+  });
+
+  test('does not delay a server that answers at once', () async {
+    when(() => checkConnection.execute()).thenAnswer((_) async => true);
+
+    await run();
+
+    expect(waited, isEmpty);
+  });
+}

--- a/test/features/recoverbull/recoverbull_bloc_test.dart
+++ b/test/features/recoverbull/recoverbull_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/recoverbull/domain/entity/encrypted_vault.dart';
 import 'package:bb_mobile/core/recoverbull/domain/entity/vault_provider.dart';
 import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart'
@@ -14,15 +16,14 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/update_latest_encrypted_backup_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/init_tor_usecase.dart';
-import 'package:bb_mobile/core/tor/data/usecases/tor_status_usecase.dart';
-import 'package:bb_mobile/core/tor/domain/ports/tor_config_port.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/recoverbull/domain/connect_to_key_server_usecase.dart';
 import 'package:bb_mobile/features/recoverbull/domain/recoverbull_failure.dart';
 import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/features/wallet/presentation/bloc/wallet_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
 
 class _MockPickVault extends Mock implements PickVaultUsecase {}
 
@@ -45,7 +46,9 @@ class _MockConnectDrive extends Mock implements ConnectToGoogleDriveUsecase {}
 
 class _MockSaveDrive extends Mock implements SaveVaultToGoogleDriveUsecase {}
 
-class _MockInitTor extends Mock implements InitTorUsecase {}
+class _MockEnsureTor extends Mock implements EnsureTorReadyUsecase {}
+
+class _MockRetryTor extends Mock implements RetryTorConnectionUsecase {}
 
 class _MockWalletBloc extends Mock implements WalletBloc {}
 
@@ -55,9 +58,8 @@ class _MockFetchLatestDrive extends Mock
 class _MockUpdateLatest extends Mock
     implements UpdateLatestEncryptedVaultTestUsecase {}
 
-class _MockTorStatus extends Mock implements TorStatusUsecase {}
-
-class _MockTorConfig extends Mock implements TorConfigPort {}
+class _MockWatchTorConnection extends Mock
+    implements WatchTorConnectionUsecase {}
 
 class _MockEncryptedVault extends Mock implements EncryptedVault {}
 
@@ -72,12 +74,12 @@ void main() {
   late _MockRestore restore;
   late _MockConnectDrive connectDrive;
   late _MockSaveDrive saveDrive;
-  late _MockInitTor initTor;
+  late _MockEnsureTor ensureTor;
+  late _MockRetryTor retryTor;
   late _MockWalletBloc walletBloc;
   late _MockFetchLatestDrive fetchLatestDrive;
   late _MockUpdateLatest updateLatest;
-  late _MockTorStatus torStatus;
-  late _MockTorConfig torConfig;
+  late _MockWatchTorConnection watchTor;
 
   setUpAll(() {
     registerFallbackValue(_MockEncryptedVault());
@@ -94,16 +96,19 @@ void main() {
     restore = _MockRestore();
     connectDrive = _MockConnectDrive();
     saveDrive = _MockSaveDrive();
-    initTor = _MockInitTor();
+    ensureTor = _MockEnsureTor();
+    retryTor = _MockRetryTor();
     walletBloc = _MockWalletBloc();
     fetchLatestDrive = _MockFetchLatestDrive();
     updateLatest = _MockUpdateLatest();
-    torStatus = _MockTorStatus();
-    torConfig = _MockTorConfig();
+    watchTor = _MockWatchTorConnection();
+    when(
+      () => watchTor.execute(),
+    ).thenAnswer((_) => const Stream<TorConnectionState>.empty());
   });
 
-  // The bloc constructor does not auto-dispatch any event, so unstubbed mocks
-  // stay untouched unless a test drives the matching flow.
+  // No event is auto-dispatched, so unstubbed mocks stay untouched unless a
+  // test drives the matching flow — the Tor subscription above excepted.
   RecoverBullBloc buildBloc({
     required RecoverBullFlow flow,
     EncryptedVault? preSelectedVault,
@@ -115,17 +120,21 @@ void main() {
     createEncryptedVaultUsecase: createVault,
     storeVaultKeyIntoServerUsecase: storeKey,
     checkKeyServerConnectionUsecase: checkConnection,
+    connectToKeyServerUsecase: ConnectToKeyServerUsecase(
+      checkConnection,
+      wait: (_) async {},
+    ),
     fetchVaultKeyFromServerUsecase: fetchKey,
     decryptVaultUsecase: decrypt,
     restoreVaultUsecase: restore,
     connectToGoogleDriveUsecase: connectDrive,
     saveToGoogleDriveUsecase: saveDrive,
-    initializeTorUsecase: initTor,
+    ensureTorReadyUsecase: ensureTor,
+    retryTorConnectionUsecase: retryTor,
     walletBloc: walletBloc,
     fetchLatestGoogleDriveVaultUsecase: fetchLatestDrive,
     updateLatestEncryptedVaultTestUsecase: updateLatest,
-    torStatusUsecase: torStatus,
-    torConfigPort: torConfig,
+    watchTorConnectionUsecase: watchTor,
   );
 
   group('OnVaultPasswordSet guard', () {
@@ -231,5 +240,166 @@ void main() {
         await bloc.close();
       },
     );
+  });
+
+  group('Tor retry concurrency', () {
+    test('drops a second retry while the first one is in flight', () async {
+      final pending = Completer<TorConnectionState>();
+      when(() => retryTor.execute()).thenAnswer((_) => pending.future);
+      final bloc = buildBloc(flow: RecoverBullFlow.recoverVault);
+
+      bloc.add(const OnTorInitialization(restart: true));
+      await pumpEventQueue();
+      bloc.add(const OnTorInitialization(restart: true));
+      await pumpEventQueue();
+
+      verify(() => retryTor.execute()).called(1);
+
+      pending.complete(
+        const TorUnavailable(
+          source: TorSource.embedded,
+          failure: TorBootstrapFailure('bootstrap failed'),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(bloc.state.failure, isA<TorNotStartedFailure>());
+      await bloc.close();
+    });
+  });
+
+  group('RecoverBull Tor readiness', () {
+    test(
+      'keeps a usable route ready during Arti directory refreshes',
+      () async {
+        final states = StreamController<TorConnectionState>();
+        when(() => watchTor.execute()).thenAnswer((_) => states.stream);
+        final bloc = buildBloc(flow: RecoverBullFlow.recoverVault);
+        final route = TorRoute(
+          source: TorSource.embedded,
+          endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+          evidence: TorReadinessEvidence.embeddedBootstrap,
+          transport: TorTransport.direct,
+        );
+
+        states.add(
+          const TorConnecting(
+            source: TorSource.embedded,
+            progress: 0.76,
+            transport: TorTransport.direct,
+          ),
+        );
+        await pumpEventQueue();
+        states.add(TorReady(route));
+        await pumpEventQueue();
+        states.add(
+          const TorConnecting(
+            source: TorSource.embedded,
+            progress: 0.42,
+            transport: TorTransport.direct,
+          ),
+        );
+        await pumpEventQueue();
+
+        expect(bloc.state.torConnection, isA<TorReady>());
+
+        states.add(
+          const TorUnavailable(
+            source: TorSource.embedded,
+            failure: TorBootstrapFailure('route lost'),
+          ),
+        );
+        await pumpEventQueue();
+        expect(bloc.state.torConnection, isA<TorUnavailable>());
+
+        await states.close();
+        await bloc.close();
+      },
+    );
+
+    test('surfaces a blockage after a previously ready route', () async {
+      final states = StreamController<TorConnectionState>();
+      when(() => watchTor.execute()).thenAnswer((_) => states.stream);
+      final bloc = buildBloc(flow: RecoverBullFlow.recoverVault);
+      final route = TorRoute(
+        source: TorSource.embedded,
+        endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+        evidence: TorReadinessEvidence.embeddedBootstrap,
+        transport: TorTransport.direct,
+      );
+
+      states.add(TorReady(route));
+      await pumpEventQueue();
+      states.add(
+        const TorConnecting(
+          source: TorSource.embedded,
+          progress: 0.42,
+          transport: TorTransport.direct,
+          diagnostic: TorDiagnostic.offline,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(
+        bloc.state.torConnection,
+        const TorConnecting(
+          source: TorSource.embedded,
+          progress: 0.42,
+          transport: TorTransport.direct,
+          diagnostic: TorDiagnostic.offline,
+        ),
+      );
+
+      await states.close();
+      await bloc.close();
+    });
+
+    // The stale-generation arm of _onTorInitialization returns without asking
+    // for a server check, so readiness arriving through the watch stream has to
+    // trigger one — otherwise the screen sits on "waiting" with no retry.
+    test(
+      'checks the server when readiness arrives through the stream',
+      () async {
+        final states = StreamController<TorConnectionState>();
+        when(() => watchTor.execute()).thenAnswer((_) => states.stream);
+        when(() => checkConnection.execute()).thenAnswer((_) async => true);
+        final bloc = buildBloc(flow: RecoverBullFlow.recoverVault);
+        final route = TorRoute(
+          source: TorSource.embedded,
+          endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+          evidence: TorReadinessEvidence.embeddedBootstrap,
+          transport: TorTransport.direct,
+        );
+
+        states.add(TorReady(route));
+        await pumpEventQueue();
+
+        expect(bloc.state.keyServerStatus, KeyServerStatus.online);
+        verify(() => checkConnection.execute()).called(greaterThanOrEqualTo(1));
+
+        await states.close();
+        await bloc.close();
+      },
+    );
+
+    test('does not dispatch a server check after the bloc closes', () async {
+      final pending = Completer<TorConnectionState>();
+      when(() => ensureTor.execute()).thenAnswer((_) => pending.future);
+      final bloc = buildBloc(flow: RecoverBullFlow.recoverVault);
+      final route = TorRoute(
+        source: TorSource.embedded,
+        endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+        evidence: TorReadinessEvidence.embeddedBootstrap,
+        transport: TorTransport.direct,
+      );
+
+      bloc.add(const OnTorInitialization());
+      await pumpEventQueue();
+      final close = bloc.close();
+      pending.complete(TorReady(route));
+      await close;
+
+      verifyNever(() => checkConnection.execute());
+    });
   });
 }


### PR DESCRIPTION
Stacked on the `feat/bull-tor-package` PR. Review that one first.

RecoverBull now opens its own isolated Tor session through `bull_tor` instead of borrowing a shared global proxy, so key-server traffic is not correlatable with the app's other Tor traffic.

Startup gains `InitializeRequiredTorUsecase` behind an `AppStartupWalletPort`, which is what lets the Tor bring-up move out of `WalletBloc`. Tor was being started from the wallet layer for a reason unrelated to wallets; it now belongs to app startup, and `wallet_bloc` loses that responsibility entirely.

`ConnectToKeyServerUsecase` owns the retry budget and backoff for reaching the key server. That logic used to sit in the bloc, which owns presentation only — as a use case it is testable without pumping a bloc, and the attempt number is still published so the screen can name the attempt in flight.

Two behaviours in the bloc are worth review attention:

- **Readiness is latched.** Arti's directory fraction is not monotonic once traffic is usable: a background directory refresh reports `TorConnecting` again while the established SOCKS route stays valid. RecoverBull only needs that route, so a benign refresh no longer undoes readiness. A refresh that carries a diagnostic is *not* treated as benign and still propagates, so a real loss of connectivity is not masked.
- **A closed bloc no longer emits.** Tor readiness can arrive after the screen is gone, which produced `Bad state: Cannot add new events after calling close` on device. Guarded.
