### PR TITLE
fix(ios): record cocoapods 1.17.0 podspec checksums in Podfile.lock

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -36,11 +36,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_legacy: 2b1517bd98433d760370884d3e2cc3ed8eeb2538
-  rust_lib_bull_sdk: 160980033dfde220ad447a6dffa22d4269f8ea6c
-  tor: 767208930250ef7be241963b75568c55c0a81890
-  universal_ble: 45519b2aeafe62761e2c6309f8927edb5288b914
-  webview_cookie_manager: d63a76cabdf42a7ea3d92768ac67d4853a1367f8
+  flutter_secure_storage_legacy: a315f1c83d88e9490f44a269454281a2c9b2c160
+  rust_lib_bull_sdk: 6bdd9a2254b376e910a31340e03bf2db56c637db
+  tor: 662a9f5b980b5c86decb8ba611de9bcd4c8286eb
+  universal_ble: 65e1257dffc557cc7991a93d253beeddc7c1dc92
+  webview_cookie_manager: eaf920722b493bd0f7611b5484771ca53fed03f7
 
 PODFILE CHECKSUM: b9aa080c2a42d4d61d216015adddd3850778d844
 


### PR DESCRIPTION
The "Upload App Store Connect" workflow fails at `pod install --deployment` with lockfile checksum changes for the 5 CocoaPods plugins (flutter_secure_storage_legacy, rust_lib_bull_sdk, tor, universal_ble, webview_cookie_manager).

## Root cause

fba70b006 hand-edited the `COCOAPODS:` line in `ios/Podfile.lock` from 1.16.2 to 1.17.0 without regenerating the lockfile. The workflow pins CocoaPods to the version recorded in the lockfile, so CI now runs 1.17.0 — whose podspec JSON serialization differs from 1.16.2 (the exact behaviour the pin was added for in 84e478f73). The committed SPEC CHECKSUMS were still the 1.16.2 values, so `--deployment` correctly rejected them.

The plugin sources themselves are unchanged: all five are pinned by ref/version in pubspec.lock and their podspec files are identical; only the checksum serialization changed.

## Fix

Record the checksums CocoaPods 1.17.0 actually computes, as reported by the failed run (run #4, "New Lockfile" values). No other lockfile drift was reported (Flutter pod, PODFILE CHECKSUM, and the dependency graph all matched).