### PR TITLE
fix(ios): drop the android-only default flavor when building the ipa

### DIFF
--- a/makefile
+++ b/makefile
@@ -102,7 +102,18 @@ ios-release:
 	@if [ "$$(uname)" != "Darwin" ]; then echo "iOS releases require macOS"; exit 1; fi
 	@case "$(BUILD_NUMBER)" in ''|*[!0-9]*|0) echo "BUILD_NUMBER must be a positive integer"; exit 1;; esac
 	@echo "Building App Store IPA (build $(BUILD_NUMBER))"
-	@fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)")
+# pubspec's `default-flavor: production` exists for the Android product flavors,
+# but Flutter applies it to every platform: with no --flavor on the command line
+# it still resolves one, then looks for a matching Xcode scheme. iOS ships a
+# single unflavored Runner scheme, so the build aborts with a misleading "You
+# must specify a --flavor option". Drop the key for the duration of the build and
+# restore it whatever happens. The only visible effect is `appFlavor` being null
+# instead of 'production', which the app reads in exactly one place, to draw the
+# beta banner (lib/main.dart).
+	@backup="$$(mktemp)"; cp pubspec.yaml "$$backup" \
+	  && trap 'cp "$$backup" pubspec.yaml; rm -f "$$backup"' EXIT INT TERM \
+	  && grep -v '^[[:space:]]*default-flavor:' "$$backup" > pubspec.yaml \
+	  && fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)")
 
 # Container runtime — default podman, override with CONTAINER=docker for
 # environments without podman.


### PR DESCRIPTION
pubspec sets default-flavor: production for the Android product flavors, but Flutter resolves it on every platform (flutter_command.dart: cliFlavor ?? defaultFlavor). flutter build ipa therefore looked for a Production scheme, which the iOS project does not define — it has a single Runner scheme and only Debug/Release/Profile configurations — and aborted with the misleading 'You must specify a --flavor option to select one of the available schemes', listing the virtual SwiftPM package schemes as if they were flavors.

Strip the key for the duration of the build and restore it on any exit path, so local iOS builds stop needing the manual edit. appFlavor becomes null instead of 'production'; the app reads it only to draw the beta banner, so production behaviour is unchanged.

Broken by 50baefdaa, which added the key; the iOS release workflow never reached this step before today.