### PR TITLE
fix: boltz 0.5.2 restore hardening — rescue skipped-swap reporting (6.12.6+206)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 201;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.4;
+				MARKETING_VERSION = 6.12.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -674,7 +674,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 201;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -687,7 +687,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.4;
+				MARKETING_VERSION = 6.12.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -705,7 +705,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CURRENT_PROJECT_VERSION = 201;
+				CURRENT_PROJECT_VERSION = 203;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -718,7 +718,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.4;
+				MARKETING_VERSION = 6.12.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 203;
+				CURRENT_PROJECT_VERSION = 206;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.5;
+				MARKETING_VERSION = 6.12.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -674,7 +674,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 203;
+				CURRENT_PROJECT_VERSION = 206;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -687,7 +687,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.5;
+				MARKETING_VERSION = 6.12.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -705,7 +705,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CURRENT_PROJECT_VERSION = 203;
+				CURRENT_PROJECT_VERSION = 206;
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
 				FLUTTER_BUILD_NAME = 6.12.4;
@@ -718,7 +718,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.12.5;
+				MARKETING_VERSION = 6.12.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";

--- a/lib/core/swaps/data/datasources/boltz_datasource.dart
+++ b/lib/core/swaps/data/datasources/boltz_datasource.dart
@@ -255,7 +255,7 @@ class BoltzDatasource {
     boltzUrl: _httpsUrl,
   );
 
-  Future<List<BtcLnSwap>> restoreBtcLnSwaps({
+  Future<RestoredBtcLnSwaps> restoreBtcLnSwaps({
     required SwapMasterKeyModel swapMasterKey,
     required String electrumUrl,
   }) => boltz.restoreLnBtcSwaps(
@@ -264,7 +264,7 @@ class BoltzDatasource {
     boltzUrl: _httpsUrl,
   );
 
-  Future<List<LbtcLnSwap>> restoreLbtcLnSwaps({
+  Future<RestoredLbtcLnSwaps> restoreLbtcLnSwaps({
     required SwapMasterKeyModel swapMasterKey,
     required String electrumUrl,
   }) => boltz.restoreLnLbtcSwaps(
@@ -273,7 +273,7 @@ class BoltzDatasource {
     boltzUrl: _httpsUrl,
   );
 
-  Future<List<ChainSwap>> restoreChainSwaps({
+  Future<RestoredChainSwaps> restoreChainSwaps({
     required SwapMasterKeyModel swapMasterKey,
     required String btcElectrumUrl,
     required String lbtcElectrumUrl,

--- a/lib/core/swaps/data/repository/boltz_swap_repository.dart
+++ b/lib/core/swaps/data/repository/boltz_swap_repository.dart
@@ -870,14 +870,14 @@ class BoltzSwapRepository {
     switch (restored.kind) {
       case RestoredSwapKind.lightningReceive:
         if (isLiquid) {
-          final swaps = await _boltz.restoreLbtcLnSwaps(
+          final restoredSwaps = await _boltz.restoreLbtcLnSwaps(
             swapMasterKey: swapMasterKey,
             electrumUrl: lbtcElectrumUrl,
           );
-          final obj = swaps.firstWhere(
+          _logSkippedRestores(restoredSwaps.skipped);
+          final obj = restoredSwaps.swaps.firstWhere(
             (s) => s.id == id,
-            orElse: () =>
-                throw 'swap $id not returned by boltz restore (possibly beyond gap limit)',
+            orElse: () => _missingFromRestore(id, restoredSwaps.skipped),
           );
           await _boltz.storage.storeLbtcLnSwap(obj);
           model = SwapModel.lnReceive(
@@ -896,14 +896,14 @@ class BoltzSwapRepository {
             invoice: obj.invoice,
           );
         } else {
-          final swaps = await _boltz.restoreBtcLnSwaps(
+          final restoredSwaps = await _boltz.restoreBtcLnSwaps(
             swapMasterKey: swapMasterKey,
             electrumUrl: btcElectrumUrl,
           );
-          final obj = swaps.firstWhere(
+          _logSkippedRestores(restoredSwaps.skipped);
+          final obj = restoredSwaps.swaps.firstWhere(
             (s) => s.id == id,
-            orElse: () =>
-                throw 'swap $id not returned by boltz restore (possibly beyond gap limit)',
+            orElse: () => _missingFromRestore(id, restoredSwaps.skipped),
           );
           await _boltz.storage.storeBtcLnSwap(obj);
           model = SwapModel.lnReceive(
@@ -924,14 +924,14 @@ class BoltzSwapRepository {
         }
       case RestoredSwapKind.lightningSend:
         if (isLiquid) {
-          final swaps = await _boltz.restoreLbtcLnSwaps(
+          final restoredSwaps = await _boltz.restoreLbtcLnSwaps(
             swapMasterKey: swapMasterKey,
             electrumUrl: lbtcElectrumUrl,
           );
-          final obj = swaps.firstWhere(
+          _logSkippedRestores(restoredSwaps.skipped);
+          final obj = restoredSwaps.swaps.firstWhere(
             (s) => s.id == id,
-            orElse: () =>
-                throw 'swap $id not returned by boltz restore (possibly beyond gap limit)',
+            orElse: () => _missingFromRestore(id, restoredSwaps.skipped),
           );
           await _boltz.storage.storeLbtcLnSwap(obj);
           model = SwapModel.lnSend(
@@ -952,14 +952,14 @@ class BoltzSwapRepository {
             paymentAmount: obj.outAmount.toInt(),
           );
         } else {
-          final swaps = await _boltz.restoreBtcLnSwaps(
+          final restoredSwaps = await _boltz.restoreBtcLnSwaps(
             swapMasterKey: swapMasterKey,
             electrumUrl: btcElectrumUrl,
           );
-          final obj = swaps.firstWhere(
+          _logSkippedRestores(restoredSwaps.skipped);
+          final obj = restoredSwaps.swaps.firstWhere(
             (s) => s.id == id,
-            orElse: () =>
-                throw 'swap $id not returned by boltz restore (possibly beyond gap limit)',
+            orElse: () => _missingFromRestore(id, restoredSwaps.skipped),
           );
           await _boltz.storage.storeBtcLnSwap(obj);
           model = SwapModel.lnSend(
@@ -981,15 +981,15 @@ class BoltzSwapRepository {
           );
         }
       case RestoredSwapKind.crossChain:
-        final swaps = await _boltz.restoreChainSwaps(
+        final restoredSwaps = await _boltz.restoreChainSwaps(
           swapMasterKey: swapMasterKey,
           btcElectrumUrl: btcElectrumUrl,
           lbtcElectrumUrl: lbtcElectrumUrl,
         );
-        final obj = swaps.firstWhere(
+        _logSkippedRestores(restoredSwaps.skipped);
+        final obj = restoredSwaps.swaps.firstWhere(
           (s) => s.id == id,
-          orElse: () =>
-              throw 'swap $id not returned by boltz restore (possibly beyond gap limit)',
+          orElse: () => _missingFromRestore(id, restoredSwaps.skipped),
         );
         await _boltz.storage.storeChainSwap(obj);
         final lockupTxid = await _boltz.chainSwapUserLockupTxid(obj);
@@ -1029,6 +1029,27 @@ class BoltzSwapRepository {
   /// network fees are NOT recomputed here — they're derived in the UI from the
   /// actual on-chain sent/received amounts. Returns null if the rate is
   /// unavailable (the swap is still rescued; the fee row is just hidden).
+  void _logSkippedRestores(List<boltz.SkippedRestoreSwap> skipped) {
+    for (final s in skipped) {
+      log.warning(
+        'SWAP_RESTORE: swap ${s.id} returned by scan but not rebuildable: '
+        '${s.error}',
+      );
+    }
+  }
+
+  Never _missingFromRestore(
+    String id,
+    List<boltz.SkippedRestoreSwap> skipped,
+  ) {
+    for (final s in skipped) {
+      if (s.id == id) {
+        throw 'swap $id could not be rebuilt from restore: ${s.error}';
+      }
+    }
+    throw 'swap $id not returned by boltz restore (possibly beyond gap limit)';
+  }
+
   Future<int?> _recoveredBoltzFee(SwapType type, int amount) async {
     try {
       final fees = await _boltz.getSwapFees(type);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,8 +158,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bitbox-transport"
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
-      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
+      resolved-ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -216,8 +216,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/boltz-stream"
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
-      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
+      resolved-ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.1.0"
@@ -305,8 +305,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/bull_sdk"
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
-      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
+      resolved-ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "1.0.0+1"
@@ -1755,8 +1755,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/bull_sdk/rust_builder"
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
-      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
+      resolved-ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"
@@ -1772,8 +1772,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/satoshifier"
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
-      resolved-ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
+      resolved-ref: "344a04e1801375042e7d238301e3ed9ac2ffde11"
       url: "https://github.com/SatoshiPortal/bull_sdk"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.12.4+201
+version: 6.12.5+203
 
 environment:
   sdk: "3.12.2"
@@ -54,17 +54,17 @@ dependencies:
   bull_sdk:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: 344a04e1801375042e7d238301e3ed9ac2ffde11
       path: packages/bull_sdk
   boltz_stream:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: 344a04e1801375042e7d238301e3ed9ac2ffde11
       path: packages/boltz-stream
   bitbox_transport:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: 344a04e1801375042e7d238301e3ed9ac2ffde11
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
   hex: ^0.2.0
@@ -119,7 +119,7 @@ dependencies:
   satoshifier:
     git:
       url: https://github.com/SatoshiPortal/bull_sdk
-      ref: bd4835ccb16dff5249cf048158389b5942cbe0fd
+      ref: 344a04e1801375042e7d238301e3ed9ac2ffde11
       path: packages/satoshifier
   flutter_nfc_kit: ^3.6.1
   ndef: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.12.5+203
+version: 6.12.6+206
 
 environment:
   sdk: "3.12.2"


### PR DESCRIPTION
Internal test build for the users failing to claim/refund restored swaps. Based off main (6.12.4+201) so the only delta vs what those users run is the restore fix chain.

## What

- **bull_sdk pin → `344a04e`** (`bump-boltz-0.5.2-for-6.12.x`): the app's current pin (`bd4835c`) plus ONLY boltz-dart 0.5.2 (develop `6f75525` — boltz-dart #56/#57/#58/#59/#60/#61). Deliberately NOT bull_sdk main (`a4dd62d`, PR #20): that tip also carries the ark.dart removal and lwk's u64→BigInt API change, both compile-breaking on app main and unrelated to this diagnostic build. Develop takes PR #20's pin later together with its ark/lwk state.
- **Restore call-site migration** to the new `Restored*Swaps { swaps, skipped }` API: datasource wrapper return types, and the five `rescueSwap` lookups now search `.swaps` with a skipped-aware miss handler.
- **Rescue failures name themselves**: a swap the scan returned but couldn't rebuild throws `swap <id> could not be rebuilt from restore: <reason>` instead of the misleading "possibly beyond gap limit", and every skipped swap is logged (`SWAP_RESTORE: swap <id> returned by scan but not rebuildable: ...`) so user logs show it.
- Version bump 6.12.6+206 (versionCode above all distributed builds).

## What this fixes for the affected users

- One submarine swap in the history no longer aborts the entire restore batch (`Claim details required…` — boltz-dart #56), which previously blocked rescuing every other swap too.
- Submarine swaps restore even without a parseable BOLT11 invoice (refund needs neither preimage nor amount — boltz-dart #61).
- Unrebuildable swaps are skipped, reported, and logged instead of silently vanishing or failing the batch.

## Verification

- `dart analyze lib test`: 0 issues. Full test suite: 499/499.
- Underlying boltz-dart changes covered by 20 rust tests (5 new) + verified fund-path analysis (refund never reads preimage/amount; script hashlock comes from the swap tree).

## Test protocol on the affected device

1. Settings → Bitcoin settings → Swap restore: list should populate (previously errored).
2. Rescue the stuck swap: refund should broadcast, or the UI/logs name the concrete rebuild failure.
3. Export logs: `SWAP_RESTORE:` lines show restored/skipped ids for diagnosis.

Note: develop owes main a merge-back of this after the release (along with the existing 6.12.x debt).