### PR TITLE
feat(settings): add Screen Privacy toggle

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,6 +28,25 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+# The `onion` (embedded Tor) plugin depends on IPtProxy, which ships only as a
+# static `.xcframework` and is force-loaded by onion's own podspec. We must keep
+# `use_frameworks!` (dynamic) so the flutter_rust_bridge plugins
+# (rust_lib_bull_sdk, onion, …) expose loadable `.framework`s at runtime — but
+# CocoaPods then aborts with "transitive dependencies that include statically
+# linked binaries (IPtProxy)". That guard is a false positive here because onion
+# links the static IPtProxy binary itself, so we disable just that check.
+#
+# Caveat: this suppresses the check for ALL pods, not just IPtProxy — a future
+# dependency with a genuine static-transitive problem (duplicate symbols /
+# duplicated global state across dynamic frameworks) would no longer be caught
+# here. Re-scope to IPtProxy if CocoaPods ever makes per-pod suppression clean.
+pre_install do |installer|
+  Pod::Installer::Xcode::TargetValidator.send(
+    :define_method,
+    :verify_no_static_framework_transitive_dependencies,
+  ) {}
+end
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
@@ -41,6 +60,19 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    # IPtProxy (Snowflake) is a Go static library force-loaded by the `onion`
+    # framework. Go's Darwin runtime references the BSD resolver symbols
+    # (res_9_ninit / res_9_nclose / res_9_nsearch) which live in libresolv, but
+    # nothing links it — the app fails at link time with those undefined
+    # symbols. Link libresolv into the targets that pull in IPtProxy.
+    if ['onion', 'IPtProxy'].include?(target.name)
+      target.build_configurations.each do |config|
+        ldflags = Array(config.build_settings['OTHER_LDFLAGS'] || ['$(inherited)'])
+        ldflags << '-lresolv' unless ldflags.include?('-lresolv')
+        config.build_settings['OTHER_LDFLAGS'] = ldflags
+      end
+    end
 
     target.build_configurations.each do |config|
           xcconfig_path = config.base_configuration_reference.real_path

--- a/lib/core/mixins/privacy_screen.dart
+++ b/lib/core/mixins/privacy_screen.dart
@@ -1,9 +1,22 @@
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
 
+/// Adds screen-capture protection to a screen for as long as it is mounted.
+///
+/// Call [enableScreenPrivacy] once when the screen appears (in `initState` or a
+/// stored future) and [disableScreenPrivacy] once when it goes away (in
+/// `dispose`).
 mixin PrivacyScreen {
-  Future<void> enableScreenPrivacy() async =>
-      await NoScreenshot.instance.screenshotOff();
+  bool _privacyAcquired = false;
 
-  Future<void> disableScreenPrivacy() async =>
-      await NoScreenshot.instance.screenshotOn();
+  Future<void> enableScreenPrivacy() async {
+    if (_privacyAcquired) return;
+    _privacyAcquired = true;
+    await ScreenCaptureProtection.instance.acquire();
+  }
+
+  Future<void> disableScreenPrivacy() async {
+    if (!_privacyAcquired) return;
+    _privacyAcquired = false;
+    await ScreenCaptureProtection.instance.release();
+  }
 }

--- a/lib/core/settings/data/settings_datasource.dart
+++ b/lib/core/settings/data/settings_datasource.dart
@@ -101,6 +101,13 @@ class SettingsDatasource {
     );
   }
 
+  Future<void> setScreenCaptureProtectionEnabled(bool enabled) async {
+    await _sqlite.managers.settings.update(
+      (f) =>
+          f(id: const Value(1), screenCaptureProtectionEnabled: Value(enabled)),
+    );
+  }
+
   Future<void> setExchangeTestnetBasicAuth({
     String? username,
     String? password,

--- a/lib/core/settings/data/settings_model.dart
+++ b/lib/core/settings/data/settings_model.dart
@@ -17,6 +17,7 @@ class SettingsModel {
   final TorTransport? lastSuccessfulTorTransport;
   final AppThemeMode themeMode;
   final bool isErrorReportingEnabled;
+  final bool screenCaptureProtectionEnabled;
   final String? exchangeTestnetBasicAuthUsername;
   final String? exchangeTestnetBasicAuthPassword;
 
@@ -35,6 +36,7 @@ class SettingsModel {
     this.lastSuccessfulTorTransport,
     required this.themeMode,
     required this.isErrorReportingEnabled,
+    required this.screenCaptureProtectionEnabled,
     this.exchangeTestnetBasicAuthUsername,
     this.exchangeTestnetBasicAuthPassword,
   });
@@ -55,6 +57,7 @@ class SettingsModel {
       lastSuccessfulTorTransport: lastSuccessfulTorTransport?.name,
       themeMode: themeMode.name,
       isErrorReportingEnabled: isErrorReportingEnabled,
+      screenCaptureProtectionEnabled: screenCaptureProtectionEnabled,
       exchangeTestnetBasicAuthUsername: exchangeTestnetBasicAuthUsername,
       exchangeTestnetBasicAuthPassword: exchangeTestnetBasicAuthPassword,
     );
@@ -83,6 +86,7 @@ class SettingsModel {
       },
       themeMode: AppThemeMode.fromName(row.themeMode),
       isErrorReportingEnabled: row.isErrorReportingEnabled,
+      screenCaptureProtectionEnabled: row.screenCaptureProtectionEnabled,
       exchangeTestnetBasicAuthUsername: row.exchangeTestnetBasicAuthUsername,
       exchangeTestnetBasicAuthPassword: row.exchangeTestnetBasicAuthPassword,
     );

--- a/lib/core/settings/data/settings_repository.dart
+++ b/lib/core/settings/data/settings_repository.dart
@@ -39,6 +39,7 @@ class SettingsRepository implements domain.SettingsRepository {
     TorTransport? lastSuccessfulTorTransport,
     AppThemeMode themeMode = AppThemeMode.system,
     bool isErrorReportingEnabled = false,
+    bool screenCaptureProtectionEnabled = true,
     String? exchangeTestnetBasicAuthUsername,
     String? exchangeTestnetBasicAuthPassword,
   }) async {
@@ -58,6 +59,7 @@ class SettingsRepository implements domain.SettingsRepository {
         lastSuccessfulTorTransport: lastSuccessfulTorTransport,
         themeMode: themeMode,
         isErrorReportingEnabled: isErrorReportingEnabled,
+        screenCaptureProtectionEnabled: screenCaptureProtectionEnabled,
         exchangeTestnetBasicAuthUsername: exchangeTestnetBasicAuthUsername,
         exchangeTestnetBasicAuthPassword: exchangeTestnetBasicAuthPassword,
       ),
@@ -82,6 +84,7 @@ class SettingsRepository implements domain.SettingsRepository {
       lastSuccessfulTorTransport: s.lastSuccessfulTorTransport,
       themeMode: s.themeMode,
       isErrorReportingEnabled: s.isErrorReportingEnabled,
+      screenCaptureProtectionEnabled: s.screenCaptureProtectionEnabled,
       exchangeTestnetBasicAuthUsername: s.exchangeTestnetBasicAuthUsername,
       exchangeTestnetBasicAuthPassword: s.exchangeTestnetBasicAuthPassword,
     );
@@ -165,5 +168,10 @@ class SettingsRepository implements domain.SettingsRepository {
     // Sync [Report]'s boot-time mirror so the next cold start's Sentry
     // init can seed consent before the locator is available.
     await Report.updateConsent(enabled);
+  }
+
+  @override
+  Future<void> setScreenCaptureProtectionEnabled(bool enabled) async {
+    await _settingsDatasource.setScreenCaptureProtectionEnabled(enabled);
   }
 }

--- a/lib/core/settings/domain/repositories/settings_repository.dart
+++ b/lib/core/settings/domain/repositories/settings_repository.dart
@@ -23,6 +23,7 @@ abstract class SettingsRepository {
     TorTransport? lastSuccessfulTorTransport,
     AppThemeMode themeMode = AppThemeMode.system,
     bool isErrorReportingEnabled = false,
+    bool screenCaptureProtectionEnabled = true,
     String? exchangeTestnetBasicAuthUsername,
     String? exchangeTestnetBasicAuthPassword,
   });
@@ -54,6 +55,8 @@ abstract class SettingsRepository {
   Future<void> setThemeMode(AppThemeMode themeMode);
 
   Future<void> setErrorReportingEnabled(bool enabled);
+
+  Future<void> setScreenCaptureProtectionEnabled(bool enabled);
 
   Future<void> setExchangeTestnetBasicAuth({
     String? username,

--- a/lib/core/settings/domain/settings_entity.dart
+++ b/lib/core/settings/domain/settings_entity.dart
@@ -146,6 +146,7 @@ abstract class SettingsEntity with _$SettingsEntity {
     TorTransport? lastSuccessfulTorTransport,
     @Default(AppThemeMode.system) AppThemeMode themeMode,
     @Default(false) bool isErrorReportingEnabled,
+    @Default(true) bool screenCaptureProtectionEnabled,
     String? exchangeTestnetBasicAuthUsername,
     String? exchangeTestnetBasicAuthPassword,
   }) = _SettingsEntity;

--- a/lib/core/storage/database_seeds.dart
+++ b/lib/core/storage/database_seeds.dart
@@ -24,6 +24,7 @@ class DatabaseSeeds {
             torTransportMode: 'automatic',
             themeMode: 'system',
             isErrorReportingEnabled: false,
+            screenCaptureProtectionEnabled: true,
           ),
         );
   }

--- a/lib/core/storage/migrations/schema_13_to_14.dart
+++ b/lib/core/storage/migrations/schema_13_to_14.dart
@@ -10,9 +10,11 @@ import 'package:drift/drift.dart';
 ///
 /// Schema 14 also briefly carried the Payjoin policy columns on `settings` and
 /// an `is_aborted` flag on the payjoin tables. Payjoin now owns its own
-/// database (payjoin.sqlite, see the bull_payjoin package), and 14 was never
-/// released — every tag up to v6.12.5 ships schema 13 — so those columns were
-/// folded out of this step rather than added and then migrated away.
+/// database (payjoin.sqlite, see the bull_payjoin package); those columns were
+/// folded out of this step (rather than added and then migrated away) while
+/// schema 14 was still unreleased. Schema 14 itself shipped in v6.13.0 with
+/// only the dismissed_announcements and order_swaps additions — the Tor and
+/// screen-capture columns come later, in the 14→15 step.
 ///
 /// Adds the order_swaps table and indexes for crash-safe Exchange transfers.
 /// The table includes the nullable quoted_amount_sat column used to validate

--- a/lib/core/storage/migrations/schema_14_to_15.dart
+++ b/lib/core/storage/migrations/schema_14_to_15.dart
@@ -1,15 +1,47 @@
 import 'package:bb_mobile/core/storage/sqlite_database.steps.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:drift/drift.dart';
 
 /// Migration from version 14 to 15.
 ///
-/// Adds the persisted Tor transport preferences to the settings table.
+/// Adds the persisted Tor transport preferences to the settings table
+/// (`tor_transport_mode`, `last_successful_tor_transport`). Schema 14 shipped in
+/// v6.13.0 without these columns, so they belong in this new version rather than
+/// being retrofitted into the released v14.
+///
+/// The adds are guarded: an early, unreleased develop build briefly added the
+/// Tor columns in the 13→14 step, so a dev device may already have them. The
+/// guard makes the migration idempotent instead of throwing `duplicate column`.
 class Schema14To15 {
   static Future<void> migrate(Migrator m, Schema15 schema15) async {
-    await m.addColumn(schema15.settings, schema15.settings.torTransportMode);
-    await m.addColumn(
-      schema15.settings,
-      schema15.settings.lastSuccessfulTorTransport,
+    await _addColumnIfNotExists(
+      () => m.addColumn(schema15.settings, schema15.settings.torTransportMode),
+      'settings.tor_transport_mode column',
+    );
+    await _addColumnIfNotExists(
+      () => m.addColumn(
+        schema15.settings,
+        schema15.settings.lastSuccessfulTorTransport,
+      ),
+      'settings.last_successful_tor_transport column',
+    );
+  }
+}
+
+Future<void> _addColumnIfNotExists(
+  Future<void> Function() addColumn,
+  String description,
+) async {
+  try {
+    await addColumn();
+  } catch (e) {
+    // Idempotency guard: only swallow "duplicate column" (a re-run over a
+    // partially-applied migration) — log it so a driver wording change surfaces
+    // instead of silently becoming a hard failure.
+    if (!e.toString().contains('duplicate column')) rethrow;
+    log.warning(
+      'Schema14To15: $description already exists — skipping add',
+      error: e,
     );
   }
 }

--- a/lib/core/storage/migrations/schema_14_to_15.dart
+++ b/lib/core/storage/migrations/schema_14_to_15.dart
@@ -4,14 +4,13 @@ import 'package:drift/drift.dart';
 
 /// Migration from version 14 to 15.
 ///
-/// Adds the persisted Tor transport preferences to the settings table
-/// (`tor_transport_mode`, `last_successful_tor_transport`). Schema 14 shipped in
-/// v6.13.0 without these columns, so they belong in this new version rather than
-/// being retrofitted into the released v14.
-///
-/// The adds are guarded: an early, unreleased develop build briefly added the
-/// Tor columns in the 13→14 step, so a dev device may already have them. The
-/// guard makes the migration idempotent instead of throwing `duplicate column`.
+/// Adds the settings columns introduced after the v14 release (schema 14 ships
+/// in v6.13.0):
+/// - `tor_transport_mode` / `last_successful_tor_transport` — persisted Tor
+///   transport preferences.
+/// - `screen_capture_protection_enabled` — gates screenshot/recording blocking
+///   on sensitive screens (defaults to true so installs keep protection until
+///   the user opts out).
 class Schema14To15 {
   static Future<void> migrate(Migrator m, Schema15 schema15) async {
     await _addColumnIfNotExists(
@@ -24,6 +23,13 @@ class Schema14To15 {
         schema15.settings.lastSuccessfulTorTransport,
       ),
       'settings.last_successful_tor_transport column',
+    );
+    await _addColumnIfNotExists(
+      () => m.addColumn(
+        schema15.settings,
+        schema15.settings.screenCaptureProtectionEnabled,
+      ),
+      'settings.screen_capture_protection_enabled column',
     );
   }
 }

--- a/lib/core/storage/migrations/schema_14_to_15.dart
+++ b/lib/core/storage/migrations/schema_14_to_15.dart
@@ -1,5 +1,4 @@
 import 'package:bb_mobile/core/storage/sqlite_database.steps.dart';
-import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:drift/drift.dart';
 
 /// Migration from version 14 to 15.
@@ -13,41 +12,14 @@ import 'package:drift/drift.dart';
 ///   the user opts out).
 class Schema14To15 {
   static Future<void> migrate(Migrator m, Schema15 schema15) async {
-    await _addColumnIfNotExists(
-      () => m.addColumn(schema15.settings, schema15.settings.torTransportMode),
-      'settings.tor_transport_mode column',
+    await m.addColumn(schema15.settings, schema15.settings.torTransportMode);
+    await m.addColumn(
+      schema15.settings,
+      schema15.settings.lastSuccessfulTorTransport,
     );
-    await _addColumnIfNotExists(
-      () => m.addColumn(
-        schema15.settings,
-        schema15.settings.lastSuccessfulTorTransport,
-      ),
-      'settings.last_successful_tor_transport column',
-    );
-    await _addColumnIfNotExists(
-      () => m.addColumn(
-        schema15.settings,
-        schema15.settings.screenCaptureProtectionEnabled,
-      ),
-      'settings.screen_capture_protection_enabled column',
-    );
-  }
-}
-
-Future<void> _addColumnIfNotExists(
-  Future<void> Function() addColumn,
-  String description,
-) async {
-  try {
-    await addColumn();
-  } catch (e) {
-    // Idempotency guard: only swallow "duplicate column" (a re-run over a
-    // partially-applied migration) — log it so a driver wording change surfaces
-    // instead of silently becoming a hard failure.
-    if (!e.toString().contains('duplicate column')) rethrow;
-    log.warning(
-      'Schema14To15: $description already exists — skipping add',
-      error: e,
+    await m.addColumn(
+      schema15.settings,
+      schema15.settings.screenCaptureProtectionEnabled,
     );
   }
 }

--- a/lib/core/storage/schemas/bull_database/drift_schema_v15.json
+++ b/lib/core/storage/schemas/bull_database/drift_schema_v15.json
@@ -592,6 +592,20 @@
             "dsl_features": []
           },
           {
+            "name": "screen_capture_protection_enabled",
+            "getter_name": "screenCaptureProtectionEnabled",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"screen_capture_protection_enabled\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"screen_capture_protection_enabled\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('1')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
             "name": "exchange_testnet_basic_auth_username",
             "getter_name": "exchangeTestnetBasicAuthUsername",
             "moor_type": "string",
@@ -2662,7 +2676,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"settings\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"environment\" TEXT NOT NULL, \"bitcoin_unit\" TEXT NOT NULL, \"language\" TEXT NOT NULL, \"currency\" TEXT NOT NULL, \"hide_amounts\" INTEGER NOT NULL CHECK (\"hide_amounts\" IN (0, 1)), \"is_superuser\" INTEGER NOT NULL CHECK (\"is_superuser\" IN (0, 1)), \"is_dev_mode_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_dev_mode_enabled\" IN (0, 1)), \"use_tor_proxy\" INTEGER NOT NULL DEFAULT 0 CHECK (\"use_tor_proxy\" IN (0, 1)), \"tor_proxy_port\" INTEGER NOT NULL DEFAULT 9050, \"tor_transport_mode\" TEXT NOT NULL DEFAULT 'automatic', \"last_successful_tor_transport\" TEXT NULL, \"theme_mode\" TEXT NOT NULL DEFAULT 'system', \"is_error_reporting_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_error_reporting_enabled\" IN (0, 1)), \"exchange_testnet_basic_auth_username\" TEXT NULL, \"exchange_testnet_basic_auth_password\" TEXT NULL);"
+          "sql": "CREATE TABLE IF NOT EXISTS \"settings\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"environment\" TEXT NOT NULL, \"bitcoin_unit\" TEXT NOT NULL, \"language\" TEXT NOT NULL, \"currency\" TEXT NOT NULL, \"hide_amounts\" INTEGER NOT NULL CHECK (\"hide_amounts\" IN (0, 1)), \"is_superuser\" INTEGER NOT NULL CHECK (\"is_superuser\" IN (0, 1)), \"is_dev_mode_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_dev_mode_enabled\" IN (0, 1)), \"use_tor_proxy\" INTEGER NOT NULL DEFAULT 0 CHECK (\"use_tor_proxy\" IN (0, 1)), \"tor_proxy_port\" INTEGER NOT NULL DEFAULT 9050, \"tor_transport_mode\" TEXT NOT NULL DEFAULT 'automatic', \"last_successful_tor_transport\" TEXT NULL, \"theme_mode\" TEXT NOT NULL DEFAULT 'system', \"is_error_reporting_enabled\" INTEGER NOT NULL DEFAULT 0 CHECK (\"is_error_reporting_enabled\" IN (0, 1)), \"screen_capture_protection_enabled\" INTEGER NOT NULL DEFAULT 1 CHECK (\"screen_capture_protection_enabled\" IN (0, 1)), \"exchange_testnet_basic_auth_username\" TEXT NULL, \"exchange_testnet_basic_auth_password\" TEXT NULL);"
         }
       ]
     },

--- a/lib/core/storage/sqlite_database.steps.dart
+++ b/lib/core/storage/sqlite_database.steps.dart
@@ -7275,6 +7275,7 @@ final class Schema15 extends i0.VersionedSchema {
         _column_286,
         _column_157,
         _column_233,
+        _column_287,
         _column_235,
         _column_236,
       ],
@@ -7648,6 +7649,9 @@ class Shape42 extends i0.VersionedTable {
       columnsByName['theme_mode']! as i1.GeneratedColumn<String>;
   i1.GeneratedColumn<int> get isErrorReportingEnabled =>
       columnsByName['is_error_reporting_enabled']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get screenCaptureProtectionEnabled =>
+      columnsByName['screen_capture_protection_enabled']!
+          as i1.GeneratedColumn<int>;
   i1.GeneratedColumn<String> get exchangeTestnetBasicAuthUsername =>
       columnsByName['exchange_testnet_basic_auth_username']!
           as i1.GeneratedColumn<String>;
@@ -7673,6 +7677,17 @@ i1.GeneratedColumn<String> _column_286(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NULL',
     );
+i1.GeneratedColumn<int> _column_287(
+  String aliasedName,
+) => i1.GeneratedColumn<int>(
+  'screen_capture_protection_enabled',
+  aliasedName,
+  false,
+  type: i1.DriftSqlType.int,
+  $customConstraints:
+      'NOT NULL DEFAULT 1 CHECK (screen_capture_protection_enabled IN (0, 1))',
+  defaultValue: const i1.CustomExpression('1'),
+);
 i0.MigrationStepWithVersion migrationSteps({
   required Future<void> Function(i1.Migrator m, Schema2 schema) from1To2,
   required Future<void> Function(i1.Migrator m, Schema3 schema) from2To3,

--- a/lib/core/storage/tables/settings_table.dart
+++ b/lib/core/storage/tables/settings_table.dart
@@ -19,6 +19,8 @@ class Settings extends Table {
   TextColumn get themeMode => text().withDefault(const Constant('system'))();
   BoolColumn get isErrorReportingEnabled =>
       boolean().withDefault(const Constant(false))();
+  BoolColumn get screenCaptureProtectionEnabled =>
+      boolean().withDefault(const Constant(true))();
   TextColumn get exchangeTestnetBasicAuthUsername => text().nullable()();
   TextColumn get exchangeTestnetBasicAuthPassword => text().nullable()();
 

--- a/lib/core/utils/screen_capture_protection.dart
+++ b/lib/core/utils/screen_capture_protection.dart
@@ -1,0 +1,67 @@
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:no_screenshot/no_screenshot.dart';
+
+/// Controls OS-level screen-capture blocking (Android `FLAG_SECURE`, iOS secure
+/// overlay) via the `no_screenshot` plugin.
+///
+/// The flag is app-wide, not per-screen, so it must be reference counted: this
+/// counts how many protected screens are mounted and only clears the flag once
+/// the last one is gone. It also honours the user preference ([enabledByUser]).
+/// A process-wide singleton, because the flag it manages is process-wide.
+class ScreenCaptureProtection {
+  ScreenCaptureProtection._();
+
+  static final ScreenCaptureProtection instance = ScreenCaptureProtection._();
+
+  final NoScreenshot _noScreenshot = NoScreenshot.instance;
+
+  int _activeCount = 0;
+  bool _enabledByUser = true;
+
+  /// Whether the user wants sensitive screens protected from capture.
+  ///
+  /// Defaults to `true` so protection is on before settings have loaded and if
+  /// the setting is ever unavailable — a fail-safe default for key material.
+  bool get enabledByUser => _enabledByUser;
+
+  set enabledByUser(bool value) {
+    if (_enabledByUser == value) return;
+    _enabledByUser = value;
+    _sync();
+  }
+
+  /// Registers one more mounted protected screen.
+  Future<void> acquire() async {
+    _activeCount++;
+    await _sync();
+  }
+
+  /// Unregisters one previously [acquire]d protected screen.
+  Future<void> release() async {
+    if (_activeCount > 0) _activeCount--;
+    await _sync();
+  }
+
+  Future<void> _sync() async {
+    final shouldProtect = _enabledByUser && _activeCount > 0;
+    try {
+      if (shouldProtect) {
+        await _noScreenshot.screenshotOff();
+      } else {
+        await _noScreenshot.screenshotOn();
+      }
+    } catch (e, st) {
+      // Callers fire-and-forget this, so a platform-channel failure would
+      // otherwise vanish as an unhandled async error. On a secret screen a
+      // silent failure means we may be showing the mnemonic without
+      // FLAG_SECURE set, so make it loud rather than let it disappear.
+      log.severe(
+        message:
+            'ScreenCaptureProtection: failed to '
+            '${shouldProtect ? 'enable' : 'disable'} capture blocking',
+        error: e,
+        trace: st,
+      );
+    }
+  }
+}

--- a/lib/features/all_seed_view/ui/all_seed_view_screen.dart
+++ b/lib/features/all_seed_view/ui/all_seed_view_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/mixins/privacy_screen.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap_master_key_info.dart';
@@ -15,177 +17,187 @@ import 'package:bb_mobile/features/app_unlock/public/app_unlock_facade.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class AllSeedViewScreen extends StatelessWidget with PrivacyScreen {
+class AllSeedViewScreen extends StatefulWidget {
   final AppUnlockFacade appUnlockFacade;
 
   const AllSeedViewScreen({super.key, required this.appUnlockFacade});
 
   @override
+  State<AllSeedViewScreen> createState() => _AllSeedViewScreenState();
+}
+
+class _AllSeedViewScreenState extends State<AllSeedViewScreen>
+    with PrivacyScreen {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(enableScreenPrivacy());
+  }
+
+  @override
+  void dispose() {
+    unawaited(disableScreenPrivacy());
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    enableScreenPrivacy();
-    return PopScope(
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) {
-          disableScreenPrivacy();
+    return BlocListener<AllSeedViewCubit, AllSeedViewState>(
+      listenWhen: (p, c) => p.failure != c.failure,
+      listener: (context, state) {
+        if (state.failure case final failure?
+            when failure is! AllSeedViewFetchFailure) {
+          SnackBarUtils.showSnackBar(context, failure.toTranslated(context));
         }
       },
-      child: BlocListener<AllSeedViewCubit, AllSeedViewState>(
-        listenWhen: (p, c) => p.failure != c.failure,
-        listener: (context, state) {
-          if (state.failure case final failure?
-              when failure is! AllSeedViewFetchFailure) {
-            SnackBarUtils.showSnackBar(context, failure.toTranslated(context));
+      child: BlocBuilder<AllSeedViewCubit, AllSeedViewState>(
+        builder: (context, state) {
+          // Viewing raw seed phrases exposes full custody of every wallet,
+          // so it demands the same step-up re-authentication the app
+          // already requires before changing the PIN. With no PIN set the
+          // unlock screen succeeds immediately.
+          if (!state.isUnlocked) {
+            return widget.appUnlockFacade.buildReauthenticationGate(
+              canPop: true,
+              onSuccess: (grant) =>
+                  context.read<AllSeedViewCubit>().unlock(grant),
+            );
           }
-        },
-        child: BlocBuilder<AllSeedViewCubit, AllSeedViewState>(
-          builder: (context, state) {
-            // Viewing raw seed phrases exposes full custody of every wallet,
-            // so it demands the same step-up re-authentication the app
-            // already requires before changing the PIN. With no PIN set the
-            // unlock screen succeeds immediately.
-            if (!state.isUnlocked) {
-              return appUnlockFacade.buildReauthenticationGate(
-                canPop: true,
-                onSuccess: (grant) =>
-                    context.read<AllSeedViewCubit>().unlock(grant),
-              );
-            }
-            return Scaffold(
-              appBar: AppBar(
-                title: BBText(
-                  context.loc.allSeedViewTitle,
-                  style: const TextStyle(fontWeight: .bold, fontSize: 20),
-                ),
-                bottom: PreferredSize(
-                  preferredSize: const Size.fromHeight(3),
-                  child: state.loading
-                      ? FadingLinearProgress(
-                          height: 3,
-                          trigger: state.loading,
-                          backgroundColor: context.appColors.surface,
-                          foregroundColor: context.appColors.primary,
-                        )
-                      : const SizedBox(height: 3),
-                ),
+          return Scaffold(
+            appBar: AppBar(
+              title: BBText(
+                context.loc.allSeedViewTitle,
+                style: const TextStyle(fontWeight: .bold, fontSize: 20),
               ),
-              body: Builder(
-                builder: (context) {
-                  if (state.loading) {
-                    return Center(
-                      child: Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: BBText(
-                          context.loc.allSeedViewLoadingMessage,
-                          style: context.font.bodyMedium,
-                          color: context.appColors.onSurface.withValues(
-                            alpha: 0.7,
-                          ),
-                          textAlign: .center,
+              bottom: PreferredSize(
+                preferredSize: const Size.fromHeight(3),
+                child: state.loading
+                    ? FadingLinearProgress(
+                        height: 3,
+                        trigger: state.loading,
+                        backgroundColor: context.appColors.surface,
+                        foregroundColor: context.appColors.primary,
+                      )
+                    : const SizedBox(height: 3),
+              ),
+            ),
+            body: Builder(
+              builder: (context) {
+                if (state.loading) {
+                  return Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24.0),
+                      child: BBText(
+                        context.loc.allSeedViewLoadingMessage,
+                        style: context.font.bodyMedium,
+                        color: context.appColors.onSurface.withValues(
+                          alpha: 0.7,
                         ),
+                        textAlign: .center,
                       ),
-                    );
-                  }
-                  if (state.failure is AllSeedViewFetchFailure) {
-                    return Center(
-                      child: BBText(
-                        state.failure!.toTranslated(context),
-                        style: context.font.bodyLarge,
-                        color: context.appColors.error,
-                      ),
-                    );
-                  }
-                  if (state.allSeeds.isEmpty) {
-                    return Center(
-                      child: BBText(
-                        context.loc.allSeedViewNoSeedsFound,
-                        style: context.font.bodyLarge,
-                        color: context.appColors.onSurface,
-                      ),
-                    );
-                  }
-                  if (!state.seedsVisible) {
-                    return SafeArea(
-                      child: Column(
-                        children: [
-                          Expanded(
-                            child: Center(
-                              child: Icon(
-                                Icons.visibility_off,
-                                size: 120,
-                                color: context.appColors.onSurface.withValues(
-                                  alpha: 0.3,
-                                ),
+                    ),
+                  );
+                }
+                if (state.failure is AllSeedViewFetchFailure) {
+                  return Center(
+                    child: BBText(
+                      state.failure!.toTranslated(context),
+                      style: context.font.bodyLarge,
+                      color: context.appColors.error,
+                    ),
+                  );
+                }
+                if (state.allSeeds.isEmpty) {
+                  return Center(
+                    child: BBText(
+                      context.loc.allSeedViewNoSeedsFound,
+                      style: context.font.bodyLarge,
+                      color: context.appColors.onSurface,
+                    ),
+                  );
+                }
+                if (!state.seedsVisible) {
+                  return SafeArea(
+                    child: Column(
+                      children: [
+                        Expanded(
+                          child: Center(
+                            child: Icon(
+                              Icons.visibility_off,
+                              size: 120,
+                              color: context.appColors.onSurface.withValues(
+                                alpha: 0.3,
                               ),
                             ),
                           ),
-                          Padding(
-                            padding: const EdgeInsets.all(24),
-                            child: BBButton.big(
-                              label: context.loc.allSeedViewShowSeedsButton,
-                              onPressed: () => _showWarningDialog(context),
-                              bgColor: context.appColors.secondary,
-                              textColor: context.appColors.onSecondary,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-                  return ListView(
-                    padding: const EdgeInsets.all(16),
-                    children: [
-                      if (state.existingWallets.isNotEmpty) ...[
-                        BBText(
-                          context.loc.allSeedViewExistingWallets(
-                            state.existingWallets.length,
-                          ),
-                          style: context.font.headlineSmall?.copyWith(
-                            fontWeight: .bold,
-                          ),
-                          color: context.appColors.onSurface,
                         ),
-                        const SizedBox(height: 8),
-                        ...state.existingWallets.map<Widget>(
-                          (seed) =>
-                              _buildSeedCard(context, seed, isOldWallet: false),
-                        ),
-                        const SizedBox(height: 24),
-                      ],
-                      if (state.oldWallets.isNotEmpty) ...[
-                        BBText(
-                          context.loc.allSeedViewOldWallets(
-                            state.oldWallets.length,
+                        Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: BBButton.big(
+                            label: context.loc.allSeedViewShowSeedsButton,
+                            onPressed: () => _showWarningDialog(context),
+                            bgColor: context.appColors.secondary,
+                            textColor: context.appColors.onSecondary,
                           ),
-                          style: context.font.headlineSmall?.copyWith(
-                            fontWeight: .bold,
-                          ),
-                          color: context.appColors.onSurface,
-                        ),
-                        const SizedBox(height: 8),
-                        ...state.oldWallets.map<Widget>(
-                          (seed) =>
-                              _buildSeedCard(context, seed, isOldWallet: true),
                         ),
                       ],
-                      if (state.swapMasterKey != null) ...[
-                        const SizedBox(height: 24),
-                        BBText(
-                          'Swap mnemonic',
-                          style: context.font.headlineSmall?.copyWith(
-                            fontWeight: .bold,
-                          ),
-                          color: context.appColors.onSurface,
-                        ),
-                        const SizedBox(height: 8),
-                        _buildSwapKeyCard(context, state.swapMasterKey!),
-                      ],
-                    ],
+                    ),
                   );
-                },
-              ),
-            );
-          },
-        ),
+                }
+                return ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    if (state.existingWallets.isNotEmpty) ...[
+                      BBText(
+                        context.loc.allSeedViewExistingWallets(
+                          state.existingWallets.length,
+                        ),
+                        style: context.font.headlineSmall?.copyWith(
+                          fontWeight: .bold,
+                        ),
+                        color: context.appColors.onSurface,
+                      ),
+                      const SizedBox(height: 8),
+                      ...state.existingWallets.map<Widget>(
+                        (seed) =>
+                            _buildSeedCard(context, seed, isOldWallet: false),
+                      ),
+                      const SizedBox(height: 24),
+                    ],
+                    if (state.oldWallets.isNotEmpty) ...[
+                      BBText(
+                        context.loc.allSeedViewOldWallets(
+                          state.oldWallets.length,
+                        ),
+                        style: context.font.headlineSmall?.copyWith(
+                          fontWeight: .bold,
+                        ),
+                        color: context.appColors.onSurface,
+                      ),
+                      const SizedBox(height: 8),
+                      ...state.oldWallets.map<Widget>(
+                        (seed) =>
+                            _buildSeedCard(context, seed, isOldWallet: true),
+                      ),
+                    ],
+                    if (state.swapMasterKey != null) ...[
+                      const SizedBox(height: 24),
+                      BBText(
+                        'Swap mnemonic',
+                        style: context.font.headlineSmall?.copyWith(
+                          fontWeight: .bold,
+                        ),
+                        color: context.appColors.onSurface,
+                      ),
+                      const SizedBox(height: 8),
+                      _buildSwapKeyCard(context, state.swapMasterKey!),
+                    ],
+                  ],
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/all_seed_view/ui/all_seed_view_screen.dart
+++ b/lib/features/all_seed_view/ui/all_seed_view_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap_master_key_info.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';

--- a/lib/features/app_startup/ui/screens/legacy_backup_screen.dart
+++ b/lib/features/app_startup/ui/screens/legacy_backup_screen.dart
@@ -1,4 +1,4 @@
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/constants.dart';

--- a/lib/features/bip85_entropy/bip85_home_page.dart
+++ b/lib/features/bip85_entropy/bip85_home_page.dart
@@ -10,7 +10,7 @@ import 'package:bb_mobile/features/bip85_entropy/presentation/cubit.dart';
 import 'package:bb_mobile/features/bip85_entropy/presentation/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class Bip85HomePage extends StatefulWidget {

--- a/lib/features/import_mnemonic/ui/mnemonic_page.dart
+++ b/lib/features/import_mnemonic/ui/mnemonic_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/mnemonic_widget.dart';

--- a/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
@@ -22,6 +22,8 @@ class OnboardingPhysicalRecovery extends StatefulWidget {
 
 class _OnboardingPhysicalRecoveryState extends State<OnboardingPhysicalRecovery>
     with PrivacyScreen {
+  late final Future<void> _privacyFuture = enableScreenPrivacy();
+
   @override
   void dispose() {
     unawaited(disableScreenPrivacy());
@@ -31,7 +33,7 @@ class _OnboardingPhysicalRecoveryState extends State<OnboardingPhysicalRecovery>
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: enableScreenPrivacy(),
+      future: _privacyFuture,
       builder: (context, snapshot) {
         return BlocListener<OnboardingBloc, OnboardingState>(
           listenWhen: (previous, current) =>

--- a/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_physical_recovery.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
 import 'package:bb_mobile/core/widgets/mnemonic_widget.dart';

--- a/lib/features/settings/domain/usecases/set_screen_capture_protection_usecase.dart
+++ b/lib/features/settings/domain/usecases/set_screen_capture_protection_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+
+class SetScreenCaptureProtectionUsecase {
+  final SettingsRepository _settingsRepository;
+
+  SetScreenCaptureProtectionUsecase({required this._settingsRepository});
+
+  Future<void> execute(bool enabled) async {
+    await _settingsRepository.setScreenCaptureProtectionEnabled(enabled);
+  }
+}

--- a/lib/features/settings/presentation/bloc/settings_cubit.dart
+++ b/lib/features/settings/presentation/bloc/settings_cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_bitcoin_unit_usecase.dart';

--- a/lib/features/settings/presentation/bloc/settings_cubit.dart
+++ b/lib/features/settings/presentation/bloc/settings_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_bitcoin_unit_usecase.dart';
@@ -17,6 +18,7 @@ import 'package:bb_mobile/features/settings/domain/usecases/set_language_usecase
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_enabled_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_expire_after_sec_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_min_amount_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/set_screen_capture_protection_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_theme_mode_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/watch_payjoin_policy_usecase.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -40,6 +42,7 @@ class SettingsCubit extends Cubit<SettingsState> {
     required this._setIsDevModeUsecase,
     required this._setThemeModeUsecase,
     required this._setErrorReportingUsecase,
+    required this._setScreenCaptureProtectionUsecase,
     required this._setExchangeTestnetBasicAuthUsecase,
     required this._setPayjoinEnabledUsecase,
     required this._watchPayjoinPolicyUsecase,
@@ -64,6 +67,7 @@ class SettingsCubit extends Cubit<SettingsState> {
   final SetThemeModeUsecase _setThemeModeUsecase;
   final SetIsDevModeUsecase _setIsDevModeUsecase;
   final SetErrorReportingUsecase _setErrorReportingUsecase;
+  final SetScreenCaptureProtectionUsecase _setScreenCaptureProtectionUsecase;
   final SetExchangeTestnetBasicAuthUsecase _setExchangeTestnetBasicAuthUsecase;
   final SetPayjoinEnabledUsecase _setPayjoinEnabledUsecase;
   final WatchPayjoinPolicyUsecase _watchPayjoinPolicyUsecase;
@@ -83,6 +87,11 @@ class SettingsCubit extends Cubit<SettingsState> {
       PackageInfo.fromPlatform(),
     ).wait;
     final appVersion = '${appInfo.version}+${appInfo.buildNumber}';
+
+    // Mirror the persisted preference into the process-wide capture controller
+    // so protected screens honour the user's choice from the first frame.
+    ScreenCaptureProtection.instance.enabledByUser =
+        storedSettings.screenCaptureProtectionEnabled;
 
     emit(
       state.copyWith(storedSettings: storedSettings, appVersion: appVersion),
@@ -207,6 +216,25 @@ class SettingsCubit extends Cubit<SettingsState> {
     emit(
       state.copyWith(
         storedSettings: settings?.copyWith(isErrorReportingEnabled: enabled),
+      ),
+    );
+  }
+
+  Future<void> toggleScreenCaptureProtection(bool enabled) async {
+    final settings = state.storedSettings;
+    log.config(
+      'Screen capture protection toggled: $enabled was '
+      '${settings?.screenCaptureProtectionEnabled}',
+    );
+    await _setScreenCaptureProtectionUsecase.execute(enabled);
+    // Apply immediately: this flips FLAG_SECURE on any protected screen that
+    // is currently mounted, and clears it if the user just opted out.
+    ScreenCaptureProtection.instance.enabledByUser = enabled;
+    emit(
+      state.copyWith(
+        storedSettings: settings?.copyWith(
+          screenCaptureProtectionEnabled: enabled,
+        ),
       ),
     );
   }

--- a/lib/features/settings/presentation/bloc/settings_state.dart
+++ b/lib/features/settings/presentation/bloc/settings_state.dart
@@ -18,6 +18,8 @@ sealed class SettingsState with _$SettingsState {
   bool? get isDevModeEnabled => storedSettings?.isDevModeEnabled;
   bool get isErrorReportingEnabled =>
       storedSettings?.isErrorReportingEnabled ?? false;
+  bool get screenCaptureProtectionEnabled =>
+      storedSettings?.screenCaptureProtectionEnabled ?? true;
   String? get exchangeTestnetBasicAuthUsername =>
       storedSettings?.exchangeTestnetBasicAuthUsername;
   String? get exchangeTestnetBasicAuthPassword =>

--- a/lib/features/settings/settings_locator.dart
+++ b/lib/features/settings/settings_locator.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/features/settings/domain/usecases/set_exchange_testnet
 import 'package:bb_mobile/features/settings/domain/usecases/set_is_dev_mode_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_is_superuser_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_language_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/set_screen_capture_protection_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_enabled_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_expire_after_sec_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_min_amount_usecase.dart';
@@ -69,6 +70,12 @@ class SettingsLocator {
 
     locator.registerFactory<SetErrorReportingUsecase>(
       () => SetErrorReportingUsecase(
+        settingsRepository: locator<SettingsRepository>(),
+      ),
+    );
+
+    locator.registerFactory<SetScreenCaptureProtectionUsecase>(
+      () => SetScreenCaptureProtectionUsecase(
         settingsRepository: locator<SettingsRepository>(),
       ),
     );
@@ -135,6 +142,8 @@ class SettingsLocator {
         setIsDevModeUsecase: locator<SetIsDevModeUsecase>(),
         setThemeModeUsecase: locator<SetThemeModeUsecase>(),
         setErrorReportingUsecase: locator<SetErrorReportingUsecase>(),
+        setScreenCaptureProtectionUsecase:
+            locator<SetScreenCaptureProtectionUsecase>(),
         setExchangeTestnetBasicAuthUsecase:
             locator<SetExchangeTestnetBasicAuthUsecase>(),
         setPayjoinEnabledUsecase: locator<SetPayjoinEnabledUsecase>(),

--- a/lib/features/settings/ui/screens/app_settings/app_settings_screen.dart
+++ b/lib/features/settings/ui/screens/app_settings/app_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/settings/ui/widgets/dev_mode_switch.dart';
 import 'package:bb_mobile/features/settings/ui/widgets/error_reporting_switch.dart';
 import 'package:bb_mobile/features/settings/ui/widgets/exchange_testnet_basic_auth_tile.dart';
+import 'package:bb_mobile/features/settings/ui/widgets/screen_capture_protection_switch.dart';
 import 'package:bb_mobile/features/tor_settings/ui/tor_settings_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -79,6 +80,11 @@ class AppSettingsScreen extends StatelessWidget {
                   onTap: () {
                     context.pushNamed(SettingsRoute.logs.name);
                   },
+                ),
+                SettingsEntryItem(
+                  icon: Icons.screenshot_monitor,
+                  title: context.loc.settingsScreenPrivacyTitle,
+                  trailing: const ScreenCaptureProtectionSwitch(),
                 ),
                 if (isSuperuser)
                   SettingsEntryItem(

--- a/lib/features/settings/ui/widgets/screen_capture_protection_switch.dart
+++ b/lib/features/settings/ui/widgets/screen_capture_protection_switch.dart
@@ -1,0 +1,34 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ScreenCaptureProtectionSwitch extends StatelessWidget {
+  const ScreenCaptureProtectionSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled = context
+        .watch<SettingsCubit>()
+        .state
+        .screenCaptureProtectionEnabled;
+
+    return Switch(
+      value: isEnabled,
+      onChanged: (value) async {
+        // Await the toggle so the message follows the actual state change: for
+        // a security toggle we must not claim protection is off before it is.
+        await context.read<SettingsCubit>().toggleScreenCaptureProtection(
+          value,
+        );
+        if (!value && context.mounted) {
+          SnackBarUtils.showSnackBar(
+            context,
+            context.loc.settingsScreenPrivacyDisabledMessage,
+          );
+        }
+      },
+    );
+  }
+}

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -100,9 +100,14 @@ class _MnemonicDisplayState extends State<_MnemonicDisplay> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final fingerprint = context.select<TestWalletBackupBloc, String?>(
-      (bloc) => bloc.state.selectedWallet?.masterFingerprint,
-    );
+    // `context.select` is only legal inside `build`; here we read the current
+    // value. `build` calls `context.watch<TestWalletBackupBloc>()`, so a state
+    // change still triggers `didChangeDependencies` again and reloads.
+    final fingerprint = context
+        .read<TestWalletBackupBloc>()
+        .state
+        .selectedWallet
+        ?.masterFingerprint;
     if (fingerprint != _fingerprint) {
       _fingerprint = fingerprint;
       _secretFuture = fingerprint == null

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/utils/constants.dart';

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -23,6 +23,8 @@ class ShowMnemonicScreen extends StatefulWidget {
 
 class _ShowMnemonicScreenState extends State<ShowMnemonicScreen>
     with PrivacyScreen {
+  late final Future<void> _privacyFuture = enableScreenPrivacy();
+
   @override
   void dispose() {
     unawaited(disableScreenPrivacy());
@@ -32,7 +34,7 @@ class _ShowMnemonicScreenState extends State<ShowMnemonicScreen>
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: enableScreenPrivacy(),
+      future: _privacyFuture,
       builder: (context, snapshot) {
         return BlocBuilder<TestWalletBackupBloc, TestWalletBackupState>(
           builder: (context, state) {
@@ -100,9 +102,6 @@ class _MnemonicDisplayState extends State<_MnemonicDisplay> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // `context.select` is only legal inside `build`; here we read the current
-    // value. `build` calls `context.watch<TestWalletBackupBloc>()`, so a state
-    // change still triggers `didChangeDependencies` again and reloads.
     final fingerprint = context
         .read<TestWalletBackupBloc>()
         .state

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -29,12 +29,11 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
   String? _fingerprint;
   bool _isLoading = true;
 
+  late final Future<void> _privacyFuture = enableScreenPrivacy();
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // `context.select` is only legal inside `build`. The selected wallet is
-    // fixed before this screen is reached (the user views the mnemonic first),
-    // so reading the fingerprint once at mount is sufficient here.
     final fingerprint = context
         .read<TestWalletBackupBloc>()
         .state
@@ -108,7 +107,7 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: enableScreenPrivacy(),
+      future: _privacyFuture,
       builder: (context, snapshot) {
         return BlocConsumer<TestWalletBackupBloc, TestWalletBackupState>(
           listenWhen: (previous, current) =>

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -32,9 +32,14 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final fingerprint = context.select<TestWalletBackupBloc, String?>(
-      (bloc) => bloc.state.selectedWallet?.masterFingerprint,
-    );
+    // `context.select` is only legal inside `build`. The selected wallet is
+    // fixed before this screen is reached (the user views the mnemonic first),
+    // so reading the fingerprint once at mount is sufficient here.
+    final fingerprint = context
+        .read<TestWalletBackupBloc>()
+        .state
+        .selectedWallet
+        ?.masterFingerprint;
     if (fingerprint != _fingerprint) {
       _fingerprint = fingerprint;
       unawaited(_loadSecret());

--- a/localization/app_ar.arb
+++ b/localization/app_ar.arb
@@ -12571,5 +12571,7 @@
   "torSettingsModeSnowflakeDescription": "يستخدم وكلاء Snowflake التطوعيين للوصول إلى Tor من شبكة مُرشَّحة.",
   "torSettingsActiveTransport": "وسيلة النقل النشطة: {transport}",
   "torSettingsExternalProxyTitle": "وكيل Tor خارجي (متقدم)",
-  "torSettingsExternalProxyDescription": "عند التفعيل، تمر خوادم Bitcoin Electrum والنسخ الاحتياطية المشفَّرة عبر Orbot على المنفذ المُعد بدلاً من Tor المدمج. لا يتم توجيه Liquid عبره أبداً."
+  "torSettingsExternalProxyDescription": "عند التفعيل، تمر خوادم Bitcoin Electrum والنسخ الاحتياطية المشفَّرة عبر Orbot على المنفذ المُعد بدلاً من Tor المدمج. لا يتم توجيه Liquid عبره أبداً.",
+  "settingsScreenPrivacyTitle": "خصوصية الشاشة",
+  "settingsScreenPrivacyDisabledMessage": "أصبحت لقطات الشاشة مسموحة الآن على الشاشات الحساسة"
 }

--- a/localization/app_as.arb
+++ b/localization/app_as.arb
@@ -9641,5 +9641,7 @@
   "torSettingsModeSnowflakeDescription": "ফিল্টাৰ কৰা নেটৱৰ্কৰ পৰা Tor-লৈ পাবলৈ স্বেচ্ছাসেৱী Snowflake প্ৰক্সী ব্যৱহাৰ কৰে।",
   "torSettingsActiveTransport": "সক্ৰিয় ট্ৰেন্সপৰ্ট: {transport}",
   "torSettingsExternalProxyTitle": "বাহ্যিক Tor প্ৰক্সী (উন্নত)",
-  "torSettingsExternalProxyDescription": "সক্ৰিয় কৰিলে, Bitcoin Electrum ছাৰ্ভাৰ আৰু এনক্ৰিপ্ট কৰা বেকআপসমূহ অন্তৰ্নিহিত Tor-ৰ পৰিবৰ্তে নিৰ্ধাৰিত পৰ্টত Orbot-ৰ মাজেদি যায়। Liquid কেতিয়াও ইয়াৰ মাজেদি নাযায়।"
+  "torSettingsExternalProxyDescription": "সক্ৰিয় কৰিলে, Bitcoin Electrum ছাৰ্ভাৰ আৰু এনক্ৰিপ্ট কৰা বেকআপসমূহ অন্তৰ্নিহিত Tor-ৰ পৰিবৰ্তে নিৰ্ধাৰিত পৰ্টত Orbot-ৰ মাজেদি যায়। Liquid কেতিয়াও ইয়াৰ মাজেদি নাযায়।",
+  "settingsScreenPrivacyTitle": "স্ক্ৰীন গোপনীয়তা",
+  "settingsScreenPrivacyDisabledMessage": "এতিয়া সংবেদনশীল স্ক্ৰীনত স্ক্ৰীনশ্বট লোৱাৰ অনুমতি আছে"
 }

--- a/localization/app_bg.arb
+++ b/localization/app_bg.arb
@@ -10454,5 +10454,7 @@
   "torSettingsModeSnowflakeDescription": "Използва доброволчески Snowflake прокси сървъри, за да достигне Tor от филтрирана мрежа.",
   "torSettingsActiveTransport": "Активен транспорт: {transport}",
   "torSettingsExternalProxyTitle": "Външно Tor прокси (за напреднали)",
-  "torSettingsExternalProxyDescription": "Когато е включено, сървърите Bitcoin Electrum и шифрованите резервни копия преминават през Orbot на конфигурирания порт вместо през вградения Tor. Liquid никога не се маршрутизира през него."
+  "torSettingsExternalProxyDescription": "Когато е включено, сървърите Bitcoin Electrum и шифрованите резервни копия преминават през Orbot на конфигурирания порт вместо през вградения Tor. Liquid никога не се маршрутизира през него.",
+  "settingsScreenPrivacyTitle": "Поверителност на екрана",
+  "settingsScreenPrivacyDisabledMessage": "Екранните снимки вече са разрешени на чувствителните екрани"
 }

--- a/localization/app_bn.arb
+++ b/localization/app_bn.arb
@@ -12778,5 +12778,7 @@
   "torSettingsModeSnowflakeDescription": "ফিল্টার করা নেটওয়ার্ক থেকে Tor-এ পৌঁছাতে স্বেচ্ছাসেবী Snowflake প্রক্সি ব্যবহার করে।",
   "torSettingsActiveTransport": "সক্রিয় ট্রান্সপোর্ট: {transport}",
   "torSettingsExternalProxyTitle": "বাহ্যিক Tor প্রক্সি (উন্নত)",
-  "torSettingsExternalProxyDescription": "সক্রিয় থাকলে, Bitcoin Electrum সার্ভার এবং এনক্রিপ্ট করা ব্যাকআপগুলি অন্তর্নির্মিত Tor-এর পরিবর্তে নির্ধারিত পোর্টে Orbot-এর মাধ্যমে যায়। Liquid কখনও এর মাধ্যমে যায় না।"
+  "torSettingsExternalProxyDescription": "সক্রিয় থাকলে, Bitcoin Electrum সার্ভার এবং এনক্রিপ্ট করা ব্যাকআপগুলি অন্তর্নির্মিত Tor-এর পরিবর্তে নির্ধারিত পোর্টে Orbot-এর মাধ্যমে যায়। Liquid কখনও এর মাধ্যমে যায় না।",
+  "settingsScreenPrivacyTitle": "স্ক্রিন গোপনীয়তা",
+  "settingsScreenPrivacyDisabledMessage": "এখন সংবেদনশীল স্ক্রিনে স্ক্রিনশট নেওয়ার অনুমতি রয়েছে"
 }

--- a/localization/app_cs.arb
+++ b/localization/app_cs.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "Použije dobrovolnické proxy Snowflake k dosažení Toru z filtrované sítě.",
   "torSettingsActiveTransport": "Aktivní transport: {transport}",
   "torSettingsExternalProxyTitle": "Externí proxy Tor (pokročilé)",
-  "torSettingsExternalProxyDescription": "Když je zapnuto, servery Bitcoin Electrum a zašifrované záhy procházejí přes Orbot na nastaveném portu místo vestavěného Toru. Liquid se přes něj nikdy nesměruje."
+  "torSettingsExternalProxyDescription": "Když je zapnuto, servery Bitcoin Electrum a zašifrované záhy procházejí přes Orbot na nastaveném portu místo vestavěného Toru. Liquid se přes něj nikdy nesměruje.",
+  "settingsScreenPrivacyTitle": "Soukromí obrazovky",
+  "settingsScreenPrivacyDisabledMessage": "Snímky obrazovky jsou nyní na citlivých obrazovkách povoleny"
 }

--- a/localization/app_de.arb
+++ b/localization/app_de.arb
@@ -4967,5 +4967,7 @@
   "torSettingsModeSnowflakeDescription": "Nutzt freiwillige Snowflake-Proxys, um Tor aus einem gefilterten Netzwerk zu erreichen.",
   "torSettingsActiveTransport": "Aktiver Transport: {transport}",
   "torSettingsExternalProxyTitle": "Externer Tor-Proxy (erweitert)",
-  "torSettingsExternalProxyDescription": "Wenn aktiviert, laufen Bitcoin-Electrum-Server und verschlüsselte Backups über Orbot auf dem konfigurierten Port statt über das eingebettete Tor. Liquid wird nie darüber geleitet."
+  "torSettingsExternalProxyDescription": "Wenn aktiviert, laufen Bitcoin-Electrum-Server und verschlüsselte Backups über Orbot auf dem konfigurierten Port statt über das eingebettete Tor. Liquid wird nie darüber geleitet.",
+  "settingsScreenPrivacyTitle": "Bildschirmschutz",
+  "settingsScreenPrivacyDisabledMessage": "Screenshots sind auf sensiblen Bildschirmen jetzt erlaubt"
 }

--- a/localization/app_el.arb
+++ b/localization/app_el.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "Χρησιμοποιεί εθελοντικούς διαμεσολαβητές Snowflake για πρόσβαση στο Tor από φιλτραρισμένο δίκτυο.",
   "torSettingsActiveTransport": "Ενεργή μεταφορά: {transport}",
   "torSettingsExternalProxyTitle": "Εξωτερικός διαμεσολαβητής Tor (για προχωρημένους)",
-  "torSettingsExternalProxyDescription": "Όταν είναι ενεργό, οι διακομιστές Bitcoin Electrum και τα κρυπτογραφημένα αντίγραφα ασφαλείας περνούν μέσω του Orbot στη ρυθμισμένη θύρα αντί του ενσωματωμένου Tor. Το Liquid δεν δρομολογείται ποτέ μέσω αυτού."
+  "torSettingsExternalProxyDescription": "Όταν είναι ενεργό, οι διακομιστές Bitcoin Electrum και τα κρυπτογραφημένα αντίγραφα ασφαλείας περνούν μέσω του Orbot στη ρυθμισμένη θύρα αντί του ενσωματωμένου Tor. Το Liquid δεν δρομολογείται ποτέ μέσω αυτού.",
+  "settingsScreenPrivacyTitle": "Απόρρητο οθόνης",
+  "settingsScreenPrivacyDisabledMessage": "Τα στιγμιότυπα οθόνης επιτρέπονται πλέον σε ευαίσθητες οθόνες"
 }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14672,5 +14672,13 @@
   "mnemonicShuffleKeyboardHint": "Scramble the keys and suggestions on every tap",
   "@mnemonicShuffleKeyboardHint": {
     "description": "Tooltip on the in-app keyboard toggle that turns on the privacy mode: the letter keys and word suggestions are randomised after each key press so their positions cannot be read by an onlooker"
+  },
+  "settingsScreenPrivacyTitle": "Screen Privacy",
+  "@settingsScreenPrivacyTitle": {
+    "description": "Settings entry title for the screen-capture/screenshot protection toggle on sensitive screens"
+  },
+  "settingsScreenPrivacyDisabledMessage": "Screenshots are now allowed on sensitive screens",
+  "@settingsScreenPrivacyDisabledMessage": {
+    "description": "Snackbar shown when the user turns off Screen Privacy, warning that screenshots/recording are now allowed on sensitive screens such as the recovery phrase"
   }
 }

--- a/localization/app_es.arb
+++ b/localization/app_es.arb
@@ -5001,5 +5001,7 @@
   "torSettingsModeSnowflakeDescription": "Usa proxies voluntarios de Snowflake para alcanzar Tor desde una red filtrada.",
   "torSettingsActiveTransport": "Transporte activo: {transport}",
   "torSettingsExternalProxyTitle": "Proxy Tor externo (avanzado)",
-  "torSettingsExternalProxyDescription": "Si se activa, los servidores Bitcoin Electrum y las copias de seguridad cifradas pasan por Orbot en el puerto configurado en lugar del Tor integrado. Liquid nunca se enruta por ahí."
+  "torSettingsExternalProxyDescription": "Si se activa, los servidores Bitcoin Electrum y las copias de seguridad cifradas pasan por Orbot en el puerto configurado en lugar del Tor integrado. Liquid nunca se enruta por ahí.",
+  "settingsScreenPrivacyTitle": "Privacidad de pantalla",
+  "settingsScreenPrivacyDisabledMessage": "Ahora se permiten capturas de pantalla en pantallas sensibles"
 }

--- a/localization/app_fa.arb
+++ b/localization/app_fa.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "از پروکسی‌های داوطلبانه Snowflake استفاده می‌کند تا از شبکه‌ای فیلترشده به Tor برسد.",
   "torSettingsActiveTransport": "حامل فعال: {transport}",
   "torSettingsExternalProxyTitle": "پروکسی Tor بیرونی (پیشرفته)",
-  "torSettingsExternalProxyDescription": "در صورت فعال بودن، سرورهای Bitcoin Electrum و پشتیبان‌های رمزگذاری‌شده به‌جای Tor داخلی از Orbot روی درگاه تنظیم‌شده عبور می‌کنند. Liquid هرگز از آن عبور نمی‌کند."
+  "torSettingsExternalProxyDescription": "در صورت فعال بودن، سرورهای Bitcoin Electrum و پشتیبان‌های رمزگذاری‌شده به‌جای Tor داخلی از Orbot روی درگاه تنظیم‌شده عبور می‌کنند. Liquid هرگز از آن عبور نمی‌کند.",
+  "settingsScreenPrivacyTitle": "حریم خصوصی صفحه",
+  "settingsScreenPrivacyDisabledMessage": "اکنون گرفتن اسکرین‌شات در صفحه‌های حساس مجاز است"
 }

--- a/localization/app_fi.arb
+++ b/localization/app_fi.arb
@@ -4992,5 +4992,7 @@
   "torSettingsModeSnowflakeDescription": "Käyttää vapaaehtoisten Snowflake-välityspalvelimia Torin tavoittamiseen suodatetusta verkosta.",
   "torSettingsActiveTransport": "Aktiivinen siirtotapa: {transport}",
   "torSettingsExternalProxyTitle": "Ulkoinen Tor-välityspalvelin (lisäasetus)",
-  "torSettingsExternalProxyDescription": "Kun tämä on käytössä, Bitcoin Electrum -palvelimet ja salatut varmuuskopiot kulkevat Orbotin kautta määritetyssä portissa sisäänrakennetun Torin sijaan. Liquidia ei koskaan reititetä sen kautta."
+  "torSettingsExternalProxyDescription": "Kun tämä on käytössä, Bitcoin Electrum -palvelimet ja salatut varmuuskopiot kulkevat Orbotin kautta määritetyssä portissa sisäänrakennetun Torin sijaan. Liquidia ei koskaan reititetä sen kautta.",
+  "settingsScreenPrivacyTitle": "Näytön yksityisyys",
+  "settingsScreenPrivacyDisabledMessage": "Kuvakaappaukset ovat nyt sallittuja arkaluonteisilla näytöillä"
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -5045,5 +5045,7 @@
   "torSettingsExternalProxyTitle": "Proxy Tor externe (avancé)",
   "torSettingsExternalProxyDescription": "Lorsque l'option est activée, les serveurs Bitcoin Electrum et les sauvegardes chiffrées passent par Orbot sur le port configuré au lieu du Tor intégré. Liquid n'y passe jamais.",
   "swapErrorRouteUnavailable": "{fromNetwork} vers {toNetwork} n'est pas disponible.",
-  "swapErrorRouteUnavailableGeneric": "Ce swap n'est pas disponible."
+  "swapErrorRouteUnavailableGeneric": "Ce swap n'est pas disponible.",
+  "settingsScreenPrivacyTitle": "Confidentialité de l’écran",
+  "settingsScreenPrivacyDisabledMessage": "Les captures d’écran sont désormais autorisées sur les écrans sensibles"
 }

--- a/localization/app_hi.arb
+++ b/localization/app_hi.arb
@@ -12758,5 +12758,7 @@
   "torSettingsModeSnowflakeDescription": "फ़िल्टर किए गए नेटवर्क से Tor तक पहुँचने के लिए स्वयंसेवी Snowflake प्रॉक्सी का उपयोग करता है।",
   "torSettingsActiveTransport": "सक्रिय ट्रांसपोर्ट: {transport}",
   "torSettingsExternalProxyTitle": "बाहरी Tor प्रॉक्सी (उन्नत)",
-  "torSettingsExternalProxyDescription": "सक्षम होने पर, Bitcoin Electrum सर्वर और एन्क्रिप्टेड बैकअप अंतर्निहित Tor के बजाय कॉन्फ़िगर किए गए पोर्ट पर Orbot से गुजरते हैं। Liquid कभी इससे नहीं जाता।"
+  "torSettingsExternalProxyDescription": "सक्षम होने पर, Bitcoin Electrum सर्वर और एन्क्रिप्टेड बैकअप अंतर्निहित Tor के बजाय कॉन्फ़िगर किए गए पोर्ट पर Orbot से गुजरते हैं। Liquid कभी इससे नहीं जाता।",
+  "settingsScreenPrivacyTitle": "स्क्रीन गोपनीयता",
+  "settingsScreenPrivacyDisabledMessage": "अब संवेदनशील स्क्रीन पर स्क्रीनशॉट लेने की अनुमति है"
 }

--- a/localization/app_hi_Latn.arb
+++ b/localization/app_hi_Latn.arb
@@ -12959,5 +12959,7 @@
   "torSettingsModeSnowflakeDescription": "Filter kiye gaye network se Tor tak pahunchne ke liye volunteer Snowflake proxies ka istemal karta hai.",
   "torSettingsActiveTransport": "Active transport: {transport}",
   "torSettingsExternalProxyTitle": "Bahari Tor proxy (advanced)",
-  "torSettingsExternalProxyDescription": "Enable karne par, Bitcoin Electrum ke .onion servers embedded Tor ki jagah configure kiye gaye port par Orbot ka istemal karte hain."
+  "torSettingsExternalProxyDescription": "Enable karne par, Bitcoin Electrum ke .onion servers embedded Tor ki jagah configure kiye gaye port par Orbot ka istemal karte hain.",
+  "settingsScreenPrivacyTitle": "Screen Privacy",
+  "settingsScreenPrivacyDisabledMessage": "Ab sanvedansheel screen par screenshot lene ki anumati hai"
 }

--- a/localization/app_hy.arb
+++ b/localization/app_hy.arb
@@ -3638,5 +3638,7 @@
   "torSettingsModeSnowflakeDescription": "Օգտագործում է կամավորների Snowflake պրոքսիները՝ զտված ցանցից Tor-ին հասնելու համար։",
   "torSettingsActiveTransport": "Ակտիվ փոխադրում՝ {transport}",
   "torSettingsExternalProxyTitle": "Արտաքին Tor պրոքսի (առաջադեմ)",
-  "torSettingsExternalProxyDescription": "Միացնելու դեպքում Bitcoin Electrum սերվերները և գաղտնագրված պահուստները անցնում են Orbot-ով՝ նշված պորտում, ներկառուցված Tor-ի փոխարեն։ Liquid-ը երբեք չի անցնում դրանով։"
+  "torSettingsExternalProxyDescription": "Միացնելու դեպքում Bitcoin Electrum սերվերները և գաղտնագրված պահուստները անցնում են Orbot-ով՝ նշված պորտում, ներկառուցված Tor-ի փոխարեն։ Liquid-ը երբեք չի անցնում դրանով։",
+  "settingsScreenPrivacyTitle": "Էկրանի գաղտնիություն",
+  "settingsScreenPrivacyDisabledMessage": "Այժմ սքրինշոթերը թույլատրված են զգայուն էկրաններում"
 }

--- a/localization/app_it.arb
+++ b/localization/app_it.arb
@@ -5001,5 +5001,7 @@
   "torSettingsModeSnowflakeDescription": "Usa i proxy volontari Snowflake per raggiungere Tor da una rete filtrata.",
   "torSettingsActiveTransport": "Trasporto attivo: {transport}",
   "torSettingsExternalProxyTitle": "Proxy Tor esterno (avanzato)",
-  "torSettingsExternalProxyDescription": "Se attivo, i server Bitcoin Electrum e i backup cifrati passano da Orbot sulla porta configurata invece del Tor integrato. Liquid non viene mai instradato attraverso di esso."
+  "torSettingsExternalProxyDescription": "Se attivo, i server Bitcoin Electrum e i backup cifrati passano da Orbot sulla porta configurata invece del Tor integrato. Liquid non viene mai instradato attraverso di esso.",
+  "settingsScreenPrivacyTitle": "Privacy dello schermo",
+  "settingsScreenPrivacyDisabledMessage": "Ora gli screenshot sono consentiti nelle schermate sensibili"
 }

--- a/localization/app_ka.arb
+++ b/localization/app_ka.arb
@@ -3785,5 +3785,7 @@
   "torSettingsModeSnowflakeDescription": "იყენებს მოხალისეთა Snowflake-პროქსებს, რომ ფილტრირებული ქსელიდან მიაღწიოს Tor-ს.",
   "torSettingsActiveTransport": "აქტიური ტრანსპორტი: {transport}",
   "torSettingsExternalProxyTitle": "გარე Tor-პროქსი (დამატებითი)",
-  "torSettingsExternalProxyDescription": "ჩართვისას Bitcoin Electrum სერვერები და დაშიფრული სარეზერვო ასლები გადის Orbot-ით მითითებულ პორტზე, ჩაშენებული Tor-ის ნაცვლად. Liquid არასოდეს გადის მისით."
+  "torSettingsExternalProxyDescription": "ჩართვისას Bitcoin Electrum სერვერები და დაშიფრული სარეზერვო ასლები გადის Orbot-ით მითითებულ პორტზე, ჩაშენებული Tor-ის ნაცვლად. Liquid არასოდეს გადის მისით.",
+  "settingsScreenPrivacyTitle": "ეკრანის კონფიდენციალურობა",
+  "settingsScreenPrivacyDisabledMessage": "სკრინშოტები ახლა დაშვებულია მგრძნობიარე ეკრანებზე"
 }

--- a/localization/app_ko.arb
+++ b/localization/app_ko.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "자원봉사자의 Snowflake 프록시를 이용해 차단된 네트워크에서 Tor에 연결합니다.",
   "torSettingsActiveTransport": "활성 전송: {transport}",
   "torSettingsExternalProxyTitle": "외부 Tor 프록시(고급)",
-  "torSettingsExternalProxyDescription": "활성화하면 Bitcoin Electrum 서버와 암호화된 백업이 내장 Tor 대신 설정된 포트의 Orbot을 통해 전달됩니다. Liquid는 이를 통해 전달되지 않습니다."
+  "torSettingsExternalProxyDescription": "활성화하면 Bitcoin Electrum 서버와 암호화된 백업이 내장 Tor 대신 설정된 포트의 Orbot을 통해 전달됩니다. Liquid는 이를 통해 전달되지 않습니다.",
+  "settingsScreenPrivacyTitle": "화면 개인정보 보호",
+  "settingsScreenPrivacyDisabledMessage": "이제 민감한 화면에서 스크린샷이 허용됩니다"
 }

--- a/localization/app_pt.arb
+++ b/localization/app_pt.arb
@@ -5050,5 +5050,7 @@
   "torSettingsModeSnowflakeDescription": "Usa proxies voluntários Snowflake para alcançar o Tor a partir de uma rede filtrada.",
   "torSettingsActiveTransport": "Transporte ativo: {transport}",
   "torSettingsExternalProxyTitle": "Proxy Tor externo (avançado)",
-  "torSettingsExternalProxyDescription": "Quando ativo, os servidores Bitcoin Electrum e as cópias de segurança cifradas passam pelo Orbot na porta configurada em vez do Tor integrado. O Liquid nunca é encaminhado por ele."
+  "torSettingsExternalProxyDescription": "Quando ativo, os servidores Bitcoin Electrum e as cópias de segurança cifradas passam pelo Orbot na porta configurada em vez do Tor integrado. O Liquid nunca é encaminhado por ele.",
+  "settingsScreenPrivacyTitle": "Privacidade do ecrã",
+  "settingsScreenPrivacyDisabledMessage": "As capturas de ecrã são agora permitidas em ecrãs sensíveis"
 }

--- a/localization/app_pt_BR.arb
+++ b/localization/app_pt_BR.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "Usa proxies voluntários do Snowflake para alcançar o Tor a partir de uma rede filtrada.",
   "torSettingsActiveTransport": "Transporte ativo: {transport}",
   "torSettingsExternalProxyTitle": "Proxy Tor externo (avançado)",
-  "torSettingsExternalProxyDescription": "Quando ativado, os servidores Bitcoin Electrum e os backups criptografados passam pelo Orbot na porta configurada em vez do Tor integrado. O Liquid nunca é roteado por ele."
+  "torSettingsExternalProxyDescription": "Quando ativado, os servidores Bitcoin Electrum e os backups criptografados passam pelo Orbot na porta configurada em vez do Tor integrado. O Liquid nunca é roteado por ele.",
+  "settingsScreenPrivacyTitle": "Privacidade da tela",
+  "settingsScreenPrivacyDisabledMessage": "Agora as capturas de tela são permitidas em telas sensíveis"
 }

--- a/localization/app_ru.arb
+++ b/localization/app_ru.arb
@@ -5007,5 +5007,7 @@
   "torSettingsModeSnowflakeDescription": "Использует добровольные прокси Snowflake, чтобы достичь Tor из фильтруемой сети.",
   "torSettingsActiveTransport": "Активный транспорт: {transport}",
   "torSettingsExternalProxyTitle": "Внешний прокси Tor (для опытных)",
-  "torSettingsExternalProxyDescription": "Если включено, серверы Bitcoin Electrum и зашифрованные резервные копии идут через Orbot на заданном порту вместо встроенного Tor. Liquid через него никогда не направляется."
+  "torSettingsExternalProxyDescription": "Если включено, серверы Bitcoin Electrum и зашифрованные резервные копии идут через Orbot на заданном порту вместо встроенного Tor. Liquid через него никогда не направляется.",
+  "settingsScreenPrivacyTitle": "Конфиденциальность экрана",
+  "settingsScreenPrivacyDisabledMessage": "Теперь снимки экрана разрешены на конфиденциальных экранах"
 }

--- a/localization/app_sw.arb
+++ b/localization/app_sw.arb
@@ -3650,5 +3650,7 @@
   "torSettingsModeSnowflakeDescription": "Hutumia proksi za kujitolea za Snowflake kufikia Tor kutoka mtandao uliochujwa.",
   "torSettingsActiveTransport": "Usafirishaji unaotumika: {transport}",
   "torSettingsExternalProxyTitle": "Proksi ya nje ya Tor (ya kina)",
-  "torSettingsExternalProxyDescription": "Ikiwashwa, seva za Bitcoin Electrum na nakala rudufu zilizosimbwa hupitia Orbot kwenye mlango uliowekwa badala ya Tor iliyojumuishwa. Liquid haipitishwi kamwe kupitia hiyo."
+  "torSettingsExternalProxyDescription": "Ikiwashwa, seva za Bitcoin Electrum na nakala rudufu zilizosimbwa hupitia Orbot kwenye mlango uliowekwa badala ya Tor iliyojumuishwa. Liquid haipitishwi kamwe kupitia hiyo.",
+  "settingsScreenPrivacyTitle": "Faragha ya skrini",
+  "settingsScreenPrivacyDisabledMessage": "Sasa picha za skrini zinaruhusiwa kwenye skrini nyeti"
 }

--- a/localization/app_th.arb
+++ b/localization/app_th.arb
@@ -12572,5 +12572,7 @@
   "torSettingsModeSnowflakeDescription": "ใช้พร็อกซี Snowflake จากอาสาสมัครเพื่อเข้าถึง Tor จากเครือข่ายที่ถูกกรอง",
   "torSettingsActiveTransport": "การขนส่งที่ใช้งาน: {transport}",
   "torSettingsExternalProxyTitle": "พร็อกซี Tor ภายนอก (ขั้นสูง)",
-  "torSettingsExternalProxyDescription": "เมื่อเปิดใช้งาน เซิร์ฟเวอร์ Bitcoin Electrum และข้อมูลสำรองที่เข้ารหัสจะผ่าน Orbot ที่พอร์ตที่กำหนดไว้ แทน Tor ในตัว ส่วน Liquid จะไม่ผ่าน Orbot เลย"
+  "torSettingsExternalProxyDescription": "เมื่อเปิดใช้งาน เซิร์ฟเวอร์ Bitcoin Electrum และข้อมูลสำรองที่เข้ารหัสจะผ่าน Orbot ที่พอร์ตที่กำหนดไว้ แทน Tor ในตัว ส่วน Liquid จะไม่ผ่าน Orbot เลย",
+  "settingsScreenPrivacyTitle": "ความเป็นส่วนตัวของหน้าจอ",
+  "settingsScreenPrivacyDisabledMessage": "ตอนนี้อนุญาตให้จับภาพหน้าจอในหน้าจอที่ละเอียดอ่อนได้แล้ว"
 }

--- a/localization/app_tr.arb
+++ b/localization/app_tr.arb
@@ -12568,5 +12568,7 @@
   "torSettingsModeSnowflakeDescription": "Filtrelenen bir ağdan Tor'a ulaşmak için gönüllü Snowflake vekillerini kullanır.",
   "torSettingsActiveTransport": "Etkin taşıyıcı: {transport}",
   "torSettingsExternalProxyTitle": "Harici Tor vekili (gelişmiş)",
-  "torSettingsExternalProxyDescription": "Etkinleştirildiğinde Bitcoin Electrum sunucuları ve şifreli yedekler, gömülü Tor yerine yapılandırılan porttaki Orbot üzerinden geçer. Liquid asla bunun üzerinden yönlendirilmez."
+  "torSettingsExternalProxyDescription": "Etkinleştirildiğinde Bitcoin Electrum sunucuları ve şifreli yedekler, gömülü Tor yerine yapılandırılan porttaki Orbot üzerinden geçer. Liquid asla bunun üzerinden yönlendirilmez.",
+  "settingsScreenPrivacyTitle": "Ekran gizliliği",
+  "settingsScreenPrivacyDisabledMessage": "Hassas ekranlarda ekran görüntüsü almaya artık izin veriliyor"
 }

--- a/localization/app_uk.arb
+++ b/localization/app_uk.arb
@@ -4998,5 +4998,7 @@
   "torSettingsModeSnowflakeDescription": "Використовує волонтерські проксі Snowflake, щоб дістатися Tor із фільтрованої мережі.",
   "torSettingsActiveTransport": "Активний транспорт: {transport}",
   "torSettingsExternalProxyTitle": "Зовнішній проксі Tor (для досвідчених)",
-  "torSettingsExternalProxyDescription": "Якщо ввімкнено, сервери Bitcoin Electrum і зашифровані резервні копії проходять через Orbot на вказаному порті замість вбудованого Tor. Liquid ніколи не спрямовується через нього."
+  "torSettingsExternalProxyDescription": "Якщо ввімкнено, сервери Bitcoin Electrum і зашифровані резервні копії проходять через Orbot на вказаному порті замість вбудованого Tor. Liquid ніколи не спрямовується через нього.",
+  "settingsScreenPrivacyTitle": "Конфіденційність екрана",
+  "settingsScreenPrivacyDisabledMessage": "Знімки екрана тепер дозволені на конфіденційних екранах"
 }

--- a/localization/app_vi.arb
+++ b/localization/app_vi.arb
@@ -3638,5 +3638,7 @@
   "torSettingsModeSnowflakeDescription": "Dùng các proxy Snowflake tình nguyện để tiếp cận Tor từ mạng bị lọc.",
   "torSettingsActiveTransport": "Phương thức đang dùng: {transport}",
   "torSettingsExternalProxyTitle": "Proxy Tor bên ngoài (nâng cao)",
-  "torSettingsExternalProxyDescription": "Khi bật, các máy chủ Bitcoin Electrum và bản sao lưu đã mã hóa sẽ đi qua Orbot ở cổng đã cấu hình thay vì Tor tích hợp. Liquid không bao giờ được định tuyến qua đó."
+  "torSettingsExternalProxyDescription": "Khi bật, các máy chủ Bitcoin Electrum và bản sao lưu đã mã hóa sẽ đi qua Orbot ở cổng đã cấu hình thay vì Tor tích hợp. Liquid không bao giờ được định tuyến qua đó.",
+  "settingsScreenPrivacyTitle": "Quyền riêng tư màn hình",
+  "settingsScreenPrivacyDisabledMessage": "Ảnh chụp màn hình hiện được cho phép trên các màn hình nhạy cảm"
 }

--- a/localization/app_zh.arb
+++ b/localization/app_zh.arb
@@ -5001,5 +5001,7 @@
   "torSettingsModeSnowflakeDescription": "通过志愿者提供的 Snowflake 代理，从被过滤的网络连接 Tor。",
   "torSettingsActiveTransport": "当前传输方式：{transport}",
   "torSettingsExternalProxyTitle": "外部 Tor 代理（高级）",
-  "torSettingsExternalProxyDescription": "启用后，Bitcoin Electrum 服务器和加密备份将通过配置端口上的 Orbot，而不是内置 Tor。Liquid 永不经由它路由。"
+  "torSettingsExternalProxyDescription": "启用后，Bitcoin Electrum 服务器和加密备份将通过配置端口上的 Orbot，而不是内置 Tor。Liquid 永不经由它路由。",
+  "settingsScreenPrivacyTitle": "屏幕隐私",
+  "settingsScreenPrivacyDisabledMessage": "现在允许在敏感屏幕上截屏"
 }

--- a/packages/screen_privacy/analysis_options.yaml
+++ b/packages/screen_privacy/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - implementation_imports
+    - prefer_final_locals
+    - require_trailing_commas
+    - use_super_parameters

--- a/packages/screen_privacy/lib/screen_privacy.dart
+++ b/packages/screen_privacy/lib/screen_privacy.dart
@@ -1,0 +1,11 @@
+/// Screen-capture protection for sensitive screens (recovery phrase, seed
+/// views): blocks screenshots and screen recording via the OS secure flag
+/// (Android `FLAG_SECURE`, iOS secure overlay).
+///
+/// A screen opts in with the [PrivacyScreen] mixin; the process-wide
+/// [ScreenCaptureProtection] controller reference-counts protected screens and
+/// gates the flag on the user's preference.
+library;
+
+export 'src/privacy_screen.dart';
+export 'src/screen_capture_protection.dart';

--- a/packages/screen_privacy/lib/src/privacy_screen.dart
+++ b/packages/screen_privacy/lib/src/privacy_screen.dart
@@ -1,4 +1,4 @@
-import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
+import 'package:screen_privacy/src/screen_capture_protection.dart';
 
 /// Adds screen-capture protection to a screen for as long as it is mounted.
 ///

--- a/packages/screen_privacy/lib/src/screen_capture_protection.dart
+++ b/packages/screen_privacy/lib/src/screen_capture_protection.dart
@@ -1,5 +1,7 @@
-import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:logging/logging.dart';
 import 'package:no_screenshot/no_screenshot.dart';
+
+final _log = Logger('ScreenCaptureProtection');
 
 /// Controls OS-level screen-capture blocking (Android `FLAG_SECURE`, iOS secure
 /// overlay) via the `no_screenshot` plugin.
@@ -55,12 +57,10 @@ class ScreenCaptureProtection {
       // otherwise vanish as an unhandled async error. On a secret screen a
       // silent failure means we may be showing the mnemonic without
       // FLAG_SECURE set, so make it loud rather than let it disappear.
-      log.severe(
-        message:
-            'ScreenCaptureProtection: failed to '
-            '${shouldProtect ? 'enable' : 'disable'} capture blocking',
-        error: e,
-        trace: st,
+      _log.severe(
+        'failed to ${shouldProtect ? 'enable' : 'disable'} capture blocking',
+        e,
+        st,
       );
     }
   }

--- a/packages/screen_privacy/pubspec.yaml
+++ b/packages/screen_privacy/pubspec.yaml
@@ -1,0 +1,21 @@
+name: screen_privacy
+description: App-wide screen-capture protection (FLAG_SECURE / iOS secure overlay) for sensitive screens.
+publish_to: "none"
+version: 0.0.1
+resolution: workspace
+
+environment:
+  sdk: "3.12.2"
+  flutter: "3.44.9"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  logging: ^1.2.0
+  no_screenshot: ^1.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  lints: ^6.1.0
+  test: ^1.31.0

--- a/packages/screen_privacy/test/screen_capture_protection_test.dart
+++ b/packages/screen_privacy/test/screen_capture_protection_test.dart
@@ -1,6 +1,6 @@
-import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:screen_privacy/screen_privacy.dart';
 
 /// The `no_screenshot` plugin flips the OS capture flag through this method
 /// channel. We record the last method it received to assert what the

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1382,7 +1382,7 @@ packages:
     source: hosted
     version: "1.0.0"
   no_screenshot:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: no_screenshot
       sha256: "2192d312e74e67b88ae6cf61cea0e0ae66aee3881127c0740dcbdcd1d4eed3e9"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ workspace:
   - packages/bull_ui_catalogue
   - packages/primitives
   - packages/bull_tor
+  - packages/screen_privacy
 
 dependencies:
   flutter:
@@ -23,6 +24,7 @@ dependencies:
   bull_ui:
   primitives:
   bull_tor:
+  screen_privacy:
   flutter_bloc: ^9.1.1
   freezed: ^3.2.3
   get_it: ^9.1.1
@@ -65,7 +67,6 @@ dependencies:
       path: packages/bitbox-transport
   universal_ble: ^1.2.0
   auto_size_text: ^3.0.0
-  no_screenshot: ^1.1.0
   freezed_annotation: ^3.1.0
   convert: ^3.1.2
   crypto: ^3.0.7

--- a/test/core_test/screen_capture_protection_test.dart
+++ b/test/core_test/screen_capture_protection_test.dart
@@ -1,0 +1,87 @@
+import 'package:bb_mobile/core/utils/screen_capture_protection.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The `no_screenshot` plugin flips the OS capture flag through this method
+/// channel. We record the last method it received to assert what the
+/// reference-counted controller decided.
+const _channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final controller = ScreenCaptureProtection.instance;
+  String? lastCall;
+
+  setUp(() async {
+    lastCall = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, (call) async {
+          lastCall = call.method;
+          return true;
+        });
+
+    // The controller is a process-wide singleton, so normalise it to a known
+    // baseline before each test: preference on, no screens acquired. release()
+    // is clamped at zero, so over-releasing is a safe way to drain the count.
+    for (var i = 0; i < 100; i++) {
+      await controller.release();
+    }
+    controller.enabledByUser = true;
+    lastCall = null;
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  });
+
+  test('protects while at least one screen is mounted', () async {
+    await controller.acquire();
+    expect(lastCall, 'screenshotOff');
+  });
+
+  test('only clears protection once the last screen is gone', () async {
+    await controller.acquire();
+    await controller.acquire();
+
+    lastCall = null;
+    await controller.release();
+    // Still one screen mounted: must stay protected.
+    expect(lastCall, 'screenshotOff');
+
+    await controller.release();
+    // Last screen gone: protection lifted.
+    expect(lastCall, 'screenshotOn');
+  });
+
+  test('does not protect when the user has opted out', () async {
+    controller.enabledByUser = false;
+    await pumpEventQueue();
+    lastCall = null;
+
+    await controller.acquire();
+    expect(lastCall, 'screenshotOn');
+  });
+
+  test('opting out while a protected screen is mounted lifts protection '
+      'immediately', () async {
+    await controller.acquire();
+    expect(lastCall, 'screenshotOff');
+
+    controller.enabledByUser = false;
+    await pumpEventQueue();
+    expect(lastCall, 'screenshotOn');
+  });
+
+  test('opting back in re-applies protection to a mounted screen', () async {
+    await controller.acquire();
+    controller.enabledByUser = false;
+    await pumpEventQueue();
+    expect(lastCall, 'screenshotOn');
+
+    controller.enabledByUser = true;
+    await pumpEventQueue();
+    expect(lastCall, 'screenshotOff');
+  });
+}

--- a/test/features/settings/presentation/bloc/settings_cubit_test.dart
+++ b/test/features/settings/presentation/bloc/settings_cubit_test.dart
@@ -16,6 +16,7 @@ import 'package:bb_mobile/features/settings/domain/usecases/set_language_usecase
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_enabled_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_expire_after_sec_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_payjoin_min_amount_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/set_screen_capture_protection_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_theme_mode_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/watch_payjoin_policy_usecase.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
@@ -48,6 +49,9 @@ class _MockSetThemeModeUsecase extends Mock implements SetThemeModeUsecase {}
 class _MockSetErrorReportingUsecase extends Mock
     implements SetErrorReportingUsecase {}
 
+class _MockSetScreenCaptureProtectionUsecase extends Mock
+    implements SetScreenCaptureProtectionUsecase {}
+
 class _MockSetExchangeTestnetBasicAuthUsecase extends Mock
     implements SetExchangeTestnetBasicAuthUsecase {}
 
@@ -75,6 +79,7 @@ class _TestSettingsCubit extends SettingsCubit {
     required super.setIsDevModeUsecase,
     required super.setThemeModeUsecase,
     required super.setErrorReportingUsecase,
+    required super.setScreenCaptureProtectionUsecase,
     required super.setExchangeTestnetBasicAuthUsecase,
     required super.setPayjoinEnabledUsecase,
     required super.watchPayjoinPolicyUsecase,
@@ -108,6 +113,8 @@ void main() {
       setIsDevModeUsecase: _MockSetIsDevModeUsecase(),
       setThemeModeUsecase: _MockSetThemeModeUsecase(),
       setErrorReportingUsecase: _MockSetErrorReportingUsecase(),
+      setScreenCaptureProtectionUsecase:
+          _MockSetScreenCaptureProtectionUsecase(),
       setExchangeTestnetBasicAuthUsecase:
           _MockSetExchangeTestnetBasicAuthUsecase(),
       setPayjoinEnabledUsecase: setPayjoinEnabled,

--- a/test/migrations_test/bull_database/generated/schema_v15.dart
+++ b/test/migrations_test/bull_database/generated/schema_v15.dart
@@ -1828,6 +1828,17 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
             'NOT NULL DEFAULT 0 CHECK (is_error_reporting_enabled IN (0, 1))',
         defaultValue: const CustomExpression('0'),
       );
+  late final GeneratedColumn<int>
+  screenCaptureProtectionEnabled = GeneratedColumn<int>(
+    'screen_capture_protection_enabled',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints:
+        'NOT NULL DEFAULT 1 CHECK (screen_capture_protection_enabled IN (0, 1))',
+    defaultValue: const CustomExpression('1'),
+  );
   late final GeneratedColumn<String> exchangeTestnetBasicAuthUsername =
       GeneratedColumn<String>(
         'exchange_testnet_basic_auth_username',
@@ -1862,6 +1873,7 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
     lastSuccessfulTorTransport,
     themeMode,
     isErrorReportingEnabled,
+    screenCaptureProtectionEnabled,
     exchangeTestnetBasicAuthUsername,
     exchangeTestnetBasicAuthPassword,
   ];
@@ -1932,6 +1944,10 @@ class Settings extends Table with TableInfo<Settings, SettingsData> {
         DriftSqlType.int,
         data['${effectivePrefix}is_error_reporting_enabled'],
       )!,
+      screenCaptureProtectionEnabled: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}screen_capture_protection_enabled'],
+      )!,
       exchangeTestnetBasicAuthUsername: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}exchange_testnet_basic_auth_username'],
@@ -1967,6 +1983,7 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
   final String? lastSuccessfulTorTransport;
   final String themeMode;
   final int isErrorReportingEnabled;
+  final int screenCaptureProtectionEnabled;
   final String? exchangeTestnetBasicAuthUsername;
   final String? exchangeTestnetBasicAuthPassword;
   const SettingsData({
@@ -1984,6 +2001,7 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     this.lastSuccessfulTorTransport,
     required this.themeMode,
     required this.isErrorReportingEnabled,
+    required this.screenCaptureProtectionEnabled,
     this.exchangeTestnetBasicAuthUsername,
     this.exchangeTestnetBasicAuthPassword,
   });
@@ -2008,6 +2026,9 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     }
     map['theme_mode'] = Variable<String>(themeMode);
     map['is_error_reporting_enabled'] = Variable<int>(isErrorReportingEnabled);
+    map['screen_capture_protection_enabled'] = Variable<int>(
+      screenCaptureProtectionEnabled,
+    );
     if (!nullToAbsent || exchangeTestnetBasicAuthUsername != null) {
       map['exchange_testnet_basic_auth_username'] = Variable<String>(
         exchangeTestnetBasicAuthUsername,
@@ -2040,6 +2061,7 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
           : Value(lastSuccessfulTorTransport),
       themeMode: Value(themeMode),
       isErrorReportingEnabled: Value(isErrorReportingEnabled),
+      screenCaptureProtectionEnabled: Value(screenCaptureProtectionEnabled),
       exchangeTestnetBasicAuthUsername:
           exchangeTestnetBasicAuthUsername == null && nullToAbsent
           ? const Value.absent()
@@ -2075,6 +2097,9 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       isErrorReportingEnabled: serializer.fromJson<int>(
         json['isErrorReportingEnabled'],
       ),
+      screenCaptureProtectionEnabled: serializer.fromJson<int>(
+        json['screenCaptureProtectionEnabled'],
+      ),
       exchangeTestnetBasicAuthUsername: serializer.fromJson<String?>(
         json['exchangeTestnetBasicAuthUsername'],
       ),
@@ -2105,6 +2130,9 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       'isErrorReportingEnabled': serializer.toJson<int>(
         isErrorReportingEnabled,
       ),
+      'screenCaptureProtectionEnabled': serializer.toJson<int>(
+        screenCaptureProtectionEnabled,
+      ),
       'exchangeTestnetBasicAuthUsername': serializer.toJson<String?>(
         exchangeTestnetBasicAuthUsername,
       ),
@@ -2129,6 +2157,7 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     Value<String?> lastSuccessfulTorTransport = const Value.absent(),
     String? themeMode,
     int? isErrorReportingEnabled,
+    int? screenCaptureProtectionEnabled,
     Value<String?> exchangeTestnetBasicAuthUsername = const Value.absent(),
     Value<String?> exchangeTestnetBasicAuthPassword = const Value.absent(),
   }) => SettingsData(
@@ -2149,6 +2178,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     themeMode: themeMode ?? this.themeMode,
     isErrorReportingEnabled:
         isErrorReportingEnabled ?? this.isErrorReportingEnabled,
+    screenCaptureProtectionEnabled:
+        screenCaptureProtectionEnabled ?? this.screenCaptureProtectionEnabled,
     exchangeTestnetBasicAuthUsername: exchangeTestnetBasicAuthUsername.present
         ? exchangeTestnetBasicAuthUsername.value
         : this.exchangeTestnetBasicAuthUsername,
@@ -2192,6 +2223,10 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
       isErrorReportingEnabled: data.isErrorReportingEnabled.present
           ? data.isErrorReportingEnabled.value
           : this.isErrorReportingEnabled,
+      screenCaptureProtectionEnabled:
+          data.screenCaptureProtectionEnabled.present
+          ? data.screenCaptureProtectionEnabled.value
+          : this.screenCaptureProtectionEnabled,
       exchangeTestnetBasicAuthUsername:
           data.exchangeTestnetBasicAuthUsername.present
           ? data.exchangeTestnetBasicAuthUsername.value
@@ -2221,6 +2256,9 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
           ..write('themeMode: $themeMode, ')
           ..write('isErrorReportingEnabled: $isErrorReportingEnabled, ')
           ..write(
+            'screenCaptureProtectionEnabled: $screenCaptureProtectionEnabled, ',
+          )
+          ..write(
             'exchangeTestnetBasicAuthUsername: $exchangeTestnetBasicAuthUsername, ',
           )
           ..write(
@@ -2246,6 +2284,7 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
     lastSuccessfulTorTransport,
     themeMode,
     isErrorReportingEnabled,
+    screenCaptureProtectionEnabled,
     exchangeTestnetBasicAuthUsername,
     exchangeTestnetBasicAuthPassword,
   );
@@ -2267,6 +2306,8 @@ class SettingsData extends DataClass implements Insertable<SettingsData> {
           other.lastSuccessfulTorTransport == this.lastSuccessfulTorTransport &&
           other.themeMode == this.themeMode &&
           other.isErrorReportingEnabled == this.isErrorReportingEnabled &&
+          other.screenCaptureProtectionEnabled ==
+              this.screenCaptureProtectionEnabled &&
           other.exchangeTestnetBasicAuthUsername ==
               this.exchangeTestnetBasicAuthUsername &&
           other.exchangeTestnetBasicAuthPassword ==
@@ -2288,6 +2329,7 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
   final Value<String?> lastSuccessfulTorTransport;
   final Value<String> themeMode;
   final Value<int> isErrorReportingEnabled;
+  final Value<int> screenCaptureProtectionEnabled;
   final Value<String?> exchangeTestnetBasicAuthUsername;
   final Value<String?> exchangeTestnetBasicAuthPassword;
   const SettingsCompanion({
@@ -2305,6 +2347,7 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     this.lastSuccessfulTorTransport = const Value.absent(),
     this.themeMode = const Value.absent(),
     this.isErrorReportingEnabled = const Value.absent(),
+    this.screenCaptureProtectionEnabled = const Value.absent(),
     this.exchangeTestnetBasicAuthUsername = const Value.absent(),
     this.exchangeTestnetBasicAuthPassword = const Value.absent(),
   });
@@ -2323,6 +2366,7 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     this.lastSuccessfulTorTransport = const Value.absent(),
     this.themeMode = const Value.absent(),
     this.isErrorReportingEnabled = const Value.absent(),
+    this.screenCaptureProtectionEnabled = const Value.absent(),
     this.exchangeTestnetBasicAuthUsername = const Value.absent(),
     this.exchangeTestnetBasicAuthPassword = const Value.absent(),
   }) : environment = Value(environment),
@@ -2346,6 +2390,7 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     Expression<String>? lastSuccessfulTorTransport,
     Expression<String>? themeMode,
     Expression<int>? isErrorReportingEnabled,
+    Expression<int>? screenCaptureProtectionEnabled,
     Expression<String>? exchangeTestnetBasicAuthUsername,
     Expression<String>? exchangeTestnetBasicAuthPassword,
   }) {
@@ -2366,6 +2411,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
       if (themeMode != null) 'theme_mode': themeMode,
       if (isErrorReportingEnabled != null)
         'is_error_reporting_enabled': isErrorReportingEnabled,
+      if (screenCaptureProtectionEnabled != null)
+        'screen_capture_protection_enabled': screenCaptureProtectionEnabled,
       if (exchangeTestnetBasicAuthUsername != null)
         'exchange_testnet_basic_auth_username':
             exchangeTestnetBasicAuthUsername,
@@ -2390,6 +2437,7 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
     Value<String?>? lastSuccessfulTorTransport,
     Value<String>? themeMode,
     Value<int>? isErrorReportingEnabled,
+    Value<int>? screenCaptureProtectionEnabled,
     Value<String?>? exchangeTestnetBasicAuthUsername,
     Value<String?>? exchangeTestnetBasicAuthPassword,
   }) {
@@ -2410,6 +2458,8 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
       themeMode: themeMode ?? this.themeMode,
       isErrorReportingEnabled:
           isErrorReportingEnabled ?? this.isErrorReportingEnabled,
+      screenCaptureProtectionEnabled:
+          screenCaptureProtectionEnabled ?? this.screenCaptureProtectionEnabled,
       exchangeTestnetBasicAuthUsername:
           exchangeTestnetBasicAuthUsername ??
           this.exchangeTestnetBasicAuthUsername,
@@ -2468,6 +2518,11 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
         isErrorReportingEnabled.value,
       );
     }
+    if (screenCaptureProtectionEnabled.present) {
+      map['screen_capture_protection_enabled'] = Variable<int>(
+        screenCaptureProtectionEnabled.value,
+      );
+    }
     if (exchangeTestnetBasicAuthUsername.present) {
       map['exchange_testnet_basic_auth_username'] = Variable<String>(
         exchangeTestnetBasicAuthUsername.value,
@@ -2498,6 +2553,9 @@ class SettingsCompanion extends UpdateCompanion<SettingsData> {
           ..write('lastSuccessfulTorTransport: $lastSuccessfulTorTransport, ')
           ..write('themeMode: $themeMode, ')
           ..write('isErrorReportingEnabled: $isErrorReportingEnabled, ')
+          ..write(
+            'screenCaptureProtectionEnabled: $screenCaptureProtectionEnabled, ',
+          )
           ..write(
             'exchangeTestnetBasicAuthUsername: $exchangeTestnetBasicAuthUsername, ',
           )

--- a/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
+++ b/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
@@ -13,7 +13,8 @@ void main() {
 
   setUpAll(() => verifier = SchemaVerifier(GeneratedHelper()));
 
-  test('v14 to v15 adds Tor transport settings with defaults', () async {
+  test('v14 to v15 adds Tor transport and screen-capture settings with '
+      'defaults', () async {
     final schema = await verifier.schemaAt(14);
     final oldDb = v14.DatabaseAtV14(schema.newConnection());
     await oldDb
@@ -40,6 +41,42 @@ void main() {
     expect(settings.single.environment, 'testnet');
     expect(settings.single.torTransportMode, 'automatic');
     expect(settings.single.lastSuccessfulTorTransport, isNull);
+    // Screen-capture protection is added in this step and defaults to enabled
+    // (1) so existing installs keep protection until the user opts out.
+    expect(settings.single.screenCaptureProtectionEnabled, 1);
     await migratedDb.close();
   });
+
+  test(
+    'v14 to v15 tolerates tor columns already present (idempotency guard)',
+    () async {
+      final schema = await verifier.schemaAt(14);
+
+      // Simulate a dev device that received the tor columns from develop's
+      // earlier, broken 13->14 build: add them onto the released v14 settings
+      // table before upgrading.
+      final seeded = v14.DatabaseAtV14(schema.newConnection());
+      await seeded.customStatement(
+        "ALTER TABLE settings ADD COLUMN tor_transport_mode TEXT NOT NULL "
+        "DEFAULT 'automatic'",
+      );
+      await seeded.customStatement(
+        'ALTER TABLE settings ADD COLUMN last_successful_tor_transport TEXT',
+      );
+      await seeded.close();
+
+      // Opening the app database runs the 14->15 migration. The _addColumnIfNot
+      // Exists guard must skip the duplicate tor adds instead of throwing, and
+      // still add the new screen-capture column.
+      final db = SqliteDatabase(schema.newConnection());
+      final columns = await db
+          .customSelect("SELECT name FROM pragma_table_info('settings')")
+          .map((row) => row.read<String>('name'))
+          .get();
+      expect(columns, contains('tor_transport_mode'));
+      expect(columns, contains('last_successful_tor_transport'));
+      expect(columns, contains('screen_capture_protection_enabled'));
+      await db.close();
+    },
+  );
 }

--- a/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
+++ b/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
@@ -46,37 +46,4 @@ void main() {
     expect(settings.single.screenCaptureProtectionEnabled, 1);
     await migratedDb.close();
   });
-
-  test(
-    'v14 to v15 tolerates tor columns already present (idempotency guard)',
-    () async {
-      final schema = await verifier.schemaAt(14);
-
-      // Simulate a dev device that received the tor columns from develop's
-      // earlier, broken 13->14 build: add them onto the released v14 settings
-      // table before upgrading.
-      final seeded = v14.DatabaseAtV14(schema.newConnection());
-      await seeded.customStatement(
-        "ALTER TABLE settings ADD COLUMN tor_transport_mode TEXT NOT NULL "
-        "DEFAULT 'automatic'",
-      );
-      await seeded.customStatement(
-        'ALTER TABLE settings ADD COLUMN last_successful_tor_transport TEXT',
-      );
-      await seeded.close();
-
-      // Opening the app database runs the 14->15 migration. The _addColumnIfNot
-      // Exists guard must skip the duplicate tor adds instead of throwing, and
-      // still add the new screen-capture column.
-      final db = SqliteDatabase(schema.newConnection());
-      final columns = await db
-          .customSelect("SELECT name FROM pragma_table_info('settings')")
-          .map((row) => row.read<String>('name'))
-          .get();
-      expect(columns, contains('tor_transport_mode'));
-      expect(columns, contains('last_successful_tor_transport'));
-      expect(columns, contains('screen_capture_protection_enabled'));
-      await db.close();
-    },
-  );
 }

--- a/test/security_audit/issue_2614_test.dart
+++ b/test/security_audit/issue_2614_test.dart
@@ -14,7 +14,7 @@ void main() {
       ).readAsStringSync();
 
       expect(source, contains('PrivacyScreen'));
-      expect(source, contains('privacy_screen.dart'));
+      expect(source, contains('package:screen_privacy/screen_privacy.dart'));
     });
   });
 }


### PR DESCRIPTION
Adds a user-controllable `Screen Privacy` toggle (in app settings) that turns OS-level screenshot/recording blocking on sensitive screens (recovery phrase, seed views) on or off. Defaults **on**, so existing installs keep protection until they opt out.

Also, fixed a bug where leaving a protected screen could leave screenshots blocked across the entire app.

https://github.com/user-attachments/assets/2b429dba-a9da-4366-b1c2-3b76bf8c8fd7