### PR TITLE
refactor(transactions): speed up transfer progress and transaction details

### DIFF
--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -1520,19 +1520,21 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           state.copyWith(
             orderSwap: broadcast,
             swap: displaySwap.copyWith(status: SwapStatus.paid, sendTxid: txId),
+            txId: txId,
           ),
         );
-        await _getWalletUsecase.execute(state.fromWallet!.id, sync: true);
+        unawaited(_syncWalletAfterBroadcast(state.fromWallet!.id));
+        return;
       } else if (state.isSameChainTransfer) {
         txId = await _broadcastBitcoinTxUsecase.execute(
           signedPsbt,
           isPsbt: true,
         );
         if (state.fromWallet != null) {
-          await _getWalletUsecase.execute(state.fromWallet!.id, sync: true);
+          unawaited(_syncWalletAfterBroadcast(state.fromWallet!.id));
         }
         if (state.toWallet != null) {
-          await _getWalletUsecase.execute(state.toWallet!.id, sync: true);
+          unawaited(_syncWalletAfterBroadcast(state.toWallet!.id));
         }
       } else {
         return;
@@ -1547,6 +1549,18 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       );
     } finally {
       emit(state.copyWith(isConfirming: false));
+    }
+  }
+
+  Future<void> _syncWalletAfterBroadcast(String walletId) async {
+    try {
+      await _getWalletUsecase.execute(walletId, sync: true);
+    } catch (error, stackTrace) {
+      log.warning(
+        'Failed to sync wallet after transfer broadcast',
+        error: error,
+        trace: stackTrace,
+      );
     }
   }
 
@@ -1647,10 +1661,10 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       ),
     );
     if (orderSwap.localStatus.isTerminal) {
-      unawaited(_getWalletUsecase.execute(state.fromWallet!.id, sync: true));
+      unawaited(_syncWalletAfterBroadcast(state.fromWallet!.id));
       final destinationWalletId = orderSwap.destinationWalletId;
       if (destinationWalletId != null) {
-        unawaited(_getWalletUsecase.execute(destinationWalletId, sync: true));
+        unawaited(_syncWalletAfterBroadcast(destinationWalletId));
       }
     }
   }

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -1530,12 +1530,12 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           signedPsbt,
           isPsbt: true,
         );
-        if (state.fromWallet != null) {
-          unawaited(_syncWalletAfterBroadcast(state.fromWallet!.id));
-        }
-        if (state.toWallet != null) {
-          unawaited(_syncWalletAfterBroadcast(state.toWallet!.id));
-        }
+        unawaited(
+          _syncWalletsAfterBroadcast([
+            if (state.fromWallet != null) state.fromWallet!.id,
+            if (state.toWallet != null) state.toWallet!.id,
+          ]),
+        );
       } else {
         return;
       }
@@ -1555,12 +1555,14 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
   Future<void> _syncWalletAfterBroadcast(String walletId) async {
     try {
       await _getWalletUsecase.execute(walletId, sync: true);
-    } catch (error, stackTrace) {
-      log.warning(
-        'Failed to sync wallet after transfer broadcast',
-        error: error,
-        trace: stackTrace,
-      );
+    } catch (_) {
+      log.warning('Failed to sync wallet after transfer broadcast');
+    }
+  }
+
+  Future<void> _syncWalletsAfterBroadcast(List<String> walletIds) async {
+    for (final walletId in walletIds) {
+      await _syncWalletAfterBroadcast(walletId);
     }
   }
 

--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -179,9 +179,8 @@ sealed class Transaction with _$Transaction {
       swap?.type == SwapType.liquidToBitcoin ||
       (orderSwap?.inNetwork == OrderSwapNetwork.liquid &&
           orderSwap?.outNetwork == OrderSwapNetwork.bitcoin);
-
   // Internal swaps are outgoing from one wallet and incoming to the other.
-  bool isIncomingWallet(String? walletId) {
+  bool isReceivingWallet(String? walletId, {bool isCounterpart = false}) {
     final orderSwap = this.orderSwap;
     if (walletId != null && orderSwap != null) {
       return orderSwap.destinationWalletId == walletId &&
@@ -191,7 +190,7 @@ sealed class Transaction with _$Transaction {
     if (walletId != null && swap is ChainSwap) {
       return swap.receiveWalletId == walletId && swap.sendWalletId != walletId;
     }
-    return isIncoming;
+    return isCounterpart ? isOutgoing : isIncoming;
   }
 
   DateTime? get timestamp =>

--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -53,6 +53,10 @@ sealed class Transaction with _$Transaction {
       order?.isLiquid ??
       false;
   String? get toAddress => walletTransaction?.toAddress ?? order?.toAddress;
+  String? get orderSwapDestinationAddress =>
+      orderSwap?.outNetwork == OrderSwapNetwork.lightning
+      ? null
+      : orderSwap?.destination;
 
   bool get isBroadcasted => walletTransaction != null;
   bool get isSwap => swap != null || orderSwap != null;
@@ -175,6 +179,20 @@ sealed class Transaction with _$Transaction {
       swap?.type == SwapType.liquidToBitcoin ||
       (orderSwap?.inNetwork == OrderSwapNetwork.liquid &&
           orderSwap?.outNetwork == OrderSwapNetwork.bitcoin);
+
+  // Internal swaps are outgoing from one wallet and incoming to the other.
+  bool isIncomingWallet(String? walletId) {
+    final orderSwap = this.orderSwap;
+    if (walletId != null && orderSwap != null) {
+      return orderSwap.destinationWalletId == walletId &&
+          orderSwap.sourceWalletId != walletId;
+    }
+    final swap = this.swap;
+    if (walletId != null && swap is ChainSwap) {
+      return swap.receiveWalletId == walletId && swap.sendWalletId != walletId;
+    }
+    return isIncoming;
+  }
 
   DateTime? get timestamp =>
       // Completed swaps are displayed (and should sort) by when they finished,

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
@@ -76,6 +76,9 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   StreamSubscription? _payjoinTxSubscription;
   StreamSubscription? _payjoinOriginalTxSubscription;
   StreamSubscription? _orderSwapSubscription;
+  String? _watchedOrderSwapTransactionId;
+  WalletTransaction? _pendingOrderSwapWalletTransaction;
+  int _orderSwapTransactionWatchGeneration = 0;
 
   // The payjoin id _payjoinSubscription is currently listening to on the
   // by-wallet-tx path, so reloads triggered by its own events don't
@@ -149,25 +152,7 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
         .execute(localId)
         .listen(
           (orderSwap) {
-            if (isClosed) return;
-            final transaction = state.transaction;
-            if (transaction?.orderSwap?.localId != orderSwap.localId) return;
-            final walletTransaction = transaction?.walletTransaction;
-            final canonicalTransactionChanged =
-                walletTransaction != null &&
-                walletTransaction.txId !=
-                    orderSwap.canonicalWalletTransactionId;
-            emit(
-              state.copyWith(
-                transaction: transaction!.copyWith(
-                  walletTransaction: canonicalTransactionChanged
-                      ? null
-                      : walletTransaction,
-                  orderSwap: orderSwap,
-                ),
-                swapCounterpartTxId: orderSwap.counterpartTransactionId,
-              ),
-            );
+            unawaited(_handleOrderSwapUpdate(orderSwap));
           },
           onError: (Object error) {
             if (isClosed) return;
@@ -176,10 +161,88 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
         );
   }
 
+  Future<void> _handleOrderSwapUpdate(OrderSwapRecord orderSwap) async {
+    if (isClosed) return;
+    final transaction = state.transaction;
+    if (transaction?.orderSwap?.localId != orderSwap.localId) {
+      await _loadDetailsByOrderSwapLocalId(orderSwap.localId);
+      await _watchOrderSwapWalletTransaction(state.transaction?.orderSwap);
+      return;
+    }
+    final walletTransaction = transaction?.walletTransaction;
+    final canonicalTransactionChanged =
+        walletTransaction != null &&
+        walletTransaction.txId != orderSwap.canonicalWalletTransactionId;
+    emit(
+      state.copyWith(
+        transaction: transaction!.copyWith(
+          walletTransaction: canonicalTransactionChanged
+              ? null
+              : walletTransaction,
+          orderSwap: orderSwap,
+        ),
+        swapCounterpartTxId: orderSwap.counterpartTransactionId,
+      ),
+    );
+    await _watchOrderSwapWalletTransaction(orderSwap);
+  }
+
+  Future<void> _watchOrderSwapWalletTransaction(
+    OrderSwapRecord? orderSwap,
+  ) async {
+    final transactionId = orderSwap?.canonicalWalletTransactionId;
+    final walletId = orderSwap?.canonicalWalletId;
+    if (transactionId == null || walletId == null) return;
+    if (_watchedOrderSwapTransactionId == transactionId) return;
+    final generation = ++_orderSwapTransactionWatchGeneration;
+    _pendingOrderSwapWalletTransaction = null;
+    await _walletTransactionSubscription?.cancel();
+    if (isClosed || generation != _orderSwapTransactionWatchGeneration) return;
+    try {
+      _walletTransactionSubscription = _watchWalletTransactionByTxIdUsecase
+          .execute(txId: transactionId, walletId: walletId)
+          .listen(
+            (walletTransaction) {
+              if (isClosed) return;
+              final latestOrderSwap = state.transaction?.orderSwap;
+              if (latestOrderSwap == null) {
+                _pendingOrderSwapWalletTransaction = walletTransaction;
+                return;
+              }
+              if (latestOrderSwap.canonicalWalletTransactionId !=
+                  transactionId) {
+                return;
+              }
+              emit(
+                state.copyWith(
+                  transaction: state.transaction?.copyWith(
+                    walletTransaction: walletTransaction,
+                  ),
+                ),
+              );
+            },
+            onError: (_) {
+              if (_watchedOrderSwapTransactionId == transactionId) {
+                _watchedOrderSwapTransactionId = null;
+              }
+              log.warning('Order swap wallet transaction watcher failed');
+            },
+          );
+      _watchedOrderSwapTransactionId = transactionId;
+    } catch (_) {
+      _watchedOrderSwapTransactionId = null;
+      log.warning('Order swap wallet transaction watcher failed');
+    }
+  }
+
   Future<void> _loadDetailsByOrderSwapLocalId(String localId) async {
     try {
       final orderSwap = await _getTransactionOrderSwapUsecase.execute(localId);
+      await _watchOrderSwapWalletTransaction(orderSwap);
       await _loadOrderSwapDetails(orderSwap);
+    } on ParallelWaitError catch (error) {
+      if (isClosed) return;
+      emit(state.copyWith(err: _firstParallelError(error)));
     } on TransactionNotFoundError catch (error) {
       if (isClosed) return;
       emit(state.copyWith(notFoundError: error));
@@ -216,10 +279,22 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
               walletId: walletId,
             ),
     ).wait;
-    final walletTransaction = switch (walletTransactionResult) {
+    final loadedWalletTransaction = switch (walletTransactionResult) {
       Ok(:final value) => value,
-      Err() => null,
+      Err() => () {
+        log.warning('Order swap wallet transaction lookup failed');
+        return null;
+      }(),
     };
+    final pendingWalletTransaction = _pendingOrderSwapWalletTransaction;
+    _pendingOrderSwapWalletTransaction = null;
+    final matchingPendingWalletTransaction =
+        pendingWalletTransaction?.txId == transactionId &&
+            pendingWalletTransaction?.walletId == walletId
+        ? pendingWalletTransaction
+        : null;
+    final walletTransaction =
+        matchingPendingWalletTransaction ?? loadedWalletTransaction;
     if (isClosed) return;
     emit(
       state.copyWith(
@@ -230,8 +305,15 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
         wallet: wallet,
         counterpartWallet: counterpartWallet,
         swapCounterpartTxId: orderSwap.counterpartTransactionId,
+        err: null,
+        notFoundError: null,
       ),
     );
+  }
+
+  Object _firstParallelError(ParallelWaitError error) {
+    final errors = error.errors as (AsyncError?, AsyncError?, AsyncError?);
+    return (errors.$1 ?? errors.$2 ?? errors.$3)?.error ?? error;
   }
 
   Future<void> _loadDetailsByWalletTxId(

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/features/swap/public/swap_facade.dart';
 import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
@@ -142,13 +143,31 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
   }
 
   Future<void> initByOrderSwapLocalId(String localId) async {
+    _reload = () => _loadDetailsByOrderSwapLocalId(localId);
     await _loadDetailsByOrderSwapLocalId(localId);
     _orderSwapSubscription = _watchTransactionOrderSwapUsecase
         .execute(localId)
         .listen(
           (orderSwap) {
             if (isClosed) return;
-            _loadOrderSwapDetails(orderSwap);
+            final transaction = state.transaction;
+            if (transaction?.orderSwap?.localId != orderSwap.localId) return;
+            final walletTransaction = transaction?.walletTransaction;
+            final canonicalTransactionChanged =
+                walletTransaction != null &&
+                walletTransaction.txId !=
+                    orderSwap.canonicalWalletTransactionId;
+            emit(
+              state.copyWith(
+                transaction: transaction!.copyWith(
+                  walletTransaction: canonicalTransactionChanged
+                      ? null
+                      : walletTransaction,
+                  orderSwap: orderSwap,
+                ),
+                swapCounterpartTxId: orderSwap.counterpartTransactionId,
+              ),
+            );
           },
           onError: (Object error) {
             if (isClosed) return;
@@ -177,32 +196,37 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
       emit(state.copyWith(err: TransactionNotFoundError()));
       return;
     }
-    final wallet = await _getWalletUsecase.execute(walletId);
     final counterpartWalletId = orderSwap.sourceWalletId == walletId
         ? orderSwap.destinationWalletId
         : orderSwap.sourceWalletId;
-    final counterpartWallet = counterpartWalletId == null
-        ? null
-        : await _getWalletUsecase.execute(counterpartWalletId);
-    var transaction = Transaction(orderSwap: orderSwap);
-    final walletTransactionId = orderSwap.canonicalWalletTransactionId;
-    if (walletTransactionId != null) {
-      try {
-        final transactions = await _getTransactionsByTxIdUsecase.execute(
-          walletTransactionId,
-        );
-        transaction = transactions.firstWhere(
-          (candidate) => candidate.walletId == walletId,
-          orElse: () => transaction,
-        );
-      } on TransactionNotFoundError {
-        // The order remains displayable while the wallet sync catches up.
-      }
-    }
+    final transactionId = orderSwap.canonicalWalletTransactionId;
+    final (wallet, counterpartWallet, walletTransactionResult) = await (
+      _getWalletUsecase.execute(walletId),
+      counterpartWalletId == null
+          ? Future<Wallet?>.value()
+          : _getWalletUsecase.execute(counterpartWalletId),
+      transactionId == null
+          ? Future.value(
+              const Ok<WalletTransaction?, WalletTransactionLookupFailure>(
+                null,
+              ),
+            )
+          : _getWalletTransactionUsecase.execute(
+              txId: transactionId,
+              walletId: walletId,
+            ),
+    ).wait;
+    final walletTransaction = switch (walletTransactionResult) {
+      Ok(:final value) => value,
+      Err() => null,
+    };
     if (isClosed) return;
     emit(
       state.copyWith(
-        transaction: transaction,
+        transaction: Transaction(
+          walletTransaction: walletTransaction,
+          orderSwap: orderSwap,
+        ),
         wallet: wallet,
         counterpartWallet: counterpartWallet,
         swapCounterpartTxId: orderSwap.counterpartTransactionId,

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -54,7 +54,10 @@ class TransactionDetailsTable extends StatelessWidget {
 
     final swap = transaction?.swap;
     final orderSwap = transaction?.orderSwap;
-    final toAddress = swap?.receiveAddress ?? transaction?.toAddress;
+    final toAddress =
+        swap?.receiveAddress ??
+        transaction?.orderSwapDestinationAddress ??
+        transaction?.toAddress;
     final payjoin = transaction?.payjoin;
     final order = transaction?.order;
     final txFee = transaction?.payjoinSenderFeeSat ?? walletTransaction?.feeSat;
@@ -115,14 +118,14 @@ class TransactionDetailsTable extends StatelessWidget {
           ),
         if (walletLabel.isNotEmpty)
           DetailsTableItem(
-            label: transaction?.isIncoming == true
+            label: transaction?.isIncomingWallet(wallet?.id) == true
                 ? context.loc.transactionDetailLabelToWallet
                 : context.loc.transactionDetailLabelFromWallet,
             displayValue: walletLabel,
           ),
         if (counterpartWalletLabel.isNotEmpty && !recovered)
           DetailsTableItem(
-            label: transaction?.isOutgoing == true
+            label: transaction?.isIncomingWallet(counterpartWallet?.id) == true
                 ? context.loc.transactionDetailLabelToWallet
                 : context.loc.transactionDetailLabelFromWallet,
             displayValue: counterpartWalletLabel,

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -118,14 +118,19 @@ class TransactionDetailsTable extends StatelessWidget {
           ),
         if (walletLabel.isNotEmpty)
           DetailsTableItem(
-            label: transaction?.isIncomingWallet(wallet?.id) == true
+            label: transaction?.isReceivingWallet(wallet?.id) == true
                 ? context.loc.transactionDetailLabelToWallet
                 : context.loc.transactionDetailLabelFromWallet,
             displayValue: walletLabel,
           ),
         if (counterpartWalletLabel.isNotEmpty && !recovered)
           DetailsTableItem(
-            label: transaction?.isIncomingWallet(counterpartWallet?.id) == true
+            label:
+                transaction?.isReceivingWallet(
+                      counterpartWallet?.id,
+                      isCounterpart: true,
+                    ) ==
+                    true
                 ? context.loc.transactionDetailLabelToWallet
                 : context.loc.transactionDetailLabelFromWallet,
             displayValue: counterpartWalletLabel,

--- a/test/features/swap/presentation/transfer_bloc_test.dart
+++ b/test/features/swap/presentation/transfer_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
@@ -231,6 +233,44 @@ void main() {
       expect(states.any((state) => state.txId == 'txid-1'), isTrue);
     },
   );
+
+  test('emits the transaction id before wallet sync completes', () async {
+    final syncCompleter = Completer<Wallet>();
+    final broadcasting = _prepared(
+      status: OrderSwapLocalStatus.broadcastUnknown,
+    );
+    final broadcasted = _prepared(
+      status: OrderSwapLocalStatus.payinBroadcast,
+      transactionId: 'txid-1',
+    );
+    when(
+      () => getWallet.execute('wallet-1', sync: true),
+    ).thenAnswer((_) => syncCompleter.future);
+    when(
+      () => markUnknown.execute('local-1'),
+    ).thenAnswer((_) async => Ok(broadcasting));
+    when(
+      () => broadcastBitcoin.execute('signed-psbt', isPsbt: true),
+    ).thenAnswer((_) async => 'txid-1');
+    when(
+      () => markBroadcast.execute(localId: 'local-1', transactionId: 'txid-1'),
+    ).thenAnswer((_) async => Ok(broadcasted));
+    bloc.emit(
+      TransferState(
+        orderSwap: prepared,
+        signedPsbt: 'signed-psbt',
+        fromWallet: _wallet(),
+        swap: _swap(),
+      ),
+    );
+
+    bloc.add(const TransferEvent.confirmed());
+    await bloc.stream.firstWhere((state) => state.txId == 'txid-1');
+
+    expect(syncCompleter.isCompleted, isFalse);
+    expect(bloc.state.orderSwap, broadcasted);
+    syncCompleter.complete(_wallet());
+  });
 
   test('resumes a stored prepared transfer on start', () async {
     final settings = SettingsEntity(

--- a/test/features/transactions/domain/entities/transaction_test.dart
+++ b/test/features/transactions/domain/entities/transaction_test.dart
@@ -43,6 +43,51 @@ PayjoinSession _senderPayjoin({
 );
 
 void main() {
+  group('Transaction swap wallet direction', () {
+    test('identifies Bitcoin to Liquid transfer wallets', () {
+      final transaction = Transaction(
+        orderSwap: _transferOrderSwap(
+          inNetwork: OrderSwapNetwork.bitcoin,
+          outNetwork: OrderSwapNetwork.liquid,
+        ),
+      );
+
+      expect(transaction.isIncomingWallet('bitcoin-wallet'), isFalse);
+      expect(transaction.isIncomingWallet('liquid-wallet'), isTrue);
+    });
+
+    test('identifies Liquid to Bitcoin transfer wallets', () {
+      final transaction = Transaction(
+        orderSwap: _transferOrderSwap(
+          inNetwork: OrderSwapNetwork.liquid,
+          outNetwork: OrderSwapNetwork.bitcoin,
+        ),
+      );
+
+      expect(transaction.isIncomingWallet('liquid-wallet'), isFalse);
+      expect(transaction.isIncomingWallet('bitcoin-wallet'), isTrue);
+    });
+  });
+
+  test('exposes only on-chain order swap destinations as addresses', () {
+    final onChain = Transaction(
+      orderSwap: _transferOrderSwap(
+        inNetwork: OrderSwapNetwork.bitcoin,
+        outNetwork: OrderSwapNetwork.liquid,
+      ),
+    );
+    final lightning = Transaction(
+      orderSwap: _transferOrderSwap(
+        inNetwork: OrderSwapNetwork.bitcoin,
+        outNetwork: OrderSwapNetwork.lightning,
+      ),
+    );
+
+    expect(onChain.orderSwapDestinationAddress, 'destination');
+    expect(lightning.orderSwapDestinationAddress, isNull);
+    expect(onChain.toAddress, isNull);
+  });
+
   group('Transaction Payjoin sender amounts', () {
     test(
       'displays the negotiated amount instead of BDK receiver-net amount',
@@ -391,6 +436,29 @@ void main() {
     });
   });
 }
+
+OrderSwapRecord _transferOrderSwap({
+  required OrderSwapNetwork inNetwork,
+  required OrderSwapNetwork outNetwork,
+}) => OrderSwapRecord(
+  localId: 'local-id',
+  purpose: OrderSwapPurpose.transfer,
+  environment: OrderSwapEnvironment.mainnet,
+  inNetwork: inNetwork,
+  outNetwork: outNetwork,
+  isInAmountFixed: true,
+  requestedAmountSat: BigInt.from(1000),
+  sourceWalletId: inNetwork == OrderSwapNetwork.bitcoin
+      ? 'bitcoin-wallet'
+      : 'liquid-wallet',
+  destinationWalletId: outNetwork == OrderSwapNetwork.bitcoin
+      ? 'bitcoin-wallet'
+      : 'liquid-wallet',
+  destination: 'destination',
+  fallback: 'fallback',
+  createdAt: DateTime.utc(2026),
+  localStatus: OrderSwapLocalStatus.creating,
+);
 
 OrderSwapRecord _receiveOrderSwap() {
   final createdAt = DateTime.utc(2026, 8, 6);

--- a/test/features/transactions/domain/entities/transaction_test.dart
+++ b/test/features/transactions/domain/entities/transaction_test.dart
@@ -52,8 +52,8 @@ void main() {
         ),
       );
 
-      expect(transaction.isIncomingWallet('bitcoin-wallet'), isFalse);
-      expect(transaction.isIncomingWallet('liquid-wallet'), isTrue);
+      expect(transaction.isReceivingWallet('bitcoin-wallet'), isFalse);
+      expect(transaction.isReceivingWallet('liquid-wallet'), isTrue);
     });
 
     test('identifies Liquid to Bitcoin transfer wallets', () {
@@ -64,8 +64,23 @@ void main() {
         ),
       );
 
-      expect(transaction.isIncomingWallet('liquid-wallet'), isFalse);
-      expect(transaction.isIncomingWallet('bitcoin-wallet'), isTrue);
+      expect(transaction.isReceivingWallet('liquid-wallet'), isFalse);
+      expect(transaction.isReceivingWallet('bitcoin-wallet'), isTrue);
+    });
+
+    test('ordinary transfer reverses direction for the counterpart', () {
+      final outgoing = Transaction(walletTransaction: _walletTx(txId: 'txid'));
+      final incoming = Transaction(
+        walletTransaction: _walletTx(
+          txId: 'incoming-txid',
+          direction: WalletTransactionDirection.incoming,
+        ),
+      );
+
+      expect(outgoing.isReceivingWallet('w1'), isFalse);
+      expect(outgoing.isReceivingWallet('w2', isCounterpart: true), isTrue);
+      expect(incoming.isReceivingWallet('w1'), isTrue);
+      expect(incoming.isReceivingWallet('w2', isCounterpart: true), isFalse);
     });
   });
 

--- a/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
@@ -215,14 +215,15 @@ void main() {
         () => getTransactionOrderSwap.execute(orderSwap.localId),
       ).thenAnswer((_) async => orderSwap);
       when(
-        () => getTransactionsByTxId.execute('liquid-payout-txid'),
+        () => getWalletTransaction.execute(
+          txId: 'liquid-payout-txid',
+          walletId: 'liquid-wallet',
+          sync: false,
+        ),
       ).thenAnswer(
-        (_) async => [
-          Transaction(
-            walletTransaction: walletTransaction,
-            orderSwap: orderSwap,
-          ),
-        ],
+        (_) async => Ok<WalletTransaction?, WalletTransactionLookupFailure>(
+          walletTransaction,
+        ),
       );
       when(
         () => getWallet.execute('liquid-wallet', sync: false),
@@ -232,10 +233,227 @@ void main() {
       addTearDown(cubit.close);
       await cubit.initByOrderSwapLocalId(orderSwap.localId);
 
+      expect(cubit.state.transaction?.orderSwap, orderSwap);
+      expect(cubit.state.wallet?.id, 'liquid-wallet');
       expect(cubit.state.transaction?.walletTransaction, walletTransaction);
       expect(cubit.state.transaction?.txId, 'liquid-payout-txid');
       expect(cubit.state.transaction?.labels?.single.label, 'coffee');
+      expect(
+        cubit.state.transaction?.orderSwapDestinationAddress,
+        'liquid-address',
+      );
       expect(cubit.state.getAmountReceived(), 19800);
+    },
+  );
+
+  test(
+    'loads both wallets before exposing internal transfer details',
+    () async {
+      final sourceWallet = Completer<Wallet?>();
+      final destinationWallet = Completer<Wallet?>();
+      final walletTransaction =
+          Completer<
+            Result<WalletTransaction?, WalletTransactionLookupFailure>
+          >();
+      final orderSwap = OrderSwapRecord(
+        localId: 'transfer-local',
+        purpose: OrderSwapPurpose.transfer,
+        environment: OrderSwapEnvironment.mainnet,
+        inNetwork: OrderSwapNetwork.bitcoin,
+        outNetwork: OrderSwapNetwork.liquid,
+        isInAmountFixed: true,
+        requestedAmountSat: BigInt.from(20000),
+        sourceWalletId: 'source-wallet',
+        destinationWalletId: 'destination-wallet',
+        destination: 'liquid-address',
+        fallback: 'bitcoin-address',
+        localPayinTransactionId: 'bitcoin-payin-txid',
+        order: OrderSwap(
+          orderId: 'transfer-order',
+          orderNumber: 2,
+          inNetwork: OrderSwapNetwork.bitcoin,
+          outNetwork: OrderSwapNetwork.liquid,
+          payinAmountSat: BigInt.from(20000),
+          payoutAmountSat: BigInt.from(19800),
+          payinCurrency: 'BTC',
+          payoutCurrency: 'LBTC',
+          payinMethod: 'Bitcoin',
+          payoutMethod: 'Liquid',
+          orderType: 'Swap',
+          orderStatus: 'Pending',
+          payinStatus: 'Pending',
+          payoutStatus: 'Pending',
+          messageCode: 'PENDING',
+          createdAt: DateTime.utc(2026),
+          confirmationDeadline: DateTime.utc(2026, 1, 1, 0, 5),
+        ),
+        createdAt: DateTime.utc(2026),
+        localStatus: OrderSwapLocalStatus.awaitingUserConfirmation,
+      );
+      when(
+        () => getTransactionOrderSwap.execute(orderSwap.localId),
+      ).thenAnswer((_) async => orderSwap);
+      when(
+        () => getWallet.execute('source-wallet', sync: false),
+      ).thenAnswer((_) => sourceWallet.future);
+      when(
+        () => getWallet.execute('destination-wallet', sync: false),
+      ).thenAnswer((_) => destinationWallet.future);
+      when(
+        () => getWalletTransaction.execute(
+          txId: any(named: 'txId'),
+          walletId: 'source-wallet',
+          sync: false,
+        ),
+      ).thenAnswer((_) => walletTransaction.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final load = cubit.initByOrderSwapLocalId(orderSwap.localId);
+      await pumpEventQueue();
+
+      verify(() => getWallet.execute('source-wallet', sync: false)).called(1);
+      verify(
+        () => getWallet.execute('destination-wallet', sync: false),
+      ).called(1);
+      verify(
+        () => getWalletTransaction.execute(
+          txId: any(named: 'txId'),
+          walletId: 'source-wallet',
+          sync: false,
+        ),
+      ).called(1);
+      expect(cubit.state.isLoading, isTrue);
+
+      sourceWallet.complete(_testWallet(origin: 'source-wallet'));
+      destinationWallet.complete(_testWallet(origin: 'destination-wallet'));
+      walletTransaction.complete(
+        Ok(_walletTx(txId: orderSwap.canonicalWalletTransactionId!)),
+      );
+      await load;
+
+      expect(cubit.state.wallet?.id, 'source-wallet');
+      expect(cubit.state.counterpartWallet?.id, 'destination-wallet');
+      expect(cubit.state.transaction?.orderSwap, orderSwap);
+      expect(cubit.state.walletTransaction, isNotNull);
+      expect(cubit.state.isLoading, isFalse);
+    },
+  );
+
+  test('order swap updates preserve the initial detail row data', () async {
+    final initial = _receiveOrderSwap();
+    final walletTransaction = _walletTx(
+      txId: initial.canonicalWalletTransactionId!,
+      walletId: initial.canonicalWalletId!,
+      network: Network.liquidMainnet,
+      direction: WalletTransactionDirection.incoming,
+      labels: [
+        Label.tx(
+          id: 1,
+          transactionId: initial.canonicalWalletTransactionId!,
+          label: 'coffee',
+        ),
+      ],
+    );
+    final updates = StreamController<OrderSwapRecord>.broadcast();
+    addTearDown(updates.close);
+    when(
+      () => getTransactionOrderSwap.execute(initial.localId),
+    ).thenAnswer((_) async => initial);
+    when(
+      () => getWalletTransaction.execute(
+        txId: initial.canonicalWalletTransactionId!,
+        walletId: initial.canonicalWalletId!,
+        sync: false,
+      ),
+    ).thenAnswer(
+      (_) async => Ok<WalletTransaction?, WalletTransactionLookupFailure>(
+        walletTransaction,
+      ),
+    );
+    when(
+      () => watchTransactionOrderSwap.execute(initial.localId),
+    ).thenAnswer((_) => updates.stream);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(initial.localId);
+    clearInteractions(getWallet);
+    clearInteractions(getWalletTransaction);
+    final updating = _copyOrderSwap(
+      initial,
+      localStatus: OrderSwapLocalStatus.payoutInProgress,
+    );
+    final completed = _copyOrderSwap(
+      initial,
+      localStatus: OrderSwapLocalStatus.completed,
+    );
+
+    updates.add(updating);
+    updates.add(completed);
+    await pumpEventQueue();
+
+    expect(cubit.state.transaction?.orderSwap, completed);
+    expect(cubit.state.walletTransaction, walletTransaction);
+    expect(cubit.state.transaction?.labels?.single.label, 'coffee');
+    verifyNever(() => getWallet.execute(any(), sync: any(named: 'sync')));
+    verifyNever(
+      () => getWalletTransaction.execute(
+        txId: any(named: 'txId'),
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+      ),
+    );
+  });
+
+  test(
+    'order swap update clears a stale canonical wallet transaction',
+    () async {
+      final initial = _receiveOrderSwap();
+      final walletTransaction = _walletTx(
+        txId: initial.canonicalWalletTransactionId!,
+        walletId: initial.canonicalWalletId!,
+        network: Network.liquidMainnet,
+        direction: WalletTransactionDirection.incoming,
+      );
+      final updates = StreamController<OrderSwapRecord>.broadcast();
+      addTearDown(updates.close);
+      when(
+        () => getTransactionOrderSwap.execute(initial.localId),
+      ).thenAnswer((_) async => initial);
+      when(
+        () => getWalletTransaction.execute(
+          txId: initial.canonicalWalletTransactionId!,
+          walletId: initial.canonicalWalletId!,
+          sync: false,
+        ),
+      ).thenAnswer(
+        (_) async => Ok<WalletTransaction?, WalletTransactionLookupFailure>(
+          walletTransaction,
+        ),
+      );
+      when(
+        () => watchTransactionOrderSwap.execute(initial.localId),
+      ).thenAnswer((_) => updates.stream);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByOrderSwapLocalId(initial.localId);
+      final updated = _copyOrderSwap(
+        initial,
+        localStatus: OrderSwapLocalStatus.completed,
+        order: _copyOrderSwapOrder(
+          initial.order!,
+          liquidTransactionId: 'replacement-txid',
+        ),
+      );
+
+      updates.add(updated);
+      await pumpEventQueue();
+
+      expect(cubit.state.transaction?.orderSwap, updated);
+      expect(cubit.state.walletTransaction, isNull);
+      expect(cubit.state.transaction?.txId, 'replacement-txid');
     },
   );
 
@@ -710,3 +928,57 @@ OrderSwapRecord _receiveOrderSwap() {
     localStatus: OrderSwapLocalStatus.completed,
   );
 }
+
+OrderSwapRecord _copyOrderSwap(
+  OrderSwapRecord record, {
+  required OrderSwapLocalStatus localStatus,
+  OrderSwap? order,
+}) => OrderSwapRecord(
+  localId: record.localId,
+  requestId: record.requestId,
+  purpose: record.purpose,
+  environment: record.environment,
+  inNetwork: record.inNetwork,
+  outNetwork: record.outNetwork,
+  isInAmountFixed: record.isInAmountFixed,
+  requestedAmountSat: record.requestedAmountSat,
+  sourceWalletId: record.sourceWalletId,
+  destinationWalletId: record.destinationWalletId,
+  destination: record.destination,
+  fallback: record.fallback,
+  note: record.note,
+  localPayinTransactionId: record.localPayinTransactionId,
+  order: order ?? record.order,
+  createdAt: record.createdAt,
+  localStatus: localStatus,
+);
+
+OrderSwap _copyOrderSwapOrder(
+  OrderSwap order, {
+  required String liquidTransactionId,
+}) => OrderSwap(
+  orderId: order.orderId,
+  orderNumber: order.orderNumber,
+  inNetwork: order.inNetwork,
+  outNetwork: order.outNetwork,
+  payinAmountSat: order.payinAmountSat,
+  payoutAmountSat: order.payoutAmountSat,
+  payinCurrency: order.payinCurrency,
+  payoutCurrency: order.payoutCurrency,
+  payinMethod: order.payinMethod,
+  payoutMethod: order.payoutMethod,
+  orderType: order.orderType,
+  orderStatus: order.orderStatus,
+  payinStatus: order.payinStatus,
+  payoutStatus: order.payoutStatus,
+  messageCode: order.messageCode,
+  bitcoinAddress: order.bitcoinAddress,
+  liquidAddress: order.liquidAddress,
+  lightningInvoice: order.lightningInvoice,
+  bitcoinTransactionId: order.bitcoinTransactionId,
+  liquidTransactionId: liquidTransactionId,
+  createdAt: order.createdAt,
+  confirmationDeadline: order.confirmationDeadline,
+  completedAt: order.completedAt,
+  sentAt: order.sentAt,
+);

--- a/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
@@ -20,6 +20,7 @@ import 'package:bb_mobile/features/transactions/application/usecases/get_payjoin
 import 'package:bb_mobile/features/transactions/application/usecases/get_payjoin_by_tx_id_usecase.dart';
 import 'package:bb_mobile/features/transactions/application/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/features/transactions/application/usecases/watch_transaction_order_swap_usecase.dart';
+import 'package:bb_mobile/features/transactions/domain/transaction_error.dart';
 import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -456,6 +457,218 @@ void main() {
       expect(cubit.state.transaction?.txId, 'replacement-txid');
     },
   );
+
+  test('adds the wallet transaction after background sync completes', () async {
+    final orderSwap = _receiveOrderSwap();
+    final walletTransactions = StreamController<WalletTransaction>.broadcast();
+    addTearDown(walletTransactions.close);
+    when(
+      () => getTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) async => orderSwap);
+    when(
+      () => watchWalletTransactionByTxId.execute(
+        txId: orderSwap.canonicalWalletTransactionId!,
+        walletId: orderSwap.canonicalWalletId!,
+      ),
+    ).thenAnswer((_) => walletTransactions.stream);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(orderSwap.localId);
+    expect(cubit.state.walletTransaction, isNull);
+
+    final walletTransaction = _walletTx(
+      txId: orderSwap.canonicalWalletTransactionId!,
+      walletId: orderSwap.canonicalWalletId!,
+      network: Network.liquidMainnet,
+      direction: WalletTransactionDirection.incoming,
+    );
+    walletTransactions.add(walletTransaction);
+    await pumpEventQueue();
+
+    expect(cubit.state.walletTransaction, walletTransaction);
+    expect(cubit.state.transaction?.orderSwap, orderSwap);
+  });
+
+  test('keeps a wallet sync result emitted during the initial load', () async {
+    final orderSwap = _receiveOrderSwap();
+    final walletTransactionLookup =
+        Completer<Result<WalletTransaction?, WalletTransactionLookupFailure>>();
+    final walletTransactions = StreamController<WalletTransaction>.broadcast();
+    addTearDown(walletTransactions.close);
+    when(
+      () => getTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) async => orderSwap);
+    when(
+      () => getWalletTransaction.execute(
+        txId: orderSwap.canonicalWalletTransactionId!,
+        walletId: orderSwap.canonicalWalletId!,
+        sync: false,
+      ),
+    ).thenAnswer((_) => walletTransactionLookup.future);
+    when(
+      () => watchWalletTransactionByTxId.execute(
+        txId: orderSwap.canonicalWalletTransactionId!,
+        walletId: orderSwap.canonicalWalletId!,
+      ),
+    ).thenAnswer((_) => walletTransactions.stream);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    final load = cubit.initByOrderSwapLocalId(orderSwap.localId);
+    await pumpEventQueue();
+
+    final walletTransaction = _walletTx(
+      txId: orderSwap.canonicalWalletTransactionId!,
+      walletId: orderSwap.canonicalWalletId!,
+      network: Network.liquidMainnet,
+      direction: WalletTransactionDirection.incoming,
+    );
+    walletTransactions.add(walletTransaction);
+    await pumpEventQueue();
+    walletTransactionLookup.complete(
+      Ok(
+        _walletTx(
+          txId: orderSwap.canonicalWalletTransactionId!,
+          walletId: orderSwap.canonicalWalletId!,
+          network: Network.liquidMainnet,
+          direction: WalletTransactionDirection.incoming,
+          amountSat: 1,
+        ),
+      ),
+    );
+    await load;
+
+    expect(cubit.state.walletTransaction, walletTransaction);
+    expect(cubit.state.transaction?.orderSwap, orderSwap);
+  });
+
+  test('watches a replacement canonical wallet transaction', () async {
+    final initial = _receiveOrderSwap();
+    final orderUpdates = StreamController<OrderSwapRecord>.broadcast();
+    final replacementTransactions =
+        StreamController<WalletTransaction>.broadcast();
+    addTearDown(orderUpdates.close);
+    addTearDown(replacementTransactions.close);
+    when(
+      () => getTransactionOrderSwap.execute(initial.localId),
+    ).thenAnswer((_) async => initial);
+    when(
+      () => watchTransactionOrderSwap.execute(initial.localId),
+    ).thenAnswer((_) => orderUpdates.stream);
+    when(
+      () => watchWalletTransactionByTxId.execute(
+        txId: 'replacement-txid',
+        walletId: initial.canonicalWalletId!,
+      ),
+    ).thenAnswer((_) => replacementTransactions.stream);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(initial.localId);
+    final updated = _copyOrderSwap(
+      initial,
+      localStatus: OrderSwapLocalStatus.completed,
+      order: _copyOrderSwapOrder(
+        initial.order!,
+        liquidTransactionId: 'replacement-txid',
+      ),
+    );
+    orderUpdates.add(updated);
+    await pumpEventQueue();
+
+    final replacement = _walletTx(
+      txId: 'replacement-txid',
+      walletId: initial.canonicalWalletId!,
+      network: Network.liquidMainnet,
+      direction: WalletTransactionDirection.incoming,
+    );
+    replacementTransactions.add(replacement);
+    await pumpEventQueue();
+
+    expect(cubit.state.walletTransaction, replacement);
+    expect(cubit.state.transaction?.orderSwap, updated);
+  });
+
+  test('recovers a failed initial load from an order update', () async {
+    final orderSwap = _receiveOrderSwap();
+    final updates = StreamController<OrderSwapRecord>.broadcast();
+    addTearDown(updates.close);
+    var attempts = 0;
+    when(() => getTransactionOrderSwap.execute(orderSwap.localId)).thenAnswer((
+      _,
+    ) async {
+      if (attempts++ == 0) throw TransactionNotFoundError();
+      return orderSwap;
+    });
+    when(
+      () => watchTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) => updates.stream);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(orderSwap.localId);
+    expect(cubit.state.transaction, isNull);
+
+    updates.add(orderSwap);
+    await pumpEventQueue();
+
+    expect(cubit.state.transaction?.orderSwap, orderSwap);
+    expect(cubit.state.err, isNull);
+    expect(cubit.state.notFoundError, isNull);
+  });
+
+  test('retries the wallet transaction watcher after a stream error', () async {
+    final orderSwap = _receiveOrderSwap();
+    final orderUpdates = StreamController<OrderSwapRecord>.broadcast();
+    final firstWatcher = StreamController<WalletTransaction>.broadcast();
+    addTearDown(orderUpdates.close);
+    addTearDown(firstWatcher.close);
+    when(
+      () => getTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) async => orderSwap);
+    when(
+      () => watchTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) => orderUpdates.stream);
+    var watcherCalls = 0;
+    when(
+      () => watchWalletTransactionByTxId.execute(
+        txId: orderSwap.canonicalWalletTransactionId!,
+        walletId: orderSwap.canonicalWalletId!,
+      ),
+    ).thenAnswer((_) {
+      watcherCalls++;
+      return watcherCalls == 1 ? firstWatcher.stream : const Stream.empty();
+    });
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(orderSwap.localId);
+    firstWatcher.addError(StateError('watch failed'));
+    await pumpEventQueue();
+
+    orderUpdates.add(orderSwap);
+    await pumpEventQueue();
+
+    expect(watcherCalls, 2);
+  });
+
+  test('reports the underlying error from parallel wallet loading', () async {
+    final orderSwap = _receiveOrderSwap();
+    final failure = StateError('wallet unavailable');
+    when(
+      () => getTransactionOrderSwap.execute(orderSwap.localId),
+    ).thenAnswer((_) async => orderSwap);
+    when(
+      () => getWallet.execute(orderSwap.canonicalWalletId!, sync: false),
+    ).thenThrow(failure);
+
+    final cubit = buildCubit();
+    addTearDown(cubit.close);
+    await cubit.initByOrderSwapLocalId(orderSwap.localId);
+
+    expect(cubit.state.err, same(failure));
+  });
 
   group('TransactionDetailsCubit.broadcastPayjoinOriginalTx guard', () {
     test(

--- a/test/features/transactions/presentation/blocs/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details_cubit_test.dart
@@ -2,10 +2,13 @@ import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/get_swap_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/features/swap/public/swap_facade.dart';
 import 'package:bb_mobile/features/transactions/application/usecases/get_transaction_order_swap_usecase.dart';
@@ -62,6 +65,7 @@ void main() {
     () async {
       final getWallet = _MockGetWalletUsecase();
       final getTransactions = _MockGetTransactionsByTxIdUsecase();
+      final getWalletTransaction = _MockGetWalletTransactionUsecase();
       final getOrderSwap = _MockGetTransactionOrderSwapUsecase();
       final watchOrderSwap = _MockWatchTransactionOrderSwapUsecase();
       final record = _record();
@@ -78,12 +82,19 @@ void main() {
         () => getWallet.execute('wallet-2'),
       ).thenAnswer((_) async => _wallet('wallet-2', Network.bitcoinTestnet));
       when(
-        () => getTransactions.execute('payin-tx'),
-      ).thenAnswer((_) async => [Transaction(orderSwap: record)]);
+        () => getWalletTransaction.execute(
+          txId: 'payin-tx',
+          walletId: 'wallet-1',
+          sync: false,
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const Ok<WalletTransaction?, WalletTransactionLookupFailure>(null),
+      );
       final cubit = TransactionDetailsCubit(
         getWalletUsecase: getWallet,
         getTransactionsByTxIdUsecase: getTransactions,
-        getWalletTransactionUsecase: _MockGetWalletTransactionUsecase(),
+        getWalletTransactionUsecase: getWalletTransaction,
         getTransactionOrderSwapUsecase: getOrderSwap,
         watchWalletTransactionByTxIdUsecase:
             _MockWatchWalletTransactionByTxIdUsecase(),

--- a/test/features/transactions/presentation/blocs/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details_cubit_test.dart
@@ -18,7 +18,6 @@ import 'package:bb_mobile/features/transactions/application/usecases/get_payjoin
 import 'package:bb_mobile/features/transactions/application/usecases/get_payjoin_by_tx_id_usecase.dart';
 import 'package:bb_mobile/features/transactions/application/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/features/transactions/application/usecases/watch_transaction_order_swap_usecase.dart';
-import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
 import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -68,6 +67,7 @@ void main() {
       final getWalletTransaction = _MockGetWalletTransactionUsecase();
       final getOrderSwap = _MockGetTransactionOrderSwapUsecase();
       final watchOrderSwap = _MockWatchTransactionOrderSwapUsecase();
+      final watchWalletTransaction = _MockWatchWalletTransactionByTxIdUsecase();
       final record = _record();
       when(
         () => getOrderSwap.execute('local-1'),
@@ -91,13 +91,18 @@ void main() {
         (_) async =>
             const Ok<WalletTransaction?, WalletTransactionLookupFailure>(null),
       );
+      when(
+        () => watchWalletTransaction.execute(
+          txId: 'payin-tx',
+          walletId: 'wallet-1',
+        ),
+      ).thenAnswer((_) => const Stream.empty());
       final cubit = TransactionDetailsCubit(
         getWalletUsecase: getWallet,
         getTransactionsByTxIdUsecase: getTransactions,
         getWalletTransactionUsecase: getWalletTransaction,
         getTransactionOrderSwapUsecase: getOrderSwap,
-        watchWalletTransactionByTxIdUsecase:
-            _MockWatchWalletTransactionByTxIdUsecase(),
+        watchWalletTransactionByTxIdUsecase: watchWalletTransaction,
         getSwapUsecase: _MockGetSwapUsecase(),
         getPayjoinByIdUsecase: _MockGetPayjoinByIdUsecase(),
         getPayjoinByTxIdUsecase: _MockGetPayjoinByTxIdUsecase(),


### PR DESCRIPTION
Speeds up transfer progress and transaction details by running wallet sync in the background and loading wallet information in parallel.

https://github.com/user-attachments/assets/c40f434c-0a83-41ed-9110-e02211431528

