### PR TITLE
test(payjoin): stop the fixture burning testnet funds at 1000 sat/vB

### DIFF
--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -45,6 +45,27 @@ Future<void> main({bool isInitialized = false}) async {
   late Wallet senderWallet;
   bool? previousPayjoinEnabled;
 
+  /// Fee rate for every transaction this fixture broadcasts, in sat/vB.
+  ///
+  /// This used to be 1000. Nothing needed it: none of the assertions below wait
+  /// for a confirmation — the happy path waits for `PayjoinStatus.completed`,
+  /// which is the protocol exchange, not a block. What it did do was burn the
+  /// fixture wallets. A ~250 vB payjoin plus two drain-consolidations cost on
+  /// the order of half a million sats per run, on every run, of every PR in the
+  /// repository. The wallets emptied faster than anyone could refill them, and
+  /// once the balance fell just below what the next transaction needed, this
+  /// test failed and turned every open PR red — the failure that sent us
+  /// looking here in the first place was 341 sats short.
+  ///
+  /// Verified against mempool.space on 2026-08-10: testnet3 and testnet4 both
+  /// report 1 sat/vB across every tier, `fastestFee` included, so there is no
+  /// backlog to outbid. 10 leaves a wide margin anyway, because testnet3 mines
+  /// in bursts — the 20-minute difficulty reset makes block intervals erratic —
+  /// and a transaction left unconfirmed between runs is what would corrupt the
+  /// next run's UTXO set. Ten times the fastest recommendation buys that safety
+  /// for a few hundred sats.
+  const testnetFeeRate = 10.0;
+
   Future<void> consolidateUtxos(String walletId) async {
     final utxos = await utxoRepository.getWalletUtxos(walletId: walletId);
     if (utxos.length <= 1) return;
@@ -55,7 +76,7 @@ Future<void> main({bool isInitialized = false}) async {
       walletId: walletId,
       address: address.address,
       drain: true,
-      networkFee: NetworkFee.relativeFromSatPerVbyte(1000),
+      networkFee: NetworkFee.relativeFromSatPerVbyte(testnetFeeRate),
     );
     final signed = await signBitcoinTx.execute(
       psbt: prepared.unsignedPsbt,
@@ -215,7 +236,7 @@ Future<void> main({bool isInitialized = false}) async {
         expect(uri.path, address.address);
         expect(uri.queryParameters, contains('pj'));
 
-        const feeRate = 1000.0;
+        const feeRate = testnetFeeRate;
         final prepared = await prepareBitcoinSend.execute(
           walletId: senderWallet.id,
           address: address.address,


### PR DESCRIPTION
The funded Payjoin fixture broadcast every transaction at 1000 sat/vB: the payjoin itself, and a drain-consolidation of each wallet before it. That is roughly 650k sats per run, on every run, of every open pull request. The fixture wallets emptied faster than they could be refilled, and once the balance landed just under what the next transaction needed the test failed and turned every open PR in the repository red. The failure that surfaced this was 341 sats short — 0.00119159 BTC available of 0.00119500 BTC needed.

Nothing needed that fee rate. None of the assertions wait for a confirmation: the happy path waits for `PayjoinStatus.completed`, which is the protocol exchange with the receiver, and the expiry test waits for a session to lapse. `coins_test.dart` already spends on testnet at 2 sat/vB.

Set to 10 sat/vB. Checked against mempool.space on 2026-08-10: testnet3 — which is what `ApiServiceConstants.testnetMempoolUrlPath` points at — and testnet4 both report 1 sat/vB across every tier, `fastestFee` included, so there is no backlog to outbid. Ten times that leaves a wide margin for testnet3's bursty block production, where the 20-minute difficulty reset makes intervals erratic and a transaction left unconfirmed between runs is what would corrupt the next run's UTXO set.

Cost per run drops from about 650k sats to about 6.5k.

The consolidation itself is kept: the skipped `supports concurrent Payjoins backed by distinct UTXOs` test documents that it exists to sidestep an upstream receiver-selection bug. It is no longer expensive, so it is no longer the problem.