### PR TITLE
fix(ios): stabilize App Store Connect release uploads

### DIFF
--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -146,10 +146,21 @@ jobs:
           rustup component add --toolchain "$BDK_RUST_VERSION" clippy rustfmt
           rustup target add --toolchain "$BDK_RUST_VERSION" aarch64-apple-ios
 
-          # Cargokit requests `rustup run stable` directly, which otherwise
-          # bypasses RUSTUP_TOOLCHAIN and floats every six weeks. bdk_dart's
-          # explicit 1.85.1 request passes through unchanged. The wrapper
-          # rewrites any bare `stable` argument, wherever it sits in argv.
+          # The wrapper does two things.
+          #
+          # 1. Cargokit requests `rustup run stable` directly, which otherwise
+          #    bypasses RUSTUP_TOOLCHAIN and floats every six weeks. bdk_dart's
+          #    explicit 1.85.1 request passes through unchanged. Any bare
+          #    `stable` argument is rewritten, wherever it sits in argv.
+          #
+          # 2. Concurrent rustup invocations corrupt each other's component
+          #    downloads (rust-lang/rustup#3690, #4910). The Xcode archive
+          #    builds several Rust crates at once, and the archive failed on
+          #    both symptoms: a half-renamed download, then a component
+          #    conflict. Serialize every invocation behind a mutex. `mkdir` is
+          #    atomic on HFS+/APFS and needs no extra tooling — macOS has no
+          #    flock(1). The lock is bounded so a crashed holder cannot wedge
+          #    the build, and released on every exit path.
           rustup_path="$(command -v rustup)"
           mv "$rustup_path" "$rustup_path.real"
           cat > "$rustup_path" <<EOF
@@ -159,7 +170,21 @@ jobs:
             [ "\$arg" = "stable" ] && arg="$RUST_VERSION"
             args+=("\$arg")
           done
-          exec "\$(dirname "\$0")/rustup.real" "\${args[@]}"
+
+          lock="\${RUSTUP_HOME:-\$HOME/.rustup}/.serialize.lock"
+          mkdir -p "\$(dirname "\$lock")"
+          waited=0
+          until mkdir "\$lock" 2>/dev/null; do
+            if [ "\$waited" -ge 900 ]; then
+              echo "rustup: stale lock at \$lock after \${waited}s, taking it" >&2
+              break
+            fi
+            sleep 1
+            waited=\$((waited + 1))
+          done
+          trap 'rmdir "\$lock" 2>/dev/null' EXIT INT TERM
+
+          "\$(dirname "\$0")/rustup.real" "\${args[@]}"
           EOF
           chmod +x "$rustup_path"
 

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -436,11 +436,6 @@ jobs:
           api-private-key: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
           backend: appstore-api
           wait-for-processing: true
-          # Same export-compliance answer previously given by hand: the app's
-          # cryptography (signatures, standard protocols) is exempt. Read back
-          # from build 204's usesNonExemptEncryption via the ASC API. Declaring
-          # it here keeps builds out of the manual "Missing Compliance" gate.
-          uses-non-exempt-encryption: 'false'
 
       - name: Remove provisioning profile
         if: always()

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -436,6 +436,11 @@ jobs:
           api-private-key: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
           backend: appstore-api
           wait-for-processing: true
+          # Same export-compliance answer previously given by hand: the app's
+          # cryptography (signatures, standard protocols) is exempt. Read back
+          # from build 204's usesNonExemptEncryption via the ASC API. Declaring
+          # it here keeps builds out of the manual "Missing Compliance" gate.
+          uses-non-exempt-encryption: 'false'
 
       - name: Remove provisioning profile
         if: always()

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -31,13 +31,6 @@ jobs:
       RUSTUP_AUTO_INSTALL: 0
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       CARGO_INCREMENTAL: 0
-      # TEMPORARY, until the Rust build is proven — see "Build signed IPA".
-      # Documented rustup knobs (rustup book, Environment variables): DEBUG
-      # logging so the component installer explains itself, and single-threaded
-      # download/IO so rustup's own internal concurrency is out of the picture.
-      RUSTUP_LOG: rustup=DEBUG
-      RUSTUP_CONCURRENT_DOWNLOADS: 1
-      RUSTUP_IO_THREADS: 1
 
     steps:
       - name: Checkout selected branch
@@ -153,21 +146,10 @@ jobs:
           rustup component add --toolchain "$BDK_RUST_VERSION" clippy rustfmt
           rustup target add --toolchain "$BDK_RUST_VERSION" aarch64-apple-ios
 
-          # The wrapper does two things.
-          #
-          # 1. Cargokit requests `rustup run stable` directly, which otherwise
-          #    bypasses RUSTUP_TOOLCHAIN and floats every six weeks. bdk_dart's
-          #    explicit 1.85.1 request passes through unchanged. Any bare
-          #    `stable` argument is rewritten, wherever it sits in argv.
-          #
-          # 2. Concurrent rustup invocations corrupt each other's component
-          #    downloads (rust-lang/rustup#3690, #4910). The Xcode archive
-          #    builds several Rust crates at once, and the archive failed on
-          #    both symptoms: a half-renamed download, then a component
-          #    conflict. Serialize every invocation behind a mutex. `mkdir` is
-          #    atomic on HFS+/APFS and needs no extra tooling — macOS has no
-          #    flock(1). The lock is bounded so a crashed holder cannot wedge
-          #    the build, and released on every exit path.
+          # Cargokit requests `rustup run stable` directly, which otherwise
+          # bypasses RUSTUP_TOOLCHAIN and floats every six weeks. bdk_dart's
+          # explicit 1.85.1 request passes through unchanged. Any bare
+          # `stable` argument is rewritten, wherever it sits in argv.
           # The image ships two rustups — /opt/homebrew/bin and ~/.cargo/bin —
           # and Xcode build phases resolve their own PATH. Wrapping only the
           # first one on this step's PATH left cargokit reaching the other:
@@ -190,21 +172,7 @@ jobs:
             [ "\$arg" = "stable" ] && arg="$RUST_VERSION"
             args+=("\$arg")
           done
-
-          lock="\${RUSTUP_HOME:-\$HOME/.rustup}/.serialize.lock"
-          mkdir -p "\$(dirname "\$lock")"
-          waited=0
-          until mkdir "\$lock" 2>/dev/null; do
-            if [ "\$waited" -ge 900 ]; then
-              echo "rustup: stale lock at \$lock after \${waited}s, taking it" >&2
-              break
-            fi
-            sleep 1
-            waited=\$((waited + 1))
-          done
-          trap 'rmdir "\$lock" 2>/dev/null' EXIT INT TERM
-
-          "\$(dirname "\$0")/rustup.real" "\${args[@]}"
+          exec "\$(dirname "\$0")/rustup.real" "\${args[@]}"
           EOF
             chmod +x "$rustup_path"
             wrapped=$((wrapped + 1))
@@ -222,21 +190,6 @@ jobs:
             "$rustup_path" run stable rustc --version | grep -F "rustc $RUST_VERSION"
           done
           rustup run "$BDK_RUST_VERSION" rustc --version | grep -F "rustc $BDK_RUST_VERSION"
-
-          # TEMPORARY. The wrapper above only covers the rustup on this step's
-          # PATH; a second copy elsewhere on the image would bypass both the
-          # pin and the mutex, which would explain why serializing changed
-          # nothing. List every candidate, and record what is already installed
-          # so a later install attempt can be told apart from a missing target.
-          echo "::group::rustup binaries on PATH"
-          type -a rustup || true
-          ls -l "$(command -v rustup)" "$(command -v rustup).real" || true
-          echo "::endgroup::"
-          echo "::group::installed toolchains and targets"
-          rustup toolchain list
-          rustup target list --installed --toolchain "$RUST_VERSION"
-          rustup target list --installed --toolchain "$BDK_RUST_VERSION"
-          echo "::endgroup::"
 
       - name: Install Flutter and generate sources
         run: |
@@ -356,18 +309,7 @@ jobs:
           echo "EXPORT_OPTIONS_PLIST=$export_options" >> "$GITHUB_ENV"
 
       - name: Build signed IPA
-        run: |
-          # TEMPORARY --verbose: Flutter surfaces only SEVERE lines from
-          # xcodebuild, so the Rust build phase's own output — including
-          # rustup's explanation of the failing component install — never
-          # reaches the log. Drop this once the archive completes.
-          set -o pipefail
-          make ios-release \
-            BUILD_NUMBER="$BUILD_NUMBER" \
-            EXPORT_OPTIONS_PLIST="$EXPORT_OPTIONS_PLIST" \
-            FLUTTER_EXTRA_ARGS=--verbose
-          echo "disk after build:"; df -h /
-          echo "rustup downloads dir:"; ls -la "$HOME/.rustup/downloads" || true
+        run: make ios-release BUILD_NUMBER="$BUILD_NUMBER" EXPORT_OPTIONS_PLIST="$EXPORT_OPTIONS_PLIST"
 
       - name: Verify signed IPA
         id: ipa
@@ -391,8 +333,14 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "${apps[0]}"
           actual_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "${apps[0]}/Info.plist")"
           actual_bundle="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${apps[0]}/Info.plist")"
-          test "$actual_build" = "$BUILD_NUMBER"
-          test "$actual_bundle" = "com.bullbitcoin.app"
+          if [ "$actual_build" != "$BUILD_NUMBER" ]; then
+            echo "::error::IPA build number is $actual_build; expected $BUILD_NUMBER."
+            exit 1
+          fi
+          if [ "$actual_bundle" != "com.bullbitcoin.app" ]; then
+            echo "::error::IPA bundle identifier is $actual_bundle; expected com.bullbitcoin.app."
+            exit 1
+          fi
 
           dsyms=(build/ios/archive/*.xcarchive/dSYMs)
           if [ "${#dsyms[@]}" -ne 1 ] || [ ! -d "${dsyms[0]}" ]; then

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -31,6 +31,13 @@ jobs:
       RUSTUP_AUTO_INSTALL: 0
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       CARGO_INCREMENTAL: 0
+      # TEMPORARY, until the Rust build is proven — see "Build signed IPA".
+      # Documented rustup knobs (rustup book, Environment variables): DEBUG
+      # logging so the component installer explains itself, and single-threaded
+      # download/IO so rustup's own internal concurrency is out of the picture.
+      RUSTUP_LOG: rustup=DEBUG
+      RUSTUP_CONCURRENT_DOWNLOADS: 1
+      RUSTUP_IO_THREADS: 1
 
     steps:
       - name: Checkout selected branch
@@ -191,6 +198,21 @@ jobs:
           rustup run stable rustc --version | grep -F "rustc $RUST_VERSION"
           rustup run "$BDK_RUST_VERSION" rustc --version | grep -F "rustc $BDK_RUST_VERSION"
 
+          # TEMPORARY. The wrapper above only covers the rustup on this step's
+          # PATH; a second copy elsewhere on the image would bypass both the
+          # pin and the mutex, which would explain why serializing changed
+          # nothing. List every candidate, and record what is already installed
+          # so a later install attempt can be told apart from a missing target.
+          echo "::group::rustup binaries on PATH"
+          type -a rustup || true
+          ls -l "$(command -v rustup)" "$(command -v rustup).real" || true
+          echo "::endgroup::"
+          echo "::group::installed toolchains and targets"
+          rustup toolchain list
+          rustup target list --installed --toolchain "$RUST_VERSION"
+          rustup target list --installed --toolchain "$BDK_RUST_VERSION"
+          echo "::endgroup::"
+
       - name: Install Flutter and generate sources
         run: |
           make fvm-check
@@ -309,7 +331,18 @@ jobs:
           echo "EXPORT_OPTIONS_PLIST=$export_options" >> "$GITHUB_ENV"
 
       - name: Build signed IPA
-        run: make ios-release BUILD_NUMBER="$BUILD_NUMBER" EXPORT_OPTIONS_PLIST="$EXPORT_OPTIONS_PLIST"
+        run: |
+          # TEMPORARY --verbose: Flutter surfaces only SEVERE lines from
+          # xcodebuild, so the Rust build phase's own output — including
+          # rustup's explanation of the failing component install — never
+          # reaches the log. Drop this once the archive completes.
+          set -o pipefail
+          make ios-release \
+            BUILD_NUMBER="$BUILD_NUMBER" \
+            EXPORT_OPTIONS_PLIST="$EXPORT_OPTIONS_PLIST" \
+            FLUTTER_EXTRA_ARGS=--verbose
+          echo "disk after build:"; df -h /
+          echo "rustup downloads dir:"; ls -la "$HOME/.rustup/downloads" || true
 
       - name: Verify signed IPA
         id: ipa

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -4,11 +4,6 @@ run-name: App Store Connect ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-    inputs:
-      build_number:
-        description: Optional CFBundleVersion override (defaults to pubspec build + workflow run number)
-        required: false
-        type: string
 
 # Never cancel an upload already in progress, and serialize build-number use.
 concurrency:
@@ -62,8 +57,6 @@ jobs:
 
       - name: Resolve release metadata
         id: metadata
-        env:
-          BUILD_NUMBER_INPUT: ${{ inputs.build_number }}
         run: |
           version_line="$(awk '/^version:/ { print $2; exit }' pubspec.yaml)"
           base_build="${version_line##*+}"
@@ -73,15 +66,7 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$BUILD_NUMBER_INPUT" ]; then
-            if ! [[ "$BUILD_NUMBER_INPUT" =~ ^[1-9][0-9]*$ ]]; then
-              echo "::error::build_number must be a positive integer."
-              exit 1
-            fi
-            build_number="$BUILD_NUMBER_INPUT"
-          else
-            build_number=$((base_build + GITHUB_RUN_NUMBER))
-          fi
+          build_number="$base_build"
 
           echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upload-app-store-connect.yml
+++ b/.github/workflows/upload-app-store-connect.yml
@@ -168,9 +168,22 @@ jobs:
           #    atomic on HFS+/APFS and needs no extra tooling — macOS has no
           #    flock(1). The lock is bounded so a crashed holder cannot wedge
           #    the build, and released on every exit path.
-          rustup_path="$(command -v rustup)"
-          mv "$rustup_path" "$rustup_path.real"
-          cat > "$rustup_path" <<EOF
+          # The image ships two rustups — /opt/homebrew/bin and ~/.cargo/bin —
+          # and Xcode build phases resolve their own PATH. Wrapping only the
+          # first one on this step's PATH left cargokit reaching the other:
+          # `stable` stayed floating (it pulled 1.97.1) and the mutex was
+          # bypassed, which is why serializing appeared to change nothing.
+          # Collect the list before touching anything, since moving a binary
+          # changes what a later lookup resolves to.
+          rustup_paths="$(type -a -p rustup | sort -u)
+          $HOME/.cargo/bin/rustup"
+          wrapped=0
+          for rustup_path in $rustup_paths; do
+            case "$rustup_path" in *.real) continue;; esac
+            [ -x "$rustup_path" ] || continue
+            [ -e "$rustup_path.real" ] && continue
+            mv "$rustup_path" "$rustup_path.real"
+            cat > "$rustup_path" <<EOF
           #!/bin/bash
           args=()
           for arg in "\$@"; do
@@ -193,9 +206,21 @@ jobs:
 
           "\$(dirname "\$0")/rustup.real" "\${args[@]}"
           EOF
-          chmod +x "$rustup_path"
+            chmod +x "$rustup_path"
+            wrapped=$((wrapped + 1))
+          done
 
-          rustup run stable rustc --version | grep -F "rustc $RUST_VERSION"
+          if [ "$wrapped" -lt 2 ]; then
+            echo "::error::Wrapped $wrapped rustup binaries, expected at least 2. The runner image layout changed; check which rustup the Xcode build phases resolve before trusting the version pin."
+            exit 1
+          fi
+
+          # Assert the pin through every wrapper, not just the one on this PATH.
+          for rustup_path in $rustup_paths; do
+            case "$rustup_path" in *.real) continue;; esac
+            [ -x "$rustup_path" ] || continue
+            "$rustup_path" run stable rustc --version | grep -F "rustc $RUST_VERSION"
+          done
           rustup run "$BDK_RUST_VERSION" rustc --version | grep -F "rustc $BDK_RUST_VERSION"
 
           # TEMPORARY. The wrapper above only covers the rustup on this step's

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -481,11 +481,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 200;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.13.0;
-				FLUTTER_BUILD_NUMBER = 200;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -494,7 +492,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.13.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -674,11 +672,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				CURRENT_PROJECT_VERSION = 200;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.13.0;
-				FLUTTER_BUILD_NUMBER = 200;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -687,7 +683,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.13.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";
@@ -705,11 +701,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				CURRENT_PROJECT_VERSION = 200;
+				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = BX99T32YGS;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 6.13.0;
-				FLUTTER_BUILD_NUMBER = 200;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = BULL;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
@@ -718,7 +712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.13.0;
+				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bullbitcoin.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = "non-global";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -16,6 +16,8 @@
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 		<key>CFBundleName</key>
 		<string>com.bullbitcoin.app</string>
 		<key>CFBundlePackageType</key>

--- a/makefile
+++ b/makefile
@@ -113,7 +113,7 @@ ios-release:
 	@backup="$$(mktemp)"; cp pubspec.yaml "$$backup" \
 	  && trap 'cp "$$backup" pubspec.yaml; rm -f "$$backup"' EXIT INT TERM \
 	  && grep -v '^[[:space:]]*default-flavor:' "$$backup" > pubspec.yaml \
-	  && fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)") $(FLUTTER_EXTRA_ARGS)
+	  && fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)")
 
 # Container runtime — default podman, override with CONTAINER=docker for
 # environments without podman.

--- a/makefile
+++ b/makefile
@@ -113,7 +113,7 @@ ios-release:
 	@backup="$$(mktemp)"; cp pubspec.yaml "$$backup" \
 	  && trap 'cp "$$backup" pubspec.yaml; rm -f "$$backup"' EXIT INT TERM \
 	  && grep -v '^[[:space:]]*default-flavor:' "$$backup" > pubspec.yaml \
-	  && fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)")
+	  && fvm flutter build ipa --release --build-number "$(BUILD_NUMBER)" $(if $(EXPORT_OPTIONS_PLIST),--export-options-plist "$(EXPORT_OPTIONS_PLIST)") $(FLUTTER_EXTRA_ARGS)
 
 # Container runtime — default podman, override with CONTAINER=docker for
 # environments without podman.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.13.0+200
+version: 6.13.0+213
 
 environment:
   sdk: "3.12.2"


### PR DESCRIPTION
The App Store Connect workflow had several independent failures that prevented a reliable iOS release:

- `default-flavor: production`, intended for Android, made Flutter look for a nonexistent iOS `Production` scheme.
- The Xcode project hardcoded build `200`, overriding Flutter's `--build-number`.
- The macOS runner provides two `rustup` binaries. Xcode reached the unwrapped one, causing Cargokit to use floating Rust `stable` 1.97.1 and race while installing the iOS target.
- The Developer API key can upload builds but cannot PATCH encryption compliance metadata after processing.
- Adding `GITHUB_RUN_NUMBER` to the pubspec build number caused Android and iOS build numbers to diverge.

## Changes

- Build iOS without the Android-only default flavor.
- Let Flutter's generated Xcode configuration control the app version and build number.
- Wrap and verify both `rustup` binaries so Cargokit consistently resolves `stable` to pinned Rust 1.95.0.
- Declare `ITSAppUsesNonExemptEncryption=false` in the app's `Info.plist` instead of performing a forbidden post-upload API PATCH.
- Make `pubspec.yaml` the single build-number source for Android and iOS.
- Set the next shared version to `6.13.0+213`.
- Remove temporary diagnostics and improve IPA validation errors.

## Verification

Workflow run 31705924556 proved the release path through Apple processing:

- Built and exported the signed IPA.
- Verified the IPA signature, bundle identifier, and build number.
- Preserved the IPA and dSYM artifacts.
- Uploaded build 212 to App Store Connect.
- Apple processed build 212 as `VALID`.

The run was marked failed only because the action attempted the now-removed encryption metadata PATCH after the successful upload.

Additional checks:

- The Developer API key authenticates and can access `com.bullbitcoin.app`.
- App Store Connect confirms builds 200 through 204 and 212 are already used.
- Build 204 reports `usesNonExemptEncryption=false`.
- Final workflow YAML, `Info.plist`, and Make targets parse successfully.

The next release will use build 213 on both platforms.