### PR TITLE
fix(wallet): make every wallet card reachable on home

### DIFF
--- a/lib/core/widgets/bb_pullable_body.dart
+++ b/lib/core/widgets/bb_pullable_body.dart
@@ -24,6 +24,7 @@ class BBPullableBody extends StatelessWidget {
     required this.onRefresh,
     required this.slivers,
     this.bottomChild,
+    this.bottomInset = 0,
   });
 
   /// Forwarded to the inner [BBRefreshIndicator]. Use a
@@ -32,6 +33,9 @@ class BBPullableBody extends StatelessWidget {
   final RefreshCallback onRefresh;
   final List<Widget> slivers;
   final Widget? bottomChild;
+
+  /// Space reserved at the end of the scroll content.
+  final double bottomInset;
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +46,8 @@ class BBPullableBody extends StatelessWidget {
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
           ...slivers,
+          if (bottomInset > 0)
+            SliverToBoxAdapter(child: SizedBox(height: bottomInset)),
           SliverFillRemaining(
             hasScrollBody: false,
             child: bottomChild == null

--- a/lib/features/wallet/ui/screens/wallet_home_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_home_screen.dart
@@ -20,6 +20,9 @@ class WalletHomeScreen extends StatefulWidget {
 }
 
 class _WalletHomeScreenState extends State<WalletHomeScreen> {
+  /// Height the pinned Receive/Send bar occupies
+  static const double _bottomBarHeight = 52.0 + 16.0 * 2;
+
   final GlobalKey<RefreshIndicatorState> _indicatorKey =
       GlobalKey<RefreshIndicatorState>();
 
@@ -116,8 +119,15 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
             BBPullableBody(
               indicatorKey: _indicatorKey,
               onRefresh: () => context.read<WalletBloc>().refresh(),
+              // Clearance for the bar pinned at the bottom of this Stack, so
+              // the last wallet card can be scrolled out from under it.
+              bottomInset:
+                  _bottomBarHeight + MediaQuery.paddingOf(context).bottom,
               slivers: [
-                const SliverToBoxAdapter(child: WalletHomeTopSection()),
+                // Pinned rather than scrolled away: the balance and the
+                // Buy/Sell/Pay/Transfer actions stay put while the wallet cards
+                // scroll underneath.
+                const PinnedHeaderSliver(child: WalletHomeTopSection()),
                 const SliverToBoxAdapter(child: AnnouncementCarousel()),
                 const SliverToBoxAdapter(child: HomeWarnings()),
                 const SliverToBoxAdapter(child: HomeConsolidationBanner()),

--- a/lib/features/wallet/ui/widgets/wallet_cards.dart
+++ b/lib/features/wallet/ui/widgets/wallet_cards.dart
@@ -52,7 +52,8 @@ class WalletCards extends StatelessWidget {
       child: Column(
         crossAxisAlignment: .stretch,
         children: [
-          for (final w in wallets) ...[
+          for (final (index, w) in wallets.indexed) ...[
+            if (index > 0) const Gap(8),
             WalletCard(
               tagColor: cardDetails(context, w),
               title: w.displayLabel(context),
@@ -62,7 +63,6 @@ class WalletCards extends StatelessWidget {
               fiatCurrency: fiatCurrency,
               onTap: () => onTap?.call(w),
             ),
-            const Gap(8),
           ],
         ],
       ),

--- a/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
+++ b/lib/features/wallet/ui/widgets/wallet_home_top_section.dart
@@ -19,22 +19,28 @@ import 'package:shimmer/shimmer.dart';
 class WalletHomeTopSection extends StatelessWidget {
   const WalletHomeTopSection({super.key});
 
+  /// Height of the dark area behind the balance (and the price chart, when it
+  /// is toggled on).
+  static const double _balanceAreaHeight = 264;
+
+  /// Distance from the top of the dark area down to the balance.
+  static const double _balanceTopSpacing = 123;
+
+  /// How far the [ActionCard] hangs below the dark area.
+  static const double _actionCardOverhang = 76;
+
+  /// Fixed height of the section.
+  static const double _height = _balanceAreaHeight + _actionCardOverhang;
+
   @override
   Widget build(BuildContext context) {
     return const SizedBox(
-      height: 264 + 78 + 46,
+      height: _height,
       child: Stack(
         children: [
           Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              SizedBox(
-                height: 264 + 78,
-                // color: Colors.red,
-                child: _UI(),
-              ),
-              // const Gap(40),
-            ],
+            children: [SizedBox(height: _balanceAreaHeight, child: _UI())],
           ),
           Positioned(
             bottom: 0,
@@ -111,9 +117,8 @@ class _Amounts extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Column(
-      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Gap(32),
+        Gap(WalletHomeTopSection._balanceTopSpacing),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [Spacer(), _BtcTotalAmt(), Gap(16), EyeToggle(), Spacer()],

--- a/test/core_test/widgets/bb_pullable_body_test.dart
+++ b/test/core_test/widgets/bb_pullable_body_test.dart
@@ -1,0 +1,104 @@
+import 'package:bb_mobile/core/widgets/bb_pullable_body.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const lastItemKey = Key('last-item');
+  const lastItemHeight = 40.0;
+  // Comfortably taller than the 600dp test viewport, so the content overflows
+  // and the scroll extent is what decides whether the last item is reachable.
+  const contentHeight = 1200.0;
+
+  Future<void> pumpBody(
+    WidgetTester tester, {
+    required double bottomInset,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BBPullableBody(
+            onRefresh: () async {},
+            bottomInset: bottomInset,
+            slivers: const [
+              SliverToBoxAdapter(
+                child: SizedBox(height: contentHeight - lastItemHeight),
+              ),
+              SliverToBoxAdapter(
+                child: SizedBox(key: lastItemKey, height: lastItemHeight),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Distance from the bottom of the last item to the bottom of the viewport,
+  /// once scrolled as far as the body allows. Zero means the item is flush with
+  /// the viewport edge — where a pinned footer would cover it.
+  Future<double> clearanceAtEndOfScroll(WidgetTester tester) async {
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -2000));
+    await tester.pumpAndSettle();
+
+    final viewportBottom = tester.getRect(find.byType(CustomScrollView)).bottom;
+    final lastItemBottom = tester.getRect(find.byKey(lastItemKey)).bottom;
+
+    return viewportBottom - lastItemBottom;
+  }
+
+  testWidgets('leaves the last item flush with the viewport by default', (
+    tester,
+  ) async {
+    await pumpBody(tester, bottomInset: 0);
+
+    expect(await clearanceAtEndOfScroll(tester), moreOrLessEquals(0));
+  });
+
+  testWidgets('scrolls the last item clear of the reserved bottom inset', (
+    tester,
+  ) async {
+    await pumpBody(tester, bottomInset: 84);
+
+    // Without the reservation this is 0 and a footer pinned over the body hides
+    // the last item for good — the wallet home regression this guards against.
+    expect(await clearanceAtEndOfScroll(tester), moreOrLessEquals(84));
+  });
+
+  testWidgets('adds the bottom inset to the scrollable extent', (tester) async {
+    await pumpBody(tester, bottomInset: 84);
+    final withInset = tester
+        .state<ScrollableState>(find.byType(Scrollable))
+        .position
+        .maxScrollExtent;
+
+    await pumpBody(tester, bottomInset: 0);
+    final withoutInset = tester
+        .state<ScrollableState>(find.byType(Scrollable))
+        .position
+        .maxScrollExtent;
+
+    expect(withInset - withoutInset, moreOrLessEquals(84));
+  });
+
+  testWidgets('keeps short content unscrollable when an inset is reserved', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BBPullableBody(
+            onRefresh: () async {},
+            bottomInset: 84,
+            slivers: const [SliverToBoxAdapter(child: SizedBox(height: 100))],
+          ),
+        ),
+      ),
+    );
+
+    final position = tester
+        .state<ScrollableState>(find.byType(Scrollable))
+        .position;
+
+    expect(position.maxScrollExtent, 0);
+  });
+}


### PR DESCRIPTION
The last wallet card was hidden behind the `Receive`/`Send` buttons and couldn't be scrolled into view. The list now reserves space for them.

https://github.com/user-attachments/assets/31a24b83-5c4b-4034-9a64-567eee885845

