### PR TITLE
feat(recoverbull): explain Tor connection progress

### DIFF
--- a/lib/core/storage/migrations/schema_13_to_14.dart
+++ b/lib/core/storage/migrations/schema_13_to_14.dart
@@ -59,6 +59,18 @@ class Schema13To14 {
       () => m.createIndex(schema14.orderSwapsLocalPayinTxid),
       'order_swaps_local_payin_txid index',
     );
+
+    await _addColumnIfNotExists(
+      () => m.addColumn(schema14.settings, schema14.settings.torTransportMode),
+      'settings.tor_transport_mode column',
+    );
+    await _addColumnIfNotExists(
+      () => m.addColumn(
+        schema14.settings,
+        schema14.settings.lastSuccessfulTorTransport,
+      ),
+      'settings.last_successful_tor_transport column',
+    );
   }
 }
 
@@ -75,6 +87,21 @@ Future<void> _createIfNotExists(
     if (!e.toString().contains('already exists')) rethrow;
     log.warning(
       'Schema13To14: $description already exists — skipping create',
+      error: e,
+    );
+  }
+}
+
+Future<void> _addColumnIfNotExists(
+  Future<void> Function() addColumn,
+  String description,
+) async {
+  try {
+    await addColumn();
+  } catch (e) {
+    if (!e.toString().contains('duplicate column name')) rethrow;
+    log.warning(
+      'Schema13To14: $description already exists — skipping add',
       error: e,
     );
   }

--- a/lib/core/storage/schemas/bull_database/drift_schema_v14.json
+++ b/lib/core/storage/schemas/bull_database/drift_schema_v14.json
@@ -548,6 +548,26 @@
             "dsl_features": []
           },
           {
+            "name": "tor_transport_mode",
+            "getter_name": "torTransportMode",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'automatic\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "last_successful_tor_transport",
+            "getter_name": "lastSuccessfulTorTransport",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
             "name": "theme_mode",
             "getter_name": "themeMode",
             "moor_type": "string",
@@ -2642,7 +2662,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"settings\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"environment\" TEXT NOT NULL, \"bitcoin_unit\" TEXT NOT NULL, \"language\" TEXT NOT NULL, \"currency\" TEXT NOT NULL, \"hide_amounts\" INTEGER NOT NULL CHECK (\"hide_amounts\" IN (0, 1)), \"is_superuser\" INTEGER NOT NULL CHECK (\"is_superuser\" IN (0, 1)), \"is_dev_mode_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_dev_mode_enabled\" IN (0, 1)), \"use_tor_proxy\" INTEGER NOT NULL DEFAULT 0 CHECK (\"use_tor_proxy\" IN (0, 1)), \"tor_proxy_port\" INTEGER NOT NULL DEFAULT 9050, \"theme_mode\" TEXT NOT NULL DEFAULT 'system', \"is_error_reporting_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_error_reporting_enabled\" IN (0, 1)), \"exchange_testnet_basic_auth_username\" TEXT NULL, \"exchange_testnet_basic_auth_password\" TEXT NULL);"
+          "sql": "CREATE TABLE IF NOT EXISTS \"settings\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"environment\" TEXT NOT NULL, \"bitcoin_unit\" TEXT NOT NULL, \"language\" TEXT NOT NULL, \"currency\" TEXT NOT NULL, \"hide_amounts\" INTEGER NOT NULL CHECK (\"hide_amounts\" IN (0, 1)), \"is_superuser\" INTEGER NOT NULL CHECK (\"is_superuser\" IN (0, 1)), \"is_dev_mode_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_dev_mode_enabled\" IN (0, 1)), \"use_tor_proxy\" INTEGER NOT NULL DEFAULT 0 CHECK (\"use_tor_proxy\" IN (0, 1)), \"tor_proxy_port\" INTEGER NOT NULL DEFAULT 9050, \"tor_transport_mode\" TEXT NOT NULL DEFAULT 'automatic', \"last_successful_tor_transport\" TEXT NULL, \"theme_mode\" TEXT NOT NULL DEFAULT 'system', \"is_error_reporting_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_error_reporting_enabled\" IN (0, 1)), \"exchange_testnet_basic_auth_username\" TEXT NULL, \"exchange_testnet_basic_auth_password\" TEXT NULL);"
         }
       ]
     },

--- a/lib/core/storage/sqlite_database.steps.dart
+++ b/lib/core/storage/sqlite_database.steps.dart
@@ -6349,7 +6349,7 @@ final class Schema14 extends i0.VersionedSchema {
     ),
     alias: null,
   );
-  late final Shape37 settings = Shape37(
+  late final Shape40 settings = Shape40(
     source: i0.VersionedTable(
       entityName: 'settings',
       withoutRowId: false,
@@ -6366,6 +6366,8 @@ final class Schema14 extends i0.VersionedSchema {
         _column_154,
         _column_155,
         _column_156,
+        _column_242,
+        _column_243,
         _column_157,
         _column_233,
         _column_235,
@@ -6614,31 +6616,29 @@ final class Schema14 extends i0.VersionedSchema {
     ),
     alias: null,
   );
-  late final Shape40 dismissedAnnouncements = Shape40(
+  late final Shape41 dismissedAnnouncements = Shape41(
     source: i0.VersionedTable(
       entityName: 'dismissed_announcements',
       withoutRowId: false,
       isStrict: false,
       tableConstraints: ['PRIMARY KEY(announcement_id)'],
-      columns: [_column_242, _column_243],
+      columns: [_column_244, _column_245],
       attachedDatabase: database,
     ),
     alias: null,
   );
-  late final Shape41 orderSwaps = Shape41(
+  late final Shape42 orderSwaps = Shape42(
     source: i0.VersionedTable(
       entityName: 'order_swaps',
       withoutRowId: false,
       isStrict: false,
       tableConstraints: ['PRIMARY KEY(local_id)'],
       columns: [
-        _column_244,
-        _column_245,
         _column_246,
         _column_247,
-        _column_148,
         _column_248,
         _column_249,
+        _column_148,
         _column_250,
         _column_251,
         _column_252,
@@ -6666,15 +6666,17 @@ final class Schema14 extends i0.VersionedSchema {
         _column_274,
         _column_275,
         _column_276,
-        _column_231,
         _column_277,
         _column_278,
+        _column_231,
         _column_279,
         _column_280,
         _column_281,
         _column_282,
         _column_283,
         _column_284,
+        _column_285,
+        _column_286,
       ],
       attachedDatabase: database,
     ),
@@ -6712,13 +6714,70 @@ final class Schema14 extends i0.VersionedSchema {
 
 class Shape40 extends i0.VersionedTable {
   Shape40({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<int> get id =>
+      columnsByName['id']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<String> get environment =>
+      columnsByName['environment']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get bitcoinUnit =>
+      columnsByName['bitcoin_unit']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get language =>
+      columnsByName['language']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get currency =>
+      columnsByName['currency']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get hideAmounts =>
+      columnsByName['hide_amounts']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get isSuperuser =>
+      columnsByName['is_superuser']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get isDevModeEnabled =>
+      columnsByName['is_dev_mode_enabled']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get useTorProxy =>
+      columnsByName['use_tor_proxy']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get torProxyPort =>
+      columnsByName['tor_proxy_port']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<String> get torTransportMode =>
+      columnsByName['tor_transport_mode']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get lastSuccessfulTorTransport =>
+      columnsByName['last_successful_tor_transport']!
+          as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get themeMode =>
+      columnsByName['theme_mode']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get isErrorReportingEnabled =>
+      columnsByName['is_error_reporting_enabled']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<String> get exchangeTestnetBasicAuthUsername =>
+      columnsByName['exchange_testnet_basic_auth_username']!
+          as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get exchangeTestnetBasicAuthPassword =>
+      columnsByName['exchange_testnet_basic_auth_password']!
+          as i1.GeneratedColumn<String>;
+}
+
+i1.GeneratedColumn<String> _column_242(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'tor_transport_mode',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL DEFAULT \'automatic\'',
+      defaultValue: const i1.CustomExpression('\'automatic\''),
+    );
+i1.GeneratedColumn<String> _column_243(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'last_successful_tor_transport',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NULL',
+    );
+
+class Shape41 extends i0.VersionedTable {
+  Shape41({required super.source, required super.alias}) : super.aliased();
   i1.GeneratedColumn<String> get announcementId =>
       columnsByName['announcement_id']! as i1.GeneratedColumn<String>;
   i1.GeneratedColumn<String> get dismissedAt =>
       columnsByName['dismissed_at']! as i1.GeneratedColumn<String>;
 }
 
-i1.GeneratedColumn<String> _column_242(String aliasedName) =>
+i1.GeneratedColumn<String> _column_244(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'announcement_id',
       aliasedName,
@@ -6726,7 +6785,7 @@ i1.GeneratedColumn<String> _column_242(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_243(String aliasedName) =>
+i1.GeneratedColumn<String> _column_245(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'dismissed_at',
       aliasedName,
@@ -6735,8 +6794,8 @@ i1.GeneratedColumn<String> _column_243(String aliasedName) =>
       $customConstraints: 'NOT NULL',
     );
 
-class Shape41 extends i0.VersionedTable {
-  Shape41({required super.source, required super.alias}) : super.aliased();
+class Shape42 extends i0.VersionedTable {
+  Shape42({required super.source, required super.alias}) : super.aliased();
   i1.GeneratedColumn<String> get localId =>
       columnsByName['local_id']! as i1.GeneratedColumn<String>;
   i1.GeneratedColumn<String> get requestId =>
@@ -6826,7 +6885,7 @@ class Shape41 extends i0.VersionedTable {
       columnsByName['labels_applied_at']! as i1.GeneratedColumn<String>;
 }
 
-i1.GeneratedColumn<String> _column_244(String aliasedName) =>
+i1.GeneratedColumn<String> _column_246(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'local_id',
       aliasedName,
@@ -6834,7 +6893,7 @@ i1.GeneratedColumn<String> _column_244(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_245(String aliasedName) =>
+i1.GeneratedColumn<String> _column_247(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'request_id',
       aliasedName,
@@ -6842,7 +6901,7 @@ i1.GeneratedColumn<String> _column_245(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_246(String aliasedName) =>
+i1.GeneratedColumn<String> _column_248(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'order_id',
       aliasedName,
@@ -6850,7 +6909,7 @@ i1.GeneratedColumn<String> _column_246(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL UNIQUE',
     );
-i1.GeneratedColumn<String> _column_247(String aliasedName) =>
+i1.GeneratedColumn<String> _column_249(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'purpose',
       aliasedName,
@@ -6858,7 +6917,7 @@ i1.GeneratedColumn<String> _column_247(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_248(String aliasedName) =>
+i1.GeneratedColumn<String> _column_250(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'in_network',
       aliasedName,
@@ -6866,7 +6925,7 @@ i1.GeneratedColumn<String> _column_248(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_249(String aliasedName) =>
+i1.GeneratedColumn<String> _column_251(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'out_network',
       aliasedName,
@@ -6874,7 +6933,7 @@ i1.GeneratedColumn<String> _column_249(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<int> _column_250(String aliasedName) =>
+i1.GeneratedColumn<int> _column_252(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'is_in_amount_fixed',
       aliasedName,
@@ -6882,7 +6941,7 @@ i1.GeneratedColumn<int> _column_250(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NOT NULL CHECK (is_in_amount_fixed IN (0, 1))',
     );
-i1.GeneratedColumn<int> _column_251(String aliasedName) =>
+i1.GeneratedColumn<int> _column_253(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'requested_amount_sat',
       aliasedName,
@@ -6890,7 +6949,7 @@ i1.GeneratedColumn<int> _column_251(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<int> _column_252(String aliasedName) =>
+i1.GeneratedColumn<int> _column_254(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'quoted_amount_sat',
       aliasedName,
@@ -6898,7 +6957,7 @@ i1.GeneratedColumn<int> _column_252(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_253(String aliasedName) =>
+i1.GeneratedColumn<String> _column_255(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'source_wallet_id',
       aliasedName,
@@ -6906,7 +6965,7 @@ i1.GeneratedColumn<String> _column_253(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_254(String aliasedName) =>
+i1.GeneratedColumn<String> _column_256(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'destination_wallet_id',
       aliasedName,
@@ -6914,7 +6973,7 @@ i1.GeneratedColumn<String> _column_254(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_255(String aliasedName) =>
+i1.GeneratedColumn<String> _column_257(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'destination',
       aliasedName,
@@ -6922,7 +6981,7 @@ i1.GeneratedColumn<String> _column_255(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_256(String aliasedName) =>
+i1.GeneratedColumn<String> _column_258(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'fallback',
       aliasedName,
@@ -6930,7 +6989,7 @@ i1.GeneratedColumn<String> _column_256(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_257(String aliasedName) =>
+i1.GeneratedColumn<String> _column_259(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'bitcoin_address',
       aliasedName,
@@ -6938,7 +6997,7 @@ i1.GeneratedColumn<String> _column_257(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_258(String aliasedName) =>
+i1.GeneratedColumn<String> _column_260(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'liquid_address',
       aliasedName,
@@ -6946,7 +7005,7 @@ i1.GeneratedColumn<String> _column_258(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_259(String aliasedName) =>
+i1.GeneratedColumn<String> _column_261(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'lightning_invoice',
       aliasedName,
@@ -6954,7 +7013,7 @@ i1.GeneratedColumn<String> _column_259(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<int> _column_260(String aliasedName) =>
+i1.GeneratedColumn<int> _column_262(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'payin_amount_sat',
       aliasedName,
@@ -6962,7 +7021,7 @@ i1.GeneratedColumn<int> _column_260(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<int> _column_261(String aliasedName) =>
+i1.GeneratedColumn<int> _column_263(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'payout_amount_sat',
       aliasedName,
@@ -6970,7 +7029,7 @@ i1.GeneratedColumn<int> _column_261(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_262(String aliasedName) =>
+i1.GeneratedColumn<String> _column_264(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payin_currency',
       aliasedName,
@@ -6978,7 +7037,7 @@ i1.GeneratedColumn<String> _column_262(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_263(String aliasedName) =>
+i1.GeneratedColumn<String> _column_265(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payout_currency',
       aliasedName,
@@ -6986,7 +7045,7 @@ i1.GeneratedColumn<String> _column_263(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_264(String aliasedName) =>
+i1.GeneratedColumn<String> _column_266(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payin_method',
       aliasedName,
@@ -6994,7 +7053,7 @@ i1.GeneratedColumn<String> _column_264(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_265(String aliasedName) =>
+i1.GeneratedColumn<String> _column_267(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payout_method',
       aliasedName,
@@ -7002,7 +7061,7 @@ i1.GeneratedColumn<String> _column_265(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_266(String aliasedName) =>
+i1.GeneratedColumn<String> _column_268(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'order_type',
       aliasedName,
@@ -7010,7 +7069,7 @@ i1.GeneratedColumn<String> _column_266(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_267(String aliasedName) =>
+i1.GeneratedColumn<String> _column_269(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'order_status',
       aliasedName,
@@ -7018,7 +7077,7 @@ i1.GeneratedColumn<String> _column_267(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_268(String aliasedName) =>
+i1.GeneratedColumn<String> _column_270(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payin_status',
       aliasedName,
@@ -7026,7 +7085,7 @@ i1.GeneratedColumn<String> _column_268(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_269(String aliasedName) =>
+i1.GeneratedColumn<String> _column_271(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'payout_status',
       aliasedName,
@@ -7034,7 +7093,7 @@ i1.GeneratedColumn<String> _column_269(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_270(String aliasedName) =>
+i1.GeneratedColumn<String> _column_272(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'message_code',
       aliasedName,
@@ -7042,7 +7101,7 @@ i1.GeneratedColumn<String> _column_270(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_271(String aliasedName) =>
+i1.GeneratedColumn<String> _column_273(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'bitcoin_transaction_id',
       aliasedName,
@@ -7050,7 +7109,7 @@ i1.GeneratedColumn<String> _column_271(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_272(String aliasedName) =>
+i1.GeneratedColumn<String> _column_274(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'liquid_transaction_id',
       aliasedName,
@@ -7058,7 +7117,7 @@ i1.GeneratedColumn<String> _column_272(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_273(String aliasedName) =>
+i1.GeneratedColumn<String> _column_275(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'local_payin_transaction_id',
       aliasedName,
@@ -7066,7 +7125,7 @@ i1.GeneratedColumn<String> _column_273(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_274(String aliasedName) =>
+i1.GeneratedColumn<String> _column_276(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'signed_payin_transaction',
       aliasedName,
@@ -7074,7 +7133,7 @@ i1.GeneratedColumn<String> _column_274(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<int> _column_275(String aliasedName) =>
+i1.GeneratedColumn<int> _column_277(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'payin_is_psbt',
       aliasedName,
@@ -7082,7 +7141,7 @@ i1.GeneratedColumn<int> _column_275(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL CHECK (payin_is_psbt IN (0, 1))',
     );
-i1.GeneratedColumn<int> _column_276(String aliasedName) =>
+i1.GeneratedColumn<int> _column_278(String aliasedName) =>
     i1.GeneratedColumn<int>(
       'order_number',
       aliasedName,
@@ -7090,7 +7149,7 @@ i1.GeneratedColumn<int> _column_276(String aliasedName) =>
       type: i1.DriftSqlType.int,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_277(String aliasedName) =>
+i1.GeneratedColumn<String> _column_279(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'server_created_at',
       aliasedName,
@@ -7098,7 +7157,7 @@ i1.GeneratedColumn<String> _column_277(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_278(String aliasedName) =>
+i1.GeneratedColumn<String> _column_280(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'confirmation_deadline',
       aliasedName,
@@ -7106,7 +7165,7 @@ i1.GeneratedColumn<String> _column_278(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_279(String aliasedName) =>
+i1.GeneratedColumn<String> _column_281(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'sent_at',
       aliasedName,
@@ -7114,7 +7173,7 @@ i1.GeneratedColumn<String> _column_279(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_280(String aliasedName) =>
+i1.GeneratedColumn<String> _column_282(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'local_status',
       aliasedName,
@@ -7122,7 +7181,7 @@ i1.GeneratedColumn<String> _column_280(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL',
     );
-i1.GeneratedColumn<String> _column_281(String aliasedName) =>
+i1.GeneratedColumn<String> _column_283(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'last_polled_at',
       aliasedName,
@@ -7130,7 +7189,7 @@ i1.GeneratedColumn<String> _column_281(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_282(String aliasedName) =>
+i1.GeneratedColumn<String> _column_284(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'note',
       aliasedName,
@@ -7138,7 +7197,7 @@ i1.GeneratedColumn<String> _column_282(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_283(String aliasedName) =>
+i1.GeneratedColumn<String> _column_285(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'server_completed_at',
       aliasedName,
@@ -7146,7 +7205,7 @@ i1.GeneratedColumn<String> _column_283(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
-i1.GeneratedColumn<String> _column_284(String aliasedName) =>
+i1.GeneratedColumn<String> _column_286(String aliasedName) =>
     i1.GeneratedColumn<String>(
       'labels_applied_at',
       aliasedName,

--- a/lib/features/recoverbull/ui/pages/connecting_page.dart
+++ b/lib/features/recoverbull/ui/pages/connecting_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
@@ -6,16 +8,178 @@ import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/features/recoverbull/presentation/recoverbull_failure_l10n.dart';
 import 'package:bb_mobile/features/recoverbull/ui/pages/password_input_page.dart';
 import 'package:bb_mobile/features/recoverbull/ui/pages/vault_provider_selection_page.dart';
-import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
-import 'package:bull_tor/tor.dart' as tor;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
-import 'package:gif/gif.dart';
 import 'package:go_router/go_router.dart';
+import 'package:bull_tor/tor.dart' as tor;
 
-class ConnectingPage extends StatelessWidget {
+/// How long a blockage must persist before it is shown as a failure.
+///
+/// Tor restarts its directory fetch as soon as the current directory becomes
+/// usable, which briefly drops readiness — a real observed dip was 100% to 45%
+/// and back within 173 ms. Without this delay that healthy refresh would put an
+/// error and a Retry button on screen.
+const _blockageGrace = Duration(seconds: 5);
+
+/// How long the progress bar survives without the fraction moving.
+///
+/// The fraction is 85% directory completeness, and the directory is cached on
+/// disk: with a warm cache and no connectivity at all it reads 0.85 from the
+/// first frame. A bar that only appears while the number is actually moving
+/// cannot make that claim.
+const _progressStale = Duration(seconds: 15);
+
+/// When to start reassuring the user that the wait is normal.
+///
+/// The directory phase is 85% of the bootstrap budget and reports progress only
+/// a handful of times — a measured cold start went 43 s between two updates —
+/// so past this point the screen looks stalled even though it is not.
+const _reassureAfter = Duration(seconds: 20);
+
+class ConnectingPage extends StatefulWidget {
   const ConnectingPage({super.key});
+
+  @override
+  State<ConnectingPage> createState() => _ConnectingPageState();
+}
+
+class _ConnectingPageState extends State<ConnectingPage> {
+  /// Ticks the elapsed counter. During the long directory phase this is the
+  /// only thing on screen that actually moves, so it carries the whole sense
+  /// of progress.
+  Timer? _ticker;
+
+  /// Start of the phase currently on screen, not of the page.
+  ///
+  /// A single page-lifetime clock lied twice: the key-server row opened at the
+  /// bootstrap's own elapsed time, attributing 50 s of Tor work to the server,
+  /// and after a retry both the counter and the "this is the longest step"
+  /// threshold carried over from the attempt that had already failed.
+  DateTime _startedAt = DateTime.now();
+  Duration _elapsed = Duration.zero;
+
+  /// Which phase the clock currently belongs to, to notice a handover.
+  bool? _torPhaseWasActive;
+
+  /// When the current user-visible blockage first appeared, for [_blockageGrace].
+  DateTime? _blockageSince;
+
+  /// When the bootstrap fraction last actually changed, for [_progressStale].
+  DateTime? _fractionMovedAt;
+  double? _lastFraction;
+
+  /// Whether this screen has already handed the flow to the next page.
+  ///
+  /// Readiness is not a single event: Tor republishes `TorReady` on every
+  /// directory refresh, and the key-server check emits its own states, so the
+  /// success condition below is satisfied more than once. Without this guard
+  /// each repetition pushed another route, stacking duplicate pages behind the
+  /// one the user sees.
+  bool _hasNavigated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() => _elapsed = DateTime.now().difference(_startedAt));
+    });
+
+    // `BlocListener` only sees emissions after it subscribes, so a blockage
+    // already present at mount would not start the grace clock until arti
+    // happened to re-emit. Seeding from the current state removes that
+    // dependency.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _onStateChanged(context, context.read<RecoverBullBloc>().state);
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  void _onStateChanged(BuildContext context, RecoverBullState state) {
+    final connection = state.torConnection;
+    final now = DateTime.now();
+
+    final fraction = switch (connection) {
+      tor.TorConnecting(:final progress) => progress,
+      _ => null,
+    };
+    final diagnostic = switch (connection) {
+      tor.TorConnecting(:final diagnostic) => diagnostic,
+      _ => null,
+    };
+
+    // `build` reads these through `_progressIsLive` and `_blockageIsSettled`,
+    // so they are widget state, not bookkeeping. Mutating them bare only
+    // appeared to work because the one-second ticker rebuilt anyway.
+    setState(() {
+      if (fraction != null && _lastFraction != fraction) {
+        _lastFraction = fraction;
+        _fractionMovedAt = now;
+      }
+      if (diagnostic == null) {
+        _blockageSince = null;
+      } else {
+        _blockageSince ??= now;
+      }
+
+      // Hand the clock over when Tor stops being the active phase, so the
+      // key-server row starts from zero instead of inheriting the bootstrap.
+      final torIsActive = connection is! tor.TorReady;
+      if (_torPhaseWasActive != null && _torPhaseWasActive != torIsActive) {
+        _startedAt = now;
+        _elapsed = Duration.zero;
+      }
+      _torPhaseWasActive = torIsActive;
+
+      // A retry restarts the wait: `OnTorInitialization` clears the failure and
+      // sets the key-server status back to unknown, so the clock has to follow.
+      if (connection is tor.TorConnecting &&
+          state.keyServerStatus == KeyServerStatus.unknown &&
+          _elapsed > Duration.zero &&
+          diagnostic == null) {
+        _startedAt = now;
+        _elapsed = Duration.zero;
+        _blockageSince = null;
+      }
+    });
+
+    if (connection is tor.TorReady &&
+        state.keyServerStatus == KeyServerStatus.online) {
+      if (_hasNavigated) return;
+      _hasNavigated = true;
+      final hasPreSelectedVault = state.vault != null;
+      final nextPage = switch (state.flow) {
+        RecoverBullFlow.secureVault => const PasswordInputPage(),
+        _ =>
+          hasPreSelectedVault
+              ? const PasswordInputPage()
+              : const VaultProviderSelectionPage(),
+      };
+
+      Navigator.of(
+        context,
+      ).pushReplacement(MaterialPageRoute(builder: (context) => nextPage));
+    }
+  }
+
+  /// Whether a blockage has lasted long enough to be worth showing.
+  bool get _blockageIsSettled {
+    final since = _blockageSince;
+    return since != null && DateTime.now().difference(since) >= _blockageGrace;
+  }
+
+  /// Whether the fraction is moving, and so worth drawing as a bar.
+  bool get _progressIsLive {
+    final at = _fractionMovedAt;
+    return at != null && DateTime.now().difference(at) < _progressStale;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,25 +187,7 @@ class ConnectingPage extends StatelessWidget {
       listenWhen: (previous, current) =>
           previous.torConnection != current.torConnection ||
           previous.keyServerStatus != current.keyServerStatus,
-      listener: (context, state) {
-        if (state.torConnection is tor.TorReady &&
-            state.keyServerStatus == KeyServerStatus.online) {
-          final flow = state.flow;
-          final hasPreSelectedVault = state.vault != null;
-
-          final nextPage = switch (flow) {
-            RecoverBullFlow.secureVault => const PasswordInputPage(),
-            _ =>
-              hasPreSelectedVault
-                  ? const PasswordInputPage()
-                  : const VaultProviderSelectionPage(),
-          };
-
-          Navigator.of(
-            context,
-          ).pushReplacement(MaterialPageRoute(builder: (context) => nextPage));
-        }
-      },
+      listener: _onStateChanged,
       child: Scaffold(
         appBar: AppBar(
           forceMaterialTransparency: true,
@@ -50,91 +196,31 @@ class ConnectingPage extends StatelessWidget {
             icon: const Icon(Icons.arrow_back),
           ),
         ),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: BlocBuilder<RecoverBullBloc, RecoverBullState>(
-            builder: (context, state) {
-              final torStatus = switch (state.torConnection) {
-                tor.TorReady() => KeyServerStatus.online,
-                tor.TorUnavailable() => KeyServerStatus.offline,
-                tor.TorConnecting() => KeyServerStatus.connecting,
-                tor.TorUninitialized() ||
-                tor.TorStopped() => KeyServerStatus.unknown,
-              };
-              final torOnline = torStatus == KeyServerStatus.online;
-              final serverOnline =
-                  state.keyServerStatus == KeyServerStatus.online;
-              final hasError =
-                  torStatus == KeyServerStatus.offline ||
-                  state.keyServerStatus == KeyServerStatus.offline;
-
-              return Column(
-                mainAxisAlignment: .center,
-                crossAxisAlignment: .center,
-                children: [
-                  if (!torOnline || !serverOnline)
-                    Gif(
-                      autostart: Autostart.loop,
-                      width: 200,
-                      height: 200,
-                      image: AssetImage(Assets.animations.cubesLoading.path),
-                    )
-                  else
-                    const SizedBox(height: 200),
-                  const Gap(24),
-                  BBText(
-                    context.loc.recoverbullCheckingConnection,
-                    textAlign: .center,
-                    style: context.font.headlineLarge?.copyWith(
-                      fontWeight: .bold,
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: BlocBuilder<RecoverBullBloc, RecoverBullState>(
+              // Centred when it fits, scrollable when it does not — without
+              // ever measuring the body's intrinsic height. `BBText` degrades
+              // to `AutoSizeText`, which is a `LayoutBuilder`, and asking a
+              // `LayoutBuilder` for intrinsics throws during layout: that is
+              // what left this screen blank for the whole bootstrap.
+              builder: (context, state) => LayoutBuilder(
+                builder: (context, constraints) => SingleChildScrollView(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraints.maxHeight,
+                    ),
+                    child: _Body(
+                      state: state,
+                      elapsed: _elapsed,
+                      showBlockage: _blockageIsSettled,
+                      progressIsLive: _progressIsLive,
                     ),
                   ),
-                  const Gap(24),
-                  _StatusRow(
-                    label: context.loc.recoverbullTorNetwork,
-                    status: torStatus,
-                  ),
-                  const Gap(12),
-                  _StatusRow(
-                    label: context.loc.recoverbullRecoverBullServer,
-                    status: state.keyServerStatus,
-                  ),
-                  const Gap(40),
-                  if (hasError) ...[
-                    BBText(
-                      state.failure?.toTranslated(context) ??
-                          context.loc.recoverbullConnectionFailed,
-                      textAlign: .center,
-                      style: context.font.bodyMedium?.copyWith(
-                        color: context.appColors.error,
-                      ),
-                      maxLines: 3,
-                    ),
-                    const Gap(24),
-                    BBButton.big(
-                      label: context.loc.recoverbullRetry,
-                      textStyle: context.font.headlineLarge,
-                      bgColor: context.appColors.onSurface,
-                      textColor: context.appColors.surface,
-                      onPressed: () {
-                        context.read<RecoverBullBloc>().add(
-                          const OnTorInitialization(restart: true),
-                        );
-                      },
-                    ),
-                  ] else ...[
-                    BBText(
-                      context.loc.recoverbullPleaseWait,
-                      textAlign: .center,
-                      style: context.font.bodyMedium?.copyWith(
-                        color: context.appColors.textMuted,
-                      ),
-                      maxLines: 2,
-                    ),
-                  ],
-                ],
-              );
-            },
+                ),
+              ),
+            ),
           ),
         ),
       ),
@@ -142,17 +228,228 @@ class ConnectingPage extends StatelessWidget {
   }
 }
 
-class _StatusRow extends StatelessWidget {
-  final String label;
-  final KeyServerStatus status;
+/// Where each of the three phases stands.
+enum _PhaseState { pending, active, done, failed }
 
-  const _StatusRow({required this.label, required this.status});
+class _Body extends StatelessWidget {
+  final RecoverBullState state;
+  final Duration elapsed;
+  final bool showBlockage;
+  final bool progressIsLive;
+
+  const _Body({
+    required this.state,
+    required this.elapsed,
+    required this.showBlockage,
+    required this.progressIsLive,
+  });
+
+  tor.TorConnectionState get _tor => state.torConnection;
+
+  /// The blockage worth acting on, once it has outlived the grace period.
+  tor.TorDiagnostic? get _diagnostic {
+    if (!showBlockage) return null;
+    return switch (_tor) {
+      tor.TorConnecting(:final diagnostic) => diagnostic,
+      _ => null,
+    };
+  }
+
+  /// The blockage a bootstrap reported when it gave up.
+  ///
+  /// Deliberately not subject to [_blockageGrace]: that grace exists to ride
+  /// out a transient readiness dip, and a terminal failure is not one. Without
+  /// this the reason was dropped exactly when it stopped being provisional.
+  tor.TorDiagnostic? get _failureDiagnostic => switch (_tor) {
+    tor.TorUnavailable(failure: tor.TorBootstrapFailure(:final diagnostic)) =>
+      diagnostic,
+    _ => null,
+  };
+
+  /// There is deliberately no separate "internet" phase.
+  ///
+  /// Nothing in the data can carry one honestly: upstream's connectivity flag is
+  /// tri-state and its "no blockage" answer covers both "fine" and "too early to
+  /// say", so the only positive proof of connectivity is Tor being ready — the
+  /// very thing the next row already reports. A missing network shows up here
+  /// instead, as the reason Tor is stuck.
+  _PhaseState get _torPhase {
+    return switch (_tor) {
+      tor.TorReady() => _PhaseState.done,
+      tor.TorUnavailable() => _PhaseState.failed,
+      tor.TorConnecting() => _PhaseState.active,
+      tor.TorUninitialized() || tor.TorStopped() => _PhaseState.pending,
+    };
+  }
+
+  _PhaseState get _serverPhase {
+    return switch (state.keyServerStatus) {
+      KeyServerStatus.online => _PhaseState.done,
+      KeyServerStatus.offline => _PhaseState.failed,
+      KeyServerStatus.connecting =>
+        _tor is tor.TorReady ? _PhaseState.active : _PhaseState.pending,
+      KeyServerStatus.unknown => _PhaseState.pending,
+    };
+  }
+
+  /// A settled blockage counts, not just a failed phase.
+  ///
+  /// Without `_diagnostic` here the whole grace-period mechanism was
+  /// unreachable: the explanation is only rendered from the failure panel, and
+  /// that panel was gated on a *failed* phase. In the mainline case this screen
+  /// exists for — device offline, Tor still `TorConnecting` with a diagnostic,
+  /// key server not yet checked — the Tor phase is `active` and the server phase
+  /// `pending`, so nothing was shown until the bootstrap gave up minutes later.
+  bool get _hasFailure =>
+      _torPhase == _PhaseState.failed ||
+      _serverPhase == _PhaseState.failed ||
+      _diagnostic != null;
+
+  /// One message, chosen by what actually failed.
+  ///
+  /// The wording stays hedged for the network diagnoses: upstream documents
+  /// them as best effort that "may declare that Arti is stuck for reasons that
+  /// are incorrect", so the screen offers an explanation and never asserts.
+  String _failureMessage(BuildContext context) {
+    final diagnostic = _diagnostic ?? _failureDiagnostic;
+    if (diagnostic != null) {
+      if (diagnostic.suggestsCensorship) {
+        return context.loc.torSettingsDescCensored;
+      }
+      return switch (diagnostic) {
+        tor.TorDiagnostic.offline => context.loc.recoverbullTorOffline,
+        tor.TorDiagnostic.clockSkewed => context.loc.recoverbullTorClockSkewed,
+        tor.TorDiagnostic.filtering ||
+        tor.TorDiagnostic.cantReachTor => context.loc.torSettingsDescCensored,
+        tor.TorDiagnostic.cantBootstrap ||
+        tor.TorDiagnostic.unknown => context.loc.recoverbullTorCantStart,
+      };
+    }
+
+    // Only blame the server when Tor actually reached readiness. Otherwise the
+    // server never got a working proxy to go through, and telling the user
+    // "Tor is working" would be false — the shape of a bug seen in testing,
+    // where a torn-down Tor still produced a server-side error message.
+    if (_serverPhase == _PhaseState.failed) {
+      return _torPhase == _PhaseState.done
+          ? context.loc.recoverbullServerUnreachableTorOk
+          : context.loc.recoverbullTorCantStart;
+    }
+
+    return state.failure?.toTranslated(context) ??
+        context.loc.recoverbullConnectionFailed;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final statusText = _getStatusText(context);
-    final statusColor = _getStatusColor(context);
-    final icon = _getIcon();
+    return Column(
+      mainAxisAlignment: .center,
+      crossAxisAlignment: .stretch,
+      children: [
+        BBText(
+          context.loc.recoverbullCheckingConnection,
+          textAlign: .center,
+          style: context.font.headlineLarge?.copyWith(fontWeight: .bold),
+        ),
+        const Gap(32),
+        _PhaseCard(
+          label: context.loc.recoverbullTorNetwork,
+          phase: _torPhase,
+          // No sub-step is named: the conn/dir split that would identify the
+          // exact phase is private upstream, so claiming one would be wrong
+          // about a third of the time.
+          caption: _torPhase == _PhaseState.active
+              ? context.loc.recoverbullPhaseNetworkInfo
+              : null,
+          // Only drawn while the number is genuinely moving — a cached
+          // directory reports 0.85 with no connectivity whatsoever.
+          fraction: _torPhase == _PhaseState.active && progressIsLive
+              ? switch (_tor) {
+                  tor.TorConnecting(:final progress) => progress,
+                  _ => null,
+                }
+              : null,
+          elapsed: _torPhase == _PhaseState.active ? elapsed : null,
+        ),
+        const Gap(8),
+        _PhaseCard(
+          label: context.loc.recoverbullRecoverBullServer,
+          phase: _serverPhase,
+          elapsed: _serverPhase == _PhaseState.active ? elapsed : null,
+          // Bare "2/3", deliberately unlocalised, like the timer.
+          trailingDetail:
+              _serverPhase == _PhaseState.active && state.keyServerAttempt > 0
+              ? '${state.keyServerAttempt}/${state.keyServerAttempts}'
+              : null,
+        ),
+        const Gap(24),
+        if (_hasFailure)
+          _FailurePanel(
+            message: _failureMessage(context),
+            // A single event: `OnTorInitialization` chains to the server check
+            // itself, and `restart` guarantees a stuck client is replaced rather
+            // than adopted — which is what left a retry waiting on a dead
+            // bootstrap after the network came back.
+            onRetry: () {
+              final bloc = context.read<RecoverBullBloc>();
+              if (_tor is tor.TorReady) {
+                bloc.add(const OnServerCheck());
+              } else {
+                bloc.add(const OnTorInitialization(restart: true));
+              }
+            },
+          )
+        else
+          BBText(
+            elapsed >= _reassureAfter
+                ? context.loc.recoverbullLongestStep
+                : context.loc.recoverbullPleaseWait,
+            textAlign: .center,
+            style: context.font.bodyMedium?.copyWith(
+              color: context.appColors.textMuted,
+            ),
+            maxLines: 3,
+          ),
+      ],
+    );
+  }
+}
+
+class _PhaseCard extends StatelessWidget {
+  final String label;
+  final _PhaseState phase;
+  final String? caption;
+  final double? fraction;
+  final Duration? elapsed;
+
+  /// An extra language-neutral token for the detail line, such as `2/3`.
+  final String? trailingDetail;
+
+  const _PhaseCard({
+    required this.label,
+    required this.phase,
+    this.caption,
+    this.fraction,
+    this.elapsed,
+    this.trailingDetail,
+  });
+
+  Color _color(BuildContext context) => switch (phase) {
+    _PhaseState.done => context.appColors.success,
+    _PhaseState.failed => context.appColors.error,
+    _PhaseState.active || _PhaseState.pending => context.appColors.textMuted,
+  };
+
+  String _statusLabel(BuildContext context) => switch (phase) {
+    _PhaseState.done => context.loc.recoverbullConnected,
+    _PhaseState.failed => context.loc.recoverbullFailed,
+    _PhaseState.active => context.loc.recoverbullConnecting,
+    _PhaseState.pending => context.loc.recoverbullWaiting,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color(context);
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -160,54 +457,158 @@ class _StatusRow extends StatelessWidget {
         color: context.appColors.surface,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: .start,
         children: [
-          Icon(icon, size: 20, color: statusColor),
-          const Gap(12),
-          Expanded(
-            child: BBText(
-              label,
-              style: context.font.bodyLarge?.copyWith(
-                color: context.appColors.onSurface,
+          Row(
+            children: [
+              _PhaseIcon(phase: phase, color: color),
+              const Gap(12),
+              Expanded(
+                child: BBText(
+                  label,
+                  style: context.font.bodyLarge?.copyWith(
+                    color: context.appColors.onSurface,
+                  ),
+                ),
+              ),
+              BBText(
+                _statusLabel(context),
+                style: context.font.bodyMedium?.copyWith(
+                  color: color,
+                  fontWeight: .w600,
+                ),
+              ),
+            ],
+          ),
+          if (caption != null ||
+              fraction != null ||
+              elapsed != null ||
+              trailingDetail != null) ...[
+            const Gap(8),
+            Padding(
+              padding: const EdgeInsets.only(left: 32),
+              child: Column(
+                crossAxisAlignment: .start,
+                children: [
+                  if (caption != null)
+                    BBText(
+                      caption!,
+                      style: context.font.bodySmall?.copyWith(
+                        color: context.appColors.textMuted,
+                      ),
+                      maxLines: 2,
+                    ),
+                  if (fraction != null) ...[
+                    const Gap(6),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: fraction!.clamp(0.0, 1.0),
+                        minHeight: 4,
+                        backgroundColor: context.appColors.onSurface.withValues(
+                          alpha: 0.1,
+                        ),
+                        valueColor: AlwaysStoppedAnimation<Color>(color),
+                      ),
+                    ),
+                  ],
+                  if (fraction != null ||
+                      elapsed != null ||
+                      trailingDetail != null) ...[
+                    const Gap(6),
+                    BBText(
+                      [
+                        if (fraction != null)
+                          context.loc.torSettingsBootstrapProgress(
+                            (fraction! * 100).round(),
+                          ),
+                        ?trailingDetail,
+                        // A bare timer, deliberately unlocalised: no words to
+                        // translate, and it is the only element that keeps
+                        // moving during the long directory phase.
+                        if (elapsed != null) _formatElapsed(elapsed!),
+                      ].join('  ·  '),
+                      style: context.font.bodySmall?.copyWith(
+                        color: context.appColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
-          ),
-          BBText(
-            statusText,
-            style: context.font.bodyMedium?.copyWith(
-              color: statusColor,
-              fontWeight: .w600,
-            ),
-          ),
+          ],
         ],
       ),
     );
   }
 
-  String _getStatusText(BuildContext context) {
-    return switch (status) {
-      KeyServerStatus.unknown => context.loc.recoverbullWaiting,
-      KeyServerStatus.connecting => context.loc.recoverbullConnecting,
-      KeyServerStatus.online => context.loc.recoverbullConnected,
-      KeyServerStatus.offline => context.loc.recoverbullFailed,
-    };
+  static String _formatElapsed(Duration d) {
+    final minutes = d.inMinutes;
+    final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
   }
+}
 
-  Color _getStatusColor(BuildContext context) {
-    return switch (status) {
-      KeyServerStatus.online => context.appColors.success,
-      KeyServerStatus.offline => context.appColors.error,
-      KeyServerStatus.connecting ||
-      KeyServerStatus.unknown => context.appColors.textMuted,
-    };
+class _PhaseIcon extends StatelessWidget {
+  final _PhaseState phase;
+  final Color color;
+
+  const _PhaseIcon({required this.phase, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    if (phase == _PhaseState.active) {
+      return SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+        ),
+      );
+    }
+
+    return Icon(
+      switch (phase) {
+        _PhaseState.done => Icons.check_circle,
+        _PhaseState.failed => Icons.error,
+        _PhaseState.pending => Icons.circle_outlined,
+        _PhaseState.active => Icons.hourglass_empty,
+      },
+      size: 20,
+      color: color,
+    );
   }
+}
 
-  IconData _getIcon() {
-    return switch (status) {
-      KeyServerStatus.online => Icons.check_circle,
-      KeyServerStatus.offline => Icons.error,
-      KeyServerStatus.connecting => Icons.hourglass_empty,
-      KeyServerStatus.unknown => Icons.circle_outlined,
-    };
+class _FailurePanel extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _FailurePanel({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        BBText(
+          message,
+          textAlign: .center,
+          style: context.font.bodyMedium?.copyWith(
+            color: context.appColors.error,
+          ),
+          maxLines: 4,
+        ),
+        const Gap(24),
+        BBButton.big(
+          label: context.loc.recoverbullRetry,
+          textStyle: context.font.headlineLarge,
+          bgColor: context.appColors.onSurface,
+          textColor: context.appColors.surface,
+          onPressed: onRetry,
+        ),
+      ],
+    );
   }
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14636,5 +14636,29 @@
   "torSettingsExternalProxyDescription": "When enabled, Bitcoin Electrum servers and encrypted backups go through Orbot at the configured port instead of embedded Tor. Liquid is never routed through it.",
   "@torSettingsExternalProxyDescription": {
     "description": "Explains the scope of the external Tor proxy override: Bitcoin Electrum (onion and clearnet) plus the RecoverBull key server, never Liquid"
+  },
+  "recoverbullPhaseNetworkInfo": "Retrieving network information",
+  "@recoverbullPhaseNetworkInfo": {
+    "description": "Caption shown while Tor downloads directory information. Covers the whole directory phase, which is 85% of bootstrap."
+  },
+  "recoverbullLongestStep": "This is the longest step. A first start can take over a minute.",
+  "@recoverbullLongestStep": {
+    "description": "Reassurance shown once bootstrap has been running a while without visible progress."
+  },
+  "recoverbullTorOffline": "There seems to be no internet connection.",
+  "@recoverbullTorOffline": {
+    "description": "Shown when Tor reports the device has no TCP connectivity. Hedged wording: the upstream diagnostic is best-effort."
+  },
+  "recoverbullTorClockSkewed": "Your device clock is off, so Tor cannot verify relay certificates. Check your date and time settings.",
+  "@recoverbullTorClockSkewed": {
+    "description": "Shown when Tor reports clock skew, which breaks certificate validation. Actionable: the user can fix the clock."
+  },
+  "recoverbullTorCantStart": "Tor could not connect right now. Please try again.",
+  "@recoverbullTorCantStart": {
+    "description": "Generic Tor bootstrap failure, for blockages with no actionable cause."
+  },
+  "recoverbullServerUnreachableTorOk": "Tor is working, but the backup server did not answer. This can take a moment right after a first start.",
+  "@recoverbullServerUnreachableTorOk": {
+    "description": "Shown when Tor is up but the RecoverBull onion service did not answer, so the failure is localised to the server."
   }
 }

--- a/test/features/recoverbull/connecting_page_test.dart
+++ b/test/features/recoverbull/connecting_page_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
+import 'package:bb_mobile/features/recoverbull/ui/pages/connecting_page.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_tor/tor.dart' as tor;
+
+/// Holds one state and never emits. The page is a pure projection of the
+/// state, so nothing here needs the real bloc's dependency graph.
+class _StaticBloc extends Fake implements RecoverBullBloc {
+  _StaticBloc(this._state);
+
+  final RecoverBullState _state;
+
+  @override
+  RecoverBullState get state => _state;
+
+  @override
+  Stream<RecoverBullState> get stream => const Stream.empty();
+
+  @override
+  Future<void> close() async {}
+}
+
+/// Emits on demand, so a test can replay the sequence the device produces.
+class _MutableBloc extends Fake implements RecoverBullBloc {
+  RecoverBullState _state;
+  final _states = StreamController<RecoverBullState>.broadcast();
+
+  _MutableBloc(this._state);
+
+  @override
+  RecoverBullState get state => _state;
+
+  @override
+  Stream<RecoverBullState> get stream => _states.stream;
+
+  void pushState(RecoverBullState state) {
+    _state = state;
+    _states.add(state);
+  }
+
+  @override
+  Future<void> close() => _states.close();
+}
+
+class _RouteObserver extends NavigatorObserver {
+  int replacements = 0;
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    replacements++;
+  }
+}
+
+void main() {
+  Future<void> pumpPage(WidgetTester tester, RecoverBullState state) async {
+    final bloc = _StaticBloc(state);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BlocProvider<RecoverBullBloc>.value(
+          value: bloc,
+          child: const ConnectingPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  // The screen the user stares at for the whole Tor bootstrap. It rendered an
+  // empty body on device — the title, both phase rows and the reassurance line
+  // were laid out but never painted.
+  testWidgets('shows both phases while Tor is still connecting', (
+    tester,
+  ) async {
+    await pumpPage(
+      tester,
+      const RecoverBullState(
+        flow: RecoverBullFlow.recoverVault,
+        torConnection: tor.TorConnecting(
+          source: tor.TorSource.embedded,
+          progress: 0.45,
+        ),
+      ),
+    );
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.recoverbullCheckingConnection), findsOneWidget);
+    expect(find.text(l10n.recoverbullTorNetwork), findsOneWidget);
+    expect(find.text(l10n.recoverbullRecoverBullServer), findsOneWidget);
+    expect(find.text(l10n.recoverbullPleaseWait), findsOneWidget);
+  });
+
+  // The headline of this screen: a blockage that outlives the grace period has
+  // to be explained *while Tor is still connecting*. It never rendered, because
+  // the only path to the explanation was gated on a failed phase — and a
+  // connecting Tor with a pending server check has neither.
+  testWidgets('explains a settled blockage while still connecting', (
+    tester,
+  ) async {
+    const connecting = RecoverBullState(
+      flow: RecoverBullFlow.recoverVault,
+      torConnection: tor.TorConnecting(
+        source: tor.TorSource.embedded,
+        progress: 0.08,
+      ),
+    );
+    final bloc = _MutableBloc(connecting);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BlocProvider<RecoverBullBloc>.value(
+          value: bloc,
+          child: const ConnectingPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Arti starts reporting a blockage while it is still connecting.
+    bloc.pushState(
+      connecting.copyWith(
+        torConnection: const tor.TorConnecting(
+          source: tor.TorSource.embedded,
+          progress: 0.08,
+          diagnostic: tor.TorDiagnostic.offline,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    // Inside the grace period: still silent, on purpose.
+    expect(find.text(l10n.recoverbullTorOffline), findsNothing);
+
+    // Two clocks have to move. The grace period is measured against the wall
+    // clock, which `pump` does not advance, so the wait is real. The rebuild then
+    // comes from the one-second ticker, which only fires when the *fake* clock
+    // advances. Six seconds of CI time is the price of pinning what shipped here.
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(seconds: 6)),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text(l10n.recoverbullTorOffline), findsOneWidget);
+    expect(find.text(l10n.recoverbullRetry), findsOneWidget);
+
+    await bloc.close();
+  });
+
+  // The grace period exists to ride out a transient readiness dip, so it must
+  // not swallow the reason a bootstrap gave up for good: this state reaches the
+  // page with no prior TorConnecting event to start the grace clock.
+  testWidgets('explains a filtered network on a failed bootstrap', (
+    tester,
+  ) async {
+    await pumpPage(
+      tester,
+      const RecoverBullState(
+        flow: RecoverBullFlow.recoverVault,
+        torConnection: tor.TorUnavailable(
+          source: tor.TorSource.embedded,
+          failure: tor.TorBootstrapFailure(
+            'filtered',
+            tor.TorDiagnostic.filtering,
+          ),
+        ),
+      ),
+    );
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.torSettingsDescCensored), findsOneWidget);
+    expect(find.text(l10n.recoverbullTorCantStart), findsNothing);
+  });
+
+  // Tor republishes readiness on every directory refresh, so the success
+  // condition is met repeatedly. Each repetition used to push another route.
+  testWidgets('navigates once even when readiness repeats', (tester) async {
+    const initial = RecoverBullState(
+      flow: RecoverBullFlow.recoverVault,
+      torConnection: tor.TorConnecting(
+        source: tor.TorSource.embedded,
+        progress: 0.3,
+      ),
+    );
+    final bloc = _MutableBloc(initial);
+    final observer = _RouteObserver();
+    final route = tor.TorRoute(
+      source: tor.TorSource.embedded,
+      endpoint: tor.TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+      evidence: tor.TorReadinessEvidence.embeddedBootstrap,
+      transport: tor.TorTransport.direct,
+    );
+    final ready = initial.copyWith(
+      torConnection: tor.TorReady(route),
+      keyServerStatus: KeyServerStatus.online,
+    );
+
+    await tester.pumpWidget(
+      BlocProvider<RecoverBullBloc>.value(
+        value: bloc,
+        child: MaterialApp(
+          theme: AppTheme.themeData(AppThemeType.light),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          navigatorObservers: [observer],
+          home: const ConnectingPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    bloc.pushState(ready);
+    await tester.pump();
+    bloc.pushState(
+      ready.copyWith(torConnection: tor.TorReady(route), keyServerAttempt: 2),
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(observer.replacements, 1);
+    await bloc.close();
+  });
+
+  testWidgets('offers a retry once Tor reports it cannot start', (
+    tester,
+  ) async {
+    await pumpPage(
+      tester,
+      const RecoverBullState(
+        flow: RecoverBullFlow.recoverVault,
+        torConnection: tor.TorUnavailable(
+          source: tor.TorSource.embedded,
+          failure: tor.TorBootstrapFailure('no directory'),
+        ),
+      ),
+    );
+
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.recoverbullRetry), findsOneWidget);
+  });
+}

--- a/test/migrations_test/bull_database/generated/schema_v14.dart
+++ b/test/migrations_test/bull_database/generated/schema_v14.dart
@@ -1790,6 +1790,24 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
     $customConstraints: 'NOT NULL DEFAULT 9050',
     defaultValue: const CustomExpression('9050'),
   );
+  late final GeneratedColumn<String> torTransportMode = GeneratedColumn<String>(
+    'tor_transport_mode',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT \'automatic\'',
+    defaultValue: const CustomExpression('\'automatic\''),
+  );
+  late final GeneratedColumn<String> lastSuccessfulTorTransport =
+      GeneratedColumn<String>(
+        'last_successful_tor_transport',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        $customConstraints: 'NULL',
+      );
   late final GeneratedColumn<String> themeMode = GeneratedColumn<String>(
     'theme_mode',
     aliasedName,
@@ -1840,6 +1858,8 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
     isDevModeEnabled,
     useTorProxy,
     torProxyPort,
+    torTransportMode,
+    lastSuccessfulTorTransport,
     themeMode,
     isErrorReportingEnabled,
     exchangeTestnetBasicAuthUsername,
@@ -1896,6 +1916,14 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
         DriftSqlType.int,
         data['${effectivePrefix}tor_proxy_port'],
       )!,
+      torTransportMode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tor_transport_mode'],
+      )!,
+      lastSuccessfulTorTransport: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_successful_tor_transport'],
+      ),
       themeMode: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}theme_mode'],
@@ -1935,6 +1963,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
   final int isDevModeEnabled;
   final int useTorProxy;
   final int torProxyPort;
+  final String torTransportMode;
+  final String? lastSuccessfulTorTransport;
   final String themeMode;
   final int isErrorReportingEnabled;
   final String? exchangeTestnetBasicAuthUsername;
@@ -1950,6 +1980,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     required this.isDevModeEnabled,
     required this.useTorProxy,
     required this.torProxyPort,
+    required this.torTransportMode,
+    this.lastSuccessfulTorTransport,
     required this.themeMode,
     required this.isErrorReportingEnabled,
     this.exchangeTestnetBasicAuthUsername,
@@ -1968,6 +2000,12 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     map['is_dev_mode_enabled'] = Variable<int>(isDevModeEnabled);
     map['use_tor_proxy'] = Variable<int>(useTorProxy);
     map['tor_proxy_port'] = Variable<int>(torProxyPort);
+    map['tor_transport_mode'] = Variable<String>(torTransportMode);
+    if (!nullToAbsent || lastSuccessfulTorTransport != null) {
+      map['last_successful_tor_transport'] = Variable<String>(
+        lastSuccessfulTorTransport,
+      );
+    }
     map['theme_mode'] = Variable<String>(themeMode);
     map['is_error_reporting_enabled'] = Variable<int>(isErrorReportingEnabled);
     if (!nullToAbsent || exchangeTestnetBasicAuthUsername != null) {
@@ -1995,6 +2033,11 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       isDevModeEnabled: Value(isDevModeEnabled),
       useTorProxy: Value(useTorProxy),
       torProxyPort: Value(torProxyPort),
+      torTransportMode: Value(torTransportMode),
+      lastSuccessfulTorTransport:
+          lastSuccessfulTorTransport == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastSuccessfulTorTransport),
       themeMode: Value(themeMode),
       isErrorReportingEnabled: Value(isErrorReportingEnabled),
       exchangeTestnetBasicAuthUsername:
@@ -2024,6 +2067,10 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       isDevModeEnabled: serializer.fromJson<int>(json['isDevModeEnabled']),
       useTorProxy: serializer.fromJson<int>(json['useTorProxy']),
       torProxyPort: serializer.fromJson<int>(json['torProxyPort']),
+      torTransportMode: serializer.fromJson<String>(json['torTransportMode']),
+      lastSuccessfulTorTransport: serializer.fromJson<String?>(
+        json['lastSuccessfulTorTransport'],
+      ),
       themeMode: serializer.fromJson<String>(json['themeMode']),
       isErrorReportingEnabled: serializer.fromJson<int>(
         json['isErrorReportingEnabled'],
@@ -2050,6 +2097,10 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       'isDevModeEnabled': serializer.toJson<int>(isDevModeEnabled),
       'useTorProxy': serializer.toJson<int>(useTorProxy),
       'torProxyPort': serializer.toJson<int>(torProxyPort),
+      'torTransportMode': serializer.toJson<String>(torTransportMode),
+      'lastSuccessfulTorTransport': serializer.toJson<String?>(
+        lastSuccessfulTorTransport,
+      ),
       'themeMode': serializer.toJson<String>(themeMode),
       'isErrorReportingEnabled': serializer.toJson<int>(
         isErrorReportingEnabled,
@@ -2074,6 +2125,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     int? isDevModeEnabled,
     int? useTorProxy,
     int? torProxyPort,
+    String? torTransportMode,
+    Value<String?> lastSuccessfulTorTransport = const Value.absent(),
     String? themeMode,
     int? isErrorReportingEnabled,
     Value<String?> exchangeTestnetBasicAuthUsername = const Value.absent(),
@@ -2089,6 +2142,10 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     isDevModeEnabled: isDevModeEnabled ?? this.isDevModeEnabled,
     useTorProxy: useTorProxy ?? this.useTorProxy,
     torProxyPort: torProxyPort ?? this.torProxyPort,
+    torTransportMode: torTransportMode ?? this.torTransportMode,
+    lastSuccessfulTorTransport: lastSuccessfulTorTransport.present
+        ? lastSuccessfulTorTransport.value
+        : this.lastSuccessfulTorTransport,
     themeMode: themeMode ?? this.themeMode,
     isErrorReportingEnabled:
         isErrorReportingEnabled ?? this.isErrorReportingEnabled,
@@ -2125,6 +2182,12 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       torProxyPort: data.torProxyPort.present
           ? data.torProxyPort.value
           : this.torProxyPort,
+      torTransportMode: data.torTransportMode.present
+          ? data.torTransportMode.value
+          : this.torTransportMode,
+      lastSuccessfulTorTransport: data.lastSuccessfulTorTransport.present
+          ? data.lastSuccessfulTorTransport.value
+          : this.lastSuccessfulTorTransport,
       themeMode: data.themeMode.present ? data.themeMode.value : this.themeMode,
       isErrorReportingEnabled: data.isErrorReportingEnabled.present
           ? data.isErrorReportingEnabled.value
@@ -2153,6 +2216,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
           ..write('isDevModeEnabled: $isDevModeEnabled, ')
           ..write('useTorProxy: $useTorProxy, ')
           ..write('torProxyPort: $torProxyPort, ')
+          ..write('torTransportMode: $torTransportMode, ')
+          ..write('lastSuccessfulTorTransport: $lastSuccessfulTorTransport, ')
           ..write('themeMode: $themeMode, ')
           ..write('isErrorReportingEnabled: $isErrorReportingEnabled, ')
           ..write(
@@ -2177,6 +2242,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     isDevModeEnabled,
     useTorProxy,
     torProxyPort,
+    torTransportMode,
+    lastSuccessfulTorTransport,
     themeMode,
     isErrorReportingEnabled,
     exchangeTestnetBasicAuthUsername,
@@ -2196,6 +2263,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
           other.isDevModeEnabled == this.isDevModeEnabled &&
           other.useTorProxy == this.useTorProxy &&
           other.torProxyPort == this.torProxyPort &&
+          other.torTransportMode == this.torTransportMode &&
+          other.lastSuccessfulTorTransport == this.lastSuccessfulTorTransport &&
           other.themeMode == this.themeMode &&
           other.isErrorReportingEnabled == this.isErrorReportingEnabled &&
           other.exchangeTestnetBasicAuthUsername ==
@@ -2215,6 +2284,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
   final Value<int> isDevModeEnabled;
   final Value<int> useTorProxy;
   final Value<int> torProxyPort;
+  final Value<String> torTransportMode;
+  final Value<String?> lastSuccessfulTorTransport;
   final Value<String> themeMode;
   final Value<int> isErrorReportingEnabled;
   final Value<String?> exchangeTestnetBasicAuthUsername;
@@ -2230,6 +2301,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     this.isDevModeEnabled = const Value.absent(),
     this.useTorProxy = const Value.absent(),
     this.torProxyPort = const Value.absent(),
+    this.torTransportMode = const Value.absent(),
+    this.lastSuccessfulTorTransport = const Value.absent(),
     this.themeMode = const Value.absent(),
     this.isErrorReportingEnabled = const Value.absent(),
     this.exchangeTestnetBasicAuthUsername = const Value.absent(),
@@ -2246,6 +2319,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     this.isDevModeEnabled = const Value.absent(),
     this.useTorProxy = const Value.absent(),
     this.torProxyPort = const Value.absent(),
+    this.torTransportMode = const Value.absent(),
+    this.lastSuccessfulTorTransport = const Value.absent(),
     this.themeMode = const Value.absent(),
     this.isErrorReportingEnabled = const Value.absent(),
     this.exchangeTestnetBasicAuthUsername = const Value.absent(),
@@ -2267,6 +2342,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     Expression<int>? isDevModeEnabled,
     Expression<int>? useTorProxy,
     Expression<int>? torProxyPort,
+    Expression<String>? torTransportMode,
+    Expression<String>? lastSuccessfulTorTransport,
     Expression<String>? themeMode,
     Expression<int>? isErrorReportingEnabled,
     Expression<String>? exchangeTestnetBasicAuthUsername,
@@ -2283,6 +2360,9 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
       if (isDevModeEnabled != null) 'is_dev_mode_enabled': isDevModeEnabled,
       if (useTorProxy != null) 'use_tor_proxy': useTorProxy,
       if (torProxyPort != null) 'tor_proxy_port': torProxyPort,
+      if (torTransportMode != null) 'tor_transport_mode': torTransportMode,
+      if (lastSuccessfulTorTransport != null)
+        'last_successful_tor_transport': lastSuccessfulTorTransport,
       if (themeMode != null) 'theme_mode': themeMode,
       if (isErrorReportingEnabled != null)
         'is_error_reporting_enabled': isErrorReportingEnabled,
@@ -2306,6 +2386,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     Value<int>? isDevModeEnabled,
     Value<int>? useTorProxy,
     Value<int>? torProxyPort,
+    Value<String>? torTransportMode,
+    Value<String?>? lastSuccessfulTorTransport,
     Value<String>? themeMode,
     Value<int>? isErrorReportingEnabled,
     Value<String?>? exchangeTestnetBasicAuthUsername,
@@ -2322,6 +2404,9 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
       isDevModeEnabled: isDevModeEnabled ?? this.isDevModeEnabled,
       useTorProxy: useTorProxy ?? this.useTorProxy,
       torProxyPort: torProxyPort ?? this.torProxyPort,
+      torTransportMode: torTransportMode ?? this.torTransportMode,
+      lastSuccessfulTorTransport:
+          lastSuccessfulTorTransport ?? this.lastSuccessfulTorTransport,
       themeMode: themeMode ?? this.themeMode,
       isErrorReportingEnabled:
           isErrorReportingEnabled ?? this.isErrorReportingEnabled,
@@ -2367,6 +2452,14 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     if (torProxyPort.present) {
       map['tor_proxy_port'] = Variable<int>(torProxyPort.value);
     }
+    if (torTransportMode.present) {
+      map['tor_transport_mode'] = Variable<String>(torTransportMode.value);
+    }
+    if (lastSuccessfulTorTransport.present) {
+      map['last_successful_tor_transport'] = Variable<String>(
+        lastSuccessfulTorTransport.value,
+      );
+    }
     if (themeMode.present) {
       map['theme_mode'] = Variable<String>(themeMode.value);
     }
@@ -2401,6 +2494,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
           ..write('isDevModeEnabled: $isDevModeEnabled, ')
           ..write('useTorProxy: $useTorProxy, ')
           ..write('torProxyPort: $torProxyPort, ')
+          ..write('torTransportMode: $torTransportMode, ')
+          ..write('lastSuccessfulTorTransport: $lastSuccessfulTorTransport, ')
           ..write('themeMode: $themeMode, ')
           ..write('isErrorReportingEnabled: $isErrorReportingEnabled, ')
           ..write(


### PR DESCRIPTION
Stacked on the `feat/tor-persistence` PR. Review that one first.

The connecting screen is what the user stares at for the whole Tor bring-up, which takes 40s or more on a cold directory. It rendered an empty body on device: the title, both phase rows and the reassurance line were laid out but never painted.

It now shows what the data can honestly support: two named phases — Tor network, then RecoverBull server — an elapsed counter, and, when arti reports a blockage that outlives a short grace period, an explanation that the network rather than the app is the problem.

Two omissions are deliberate:

- **No separate "internet" phase.** Arti's connectivity flag is tri-state and its "no blockage" answer covers both "fine" and "too early to say", so the only positive proof of connectivity is Tor becoming ready — which the next row already reports. A missing network surfaces as the reason Tor is stuck.
- **No named bootstrap sub-steps.** The conn/dir split that would identify the exact phase is private upstream, so naming one would be wrong a large fraction of the time.

The grace period exists to ride out a transient readiness dip, so it deliberately does not apply to a terminal failure: `TorUnavailable` carries its diagnostic straight through, otherwise the reason was dropped exactly when it stopped being provisional and the user was told to "try again" with no explanation.

Also fixes a navigation defect in this screen: readiness is not a single event — Tor republishes `TorReady` on every directory refresh and the key-server check emits its own states — so the success condition is satisfied repeatedly and each repetition pushed another route, stacking duplicate pages behind the visible one. Guarded, with a test that replays the device sequence.