### PR TITLE
fix(send): show expiry screen instead of refund for orders with no payin

### DIFF
--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -1828,8 +1828,18 @@ class SendSucessScreen extends StatelessWidget {
         (orderSwap.inNetwork == OrderSwapNetwork.lightning ||
             orderSwap.outNetwork == OrderSwapNetwork.lightning);
     final isChainSwap = chainSwap != null || (orderSwap != null && !isLnSwap);
-    final isSwap = isLnSwap || isChainSwap;
-
+    // An order that expired before payin holds no funds — show expiry, not refund.
+    final expiredBeforePayin =
+        orderSwap != null &&
+        orderSwap.localStatus == OrderSwapLocalStatus.expired &&
+        orderSwap.localPayinTransactionId == null;
+    // Decides whether the View Details button appears.
+    final hasDetails =
+        walletTransaction != null ||
+        (orderSwap != null
+            ? orderSwap.localPayinTransactionId != null &&
+                  orderSwap.sourceWalletId != null
+            : chainSwap != null || payjoin != null);
     return Scaffold(
       appBar: AppBar(
         forceMaterialTransparency: true,
@@ -1851,7 +1861,19 @@ class SendSucessScreen extends StatelessWidget {
               child: Column(
                 children: [
                   const Gap(8),
-                  if (orderSwap?.localStatus == OrderSwapLocalStatus.failed ||
+                  if (expiredBeforePayin) ...[
+                    BBText(
+                      context.loc.sendSwapExpiredTitle,
+                      style: context.font.headlineLarge,
+                      textAlign: .center,
+                    ),
+                    BBText(
+                      context.loc.sendSwapExpiredMessage,
+                      style: context.font.headlineLarge,
+                      textAlign: .center,
+                    ),
+                  ] else if (orderSwap?.localStatus ==
+                          OrderSwapLocalStatus.failed ||
                       orderSwap?.localStatus == OrderSwapLocalStatus.expired ||
                       chainSwap?.status == SwapStatus.failed ||
                       chainSwap?.status == SwapStatus.expired ||
@@ -1963,7 +1985,7 @@ class SendSucessScreen extends StatelessWidget {
               OrderSwapUnderReviewCard(orderSwap: orderSwap!),
             ],
             const Spacer(flex: 2),
-            if (walletTransaction != null || isSwap || payjoin != null)
+            if (hasDetails)
               BBButton.big(
                 label: context.loc.sendViewDetails,
                 onPressed: () {

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12560,5 +12560,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "انتهت مهلة الدفع",
   "coreSwapsStatusScheduled": "مجدول",
   "coreSwapsStatusAwaitingClaim": "في انتظار المطالبة",
-  "coreSwapsStatusUnknown": "غير معروف"
+  "coreSwapsStatusUnknown": "غير معروف",
+  "sendSwapExpiredTitle": "انتهت صلاحية الطلب",
+  "sendSwapExpiredMessage": "انتهت صلاحية هذا الطلب قبل إرسال أي أموال. لم يتم إرسال أي شيء من محفظتك."
 }

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -9627,5 +9627,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "পৰিশোধৰ সময়সীমা শেষ",
   "coreSwapsStatusScheduled": "নিৰ্ধাৰিত",
   "coreSwapsStatusAwaitingClaim": "দাবীৰ অপেক্ষাত",
-  "coreSwapsStatusUnknown": "অজ্ঞাত"
+  "coreSwapsStatusUnknown": "অজ্ঞাত",
+  "sendSwapExpiredTitle": "অৰ্ডাৰৰ ম্যাদ উত্তীৰ্ণ হৈছে",
+  "sendSwapExpiredMessage": "কোনো ধন পঠোৱাৰ আগতেই এই অৰ্ডাৰৰ ম্যাদ উত্তীৰ্ণ হৈছে। আপোনাৰ wallet ৰ পৰা কিছুও পঠোৱা হোৱা নাই।"
 }

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -10434,5 +10434,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Срокът за плащане изтече",
   "coreSwapsStatusScheduled": "Планирано",
   "coreSwapsStatusAwaitingClaim": "Очаква получаване",
-  "coreSwapsStatusUnknown": "Неизвестно"
+  "coreSwapsStatusUnknown": "Неизвестно",
+  "sendSwapExpiredTitle": "Поръчката изтече",
+  "sendSwapExpiredMessage": "Тази поръчка изтече, преди да бъдат изпратени средства. От портфейла ви не е изпратено нищо."
 }

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12767,5 +12767,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "পেমেন্টের সময়সীমা শেষ",
   "coreSwapsStatusScheduled": "নির্ধারিত",
   "coreSwapsStatusAwaitingClaim": "দাবির অপেক্ষায়",
-  "coreSwapsStatusUnknown": "অজানা"
+  "coreSwapsStatusUnknown": "অজানা",
+  "sendSwapExpiredTitle": "অর্ডারের সময়সীমা শেষ",
+  "sendSwapExpiredMessage": "কোনো তহবিল পাঠানোর আগেই এই অর্ডারের সময়সীমা শেষ হয়ে গেছে। আপনার ওয়ালেট থেকে কিছুই পাঠানো হয়নি।"
 }

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -12557,5 +12557,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Platební lhůta vypršela",
   "coreSwapsStatusScheduled": "Naplánováno",
   "coreSwapsStatusAwaitingClaim": "Čeká na vyzvednutí",
-  "coreSwapsStatusUnknown": "Neznámé"
+  "coreSwapsStatusUnknown": "Neznámé",
+  "sendSwapExpiredTitle": "Objednávka vypršela",
+  "sendSwapExpiredMessage": "Tato objednávka vypršela před odesláním jakýchkoli prostředků. Z vaší peněženky nebylo nic odesláno."
 }

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -4924,5 +4924,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Zahlungsfrist abgelaufen",
   "coreSwapsStatusScheduled": "Geplant",
   "coreSwapsStatusAwaitingClaim": "Warten auf Einlösung",
-  "coreSwapsStatusUnknown": "Unbekannt"
+  "coreSwapsStatusUnknown": "Unbekannt",
+  "sendSwapExpiredTitle": "Auftrag abgelaufen",
+  "sendSwapExpiredMessage": "Dieser Auftrag ist abgelaufen, bevor Mittel gesendet wurden. Es wurde nichts aus der Wallet gesendet."
 }

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -12557,5 +12557,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Η προθεσμία πληρωμής έληξε",
   "coreSwapsStatusScheduled": "Προγραμματισμένο",
   "coreSwapsStatusAwaitingClaim": "Αναμονή διεκδίκησης",
-  "coreSwapsStatusUnknown": "Άγνωστο"
+  "coreSwapsStatusUnknown": "Άγνωστο",
+  "sendSwapExpiredTitle": "Η παραγγελία έληξε",
+  "sendSwapExpiredMessage": "Αυτή η παραγγελία έληξε προτού σταλούν χρήματα. Δεν στάλθηκε τίποτα από το πορτοφόλι σας."
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14546,5 +14546,13 @@
   "coreSwapsStatusUnknown": "Unknown",
   "@coreSwapsStatusUnknown": {
     "description": "Order status label: status not recognized."
+  },
+  "sendSwapExpiredTitle": "Order Expired",
+  "@sendSwapExpiredTitle": {
+    "description": "Title on the send result screen when a swap order expired before any funds were sent."
+  },
+  "sendSwapExpiredMessage": "This order expired before any funds were sent. Nothing was sent from your wallet.",
+  "@sendSwapExpiredMessage": {
+    "description": "Message on the send result screen when a swap order expired before any funds were sent, so there is nothing to refund."
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -4980,5 +4980,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Plazo de pago vencido",
   "coreSwapsStatusScheduled": "Programado",
   "coreSwapsStatusAwaitingClaim": "Esperando reclamación",
-  "coreSwapsStatusUnknown": "Desconocido"
+  "coreSwapsStatusUnknown": "Desconocido",
+  "sendSwapExpiredTitle": "Orden expirada",
+  "sendSwapExpiredMessage": "Esta orden expiró antes de que se enviaran fondos. No se envió nada desde tu billetera."
 }

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12557,5 +12557,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "مهلت پرداخت به پایان رسید",
   "coreSwapsStatusScheduled": "زمان‌بندی‌شده",
   "coreSwapsStatusAwaitingClaim": "در انتظار دریافت",
-  "coreSwapsStatusUnknown": "نامشخص"
+  "coreSwapsStatusUnknown": "نامشخص",
+  "sendSwapExpiredTitle": "سفارش منقضی شد",
+  "sendSwapExpiredMessage": "این سفارش پیش از ارسال هرگونه وجهی منقضی شد. هیچ مبلغی از کیف پول شما ارسال نشد."
 }

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4972,5 +4972,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Maksun määräaika umpeutui",
   "coreSwapsStatusScheduled": "Ajoitettu",
   "coreSwapsStatusAwaitingClaim": "Odottaa lunastusta",
-  "coreSwapsStatusUnknown": "Tuntematon"
+  "coreSwapsStatusUnknown": "Tuntematon",
+  "sendSwapExpiredTitle": "Tilaus vanheni",
+  "sendSwapExpiredMessage": "Tämä tilaus vanheni ennen kuin varoja lähetettiin. Lompakostasi ei lähetetty mitään."
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -5020,5 +5020,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Délai de paiement expiré",
   "coreSwapsStatusScheduled": "Planifié",
   "coreSwapsStatusAwaitingClaim": "En attente de réclamation",
-  "coreSwapsStatusUnknown": "Inconnu"
+  "coreSwapsStatusUnknown": "Inconnu",
+  "sendSwapExpiredTitle": "Commande expirée",
+  "sendSwapExpiredMessage": "Cette commande a expiré avant l'envoi de fonds. Rien n'a été envoyé depuis votre portefeuille."
 }

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12747,5 +12747,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "भुगतान की समय-सीमा समाप्त",
   "coreSwapsStatusScheduled": "निर्धारित",
   "coreSwapsStatusAwaitingClaim": "दावे की प्रतीक्षा",
-  "coreSwapsStatusUnknown": "अज्ञात"
+  "coreSwapsStatusUnknown": "अज्ञात",
+  "sendSwapExpiredTitle": "ऑर्डर समाप्त हो गया",
+  "sendSwapExpiredMessage": "कोई भी राशि भेजे जाने से पहले ही यह ऑर्डर समाप्त हो गया। आपके वॉलेट से कुछ भी नहीं भेजा गया।"
 }

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -12948,5 +12948,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Bhugtan ki samay-seema samapt",
   "coreSwapsStatusScheduled": "Nirdharit",
   "coreSwapsStatusAwaitingClaim": "Dawe ka intezaar",
-  "coreSwapsStatusUnknown": "Agyaat"
+  "coreSwapsStatusUnknown": "Agyaat",
+  "sendSwapExpiredTitle": "Order Khatam Ho Gaya",
+  "sendSwapExpiredMessage": "Koi bhi rashi bheje jaane se pehle hi yeh order khatam ho gaya. Aapke wallet se kuch bhi nahi bheja gaya."
 }

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -3618,5 +3618,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Վճարման ժամկետը լրացել է",
   "coreSwapsStatusScheduled": "Պլանավորված",
   "coreSwapsStatusAwaitingClaim": "Սպասում է ստացման",
-  "coreSwapsStatusUnknown": "Անհայտ"
+  "coreSwapsStatusUnknown": "Անհայտ",
+  "sendSwapExpiredTitle": "Պատվերի ժամկետը լրացել է",
+  "sendSwapExpiredMessage": "Այս պատվերի ժամկետը լրացել է նախքան միջոցներ ուղարկելը։ Ձեր դրամապանակից ոչինչ չի ուղարկվել։"
 }

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -4981,5 +4981,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Termine di pagamento scaduto",
   "coreSwapsStatusScheduled": "Programmato",
   "coreSwapsStatusAwaitingClaim": "In attesa di riscossione",
-  "coreSwapsStatusUnknown": "Sconosciuto"
+  "coreSwapsStatusUnknown": "Sconosciuto",
+  "sendSwapExpiredTitle": "Ordine scaduto",
+  "sendSwapExpiredMessage": "Questo ordine è scaduto prima dell'invio di fondi. Non è stato inviato nulla dal tuo portafoglio."
 }

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -3768,5 +3768,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "გადახდის ვადა ამოიწურა",
   "coreSwapsStatusScheduled": "დაგეგმილია",
   "coreSwapsStatusAwaitingClaim": "ელოდება მიღებას",
-  "coreSwapsStatusUnknown": "უცნობი"
+  "coreSwapsStatusUnknown": "უცნობი",
+  "sendSwapExpiredTitle": "შეკვეთის ვადა ამოიწურა",
+  "sendSwapExpiredMessage": "ამ შეკვეთის ვადა ამოიწურა თანხის გაგზავნამდე. თქვენი საფულიდან არაფერი გაიგზავნა."
 }

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12557,5 +12557,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "결제 기한 만료",
   "coreSwapsStatusScheduled": "예약됨",
   "coreSwapsStatusAwaitingClaim": "수령 대기 중",
-  "coreSwapsStatusUnknown": "알 수 없음"
+  "coreSwapsStatusUnknown": "알 수 없음",
+  "sendSwapExpiredTitle": "주문 만료",
+  "sendSwapExpiredMessage": "자금이 전송되기 전에 이 주문이 만료되었습니다. 지갑에서 아무것도 전송되지 않았습니다."
 }

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -5036,5 +5036,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Prazo de pagamento expirado",
   "coreSwapsStatusScheduled": "Agendado",
   "coreSwapsStatusAwaitingClaim": "Aguardando resgate",
-  "coreSwapsStatusUnknown": "Desconhecido"
+  "coreSwapsStatusUnknown": "Desconhecido",
+  "sendSwapExpiredTitle": "Ordem expirada",
+  "sendSwapExpiredMessage": "Esta ordem expirou antes de serem enviados fundos. Nada foi enviado da sua carteira."
 }

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -12554,5 +12554,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Prazo de pagamento expirado",
   "coreSwapsStatusScheduled": "Agendado",
   "coreSwapsStatusAwaitingClaim": "Aguardando resgate",
-  "coreSwapsStatusUnknown": "Desconhecido"
+  "coreSwapsStatusUnknown": "Desconhecido",
+  "sendSwapExpiredTitle": "Ordem expirada",
+  "sendSwapExpiredMessage": "Esta ordem expirou antes de qualquer fundo ser enviado. Nada foi enviado da sua carteira."
 }

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -4987,5 +4987,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Срок оплаты истёк",
   "coreSwapsStatusScheduled": "Запланировано",
   "coreSwapsStatusAwaitingClaim": "Ожидание получения",
-  "coreSwapsStatusUnknown": "Неизвестно"
+  "coreSwapsStatusUnknown": "Неизвестно",
+  "sendSwapExpiredTitle": "Заявка истекла",
+  "sendSwapExpiredMessage": "Срок этой заявки истёк до отправки средств. Из вашего кошелька ничего не отправлено."
 }

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -3630,5 +3630,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Muda wa malipo umeisha",
   "coreSwapsStatusScheduled": "Imepangwa",
   "coreSwapsStatusAwaitingClaim": "Inasubiri kudai",
-  "coreSwapsStatusUnknown": "Haijulikani"
+  "coreSwapsStatusUnknown": "Haijulikani",
+  "sendSwapExpiredTitle": "Muda wa Oda Umeisha",
+  "sendSwapExpiredMessage": "Oda hii ilipitwa na wakati kabla ya fedha zozote kutumwa. Hakuna kilichotumwa kutoka kwenye pochi yako."
 }

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12561,5 +12561,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "หมดกำหนดชำระเงิน",
   "coreSwapsStatusScheduled": "กำหนดเวลาแล้ว",
   "coreSwapsStatusAwaitingClaim": "รอการรับ",
-  "coreSwapsStatusUnknown": "ไม่ทราบ"
+  "coreSwapsStatusUnknown": "ไม่ทราบ",
+  "sendSwapExpiredTitle": "คำสั่งหมดอายุ",
+  "sendSwapExpiredMessage": "คำสั่งนี้หมดอายุก่อนที่จะมีการส่งเงิน ไม่มีการส่งเงินออกจากกระเป๋าสตางค์ของคุณ"
 }

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12557,5 +12557,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Ödeme süresi doldu",
   "coreSwapsStatusScheduled": "Planlandı",
   "coreSwapsStatusAwaitingClaim": "Talep bekleniyor",
-  "coreSwapsStatusUnknown": "Bilinmiyor"
+  "coreSwapsStatusUnknown": "Bilinmiyor",
+  "sendSwapExpiredTitle": "Sipariş Süresi Doldu",
+  "sendSwapExpiredMessage": "Bu siparişin süresi, herhangi bir fon gönderilmeden önce doldu. Cüzdanınızdan hiçbir şey gönderilmedi."
 }

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4978,5 +4978,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Термін оплати минув",
   "coreSwapsStatusScheduled": "Заплановано",
   "coreSwapsStatusAwaitingClaim": "Очікування отримання",
-  "coreSwapsStatusUnknown": "Невідомо"
+  "coreSwapsStatusUnknown": "Невідомо",
+  "sendSwapExpiredTitle": "Термін заявки минув",
+  "sendSwapExpiredMessage": "Термін дії цієї заявки минув до відправлення коштів. З вашого гаманця нічого не відправлено."
 }

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -3618,5 +3618,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "Đã hết hạn thanh toán",
   "coreSwapsStatusScheduled": "Đã lên lịch",
   "coreSwapsStatusAwaitingClaim": "Đang chờ nhận",
-  "coreSwapsStatusUnknown": "Không xác định"
+  "coreSwapsStatusUnknown": "Không xác định",
+  "sendSwapExpiredTitle": "Đơn hàng đã hết hạn",
+  "sendSwapExpiredMessage": "Đơn hàng này đã hết hạn trước khi bất kỳ khoản tiền nào được gửi. Không có gì được gửi từ ví của bạn."
 }

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -4981,5 +4981,7 @@
   "coreSwapsStatusPaymentDeadlineExpired": "付款期限已过",
   "coreSwapsStatusScheduled": "已排定",
   "coreSwapsStatusAwaitingClaim": "等待领取",
-  "coreSwapsStatusUnknown": "未知"
+  "coreSwapsStatusUnknown": "未知",
+  "sendSwapExpiredTitle": "订单已过期",
+  "sendSwapExpiredMessage": "此订单在发送任何资金前已过期。您的钱包未发送任何资金。"
 }


### PR DESCRIPTION
Fixes #2592

<img width="450" alt="Simulator Screenshot - iPhone 17e - 2026-08-11 at 17 39 58" src="https://github.com/user-attachments/assets/4efb2386-dd17-4f27-9e60-70e30cccb5ad" />

