### PR TITLE
fix(buy): expire the payjoin payout session with the exchange

### DIFF
--- a/lib/features/buy/domain/create_buy_order_usecase.dart
+++ b/lib/features/buy/domain/create_buy_order_usecase.dart
@@ -7,6 +7,15 @@ import 'package:bull_payjoin/bull_payjoin.dart';
 import 'package:primitives/primitives.dart';
 
 class CreateBuyOrderUsecase {
+  /// Maximum requested lifetime for an exchange payout receiver.
+  ///
+  /// The exchange starts its five-minute window when it creates the order. Our
+  /// receiver starts first so its URI can be included in that request; one
+  /// additional minute prevents receiver setup, network latency, or clock skew
+  /// from making it expire before the exchange. A shorter user-configured
+  /// session lifetime still takes precedence in the Payjoin runtime.
+  static const _payjoinPayoutWindow = Duration(minutes: 6);
+
   final ExchangeOrderRepository _mainnetExchangeOrderRepository;
   final ExchangeOrderRepository _testnetExchangeOrderRepository;
   final SettingsRepository _settingsRepository;
@@ -74,11 +83,20 @@ class CreateBuyOrderUsecase {
                   : BitcoinNetwork.mainnet,
               address: toAddress,
               amount: Sats.fromInt(payjoinAmountSat),
-              // The URI cannot be revised after order placement, so the
-              // exchange payout uses the protocol maximum lifetime.
-              expiresAt: DateTime.now().add(
-                PayjoinPolicy.maximumSessionLifetime,
-              ),
+              // The exchange gives up five minutes after creating the order.
+              // This receiver starts before that request, so request one
+              // additional minute to cover setup and network latency. The
+              // user's configured session lifetime may shorten this window.
+              // The previous 24h protocol maximum only resumed and re-watched
+              // a dead session on every app start for a day.
+              //
+              // Expiring costs nothing either. The BIP21 still carries a plain
+              // address, so an exchange payout that arrives late is an ordinary
+              // payment; only the payjoin is lost. And an idle receiver freezes
+              // no coins — `getUtxosFrozenByOngoingPayjoins` skips a session
+              // whose proposal PSBT is null, which is exactly a session no
+              // sender ever contacted.
+              expiresAt: DateTime.now().add(_payjoinPayoutWindow),
             ),
           );
           final receiver = switch (result) {

--- a/test/features/buy/create_buy_order_usecase_test.dart
+++ b/test/features/buy/create_buy_order_usecase_test.dart
@@ -1,0 +1,109 @@
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/features/buy/domain/create_buy_order_usecase.dart';
+import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+class _MockOrderRepository extends Mock implements ExchangeOrderRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+class _MockPayjoinReceiver extends Mock implements PayjoinReceiver {}
+
+class _MockPayjoinPolicyAccess extends Mock implements PayjoinPolicyAccess {}
+
+class _MockBuyOrder extends Mock implements BuyOrder {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      StartPayjoinReceiver(
+        walletId: 'fallback',
+        network: BitcoinNetwork.testnet,
+        address: 'tb1qfallback',
+      ),
+    );
+  });
+
+  // The receiver starts before the exchange's five-minute payout window. It
+  // needs a short margin without surviving for the protocol's 24-hour default.
+  test(
+    'the payjoin payout session expires with the exchange, not in 24h',
+    () async {
+      final orders = _MockOrderRepository();
+      final settings = _MockSettingsRepository();
+      final receiver = _MockPayjoinReceiver();
+      final policy = _MockPayjoinPolicyAccess();
+
+      when(() => settings.fetch()).thenAnswer(
+        (_) async => const SettingsEntity(
+          environment: Environment.testnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'CAD',
+        ),
+      );
+      when(() => policy.load()).thenAnswer(
+        (_) async => Ok(
+          PayjoinPolicy(
+            enabled: true,
+            minimumAmount: PayjoinPolicy.minimumAllowedAmount,
+            sessionLifetime: PayjoinPolicy.minimumSessionLifetime,
+          ),
+        ),
+      );
+      when(
+        () => orders.placeBuyOrder(
+          toAddress: 'tb1qexampleaddress',
+          orderAmount: const FiatAmount(100),
+          currency: FiatCurrency.cad,
+          network: OrderBitcoinNetwork.bitcoin,
+          isOwner: true,
+          payjoinBip21: null,
+        ),
+      ).thenAnswer((_) async => _MockBuyOrder());
+
+      StartPayjoinReceiver? captured;
+      when(() => receiver.start(any())).thenAnswer((invocation) async {
+        captured = invocation.positionalArguments.first as StartPayjoinReceiver;
+        throw StateError('stop here: the expiry is what this test is about');
+      });
+
+      final usecase = CreateBuyOrderUsecase(
+        mainnetExchangeOrderRepository: orders,
+        testnetExchangeOrderRepository: orders,
+        settingsRepository: settings,
+        payjoinReceiver: receiver,
+        payjoinPolicy: policy,
+      );
+
+      final before = DateTime.now();
+      await usecase.execute(
+        toAddress: 'tb1qexampleaddress',
+        orderAmount: const FiatAmount(100),
+        currency: FiatCurrency.cad,
+        isLiquid: false,
+        isOwner: true,
+        payjoinWalletId: 'wallet-1',
+        payjoinAmountSat: 50000,
+      );
+      final after = DateTime.now();
+
+      final expiresAt = captured?.expiresAt;
+      expect(expiresAt, isNotNull, reason: 'a payjoin session must be started');
+
+      // Bracketed against the wall clock either side of the call: the use case
+      // computes its own `now` somewhere between `before` and `after`, so the
+      // deadline must land in [before + 6m, after + 6m]. Tight enough that 24h
+      // fails, loose enough that a slow machine does not.
+      expect(
+        expiresAt!.isBefore(before.add(const Duration(minutes: 6))),
+        isFalse,
+      );
+      expect(expiresAt.isAfter(after.add(const Duration(minutes: 6))), isFalse);
+    },
+  );
+}


### PR DESCRIPTION
A buy order that pays out over payjoin opened its receiver session with `PayjoinPolicy.maximumSessionLifetime` — 24 hours, the protocol maximum. The exchange gives up on the payout after five minutes, so for the remaining 23 hours and 55 minutes the session was unreachable by the only party that could ever contact it.

That is not free. An unfinished session is resumed and re-watched on every app start until it expires, and it holds a subscription at the payjoin directory for the whole window, which is a long-lived identifier there for no benefit.

Expiring early costs nothing. The BIP21 handed to the exchange still carries a plain address, so a payout arriving after the window is an ordinary payment and only the payjoin is lost — which is already the outcome once the exchange has stopped trying. And an idle receiver locks no coins: `getUtxosFrozenByOngoingPayjoins` skips any session whose proposal PSBT is null, which is precisely a session no sender ever contacted.

Sell, pay and send are unaffected. They start *senders*, and already take the user's `expireAfterSec` setting; the buy receiver was the one place with a hardcoded lifetime.

The test brackets the deadline against the wall clock either side of the call rather than asserting an exact instant, and was confirmed to fail against the previous 24h value.