### PR TITLE
feat(electrum): route onion servers through isolated Tor

### DIFF
--- a/lib/core/electrum/adapters/electrum_servers_adapter.dart
+++ b/lib/core/electrum/adapters/electrum_servers_adapter.dart
@@ -1,25 +1,33 @@
+import 'dart:io';
+
 import 'package:bb_mobile/core/electrum/domain/electrum_fallback_runner.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bull_tor/tor.dart';
 
 /// Concrete [ElectrumServersPort]. Owns the only place in the app where the
-/// active server list is resolved, merged with electrum + Tor settings, and
+/// active server list is resolved, merged with Electrum + Orbot settings, and
 /// iterated — there is no other path consumers can take to reach an Electrum
 /// server, which is what enforces the R1/R2/R2a privacy rule by construction.
 class ElectrumServersAdapter implements ElectrumServersPort {
   final ElectrumServerRepository _serverRepository;
   final ElectrumSettingsRepository _settingsRepository;
   final SettingsRepository _appSettingsRepository;
+  final ElectrumTorSessionPort _torSessionPort;
 
   ElectrumServersAdapter({
     required this._serverRepository,
     required this._settingsRepository,
     required this._appSettingsRepository,
+    required this._torSessionPort,
   });
 
   @override
@@ -54,11 +62,6 @@ class ElectrumServersAdapter implements ElectrumServersPort {
       throw NoElectrumServersConfiguredException(network);
     }
 
-    // Tor proxy applies to Bitcoin only, never Liquid.
-    final socks5 = (appSettings.useTorProxy && !network.isLiquid)
-        ? (settings.socks5 ?? '127.0.0.1:${appSettings.torProxyPort}')
-        : settings.socks5;
-
     final connections = servers
         .map(
           (server) => ElectrumConnection(
@@ -68,7 +71,7 @@ class ElectrumServersAdapter implements ElectrumServersPort {
             stopGap: settings.stopGap,
             validateDomain: settings.validateDomain,
             isCustom: server.isCustom,
-            socks5: socks5,
+            socks5: settings.socks5,
           ),
         )
         .toList();
@@ -77,8 +80,82 @@ class ElectrumServersAdapter implements ElectrumServersPort {
       servers: connections,
       urlOf: (c) => c.url,
       isCustomOf: (c) => c.isCustom,
-      operation: operation,
-      isTransient: isTransient,
+      operation: (connection) async {
+        final ElectrumTorRoute? route;
+        try {
+          route = await _torSessionPort.open(
+            network: network,
+            serverUrl: connection.url,
+            externalProxyEnabled: appSettings.useTorProxy,
+            externalProxyPort: appSettings.torProxyPort,
+          );
+        } catch (_) {
+          // Opening the route can fail on its own — an embedded bootstrap that
+          // never completes is arguably the likeliest way an onion server
+          // becomes unusable. That makes *this server* unroutable, not the whole
+          // active set, so it has to surface as the type the fallback loop
+          // already treats as transient. Otherwise a caller that narrows
+          // `isTransient` to its own error rethrows immediately and never tries
+          // the healthy clearnet default sitting next in the set.
+          throw OnionServerWithoutTorException(connection.url);
+        }
+        try {
+          // Precedence matters and predates this stack: an explicitly persisted
+          // SOCKS setting wins over the Tor proxy toggle, which is the old
+          // `settings.socks5 ?? torProxy` semantics. The onion route comes first
+          // because it is the only one that can carry a hidden service.
+          final routed = connection.withSocks5(
+            route?.endpoint.authority ??
+                connection.socks5 ??
+                _clearnetProxy(network, appSettings),
+          );
+          // The chokepoint that makes the invariant unavoidable: not every
+          // consumer goes through our socket connector — BDK and LWK open
+          // their own — so refusing here is the only check they all share.
+          if (_isUnroutableOnion(routed)) {
+            throw OnionServerWithoutTorException(routed.url);
+          }
+          return await operation(routed);
+        } finally {
+          try {
+            await route?.close();
+          } catch (_) {
+            // Route cleanup must not turn a successful server operation into a
+            // fallback attempt.
+          }
+        }
+      },
+      // An unroutable onion server is skipped, not fatal: the rest of the
+      // active set may still be reachable. Callers narrowing `isTransient` to
+      // their own error type must not turn that into a hard stop.
+      isTransient: isTransient == null
+          ? null
+          : (error) =>
+                error is OnionServerWithoutTorException || isTransient(error),
     );
   }
+
+  /// The external proxy for a *clearnet* Bitcoin server, when one is configured.
+  ///
+  /// Onion servers get a dedicated route from [_torSessionPort]; this covers
+  /// everything else. Without it, enabling the Tor proxy would silently stop
+  /// protecting the default Electrum servers — which are clearnet, and are
+  /// exactly what a user hides their IP from by turning Orbot on. The setting
+  /// has always been documented as applying to Bitcoin, not to onions only.
+  ///
+  /// Liquid stays excluded, as it always has been.
+  static String? _clearnetProxy(
+    ElectrumServerNetwork network,
+    SettingsEntity appSettings,
+  ) {
+    if (network.isLiquid || !appSettings.useTorProxy) return null;
+    return TorProxyEndpoint(
+      host: InternetAddress.loopbackIPv4.address,
+      port: appSettings.torProxyPort,
+    ).authority;
+  }
+
+  static bool _isUnroutableOnion(ElectrumConnection connection) =>
+      ElectrumServerUrl(connection.url).isOnion &&
+      (connection.socks5?.isEmpty ?? true);
 }

--- a/lib/core/electrum/adapters/electrum_tor_session_adapter.dart
+++ b/lib/core/electrum/adapters/electrum_tor_session_adapter.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
+import 'package:bull_tor/tor.dart';
+
+final class ElectrumTorSessionAdapter implements ElectrumTorSessionPort {
+  final Tor Function() _tor;
+
+  const ElectrumTorSessionAdapter(this._tor);
+
+  @override
+  Future<ElectrumTorRoute?> open({
+    required ElectrumServerNetwork network,
+    required String serverUrl,
+    required bool externalProxyEnabled,
+    required int externalProxyPort,
+  }) async {
+    if (network.isLiquid || !ElectrumServerUrl(serverUrl).isOnion) return null;
+
+    if (externalProxyEnabled) {
+      return ElectrumTorRoute(
+        TorProxyEndpoint(
+          host: InternetAddress.loopbackIPv4.address,
+          port: externalProxyPort,
+        ),
+        () async {},
+      );
+    }
+
+    final session = await _tor().embedded.sessions.open();
+    return ElectrumTorRoute(session.endpoint, session.close);
+  }
+}

--- a/lib/core/electrum/adapters/server_status_adapter.dart
+++ b/lib/core/electrum/adapters/server_status_adapter.dart
@@ -1,14 +1,17 @@
-import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bull_tor/tor.dart';
 
 class ServerStatusAdapter implements ServerStatusPort {
-  const ServerStatusAdapter();
+  final ElectrumSocketConnector _socketConnector;
+
+  const ServerStatusAdapter(this._socketConnector);
 
   /// Bitcoin pizza day — first real-world BTC purchase, May 22 2010.
   static const _bitcoinMainnetProbeTxid =
@@ -22,8 +25,7 @@ class ServerStatusAdapter implements ServerStatusPort {
   Future<ElectrumServerStatus> checkSocket({
     required String url,
     int? timeout,
-    bool useTorProxy = false,
-    int torProxyPort = 9050,
+    TorProxyEndpoint? proxyEndpoint,
   }) async {
     try {
       if (url.isEmpty) return ElectrumServerStatus.unknown;
@@ -33,23 +35,18 @@ class ServerStatusAdapter implements ServerStatusPort {
 
       final effectiveTimeout = _resolveTimeout(uri, timeout);
 
-      final isConnectable = useTorProxy
-          ? await _checkThroughSocks5(
-              uri: uri,
-              proxyPort: torProxyPort,
-              timeoutSeconds: effectiveTimeout,
-            )
-          : await _checkRawSocket(uri: uri, timeoutSeconds: effectiveTimeout);
-
-      return isConnectable
-          ? ElectrumServerStatus.online
-          : ElectrumServerStatus.offline;
-    } catch (e) {
-      log.severe(
-        message: 'Error checking server socket for $url',
-        error: e,
-        trace: StackTrace.current,
+      final socket = await _socketConnector.connect(
+        server: uri,
+        proxy: proxyEndpoint,
+        timeout: Duration(seconds: effectiveTimeout),
+        allowBadCertificate: true,
       );
+      socket.destroy();
+      return ElectrumServerStatus.online;
+    } catch (e) {
+      // A server we cannot reach is the expected answer of this check, not a
+      // fault: `severe` would report every offline server to Sentry.
+      log.warning('Socket check failed for $url - $e');
       return ElectrumServerStatus.offline;
     }
   }
@@ -60,6 +57,7 @@ class ServerStatusAdapter implements ServerStatusPort {
     required ElectrumServerNetwork network,
     required bool validateDomain,
     int? timeout,
+    TorProxyEndpoint? proxyEndpoint,
   }) async {
     try {
       if (url.isEmpty) return ElectrumServerStatus.unknown;
@@ -81,6 +79,7 @@ class ServerStatusAdapter implements ServerStatusPort {
         request: request,
         timeoutSeconds: effectiveTimeout,
         validateDomain: validateDomain,
+        proxyEndpoint: proxyEndpoint,
       );
 
       if (response.isEmpty) return ElectrumServerStatus.offline;
@@ -126,34 +125,30 @@ class ServerStatusAdapter implements ServerStatusPort {
   /// Onion addresses need longer timeouts due to Tor circuit building.
   /// Default: 5 seconds for clearnet, 30 seconds for .onion addresses.
   int _resolveTimeout(Uri uri, int? timeout) {
-    final isOnion = uri.host.endsWith('.onion');
+    final isOnion = ElectrumServerUrl.isOnionHost(uri.host);
     return timeout ?? (isOnion ? 30 : 5);
   }
 
-  /// Sends a JSON-RPC request and returns the raw response line.
-  /// [SecureSocket] extends [Socket], so both branches share the same
-  /// write/read logic after construction.
+  /// Sends a JSON-RPC request and returns the raw response line. Plain, TLS
+  /// and proxied sockets all arrive as a [Socket], so the read/write path
+  /// below is the same for every transport.
   Future<String> _sendRequest({
     required Uri uri,
     required String request,
     required int timeoutSeconds,
     required bool validateDomain,
+    TorProxyEndpoint? proxyEndpoint,
   }) async {
-    // A null onBadCertificate callback enforces strict CA validation. The
-    // flag comes from the user's electrum settings, so the probe accepts
-    // exactly the certificates the BDK/LWK sync would accept.
-    final Socket socket = uri.scheme == 'ssl'
-        ? await SecureSocket.connect(
-            uri.host,
-            uri.port,
-            timeout: Duration(seconds: timeoutSeconds),
-            onBadCertificate: validateDomain ? null : (_) => true,
-          )
-        : await Socket.connect(
-            uri.host,
-            uri.port,
-            timeout: Duration(seconds: timeoutSeconds),
-          );
+    // Certificates follow the user's `validateDomain` setting rather than
+    // being blanket-accepted: probing laxer than the sync reports a server
+    // online that the sync will then refuse, and probing stricter hides a
+    // server that would have worked.
+    final socket = await _socketConnector.connect(
+      server: uri,
+      proxy: proxyEndpoint,
+      timeout: Duration(seconds: timeoutSeconds),
+      allowBadCertificate: !validateDomain,
+    );
 
     try {
       socket.write(request);
@@ -166,128 +161,5 @@ class ServerStatusAdapter implements ServerStatusPort {
     } finally {
       socket.destroy();
     }
-  }
-
-  Future<bool> _checkRawSocket({
-    required Uri uri,
-    required int timeoutSeconds,
-  }) async {
-    try {
-      final socket = await Socket.connect(
-        uri.host,
-        uri.port,
-        timeout: Duration(seconds: timeoutSeconds),
-      );
-      socket.destroy();
-      return true;
-    } on SocketException catch (e) {
-      log.warning('Socket connection failed for $uri - $e');
-      return false;
-    } catch (e) {
-      log.severe(
-        message: 'Unexpected error checking socket for $uri',
-        error: e,
-        trace: StackTrace.current,
-      );
-      return false;
-    }
-  }
-
-  /// Checks connectivity through a SOCKS5 proxy (used for Tor).
-  Future<bool> _checkThroughSocks5({
-    required Uri uri,
-    required int proxyPort,
-    required int timeoutSeconds,
-  }) async {
-    Socket? socket;
-    StreamSubscription<List<int>>? subscription;
-    try {
-      socket = await Socket.connect(
-        '127.0.0.1',
-        proxyPort,
-        timeout: Duration(seconds: timeoutSeconds),
-      );
-
-      final handshakeCompleter = Completer<List<int>>();
-      final connectCompleter = Completer<List<int>>();
-      var isHandshakeDone = false;
-
-      subscription = socket.listen(
-        (List<int> data) {
-          if (!isHandshakeDone) {
-            handshakeCompleter.complete(data);
-            isHandshakeDone = true;
-          } else {
-            connectCompleter.complete(data);
-          }
-        },
-        onError: (Object error) {
-          if (!handshakeCompleter.isCompleted) {
-            handshakeCompleter.completeError(error);
-          }
-          if (!connectCompleter.isCompleted) {
-            connectCompleter.completeError(error);
-          }
-        },
-        cancelOnError: true,
-      );
-
-      // SOCKS5 handshake: version 5, 1 auth method (no auth)
-      socket.add([0x05, 0x01, 0x00]);
-
-      final handshakeResponse = await handshakeCompleter.future.timeout(
-        Duration(seconds: timeoutSeconds),
-      );
-
-      if (handshakeResponse.length < 2 || handshakeResponse[0] != 0x05) {
-        log.warning('Invalid SOCKS5 handshake response');
-        return false;
-      }
-
-      socket.add(_buildSocks5ConnectRequest(uri));
-
-      final connectResponse = await connectCompleter.future.timeout(
-        Duration(seconds: timeoutSeconds),
-      );
-
-      if (connectResponse.length < 2 ||
-          connectResponse[0] != 0x05 ||
-          connectResponse[1] != 0x00) {
-        log.severe(
-          error: Exception('SOCKS5 connection failed'),
-          trace: StackTrace.current,
-        );
-        return false;
-      }
-
-      return true;
-    } catch (e) {
-      log.severe(
-        message: 'SOCKS5 connection check failed for $uri',
-        error: e,
-        trace: StackTrace.current,
-      );
-      return false;
-    } finally {
-      await subscription?.cancel();
-      socket?.destroy();
-    }
-  }
-
-  /// Builds a SOCKS5 CONNECT request.
-  /// Format: [version, command, reserved, address_type, address, port]
-  List<int> _buildSocks5ConnectRequest(Uri uri) {
-    final request = <int>[
-      0x05, // SOCKS version 5
-      0x01, // CONNECT command
-      0x00, // Reserved
-      0x03, // Address type: domain name
-    ];
-    final hostBytes = uri.host.codeUnits;
-    request.add(hostBytes.length);
-    request.addAll(hostBytes);
-    request.add((uri.port >> 8) & 0xFF);
-    request.add(uri.port & 0xFF);
-    return request;
   }
 }

--- a/lib/core/electrum/application/usecases/add_custom_server_usecase.dart
+++ b/lib/core/electrum/application/usecases/add_custom_server_usecase.dart
@@ -2,10 +2,10 @@ import 'package:bb_mobile/core/electrum/application/dtos/requests/add_custom_ser
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_settings.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_failure.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
-import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
@@ -17,12 +17,14 @@ class AddCustomServerUsecase {
   final ElectrumSettingsRepository _electrumSettingsRepository;
   final ServerStatusPort _serverStatusPort;
   final SettingsRepository _settingsRepository;
+  final ElectrumTorSessionPort _torSessionPort;
 
   AddCustomServerUsecase({
     required this._electrumServerRepository,
     required this._electrumSettingsRepository,
     required this._serverStatusPort,
     required this._settingsRepository,
+    required this._torSessionPort,
   });
 
   @useResult
@@ -51,20 +53,6 @@ class AddCustomServerUsecase {
 
       // Fetch app settings to get Tor configuration
       final appSettings = await _settingsRepository.fetch();
-      final useTorProxy = !server.network.isLiquid && appSettings.useTorProxy;
-
-      // Step 1: verify the TCP/SSL socket is reachable
-      final socketStatus = await _serverStatusPort.checkSocket(
-        url: server.url,
-        useTorProxy: useTorProxy,
-        torProxyPort: appSettings.torProxyPort,
-      );
-      if (socketStatus == ElectrumServerStatus.offline) {
-        return const Err(ElectrumServerUnreachableFailure());
-      }
-
-      // Step 2: verify the server actually serves chain data by fetching a
-      // known historical tx (falls back to server.version on testnets).
       // Probe with the user's own validateDomain setting: accepting a
       // certificate the sync would refuse saves a server that can never be
       // used, and the failure only surfaces later as a broken sync.
@@ -78,13 +66,35 @@ class AddCustomServerUsecase {
           return Err(failure);
       }
 
-      final protocolStatus = await _serverStatusPort.checkElectrum(
-        url: server.url,
+      final route = await _torSessionPort.open(
         network: server.network,
-        validateDomain: electrumSettings.validateDomain,
+        serverUrl: server.url,
+        externalProxyEnabled: appSettings.useTorProxy,
+        externalProxyPort: appSettings.torProxyPort,
       );
-      if (protocolStatus == ElectrumServerStatus.offline) {
-        return const Err(ElectrumServerUnreachableFailure());
+      try {
+        // Step 1: verify the TCP/SSL socket is reachable.
+        final socketStatus = await _serverStatusPort.checkSocket(
+          url: server.url,
+          proxyEndpoint: route?.endpoint,
+        );
+        if (socketStatus == ElectrumServerStatus.offline) {
+          return const Err(ElectrumServerUnreachableFailure());
+        }
+
+        // Step 2: verify the server actually serves chain data by fetching a
+        // known historical tx (falls back to server.version on testnets).
+        final protocolStatus = await _serverStatusPort.checkElectrum(
+          url: server.url,
+          network: server.network,
+          validateDomain: electrumSettings.validateDomain,
+          proxyEndpoint: route?.endpoint,
+        );
+        if (protocolStatus == ElectrumServerStatus.offline) {
+          return const Err(ElectrumServerUnreachableFailure());
+        }
+      } finally {
+        await route?.close();
       }
 
       // Both checks passed — persist the server.

--- a/lib/core/electrum/application/usecases/load_electrum_server_data_usecase.dart
+++ b/lib/core/electrum/application/usecases/load_electrum_server_data_usecase.dart
@@ -6,10 +6,11 @@ import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_settings.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_failure.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/environment_port.dart';
-import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_environment.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_environment.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
@@ -23,6 +24,7 @@ class LoadElectrumServerDataUsecase {
   final EnvironmentPort _environmentPort;
   final ServerStatusPort _serverStatusPort;
   final SettingsRepository _settingsRepository;
+  final ElectrumTorSessionPort _torSessionPort;
 
   const LoadElectrumServerDataUsecase({
     required this._electrumServerRepository,
@@ -30,6 +32,7 @@ class LoadElectrumServerDataUsecase {
     required this._environmentPort,
     required this._serverStatusPort,
     required this._settingsRepository,
+    required this._torSessionPort,
   });
 
   @useResult
@@ -39,6 +42,10 @@ class LoadElectrumServerDataUsecase {
     try {
       final isLiquid = request.isLiquid;
       final environment = await _environmentPort.getEnvironment();
+      final network = ElectrumServerNetwork.fromEnvironment(
+        isTestnet: environment.isTestnet,
+        isLiquid: isLiquid,
+      );
 
       // Fetch servers, settings, and app settings in parallel
       final (serversResult, settingsResult, appSettings) = await (
@@ -46,12 +53,7 @@ class LoadElectrumServerDataUsecase {
           isTestnet: environment.isTestnet,
           isLiquid: isLiquid,
         ),
-        _electrumSettingsRepository.fetchByNetwork(
-          ElectrumServerNetwork.fromEnvironment(
-            isTestnet: environment.isTestnet,
-            isLiquid: isLiquid,
-          ),
-        ),
+        _electrumSettingsRepository.fetchByNetwork(network),
         _settingsRepository.fetch(),
       ).wait;
 
@@ -74,17 +76,26 @@ class LoadElectrumServerDataUsecase {
         return const Err(ElectrumLoadFailure('No Electrum servers found'));
       }
 
-      // Check server statuses (use Tor proxy if enabled for Bitcoin/Testnet, not Liquid)
-      final useTorProxy = !isLiquid && appSettings.useTorProxy;
       final serverStatusMap = <String, ElectrumServerStatus>{};
       await Future.wait(
         servers.map((server) async {
-          final status = await _serverStatusPort.checkSocket(
-            url: server.url,
-            useTorProxy: useTorProxy,
-            torProxyPort: appSettings.torProxyPort,
-          );
-          serverStatusMap[server.url] = status;
+          ElectrumTorRoute? route;
+          try {
+            route = await _torSessionPort.open(
+              network: network,
+              serverUrl: server.url,
+              externalProxyEnabled: appSettings.useTorProxy,
+              externalProxyPort: appSettings.torProxyPort,
+            );
+            serverStatusMap[server.url] = await _serverStatusPort.checkSocket(
+              url: server.url,
+              proxyEndpoint: route?.endpoint,
+            );
+          } catch (_) {
+            serverStatusMap[server.url] = ElectrumServerStatus.offline;
+          } finally {
+            await route?.close();
+          }
         }),
       );
 

--- a/lib/core/electrum/data/electrum_socket_connector.dart
+++ b/lib/core/electrum/data/electrum_socket_connector.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
+import 'package:socks5_proxy/socks_client.dart';
+import 'package:bull_tor/tor.dart';
+
+final class ElectrumSocketConnector {
+  const ElectrumSocketConnector();
+
+  Future<Socket> connect({
+    required Uri server,
+    required Duration timeout,
+    TorProxyEndpoint? proxy,
+    bool allowBadCertificate = false,
+  }) async {
+    // Refused rather than attempted: `Socket.connect` would pass the
+    // hidden-service name to the system resolver, disclosing it to whoever
+    // runs the DNS, and then fail anyway because no resolver answers for
+    // `.onion`. Callers reach this connector from several paths, so the check
+    // belongs here rather than in each of them.
+    if (proxy == null && ElectrumServerUrl.isOnionHost(server.host)) {
+      throw OnionServerWithoutTorException(server.host);
+    }
+
+    if (proxy == null) {
+      if (server.scheme == 'ssl') {
+        return SecureSocket.connect(
+          server.host,
+          server.port,
+          timeout: timeout,
+          onBadCertificate: allowBadCertificate ? (_) => true : null,
+        );
+      }
+      return Socket.connect(server.host, server.port, timeout: timeout);
+    }
+
+    final connectFuture = SocksTCPClient.connect(
+      [ProxySettings(InternetAddress(proxy.host), proxy.port, password: null)],
+      // `socks5_proxy` takes an `InternetAddress`, which normally means the
+      // name is already resolved — locally, over clearnet DNS. The `unix` type
+      // is the one constructor that accepts an arbitrary string without
+      // resolving it, so the package emits SOCKS5 ATYP 0x03 (domain name) and
+      // the exit relay does the lookup instead. See `hostnameOf` in
+      // socks5_proxy's `socks_client.dart`.
+      //
+      // It is a load-bearing quirk of a third-party package, not an idiom:
+      // `electrum_socket_connector_test.dart` pins the resulting wire bytes so
+      // an upgrade that changes the behaviour fails a test rather than quietly
+      // reintroducing a DNS leak.
+      InternetAddress(server.host, type: InternetAddressType.unix),
+      server.port,
+    );
+    try {
+      final socksSocket = await connectFuture.timeout(timeout);
+      if (server.scheme != 'ssl') return socksSocket;
+      try {
+        return await socksSocket
+            .secure(
+              server.host,
+              onBadCertificate: allowBadCertificate ? (_) => true : null,
+            )
+            .timeout(timeout);
+      } catch (_) {
+        socksSocket.destroy();
+        rethrow;
+      }
+    } on TimeoutException {
+      unawaited(
+        connectFuture.then<void>((socket) => socket.destroy(), onError: (_) {}),
+      );
+      rethrow;
+    }
+  }
+}

--- a/lib/core/electrum/domain/errors/electrum_fallback_exception.dart
+++ b/lib/core/electrum/domain/errors/electrum_fallback_exception.dart
@@ -46,6 +46,22 @@ class NoElectrumServersConfiguredException extends ElectrumFallbackException {
     : super('No Electrum servers configured for $network.');
 }
 
+/// A `.onion` server was reached for without a Tor route to carry it.
+///
+/// Connecting anyway would hand the hidden-service address to the device's DNS
+/// resolver — the exact disclosure the user chose an onion server to avoid —
+/// and fail regardless, since no resolver can answer for `.onion`. The attempt
+/// is therefore abandoned before a socket is opened.
+///
+/// Reachable today when a Liquid server is configured as an onion address: LWK
+/// exposes no SOCKS parameter, so that route cannot be built at all.
+class OnionServerWithoutTorException extends ElectrumFallbackException {
+  final String url;
+
+  OnionServerWithoutTorException(this.url)
+    : super('No Tor route available for onion Electrum server $url.');
+}
+
 /// Every server in the active set failed with a transient error.
 ///
 /// The active set is resolved once and is *either* all custom *or* all default

--- a/lib/core/electrum/domain/ports/electrum_tor_session_port.dart
+++ b/lib/core/electrum/domain/ports/electrum_tor_session_port.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bull_tor/tor.dart';
+
+final class ElectrumTorRoute {
+  final TorProxyEndpoint endpoint;
+  final Future<void> Function() _onClose;
+  Future<void>? _closing;
+
+  ElectrumTorRoute(this.endpoint, this._onClose);
+
+  Future<void> close() => _closing ??= _onClose();
+}
+
+/// Opens the proxy route for one Electrum server attempt.
+abstract interface class ElectrumTorSessionPort {
+  Future<ElectrumTorRoute?> open({
+    required ElectrumServerNetwork network,
+    required String serverUrl,
+    required bool externalProxyEnabled,
+    required int externalProxyPort,
+  });
+}

--- a/lib/core/electrum/domain/ports/server_status_port.dart
+++ b/lib/core/electrum/domain/ports/server_status_port.dart
@@ -1,12 +1,12 @@
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
+import 'package:bull_tor/tor.dart';
 
 abstract class ServerStatusPort {
   Future<ElectrumServerStatus> checkSocket({
     required String url,
     int? timeout,
-    bool useTorProxy = false,
-    int torProxyPort = 9050,
+    TorProxyEndpoint? proxyEndpoint,
   });
 
   /// Verifies the server actually serves real chain data by fetching a known
@@ -29,5 +29,6 @@ abstract class ServerStatusPort {
     required ElectrumServerNetwork network,
     required bool validateDomain,
     int? timeout,
+    TorProxyEndpoint? proxyEndpoint,
   });
 }

--- a/lib/core/electrum/domain/repositories/electrum_transaction_repository.dart
+++ b/lib/core/electrum/domain/repositories/electrum_transaction_repository.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 /// Returns the parsed [BitcoinTx]; cross-module domain mapping is left to
 /// callers so the electrum module's domain does not depend on another
 /// module's domain entities.
-abstract class ElectrumTransactionRepository {
+abstract interface class ElectrumTransactionRepository {
   Future<BitcoinTx> fetch({
     required ElectrumConnection connection,
     required String txid,

--- a/lib/core/electrum/domain/value_objects/electrum_connection.dart
+++ b/lib/core/electrum/domain/value_objects/electrum_connection.dart
@@ -5,7 +5,11 @@
 /// attempt by merging:
 /// - the active server set (custom-if-set else defaults, in priority order),
 /// - the persisted electrum settings (retry / timeout / stopGap / validate),
-/// - the current Tor preference (socks5 proxy).
+/// - the proxy this server should go through, if any.
+///
+/// [socks5] is a `host:port` string rather than a typed endpoint because that
+/// is the shape its consumers take: BDK's Electrum client accepts a string,
+/// and the advanced options let the user type one by hand.
 ///
 /// [isCustom] is carried only so the executor's error reporting can tell the
 /// caller which tier was exhausted — datasources should not branch on it.
@@ -27,4 +31,14 @@ class ElectrumConnection {
     required this.isCustom,
     this.socks5,
   });
+
+  ElectrumConnection withSocks5(String? socks5) => ElectrumConnection(
+    url: url,
+    retry: retry,
+    timeout: timeout,
+    stopGap: stopGap,
+    validateDomain: validateDomain,
+    isCustom: isCustom,
+    socks5: socks5,
+  );
 }

--- a/lib/core/electrum/domain/value_objects/electrum_server_url.dart
+++ b/lib/core/electrum/domain/value_objects/electrum_server_url.dart
@@ -1,0 +1,49 @@
+/// An Electrum server address as configured.
+///
+/// Servers are stored with or without a scheme — Liquid entries usually omit
+/// it and are always TLS — so anything that wants the host, the protocol, or
+/// "is this an onion service" has to normalize first. That normalization used
+/// to be copied into every caller; it lives here now.
+///
+/// Deliberately not self-validating: users type custom server URLs, and a
+/// malformed one must still be displayable in the settings list. [uri] returns
+/// null instead, so callers decide what an unusable address means to them.
+final class ElectrumServerUrl {
+  static const _defaultScheme = 'ssl';
+
+  final String raw;
+
+  const ElectrumServerUrl(this.raw);
+
+  static bool isOnionHost(String host) =>
+      host.endsWith('.onion') || host.endsWith('.onion.');
+
+  String get _trimmed => raw.trim();
+
+  bool get _hasScheme => _trimmed.contains('://');
+
+  /// The configured scheme, or `ssl` when the address carries none.
+  String get scheme =>
+      _hasScheme ? _trimmed.split('://').first : _defaultScheme;
+
+  /// Host and port without the scheme — what the user typed, and what the
+  /// settings list shows.
+  String get authority => _hasScheme ? _trimmed.split('://').last : _trimmed;
+
+  /// Null when the address cannot be resolved to a host and port.
+  Uri? get uri {
+    final address = _trimmed;
+    if (address.isEmpty) return null;
+
+    final parsed = Uri.tryParse(
+      _hasScheme ? address : '$_defaultScheme://$address',
+    );
+    if (parsed == null || parsed.host.isEmpty) return null;
+    return parsed;
+  }
+
+  bool get isOnion {
+    final host = uri?.host;
+    return host != null && isOnionHost(host);
+  }
+}

--- a/lib/core/electrum/frameworks/di/electrum_locator.dart
+++ b/lib/core/electrum/frameworks/di/electrum_locator.dart
@@ -1,9 +1,19 @@
+import 'package:bb_mobile/core/electrum/adapters/drift_electrum_server_repository.dart';
+import 'package:bb_mobile/core/electrum/adapters/drift_electrum_settings_repository.dart';
+import 'package:bb_mobile/core/electrum/adapters/drift_electrum_transaction_repository.dart';
+import 'package:bb_mobile/core/electrum/adapters/electrum_servers_adapter.dart';
+import 'package:bb_mobile/core/electrum/adapters/electrum_tor_session_adapter.dart';
+import 'package:bb_mobile/core/electrum/adapters/electrum_transaction_port_adapter.dart';
+import 'package:bb_mobile/core/electrum/adapters/environment_adapter.dart';
+import 'package:bb_mobile/core/electrum/adapters/server_status_adapter.dart';
 import 'package:bb_mobile/core/electrum/application/usecases/add_custom_server_usecase.dart';
 import 'package:bb_mobile/core/electrum/application/usecases/delete_custom_server_usecase.dart';
 import 'package:bb_mobile/core/electrum/application/usecases/load_electrum_server_data_usecase.dart';
 import 'package:bb_mobile/core/electrum/application/usecases/set_advanced_electrum_options_usecase.dart';
 import 'package:bb_mobile/core/electrum/application/usecases/set_custom_servers_priority_usecase.dart';
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/environment_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
@@ -12,17 +22,11 @@ import 'package:bb_mobile/core/electrum/domain/repositories/electrum_transaction
 import 'package:bb_mobile/core/electrum/frameworks/drift/datasources/electrum_remote_datasource.dart';
 import 'package:bb_mobile/core/electrum/frameworks/drift/datasources/electrum_server_storage_datasource.dart';
 import 'package:bb_mobile/core/electrum/frameworks/drift/datasources/electrum_settings_storage_datasource.dart';
-import 'package:bb_mobile/core/electrum/adapters/drift_electrum_server_repository.dart';
-import 'package:bb_mobile/core/electrum/adapters/drift_electrum_settings_repository.dart';
-import 'package:bb_mobile/core/electrum/adapters/drift_electrum_transaction_repository.dart';
-import 'package:bb_mobile/core/electrum/adapters/electrum_servers_adapter.dart';
-import 'package:bb_mobile/core/electrum/adapters/electrum_transaction_port_adapter.dart';
-import 'package:bb_mobile/core/electrum/adapters/environment_adapter.dart';
-import 'package:bb_mobile/core/electrum/adapters/server_status_adapter.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/transactions/domain/transaction_port.dart';
 import 'package:get_it/get_it.dart';
+import 'package:bull_tor/tor.dart';
 
 class ElectrumLocator {
   static Future<void> registerDatasources(GetIt locator) async {
@@ -34,7 +38,13 @@ class ElectrumLocator {
           ElectrumSettingsStorageDatasource(sqlite: locator<SqliteDatabase>()),
     );
     locator.registerLazySingleton<ElectrumRemoteDatasource>(
-      () => ElectrumRemoteDatasource(sqlite: locator<SqliteDatabase>()),
+      () => ElectrumRemoteDatasource(
+        sqlite: locator<SqliteDatabase>(),
+        socketConnector: locator<ElectrumSocketConnector>(),
+      ),
+    );
+    locator.registerLazySingleton<ElectrumSocketConnector>(
+      ElectrumSocketConnector.new,
     );
   }
 
@@ -66,13 +76,17 @@ class ElectrumLocator {
           EnvironmentAdapter(settingsRepository: locator<SettingsRepository>()),
     );
     locator.registerLazySingleton<ServerStatusPort>(
-      () => const ServerStatusAdapter(),
+      () => ServerStatusAdapter(locator<ElectrumSocketConnector>()),
+    );
+    locator.registerLazySingleton<ElectrumTorSessionPort>(
+      () => ElectrumTorSessionAdapter(() => locator<Tor>()),
     );
     locator.registerLazySingleton<ElectrumServersPort>(
       () => ElectrumServersAdapter(
         serverRepository: locator<ElectrumServerRepository>(),
         settingsRepository: locator<ElectrumSettingsRepository>(),
         appSettingsRepository: locator<SettingsRepository>(),
+        torSessionPort: locator<ElectrumTorSessionPort>(),
       ),
     );
     locator.registerLazySingleton<TransactionPort>(
@@ -91,6 +105,7 @@ class ElectrumLocator {
         electrumSettingsRepository: locator<ElectrumSettingsRepository>(),
         serverStatusPort: locator<ServerStatusPort>(),
         settingsRepository: locator<SettingsRepository>(),
+        torSessionPort: locator<ElectrumTorSessionPort>(),
       ),
     );
     locator.registerFactory<SetCustomServersPriorityUsecase>(
@@ -110,6 +125,7 @@ class ElectrumLocator {
         environmentPort: locator<EnvironmentPort>(),
         serverStatusPort: locator<ServerStatusPort>(),
         settingsRepository: locator<SettingsRepository>(),
+        torSessionPort: locator<ElectrumTorSessionPort>(),
       ),
     );
     locator.registerFactory<SetAdvancedElectrumOptionsUsecase>(

--- a/lib/core/electrum/frameworks/drift/datasources/electrum_remote_datasource.dart
+++ b/lib/core/electrum/frameworks/drift/datasources/electrum_remote_datasource.dart
@@ -1,15 +1,26 @@
 import 'dart:convert';
-import 'dart:io' show SecureSocket, Socket;
+import 'dart:io' show Socket;
 
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:convert/convert.dart';
+import 'package:bull_tor/tor.dart';
 
 class ElectrumRemoteDatasource {
-  final SqliteDatabase _sqlite;
+  /// Generous on purpose: this request can be routed through Orbot, where a
+  /// circuit to an onion service is built before any byte moves.
+  static const _requestTimeout = Duration(seconds: 30);
 
-  ElectrumRemoteDatasource({required this._sqlite});
+  final SqliteDatabase _sqlite;
+  final ElectrumSocketConnector _socketConnector;
+
+  ElectrumRemoteDatasource({
+    required this._sqlite,
+    required this._socketConnector,
+  });
 
   Future<TransactionModel> fetch({
     required ElectrumConnection connection,
@@ -42,14 +53,39 @@ class ElectrumRemoteDatasource {
     ElectrumConnection connection,
     String txid,
   ) async {
+    final serverUri = ElectrumServerUrl(connection.url).uri;
+    if (serverUri == null) {
+      throw Exception('Electrum RPC error: unusable server address');
+    }
+
+    // Empty means "no proxy", which is how persisted settings represent it and
+    // how the BDK datasource has always read it. Only a non-empty value that
+    // fails to parse is a real misconfiguration worth refusing.
+    final socks5 = connection.socks5?.trim();
+    final hasProxy = socks5 != null && socks5.isNotEmpty;
+    final proxy = hasProxy ? TorProxyEndpoint.tryParse(socks5) : null;
+    if (hasProxy && proxy == null) {
+      throw Exception('Electrum RPC error: unusable SOCKS5 proxy');
+    }
+
+    // An onion circuit is built before the first byte moves, so the user's
+    // clearnet timeout is not a sensible ceiling there. Mirrors
+    // `ServerStatusAdapter._resolveTimeout`.
+    final timeout = proxy == null
+        ? Duration(seconds: connection.timeout)
+        : _requestTimeout;
+
+    Socket? socket;
     try {
-      final timeout = Duration(seconds: connection.timeout);
-      // This datasource has no SOCKS implementation. Never silently bypass
-      // Tor; the fallback runner will advance to the next server instead.
-      if (connection.socks5?.isNotEmpty == true) {
-        throw Exception('Proxy-aware Electrum transport unavailable');
-      }
-      final socket = await _connect(connection);
+      // Certificates follow the user's `validateDomain` setting — the flag the
+      // BDK/LWK sync already obeys — so a personal node with a self-signed
+      // certificate behaves the same on both paths.
+      socket = await _socketConnector.connect(
+        server: serverUri,
+        timeout: timeout,
+        proxy: proxy,
+        allowBadCertificate: !connection.validateDomain,
+      );
 
       final request = {
         'id': 1,
@@ -61,43 +97,12 @@ class ElectrumRemoteDatasource {
 
       final lines = utf8.decoder.bind(socket).transform(const LineSplitter());
       final firstLine = await lines.first.timeout(timeout);
-      await socket.close();
 
       return hex.decode(json.decode(firstLine)['result'] as String);
     } catch (e) {
       throw Exception('Electrum RPC error: $e');
+    } finally {
+      socket?.destroy();
     }
   }
-
-  /// Opens the socket described by the resolved [connection] rather than
-  /// assuming a CA-validated TLS endpoint.
-  ///
-  /// A `tcp://` server is reached in the clear, and certificates are validated
-  /// according to the user's `validateDomain` setting — the very flag the
-  /// BDK/LWK sync obeys — so a personal node with a self-signed certificate
-  /// behaves the same on both paths instead of syncing fine but failing here.
-  Future<Socket> _connect(ElectrumConnection connection) {
-    final uri = _parseUrl(connection.url);
-    final timeout = Duration(seconds: connection.timeout);
-
-    if (uri.scheme == 'tcp') {
-      return Socket.connect(uri.host, uri.port, timeout: timeout);
-    }
-
-    return SecureSocket.connect(
-      uri.host,
-      uri.port,
-      timeout: timeout,
-      onBadCertificate: connection.validateDomain ? null : (_) => true,
-    );
-  }
-
-  /// Servers are stored either with an explicit `ssl://` / `tcp://` scheme or
-  /// as a bare `host:port` (how Liquid urls are persisted), which `Uri.parse`
-  /// would otherwise read as the scheme. Bare urls default to TLS, matching
-  /// the rest of the electrum module.
-  Uri _parseUrl(String url) =>
-      url.startsWith('ssl://') || url.startsWith('tcp://')
-      ? Uri.parse(url)
-      : Uri.parse('ssl://$url');
 }

--- a/lib/core/status/interface_adapters/adapter/electrum_connectivity_adapter.dart
+++ b/lib/core/status/interface_adapters/adapter/electrum_connectivity_adapter.dart
@@ -1,19 +1,17 @@
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
-import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
-import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
 import 'package:bb_mobile/core/status/domain/ports/electrum_connectivity_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bull_tor/tor.dart';
 
 class ElectrumConnectivityAdapter implements ElectrumConnectivityPort {
-  final ElectrumServerRepository _electrumServerRepository;
-  final ElectrumSettingsRepository _electrumSettingsRepository;
+  final ElectrumServersPort _electrumServersPort;
   final ServerStatusPort _serverStatusPort;
 
   ElectrumConnectivityAdapter({
-    required this._electrumServerRepository,
-    required this._electrumSettingsRepository,
+    required this._electrumServersPort,
     required this._serverStatusPort,
   });
 
@@ -24,48 +22,45 @@ class ElectrumConnectivityAdapter implements ElectrumConnectivityPort {
       isLiquid: network.isLiquid,
     );
 
-    final (serversResult, settingsResult) = await (
-      _electrumServerRepository.fetchAll(
-        isTestnet: serverNetwork.isTestnet,
-        isLiquid: serverNetwork.isLiquid,
-      ),
-      _electrumSettingsRepository.fetchByNetwork(serverNetwork),
-    ).wait;
-
-    final servers = serversResult.fold(
-      (value) => value,
-      (failure) => throw Exception(
-        failure.logMessage ?? 'Failed to fetch electrum servers',
-      ),
-    );
-    final settings = settingsResult.fold(
-      (value) => value,
-      (failure) => throw Exception(
-        failure.logMessage ?? 'Failed to fetch electrum settings',
-      ),
-    );
-
-    if (servers.isEmpty) return false;
-
-    // Prefer custom servers if any are configured
-    final customServers = servers.where((s) => s.isCustom).toList();
-    final serversToCheck = customServers.isNotEmpty ? customServers : servers;
-
-    // Check all servers concurrently by fetching a known historical tx —
-    // proves the server actually serves chain data, not just that it speaks
-    // the Electrum protocol. Online if at least one server responds correctly.
-    final statuses = await Future.wait(
-      serversToCheck.map(
-        (server) => _serverStatusPort.checkElectrum(
-          url: server.url,
-          network: serverNetwork,
-          // The user's own setting, so "online" here means the sync can
-          // actually reach the server too.
-          validateDomain: settings.validateDomain,
-        ),
-      ),
-    );
-
-    return statuses.any((s) => s == ElectrumServerStatus.online);
+    try {
+      return await _electrumServersPort.runWithFallback<bool>(
+        network: serverNetwork,
+        operation: (connection) async {
+          // An empty string is "no proxy", not a malformed one: settings persist
+          // `''` in practice, and treating it as malformed marked every server
+          // offline.
+          final socks5 = connection.socks5?.trim();
+          final proxyEndpoint = switch (socks5) {
+            null || '' => null,
+            final proxy =>
+              TorProxyEndpoint.tryParse(proxy) ??
+                  (throw const _ElectrumServerOfflineException()),
+          };
+          final status = await _serverStatusPort.checkElectrum(
+            url: connection.url,
+            network: serverNetwork,
+            // The user's own setting, so "online" here means the sync can
+            // actually reach the server too.
+            validateDomain: connection.validateDomain,
+            // Deliberately not `connection.timeout`: that is the user's clearnet
+            // ceiling, seeded at 5s, and it would override the longer onion
+            // default. Five seconds cannot cover a SOCKS handshake, a circuit
+            // build, TLS and a JSON-RPC round trip, so a healthy onion server
+            // would report offline and trip the Tor error banner.
+            timeout: proxyEndpoint == null ? connection.timeout : null,
+            proxyEndpoint: proxyEndpoint,
+          );
+          if (status == ElectrumServerStatus.online) return true;
+          throw const _ElectrumServerOfflineException();
+        },
+        isTransient: (error) => error is _ElectrumServerOfflineException,
+      );
+    } on Exception {
+      return false;
+    }
   }
+}
+
+final class _ElectrumServerOfflineException implements Exception {
+  const _ElectrumServerOfflineException();
 }

--- a/lib/core/status/status_locator.dart
+++ b/lib/core/status/status_locator.dart
@@ -1,6 +1,5 @@
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
-import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
-import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_rate_repository.dart';
 import 'package:bb_mobile/core/fees/domain/repositories/fees_repository.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
@@ -9,16 +8,15 @@ import 'package:bb_mobile/core/status/domain/usecases/check_all_service_status_u
 import 'package:bb_mobile/core/status/interface_adapters/adapter/electrum_connectivity_adapter.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
-import 'package:bull_tor/tor.dart';
 import 'package:get_it/get_it.dart';
+import 'package:bull_tor/tor.dart';
 
 class StatusLocator {
   static void setup(GetIt locator) {
     // Port
     locator.registerFactory<ElectrumConnectivityPort>(
       () => ElectrumConnectivityAdapter(
-        electrumServerRepository: locator<ElectrumServerRepository>(),
-        electrumSettingsRepository: locator<ElectrumSettingsRepository>(),
+        electrumServersPort: locator<ElectrumServersPort>(),
         serverStatusPort: locator<ServerStatusPort>(),
       ),
     );

--- a/lib/features/electrum_settings/frameworks/ui/widgets/tor_proxy_error_banner.dart
+++ b/lib/features/electrum_settings/frameworks/ui/widgets/tor_proxy_error_banner.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/tor/tor_status.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/cards/info_card.dart';
 import 'package:bb_mobile/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_bloc.dart';
 import 'package:bb_mobile/features/tor_settings/presentation/bloc/tor_settings_cubit.dart';
@@ -17,8 +18,8 @@ class TorProxyErrorBanner extends StatelessWidget {
     final torStatus = context.select(
       (TorSettingsCubit cubit) => cubit.state.status,
     );
-    final areAllServersOffline = context.select(
-      (ElectrumSettingsBloc bloc) => bloc.state.areAllServersOffline(),
+    final activeOnionServersAreOffline = context.select(
+      (ElectrumSettingsBloc bloc) => bloc.state.activeOnionServersAreOffline,
     );
     final isLiquid = context.select(
       (ElectrumSettingsBloc bloc) => bloc.state.isLiquid,
@@ -27,11 +28,11 @@ class TorProxyErrorBanner extends StatelessWidget {
     // Don't show banner if:
     // - Tor is not enabled
     // - Tor proxy is online
-    // - Not all servers are offline
+    // - The active server set has no onion server or is not fully offline
     // - Only show for Bitcoin (not Liquid)
     if (!useTorProxy ||
         torStatus == TorStatus.online ||
-        !areAllServersOffline ||
+        !activeOnionServersAreOffline ||
         isLiquid) {
       return const SizedBox.shrink();
     }
@@ -39,8 +40,7 @@ class TorProxyErrorBanner extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(top: 8),
       child: InfoCard(
-        description:
-            'Tor proxy is enabled but cannot connect. Make sure Orbot or similar app is running, or disable Tor proxy in Advanced Options (server will see your IP address).',
+        description: context.loc.torSettingsDescDisconnected,
         tagColor: context.appColors.error,
         bgColor: context.appColors.errorContainer,
       ),

--- a/lib/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_state.dart
+++ b/lib/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_state.dart
@@ -47,4 +47,14 @@ sealed class ElectrumSettingsState with _$ElectrumSettingsState {
       (server) => server.status == ElectrumServerStatus.offline,
     );
   }
+
+  bool get activeOnionServersAreOffline {
+    final activeServers = customServers.isNotEmpty
+        ? customServers
+        : defaultServers;
+    return activeServers.any((server) => server.isOnion) &&
+        activeServers.every(
+          (server) => server.status == ElectrumServerStatus.offline,
+        );
+  }
 }

--- a/lib/features/electrum_settings/interface_adapters/presenters/view_models/electrum_server_view_model.dart
+++ b/lib/features/electrum_settings/interface_adapters/presenters/view_models/electrum_server_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'electrum_server_view_model.freezed.dart';
@@ -14,21 +15,14 @@ sealed class ElectrumServerViewModel with _$ElectrumServerViewModel {
   }) = _ElectrumServerViewModel;
   const ElectrumServerViewModel._();
 
-  String get displayName {
-    // Remove scheme if present (e.g., "ssl://" or "tcp://")
-    if (url.contains('://')) {
-      return url.split('://').last;
-    }
-    return url;
-  }
+  ElectrumServerUrl get _address => ElectrumServerUrl(url);
 
-  String get protocol {
-    // Extract protocol if present (e.g., "ssl" or "tcp")
-    if (url.contains('://')) {
-      return url.split('://').first;
-    }
-    // Default to 'ssl' if no protocol specified, for Liquid servers that
-    // don't require a scheme for example but always use SSL automatically.
-    return 'ssl';
-  }
+  /// Address without the scheme (e.g. `ssl://` or `tcp://`).
+  String get displayName => _address.authority;
+
+  /// Configured protocol, defaulting to `ssl` for entries that omit it —
+  /// Liquid servers, for example, are always TLS without saying so.
+  String get protocol => _address.scheme;
+
+  bool get isOnion => _address.isOnion;
 }

--- a/test/core_test/electrum/electrum_remote_datasource_test.dart
+++ b/test/core_test/electrum/electrum_remote_datasource_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/electrum/frameworks/drift/datasources/electrum_remote_datasource.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
@@ -9,8 +10,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'self_signed_electrum_server.dart';
 
 /// The datasource must open the socket described by the resolved connection
-/// instead of always forcing CA-validated TLS. These tests pin the three
-/// decisions it makes: the url scheme, and the `validateDomain` flag.
+/// instead of always forcing CA-validated TLS. These tests pin the decisions it
+/// makes: the url scheme, the `validateDomain` flag, and the proxy.
 ///
 /// The fake servers never return a real transaction, so every call ends in an
 /// error. What matters is *which* error: a TLS/certificate failure means the
@@ -29,10 +30,27 @@ void main() {
 
   setUp(() {
     db = SqliteDatabase(NativeDatabase.memory());
-    datasource = ElectrumRemoteDatasource(sqlite: db);
+    datasource = ElectrumRemoteDatasource(
+      sqlite: db,
+      socketConnector: const ElectrumSocketConnector(),
+    );
   });
 
   tearDown(() => db.close());
+
+  ElectrumConnection connectionTo(
+    String url, {
+    required bool validateDomain,
+    String? socks5,
+  }) => ElectrumConnection(
+    url: url,
+    retry: 1,
+    timeout: 5,
+    stopGap: 20,
+    validateDomain: validateDomain,
+    isCustom: true,
+    socks5: socks5,
+  );
 
   Future<String> errorFor(ElectrumConnection connection) async {
     try {
@@ -42,16 +60,6 @@ void main() {
       return e.toString();
     }
   }
-
-  ElectrumConnection connectionTo(String url, {required bool validateDomain}) =>
-      ElectrumConnection(
-        url: url,
-        retry: 1,
-        timeout: 5,
-        stopGap: 20,
-        validateDomain: validateDomain,
-        isCustom: true,
-      );
 
   test('tcp:// reaches a plain server without attempting TLS', () async {
     final server = await ServerSocket.bind('127.0.0.1', 0);
@@ -110,5 +118,20 @@ void main() {
     // TLS attempted against a plain socket — proves the url was not mistaken
     // for a `host` scheme by Uri.parse.
     expect(error, contains('HandshakeException'));
+  });
+
+  test('rejects an unusable proxy instead of connecting directly', () async {
+    // A malformed SOCKS endpoint must abort the request. Falling through to a
+    // direct connection would silently send over clearnet the traffic the
+    // caller asked to route through Tor.
+    final error = await errorFor(
+      connectionTo(
+        'ssl://127.0.0.1:1',
+        validateDomain: true,
+        socks5: '127.0.0.1:not-a-port',
+      ),
+    );
+
+    expect(error, contains('unusable SOCKS5 proxy'));
   });
 }

--- a/test/core_test/electrum/electrum_server_url_test.dart
+++ b/test/core_test/electrum/electrum_server_url_test.dart
@@ -1,0 +1,61 @@
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_url.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('with a scheme', () {
+    const url = ElectrumServerUrl('tcp://electrum.example.com:50001');
+
+    test('keeps the scheme and strips it from the authority', () {
+      expect(url.scheme, 'tcp');
+      expect(url.authority, 'electrum.example.com:50001');
+      expect(url.uri?.host, 'electrum.example.com');
+      expect(url.uri?.port, 50001);
+    });
+  });
+
+  group('without a scheme', () {
+    // Liquid servers are stored bare and are always TLS.
+    const url = ElectrumServerUrl('blockstream.info:995');
+
+    test('defaults to ssl and leaves the authority untouched', () {
+      expect(url.scheme, 'ssl');
+      expect(url.authority, 'blockstream.info:995');
+      expect(url.uri?.scheme, 'ssl');
+      expect(url.uri?.host, 'blockstream.info');
+    });
+  });
+
+  group('isOnion', () {
+    test('is true for an onion host, with or without a scheme', () {
+      expect(const ElectrumServerUrl('abc.onion:50002').isOnion, isTrue);
+      expect(const ElectrumServerUrl('ssl://abc.onion:50002').isOnion, isTrue);
+    });
+
+    test('is true for an absolute onion hostname', () {
+      expect(const ElectrumServerUrl('abc.onion.:50002').isOnion, isTrue);
+      expect(const ElectrumServerUrl('ssl://abc.onion.:50002').isOnion, isTrue);
+    });
+
+    test('is false for clearnet and for a host merely containing "onion"', () {
+      expect(const ElectrumServerUrl('electrum.example.com').isOnion, isFalse);
+      expect(const ElectrumServerUrl('onion.example.com:50002').isOnion, false);
+    });
+  });
+
+  group('unusable addresses', () {
+    // Custom servers are typed by hand: a blank one must not resolve to a
+    // host, and the settings list still has to render it without crashing.
+    test('expose no uri and are never onion', () {
+      const blank = ElectrumServerUrl('   ');
+      expect(blank.uri, isNull);
+      expect(blank.isOnion, isFalse);
+      expect(blank.authority, isEmpty);
+    });
+
+    test('tolerate surrounding whitespace around a real address', () {
+      const padded = ElectrumServerUrl('  ssl://abc.onion:50002  ');
+      expect(padded.isOnion, isTrue);
+      expect(padded.authority, 'abc.onion:50002');
+    });
+  });
+}

--- a/test/core_test/electrum/electrum_servers_adapter_test.dart
+++ b/test/core_test/electrum/electrum_servers_adapter_test.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/core/electrum/adapters/electrum_servers_adapter.dart';
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_server.dart';
 import 'package:bb_mobile/core/electrum/domain/entities/electrum_settings.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
@@ -10,6 +11,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
 
 class _MockServerRepository extends Mock implements ElectrumServerRepository {}
 
@@ -17,6 +19,8 @@ class _MockSettingsRepository extends Mock
     implements ElectrumSettingsRepository {}
 
 class _MockAppSettingsRepository extends Mock implements SettingsRepository {}
+
+class _MockTorSessionPort extends Mock implements ElectrumTorSessionPort {}
 
 const _network = ElectrumServerNetwork.bitcoinMainnet;
 const _liquidNetwork = ElectrumServerNetwork.liquidMainnet;
@@ -58,6 +62,7 @@ void main() {
   late _MockServerRepository serverRepo;
   late _MockSettingsRepository settingsRepo;
   late _MockAppSettingsRepository appSettingsRepo;
+  late _MockTorSessionPort torSessionPort;
   late ElectrumServersAdapter adapter;
 
   setUpAll(() {
@@ -68,10 +73,20 @@ void main() {
     serverRepo = _MockServerRepository();
     settingsRepo = _MockSettingsRepository();
     appSettingsRepo = _MockAppSettingsRepository();
+    torSessionPort = _MockTorSessionPort();
+    when(
+      () => torSessionPort.open(
+        network: any(named: 'network'),
+        serverUrl: any(named: 'serverUrl'),
+        externalProxyEnabled: any(named: 'externalProxyEnabled'),
+        externalProxyPort: any(named: 'externalProxyPort'),
+      ),
+    ).thenAnswer((_) async => null);
     adapter = ElectrumServersAdapter(
       serverRepository: serverRepo,
       settingsRepository: settingsRepo,
       appSettingsRepository: appSettingsRepo,
+      torSessionPort: torSessionPort,
     );
   });
 
@@ -254,7 +269,116 @@ void main() {
       },
     );
 
-    test('Tor enabled on Bitcoin → injects 127.0.0.1:<port>', () async {
+    test('an onion server uses the resolved isolated Tor route', () async {
+      var closed = false;
+      when(
+        () => torSessionPort.open(
+          network: _network,
+          serverUrl: 'ssl://hidden.onion:50002',
+          externalProxyEnabled: true,
+          externalProxyPort: 9050,
+        ),
+      ).thenAnswer(
+        (_) async => ElectrumTorRoute(
+          TorProxyEndpoint(host: '127.0.0.1', port: 41234),
+          () async => closed = true,
+        ),
+      );
+      stub(
+        servers: [_server('ssl://hidden.onion:50002')],
+        settings: _settings(),
+        appSettings: _appSettings(useTorProxy: true, torProxyPort: 9050),
+      );
+
+      late final String? socks5;
+      await adapter.runWithFallback<void>(
+        network: _network,
+        operation: (connection) async {
+          socks5 = connection.socks5;
+        },
+      );
+
+      expect(socks5, '127.0.0.1:41234');
+      expect(closed, isTrue);
+    });
+
+    test(
+      'does not turn a successful operation into a failure if close throws',
+      () async {
+        when(
+          () => torSessionPort.open(
+            network: _network,
+            serverUrl: 'ssl://hidden.onion:50002',
+            externalProxyEnabled: true,
+            externalProxyPort: 9050,
+          ),
+        ).thenAnswer(
+          (_) async => ElectrumTorRoute(
+            TorProxyEndpoint(host: '127.0.0.1', port: 41234),
+            () async => throw StateError('close failed'),
+          ),
+        );
+        stub(
+          servers: [
+            _server('ssl://hidden.onion:50002'),
+            _server('ssl://fallback:50002'),
+          ],
+          settings: _settings(),
+          appSettings: _appSettings(useTorProxy: true, torProxyPort: 9050),
+        );
+
+        final attempted = <String>[];
+        final result = await adapter.runWithFallback<String>(
+          network: _network,
+          operation: (connection) async {
+            attempted.add(connection.url);
+            return 'ok';
+          },
+        );
+
+        expect(result, 'ok');
+        expect(attempted, ['ssl://hidden.onion:50002']);
+      },
+    );
+
+    // A failed embedded bootstrap makes one onion server unusable, not the whole
+    // set. Before this, the raw error escaped a caller that narrowed
+    // `isTransient` to its own type, so the healthy clearnet default next in the
+    // set was never tried and connectivity reported offline.
+    test('a failing Tor route skips to the next server', () async {
+      when(
+        () => torSessionPort.open(
+          network: _network,
+          serverUrl: 'ssl://hidden.onion:50002',
+          externalProxyEnabled: false,
+          externalProxyPort: 9050,
+        ),
+      ).thenThrow(Exception('embedded Tor never bootstrapped'));
+      stub(
+        servers: [
+          _server('ssl://hidden.onion:50002'),
+          _server('ssl://fallback:50002'),
+        ],
+        settings: _settings(),
+        appSettings: _appSettings(),
+      );
+
+      final attempted = <String>[];
+      await adapter.runWithFallback<void>(
+        network: _network,
+        operation: (connection) async => attempted.add(connection.url),
+        // Narrowed to a type this adapter never throws, which is what makes the
+        // regression visible: the route error must still be treated as transient.
+        isTransient: (error) => error is FormatException,
+      );
+
+      expect(attempted, ['ssl://fallback:50002']);
+    });
+
+    // The Tor proxy setting has always been documented as applying to Bitcoin,
+    // not to onion servers only. The default Electrum servers are clearnet, so
+    // they are exactly what a user hides their IP from by enabling Orbot.
+    test('Orbot enabled routes a clearnet Bitcoin server too', () async {
       stub(
         servers: [_server('ssl://a:50002')],
         settings: _settings(),
@@ -272,7 +396,25 @@ void main() {
       expect(socks5, '127.0.0.1:9150');
     });
 
-    test('Tor enabled but persisted socks5 set → persisted wins', () async {
+    test('Orbot disabled leaves a clearnet Bitcoin server direct', () async {
+      stub(
+        servers: [_server('ssl://a:50002')],
+        settings: _settings(),
+        appSettings: _appSettings(),
+      );
+
+      late final String? socks5;
+      await adapter.runWithFallback<void>(
+        network: _network,
+        operation: (connection) async {
+          socks5 = connection.socks5;
+        },
+      );
+
+      expect(socks5, isNull);
+    });
+
+    test('a persisted custom SOCKS setting remains available', () async {
       stub(
         servers: [_server('ssl://a:50002')],
         settings: _settings(socks5: 'proxy.example:9999'),
@@ -290,7 +432,7 @@ void main() {
       expect(socks5, 'proxy.example:9999');
     });
 
-    test('Tor enabled on Liquid → socks5 is NOT applied', () async {
+    test('Orbot enabled is not applied to Liquid Electrum', () async {
       when(
         () => serverRepo.fetchActiveServers(network: any(named: 'network')),
       ).thenAnswer(
@@ -320,5 +462,81 @@ void main() {
 
       expect(socks5, isNull);
     });
+
+    test(
+      'a Liquid onion server is skipped, never contacted directly',
+      () async {
+        // LWK exposes no SOCKS parameter, so no route can be built for a Liquid
+        // onion server. Handing it to the operation anyway would leak the
+        // hidden-service name to the device's DNS resolver.
+        when(
+          () => serverRepo.fetchActiveServers(network: any(named: 'network')),
+        ).thenAnswer(
+          (_) async => Ok([
+            ElectrumServer.existing(
+              url: 'ssl://hidden.onion:50002',
+              network: _liquidNetwork,
+              isCustom: true,
+              priority: 0,
+            ),
+          ]),
+        );
+        when(
+          () => settingsRepo.fetchByNetwork(any()),
+        ).thenAnswer((_) async => Ok(_settings()));
+        when(
+          () => appSettingsRepo.fetch(),
+        ).thenAnswer((_) async => _appSettings());
+
+        var reached = false;
+        await expectLater(
+          adapter.runWithFallback<void>(
+            network: _liquidNetwork,
+            operation: (_) async => reached = true,
+          ),
+          throwsA(isA<AllElectrumServersFailedException>()),
+        );
+
+        expect(reached, isFalse, reason: 'no connection may be attempted');
+      },
+    );
+
+    test(
+      'an unroutable onion server does not stop the rest of the set',
+      () async {
+        when(
+          () => serverRepo.fetchActiveServers(network: any(named: 'network')),
+        ).thenAnswer(
+          (_) async => Ok([
+            ElectrumServer.existing(
+              url: 'ssl://hidden.onion:50002',
+              network: _liquidNetwork,
+              isCustom: true,
+              priority: 0,
+            ),
+            ElectrumServer.existing(
+              url: 'ssl://liquid.example:50002',
+              network: _liquidNetwork,
+              isCustom: true,
+              priority: 1,
+            ),
+          ]),
+        );
+        when(
+          () => settingsRepo.fetchByNetwork(any()),
+        ).thenAnswer((_) async => Ok(_settings()));
+        when(
+          () => appSettingsRepo.fetch(),
+        ).thenAnswer((_) async => _appSettings());
+
+        final reached = <String>[];
+        await adapter.runWithFallback<void>(
+          network: _liquidNetwork,
+          operation: (connection) async => reached.add(connection.url),
+        );
+
+        expect(reached, ['ssl://liquid.example:50002']);
+      },
+    );
   });
 }

--- a/test/core_test/electrum/electrum_settings_failure_test.dart
+++ b/test/core_test/electrum/electrum_settings_failure_test.dart
@@ -15,8 +15,10 @@ import 'package:bb_mobile/core/electrum/domain/entities/electrum_settings.dart';
 import 'package:bb_mobile/core/electrum/domain/errors/electrum_failure.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/environment_port.dart';
 import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
 import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_environment.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
@@ -24,6 +26,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
 
 class _MockServerRepository extends Mock implements ElectrumServerRepository {}
 
@@ -36,6 +39,8 @@ class _MockAppSettingsRepository extends Mock implements SettingsRepository {}
 
 class _MockEnvironmentPort extends Mock implements EnvironmentPort {}
 
+class _MockTorSessionPort extends Mock implements ElectrumTorSessionPort {}
+
 const _network = ElectrumServerNetwork.bitcoinMainnet;
 
 ElectrumSettings _settings({bool validateDomain = true}) => ElectrumSettings(
@@ -47,6 +52,8 @@ ElectrumSettings _settings({bool validateDomain = true}) => ElectrumSettings(
 );
 
 void main() {
+  setUpAll(() => registerFallbackValue(_network));
+
   group('DeleteCustomServerUsecase', () {
     test('propagates the sanitized failure from the repository', () async {
       final repo = _MockServerRepository();
@@ -69,6 +76,7 @@ void main() {
     late _MockSettingsRepository electrumSettingsRepo;
     late _MockServerStatusPort statusPort;
     late _MockAppSettingsRepository appSettingsRepo;
+    late _MockTorSessionPort torSessionPort;
     late AddCustomServerUsecase usecase;
 
     AddCustomServerRequest request() => AddCustomServerRequest(
@@ -85,11 +93,21 @@ void main() {
       electrumSettingsRepo = _MockSettingsRepository();
       statusPort = _MockServerStatusPort();
       appSettingsRepo = _MockAppSettingsRepository();
+      torSessionPort = _MockTorSessionPort();
+      when(
+        () => torSessionPort.open(
+          network: any(named: 'network'),
+          serverUrl: any(named: 'serverUrl'),
+          externalProxyEnabled: any(named: 'externalProxyEnabled'),
+          externalProxyPort: any(named: 'externalProxyPort'),
+        ),
+      ).thenAnswer((_) async => null);
       usecase = AddCustomServerUsecase(
         electrumServerRepository: serverRepo,
         electrumSettingsRepository: electrumSettingsRepo,
         serverStatusPort: statusPort,
         settingsRepository: appSettingsRepo,
+        torSessionPort: torSessionPort,
       );
     });
 
@@ -141,10 +159,12 @@ void main() {
           ),
         );
         when(
+          () => electrumSettingsRepo.fetchByNetwork(_network),
+        ).thenAnswer((_) async => Ok(_settings()));
+        when(
           () => statusPort.checkSocket(
             url: any(named: 'url'),
-            useTorProxy: any(named: 'useTorProxy'),
-            torProxyPort: any(named: 'torProxyPort'),
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         ).thenAnswer((_) async => ElectrumServerStatus.offline);
 
@@ -176,8 +196,7 @@ void main() {
         when(
           () => statusPort.checkSocket(
             url: any(named: 'url'),
-            useTorProxy: any(named: 'useTorProxy'),
-            torProxyPort: any(named: 'torProxyPort'),
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         ).thenAnswer((_) async => ElectrumServerStatus.online);
         when(
@@ -188,6 +207,7 @@ void main() {
             url: any(named: 'url'),
             network: _network,
             validateDomain: any(named: 'validateDomain'),
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         ).thenAnswer((_) async => ElectrumServerStatus.offline);
 
@@ -199,6 +219,7 @@ void main() {
             url: any(named: 'url'),
             network: _network,
             validateDomain: false,
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         ).called(1);
       },
@@ -222,8 +243,7 @@ void main() {
         when(
           () => statusPort.checkSocket(
             url: any(named: 'url'),
-            useTorProxy: any(named: 'useTorProxy'),
-            torProxyPort: any(named: 'torProxyPort'),
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         ).thenAnswer((_) async => ElectrumServerStatus.online);
         when(() => electrumSettingsRepo.fetchByNetwork(_network)).thenAnswer(
@@ -239,10 +259,67 @@ void main() {
             url: any(named: 'url'),
             network: _network,
             validateDomain: any(named: 'validateDomain'),
+            proxyEndpoint: any(named: 'proxyEndpoint'),
           ),
         );
       },
     );
+
+    test('checks an onion server through a closed isolated route', () async {
+      var routeClosed = false;
+      final endpoint = TorProxyEndpoint(host: '127.0.0.1', port: 41001);
+      when(
+        () => serverRepo.fetchByUrl(any()),
+      ).thenAnswer((_) async => Ok(null));
+      when(() => appSettingsRepo.fetch()).thenAnswer(
+        (_) async => SettingsEntity(
+          environment: Environment.mainnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+          useTorProxy: false,
+          torProxyPort: 9050,
+        ),
+      );
+      when(
+        () => electrumSettingsRepo.fetchByNetwork(_network),
+      ).thenAnswer((_) async => Ok(_settings()));
+      when(
+        () => torSessionPort.open(
+          network: _network,
+          serverUrl: 'ssl://hidden.onion:50002',
+          externalProxyEnabled: false,
+          externalProxyPort: 9050,
+        ),
+      ).thenAnswer(
+        (_) async => ElectrumTorRoute(endpoint, () async => routeClosed = true),
+      );
+      when(
+        () => statusPort.checkSocket(
+          url: 'ssl://hidden.onion:50002',
+          proxyEndpoint: endpoint,
+        ),
+      ).thenAnswer((_) async => ElectrumServerStatus.offline);
+
+      final result = await usecase.execute(
+        AddCustomServerRequest(
+          server: ElectrumServerDto(
+            url: 'hidden.onion:50002',
+            network: _network,
+            isCustom: true,
+            priority: 0,
+          ),
+        ),
+      );
+
+      expect(result, isA<Err>());
+      expect(routeClosed, isTrue);
+      verify(
+        () => statusPort.checkSocket(
+          url: 'ssl://hidden.onion:50002',
+          proxyEndpoint: endpoint,
+        ),
+      ).called(1);
+    });
   });
 
   group('SetAdvancedElectrumOptionsUsecase', () {
@@ -304,12 +381,14 @@ void main() {
         final envPort = _MockEnvironmentPort();
         final statusPort = _MockServerStatusPort();
         final appSettingsRepo = _MockAppSettingsRepository();
+        final torSessionPort = _MockTorSessionPort();
         final usecase = LoadElectrumServerDataUsecase(
           electrumServerRepository: serverRepo,
           electrumSettingsRepository: settingsRepo,
           environmentPort: envPort,
           serverStatusPort: statusPort,
           settingsRepository: appSettingsRepo,
+          torSessionPort: torSessionPort,
         );
         // EnvironmentPort still throws; the use-case is the boundary that maps it.
         when(() => envPort.getEnvironment()).thenThrow(Exception('boom'));
@@ -322,6 +401,72 @@ void main() {
         expect((result as Err).failure, isA<ElectrumUnexpectedFailure>());
       },
     );
+
+    test('checks an onion server through a closed isolated route', () async {
+      final serverRepo = _MockServerRepository();
+      final settingsRepo = _MockSettingsRepository();
+      final envPort = _MockEnvironmentPort();
+      final statusPort = _MockServerStatusPort();
+      final appSettingsRepo = _MockAppSettingsRepository();
+      final torSessionPort = _MockTorSessionPort();
+      final endpoint = TorProxyEndpoint(host: '127.0.0.1', port: 41002);
+      var routeClosed = false;
+      final server = ElectrumServer.existing(
+        url: 'ssl://hidden.onion:50002',
+        network: _network,
+        isCustom: false,
+        priority: 0,
+      );
+      final usecase = LoadElectrumServerDataUsecase(
+        electrumServerRepository: serverRepo,
+        electrumSettingsRepository: settingsRepo,
+        environmentPort: envPort,
+        serverStatusPort: statusPort,
+        settingsRepository: appSettingsRepo,
+        torSessionPort: torSessionPort,
+      );
+      when(
+        () => envPort.getEnvironment(),
+      ).thenAnswer((_) async => ElectrumEnvironment.mainnet);
+      when(
+        () => serverRepo.fetchAll(isTestnet: false, isLiquid: false),
+      ).thenAnswer((_) async => Ok([server]));
+      when(
+        () => settingsRepo.fetchByNetwork(_network),
+      ).thenAnswer((_) async => Ok(_settings()));
+      when(() => appSettingsRepo.fetch()).thenAnswer(
+        (_) async => SettingsEntity(
+          environment: Environment.mainnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+          useTorProxy: false,
+          torProxyPort: 9050,
+        ),
+      );
+      when(
+        () => torSessionPort.open(
+          network: _network,
+          serverUrl: server.url,
+          externalProxyEnabled: false,
+          externalProxyPort: 9050,
+        ),
+      ).thenAnswer(
+        (_) async => ElectrumTorRoute(endpoint, () async => routeClosed = true),
+      );
+      when(
+        () => statusPort.checkSocket(url: server.url, proxyEndpoint: endpoint),
+      ).thenAnswer((_) async => ElectrumServerStatus.online);
+
+      final result = await usecase.execute(
+        LoadElectrumServerDataRequest(isLiquid: false),
+      );
+
+      expect(result, isA<Ok>());
+      expect(routeClosed, isTrue);
+      verify(
+        () => statusPort.checkSocket(url: server.url, proxyEndpoint: endpoint),
+      ).called(1);
+    });
   });
 
   group('SetCustomServersPriorityUsecase', () {

--- a/test/core_test/electrum/electrum_socket_connector_test.dart
+++ b/test/core_test/electrum/electrum_socket_connector_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
+import 'package:bb_mobile/core/electrum/domain/errors/electrum_fallback_exception.dart';
+import 'package:bull_tor/tor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _connector = ElectrumSocketConnector();
+const _timeout = Duration(seconds: 2);
+
+void main() {
+  group('onion without a proxy', () {
+    test('is refused before any socket is opened', () async {
+      await expectLater(
+        _connector.connect(
+          server: Uri.parse('tcp://qwerty234.onion:50001'),
+          timeout: _timeout,
+        ),
+        throwsA(isA<OnionServerWithoutTorException>()),
+      );
+    });
+
+    test('is refused for a trailing-dot onion host too', () async {
+      await expectLater(
+        _connector.connect(
+          server: Uri.parse('ssl://qwerty234.onion.:50002'),
+          timeout: _timeout,
+        ),
+        throwsA(isA<OnionServerWithoutTorException>()),
+      );
+    });
+
+    test('does not refuse a clearnet host that merely contains "onion"', () {
+      // `onion.example.com` is a normal domain; refusing it would break a
+      // legitimate server for a substring match.
+      expect(
+        _connector.connect(
+          server: Uri.parse('tcp://onion.example.com:50001'),
+          timeout: const Duration(milliseconds: 1),
+        ),
+        throwsA(isNot(isA<OnionServerWithoutTorException>())),
+      );
+    });
+  });
+
+  group('through a proxy', () {
+    late _FakeSocksServer proxy;
+
+    setUp(() async => proxy = await _FakeSocksServer.start());
+    tearDown(() async => proxy.close());
+
+    /// The DNS-leak regression guard. `socks5_proxy` takes an
+    /// `InternetAddress`, so the obvious call resolves the name locally; the
+    /// connector works around that. If an upgrade breaks the workaround, the
+    /// request below carries ATYP 0x01 and a resolved IP instead of the name,
+    /// and this test fails rather than the leak shipping.
+    test('sends the hostname as a SOCKS5 domain name, never an IP', () async {
+      unawaited(
+        _connector
+            .connect(
+              server: Uri.parse('tcp://qwerty234.onion:50001'),
+              timeout: _timeout,
+              proxy: TorProxyEndpoint(
+                host: InternetAddress.loopbackIPv4.address,
+                port: proxy.port,
+              ),
+            )
+            .then<void>((socket) => socket.destroy(), onError: (_) {}),
+      );
+
+      final request = await proxy.request;
+
+      expect(request[0], 0x05, reason: 'SOCKS5');
+      expect(request[1], 0x01, reason: 'CONNECT');
+      expect(
+        request[3],
+        0x03,
+        reason: 'ATYP must be domain-name; 0x01 would mean a local DNS lookup',
+      );
+      final length = request[4];
+      final host = String.fromCharCodes(request.sublist(5, 5 + length));
+      expect(host, 'qwerty234.onion');
+      final port = (request[5 + length] << 8) | request[6 + length];
+      expect(port, 50001);
+    });
+  });
+}
+
+/// A loopback listener that completes the SOCKS5 greeting and then captures the
+/// connect request verbatim.
+class _FakeSocksServer {
+  final ServerSocket _server;
+  final Completer<List<int>> _request = Completer<List<int>>();
+
+  _FakeSocksServer(this._server) {
+    _server.listen((socket) {
+      final buffer = <int>[];
+      var greeted = false;
+      socket.listen((chunk) {
+        if (!greeted) {
+          // Client greeting: accept "no authentication".
+          greeted = true;
+          socket.add([0x05, 0x00]);
+          return;
+        }
+        buffer.addAll(chunk);
+        if (!_request.isCompleted) _request.complete(buffer);
+      }, onError: (_) {});
+    });
+  }
+
+  static Future<_FakeSocksServer> start() async => _FakeSocksServer(
+    await ServerSocket.bind(InternetAddress.loopbackIPv4, 0),
+  );
+
+  int get port => _server.port;
+
+  Future<List<int>> get request => _request.future.timeout(_timeout);
+
+  Future<void> close() => _server.close();
+}

--- a/test/core_test/electrum/electrum_tor_session_adapter_test.dart
+++ b/test/core_test/electrum/electrum_tor_session_adapter_test.dart
@@ -1,0 +1,89 @@
+import 'package:bb_mobile/core/electrum/adapters/electrum_tor_session_adapter.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_tor_session_port.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/electrum/frameworks/di/electrum_locator.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:bull_tor/tor.dart';
+
+class _MockTor extends Mock implements Tor {}
+
+class _MockEmbeddedTor extends Mock implements EmbeddedTor {}
+
+class _MockTorSessions extends Mock implements TorSessions {}
+
+void main() {
+  late _MockTor tor;
+  late _MockEmbeddedTor embedded;
+  late _MockTorSessions sessions;
+  late ElectrumTorSessionAdapter adapter;
+
+  setUp(() {
+    tor = _MockTor();
+    embedded = _MockEmbeddedTor();
+    sessions = _MockTorSessions();
+    when(() => tor.embedded).thenReturn(embedded);
+    when(() => embedded.sessions).thenReturn(sessions);
+    adapter = ElectrumTorSessionAdapter(() => tor);
+  });
+
+  test('can be resolved before the Tor facade is registered', () {
+    final locator = GetIt.asNewInstance();
+    ElectrumLocator.registerPorts(locator);
+
+    expect(locator<ElectrumTorSessionPort>(), isA<ElectrumTorSessionAdapter>());
+  });
+
+  test('opens an embedded session for Bitcoin onion servers', () async {
+    var closed = false;
+    final session = TorSession(
+      TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+      TorTransport.snowflake,
+      () async => closed = true,
+    );
+    when(() => sessions.open()).thenAnswer((_) async => session);
+
+    final route = await adapter.open(
+      network: ElectrumServerNetwork.bitcoinMainnet,
+      serverUrl: 'ssl://hidden.onion:50002',
+      externalProxyEnabled: false,
+      externalProxyPort: 9050,
+    );
+
+    expect(route?.endpoint, session.endpoint);
+    await route?.close();
+    expect(closed, isTrue);
+  });
+
+  test('keeps Orbot as an explicit external override', () async {
+    final route = await adapter.open(
+      network: ElectrumServerNetwork.bitcoinMainnet,
+      serverUrl: 'ssl://hidden.onion:50002',
+      externalProxyEnabled: true,
+      externalProxyPort: 9150,
+    );
+
+    expect(route?.endpoint.authority, '127.0.0.1:9150');
+    verifyNever(() => sessions.open());
+  });
+
+  test('leaves clearnet and Liquid servers direct', () async {
+    final clearnet = await adapter.open(
+      network: ElectrumServerNetwork.bitcoinMainnet,
+      serverUrl: 'ssl://electrum.example:50002',
+      externalProxyEnabled: false,
+      externalProxyPort: 9050,
+    );
+    final liquid = await adapter.open(
+      network: ElectrumServerNetwork.liquidMainnet,
+      serverUrl: 'ssl://hidden.onion:50002',
+      externalProxyEnabled: false,
+      externalProxyPort: 9050,
+    );
+
+    expect(clearnet, isNull);
+    expect(liquid, isNull);
+    verifyNever(() => sessions.open());
+  });
+}

--- a/test/core_test/electrum/server_status_adapter_test.dart
+++ b/test/core_test/electrum/server_status_adapter_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:bb_mobile/core/electrum/adapters/server_status_adapter.dart';
+import 'package:bb_mobile/core/electrum/data/electrum_socket_connector.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,7 +11,7 @@ import 'self_signed_electrum_server.dart';
 /// The probe must accept exactly the certificates the BDK/LWK sync accepts,
 /// so that "online" here means the wallet can really use the server.
 void main() {
-  const adapter = ServerStatusAdapter();
+  const adapter = ServerStatusAdapter(ElectrumSocketConnector());
   const network = ElectrumServerNetwork.bitcoinMainnet;
 
   late SelfSignedElectrumServer fixture;

--- a/test/core_test/status/electrum_connectivity_adapter_test.dart
+++ b/test/core_test/status/electrum_connectivity_adapter_test.dart
@@ -1,0 +1,156 @@
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
+import 'package:bb_mobile/core/electrum/domain/ports/server_status_port.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
+import 'package:bb_mobile/core/status/interface_adapters/adapter/electrum_connectivity_adapter.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_tor/tor.dart';
+
+void main() {
+  test('checks an onion server through its resolved embedded route', () async {
+    final serversPort = _FakeElectrumServersPort(
+      _connection(socks5: '127.0.0.1:41001'),
+    );
+    final statusPort = _FakeServerStatusPort(ElectrumServerStatus.online);
+    final adapter = ElectrumConnectivityAdapter(
+      electrumServersPort: serversPort,
+      serverStatusPort: statusPort,
+    );
+
+    final online = await adapter.checkServersInUseAreOnlineForNetwork(
+      Network.bitcoinMainnet,
+    );
+
+    expect(online, isTrue);
+    expect(serversPort.network, ElectrumServerNetwork.bitcoinMainnet);
+    expect(statusPort.proxyEndpoint?.authority, '127.0.0.1:41001');
+    // Null, so the port applies its longer onion default. Passing the user's 5s
+    // clearnet ceiling here made healthy onion servers report offline and lit
+    // the Tor error banner.
+    expect(statusPort.timeout, isNull);
+  });
+
+  test('an unproxied server keeps the user timeout', () async {
+    final serversPort = _FakeElectrumServersPort(_connection());
+    final statusPort = _FakeServerStatusPort(ElectrumServerStatus.online);
+    final adapter = ElectrumConnectivityAdapter(
+      electrumServersPort: serversPort,
+      serverStatusPort: statusPort,
+    );
+
+    await adapter.checkServersInUseAreOnlineForNetwork(Network.bitcoinMainnet);
+
+    expect(statusPort.timeout, 5);
+  });
+
+  test('an empty proxy string means no proxy, not a malformed one', () async {
+    final serversPort = _FakeElectrumServersPort(_connection(socks5: '  '));
+    final statusPort = _FakeServerStatusPort(ElectrumServerStatus.online);
+    final adapter = ElectrumConnectivityAdapter(
+      electrumServersPort: serversPort,
+      serverStatusPort: statusPort,
+    );
+
+    final online = await adapter.checkServersInUseAreOnlineForNetwork(
+      Network.bitcoinMainnet,
+    );
+
+    expect(online, isTrue);
+    expect(statusPort.proxyEndpoint, isNull);
+  });
+
+  test('does not bypass a malformed configured proxy', () async {
+    final statusPort = _FakeServerStatusPort(ElectrumServerStatus.online);
+    final adapter = ElectrumConnectivityAdapter(
+      electrumServersPort: _FakeElectrumServersPort(
+        _connection(socks5: 'not-an-endpoint'),
+      ),
+      serverStatusPort: statusPort,
+    );
+
+    final online = await adapter.checkServersInUseAreOnlineForNetwork(
+      Network.bitcoinMainnet,
+    );
+
+    expect(online, isFalse);
+    expect(statusPort.calls, 0);
+  });
+
+  test('reports an unreachable active server set as offline', () async {
+    final adapter = ElectrumConnectivityAdapter(
+      electrumServersPort: _FakeElectrumServersPort(_connection()),
+      serverStatusPort: _FakeServerStatusPort(ElectrumServerStatus.offline),
+    );
+
+    expect(
+      await adapter.checkServersInUseAreOnlineForNetwork(
+        Network.bitcoinMainnet,
+      ),
+      isFalse,
+    );
+  });
+}
+
+/// The seeded default for `timeout` is 5 seconds, so the fixture uses it: a
+/// proxied probe must not inherit that clearnet ceiling.
+ElectrumConnection _connection({String? socks5, int timeout = 5}) =>
+    ElectrumConnection(
+      url: 'ssl://hiddenservice.onion:50002',
+      retry: 1,
+      timeout: timeout,
+      stopGap: 20,
+      validateDomain: true,
+      isCustom: false,
+      socks5: socks5,
+    );
+
+final class _FakeElectrumServersPort implements ElectrumServersPort {
+  final ElectrumConnection connection;
+  ElectrumServerNetwork? network;
+
+  _FakeElectrumServersPort(this.connection);
+
+  @override
+  Future<T> runWithFallback<T>({
+    required ElectrumServerNetwork network,
+    required Future<T> Function(ElectrumConnection connection) operation,
+    bool Function(Object error)? isTransient,
+  }) {
+    this.network = network;
+    return operation(connection);
+  }
+}
+
+final class _FakeServerStatusPort implements ServerStatusPort {
+  final ElectrumServerStatus result;
+  TorProxyEndpoint? proxyEndpoint;
+  int? timeout;
+  bool? validateDomain;
+  int calls = 0;
+
+  _FakeServerStatusPort(this.result);
+
+  @override
+  Future<ElectrumServerStatus> checkElectrum({
+    required String url,
+    required ElectrumServerNetwork network,
+    required bool validateDomain,
+    int? timeout,
+    TorProxyEndpoint? proxyEndpoint,
+  }) async {
+    calls++;
+    this.timeout = timeout;
+    this.proxyEndpoint = proxyEndpoint;
+    this.validateDomain = validateDomain;
+    return result;
+  }
+
+  @override
+  Future<ElectrumServerStatus> checkSocket({
+    required String url,
+    int? timeout,
+    TorProxyEndpoint? proxyEndpoint,
+  }) => throw UnimplementedError();
+}

--- a/test/features/electrum_settings/electrum_settings_state_test.dart
+++ b/test/features/electrum_settings/electrum_settings_state_test.dart
@@ -1,0 +1,48 @@
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_status.dart';
+import 'package:bb_mobile/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_bloc.dart';
+import 'package:bb_mobile/features/electrum_settings/interface_adapters/presenters/view_models/electrum_server_view_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ElectrumServerViewModel _server(String url, ElectrumServerStatus status) =>
+    ElectrumServerViewModel(url: url, status: status, priority: 0);
+
+void main() {
+  test('clearnet failures do not report an Orbot failure', () {
+    final state = ElectrumSettingsState(
+      defaultServers: [
+        _server(
+          'ssl://electrum.example.com:50002',
+          ElectrumServerStatus.offline,
+        ),
+      ],
+    );
+
+    expect(state.activeOnionServersAreOffline, isFalse);
+  });
+
+  test('offline custom onion servers report an Orbot failure', () {
+    final state = ElectrumSettingsState(
+      defaultServers: [
+        _server(
+          'ssl://electrum.example.com:50002',
+          ElectrumServerStatus.online,
+        ),
+      ],
+      customServers: [
+        _server('ssl://hidden.onion:50002', ElectrumServerStatus.offline),
+      ],
+    );
+
+    expect(state.activeOnionServersAreOffline, isTrue);
+  });
+
+  test('an online onion server does not report an Orbot failure', () {
+    final state = ElectrumSettingsState(
+      customServers: [
+        _server('ssl://hidden.onion:50002', ElectrumServerStatus.online),
+      ],
+    );
+
+    expect(state.activeOnionServersAreOffline, isFalse);
+  });
+}


### PR DESCRIPTION
Stacked on the `feat/tor-recoverbull` PR. Review that one first.

The second Tor consumer moves onto `bull_tor`: an Electrum server reached over `.onion` now gets its own isolated session, separate from RecoverBull's.

`ElectrumServerUrl` becomes a value object that parses and validates a server address and answers whether it is an onion host, instead of that decision being made from string checks at the call sites. `ElectrumSocketConnector` performs the connection, over Tor or clear, and `ElectrumTorSessionPort` is the capability the Electrum layer depends on so it never reaches into `bull_tor`'s data layer.

`ElectrumFallbackException` makes the fallback path explicit: when an onion server cannot be reached, the caller learns that the fallback happened rather than silently getting a clearnet connection. The connectivity and server-status adapters are updated accordingly, and the Tor proxy error banner now reflects the real state.

Verified: whole-project analyze clean, and the Electrum suites pass, including the new `electrum_server_url_test.dart`, `electrum_socket_connector_test.dart`, `electrum_tor_session_adapter_test.dart` and the connectivity adapter tests.