### PR TITLE
perf: eliminate idle rendering and add mobile benchmarks

### DIFF
--- a/lib/core/widgets/loading/fading_linear_progress.dart
+++ b/lib/core/widgets/loading/fading_linear_progress.dart
@@ -21,21 +21,19 @@ class FadingLinearProgress extends StatefulWidget {
 }
 
 class _FadingLinearProgressState extends State<FadingLinearProgress> {
-  bool isVisible = false;
+  late bool _tickerEnabled;
 
   @override
   void initState() {
     super.initState();
-    isVisible = widget.trigger;
+    _tickerEnabled = widget.trigger;
   }
 
   @override
   void didUpdateWidget(FadingLinearProgress oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.trigger != oldWidget.trigger) {
-      setState(() {
-        isVisible = widget.trigger;
-      });
+    if (widget.trigger && !oldWidget.trigger) {
+      setState(() => _tickerEnabled = true);
     }
   }
 
@@ -44,11 +42,19 @@ class _FadingLinearProgressState extends State<FadingLinearProgress> {
     return SizedBox(
       height: widget.height,
       child: AnimatedOpacity(
-        opacity: isVisible ? 1.0 : 0.0,
+        opacity: widget.trigger ? 1.0 : 0.0,
         duration: widget.duration,
-        child: LinearProgressIndicator(
-          backgroundColor: widget.backgroundColor,
-          color: widget.foregroundColor,
+        onEnd: () {
+          if (!widget.trigger && _tickerEnabled) {
+            setState(() => _tickerEnabled = false);
+          }
+        },
+        child: TickerMode(
+          enabled: _tickerEnabled,
+          child: LinearProgressIndicator(
+            backgroundColor: widget.backgroundColor,
+            color: widget.foregroundColor,
+          ),
         ),
       ),
     );

--- a/lib/features/bitcoin_price/ui/price_chart_widget.dart
+++ b/lib/features/bitcoin_price/ui/price_chart_widget.dart
@@ -308,10 +308,7 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
   late Animation<double> _lineAnimation;
   late AnimationController _pulseAnimationController;
   late Animation<double> _pulseAnimation;
-  late AnimationController _dotPositionController;
-  late Animation<double> _dotPositionAnimation;
-  int _previousIndex = 0;
-  bool _isDragging = false;
+  late final Listenable _chartAnimations;
 
   @override
   void initState() {
@@ -342,34 +339,13 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
         );
     _pulseAnimationController.forward();
 
-    _dotPositionController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 300),
-    );
-    _dotPositionAnimation = CurvedAnimation(
-      parent: _dotPositionController,
-      curve: Curves.easeOutCubic,
-    );
-  }
-
-  @override
-  void didUpdateWidget(_Chart oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    final currentIndex =
-        widget.selectedIndex ?? _touchedIndex ?? (widget.rates.length - 1);
-    if (currentIndex != _previousIndex && !_isDragging) {
-      _previousIndex = currentIndex;
-      _dotPositionController.reset();
-      _dotPositionController.forward();
-    }
+    _chartAnimations = Listenable.merge([_lineAnimation, _pulseAnimation]);
   }
 
   @override
   void dispose() {
     _lineAnimationController.dispose();
     _pulseAnimationController.dispose();
-    _dotPositionController.dispose();
     super.dispose();
   }
 
@@ -388,11 +364,6 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
         widget.selectedIndex ?? _touchedIndex ?? rates.length - 1;
 
     return GestureDetector(
-      onHorizontalDragStart: (_) {
-        setState(() {
-          _isDragging = true;
-        });
-      },
       onHorizontalDragUpdate: (details) {
         final box = context.findRenderObject() as RenderBox?;
         if (box == null) return;
@@ -410,11 +381,6 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
           widget.onTap(index);
         }
       },
-      onHorizontalDragEnd: (_) {
-        setState(() {
-          _isDragging = false;
-        });
-      },
       onTapDown: (details) {
         final box = context.findRenderObject() as RenderBox?;
         if (box == null) return;
@@ -430,28 +396,20 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
         });
         widget.onTap(index);
       },
-      child: AnimatedBuilder(
-        animation: Listenable.merge([
-          _lineAnimation,
-          _pulseAnimation,
-          _dotPositionAnimation,
-        ]),
-        builder: (context, child) {
-          return CustomPaint(
-            size: Size.infinite,
-            painter: _ChartPainter(
-              prices: prices,
-              minPrice: minPrice - padding,
-              maxPrice: maxPrice + padding,
-              lineColor: context.appColors.onPrimary,
-              selectedIndex: displayIndex,
-              lineAnimation: _lineAnimation.value,
-              pulseScale: _pulseAnimation.value,
-              dotColor: context.appColors.onTertiary,
-              borderColor: context.appColors.onPrimary,
-            ),
-          );
-        },
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: _ChartPainter(
+          prices: prices,
+          minPrice: minPrice - padding,
+          maxPrice: maxPrice + padding,
+          lineColor: context.appColors.onPrimary,
+          selectedIndex: displayIndex,
+          lineAnimation: _lineAnimation,
+          pulseAnimation: _pulseAnimation,
+          repaint: _chartAnimations,
+          dotColor: context.appColors.onTertiary,
+          borderColor: context.appColors.onPrimary,
+        ),
       ),
     );
   }
@@ -465,18 +423,19 @@ class _ChartPainter extends CustomPainter {
     required this.lineColor,
     this.selectedIndex,
     required this.lineAnimation,
-    required this.pulseScale,
+    required this.pulseAnimation,
+    required Listenable repaint,
     required this.dotColor,
     required this.borderColor,
-  });
+  }) : super(repaint: repaint);
 
   final List<double> prices;
   final double minPrice;
   final double maxPrice;
   final Color lineColor;
   final int? selectedIndex;
-  final double lineAnimation;
-  final double pulseScale;
+  final Animation<double> lineAnimation;
+  final Animation<double> pulseAnimation;
   final Color dotColor;
   final Color borderColor;
 
@@ -499,7 +458,7 @@ class _ChartPainter extends CustomPainter {
       ..style = PaintingStyle.stroke;
 
     final path = Path();
-    final visibleCount = (prices.length * lineAnimation).ceil();
+    final visibleCount = (prices.length * lineAnimation.value).ceil();
     final startIndex = (prices.length - visibleCount).clamp(
       0,
       prices.length - 1,
@@ -559,7 +518,7 @@ class _ChartPainter extends CustomPainter {
       final normalizedPrice = (prices[selectedIndex!] - minPrice) / priceRange;
       final y = size.height - (normalizedPrice * size.height);
 
-      final dotRadius = 6.0 * pulseScale;
+      final dotRadius = 6.0 * pulseAnimation.value;
       final glowRadius = dotRadius + 4;
 
       final glowPaint = Paint()
@@ -588,7 +547,10 @@ class _ChartPainter extends CustomPainter {
   bool shouldRepaint(_ChartPainter oldDelegate) {
     return oldDelegate.prices != prices ||
         oldDelegate.selectedIndex != selectedIndex ||
-        oldDelegate.lineAnimation != lineAnimation ||
-        oldDelegate.pulseScale != pulseScale;
+        oldDelegate.lineColor != lineColor ||
+        oldDelegate.dotColor != dotColor ||
+        oldDelegate.borderColor != borderColor ||
+        oldDelegate.minPrice != minPrice ||
+        oldDelegate.maxPrice != maxPrice;
   }
 }

--- a/lib/features/bitcoin_price/ui/price_chart_widget.dart
+++ b/lib/features/bitcoin_price/ui/price_chart_widget.dart
@@ -330,13 +330,17 @@ class _ChartState extends State<_Chart> with TickerProviderStateMixin {
       vsync: this,
       duration: const Duration(milliseconds: 1500),
     );
-    _pulseAnimation = Tween<double>(begin: 0.8, end: 1.2).animate(
-      CurvedAnimation(
-        parent: _pulseAnimationController,
-        curve: Curves.easeInOut,
-      ),
-    );
-    _pulseAnimationController.repeat(reverse: true);
+    _pulseAnimation =
+        TweenSequence<double>([
+          TweenSequenceItem(tween: Tween(begin: 0.8, end: 1.2), weight: 1),
+          TweenSequenceItem(tween: Tween(begin: 1.2, end: 1.0), weight: 1),
+        ]).animate(
+          CurvedAnimation(
+            parent: _pulseAnimationController,
+            curve: Curves.easeInOut,
+          ),
+        );
+    _pulseAnimationController.forward();
 
     _dotPositionController = AnimationController(
       vsync: this,

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -797,6 +797,7 @@ class PayBloc extends Bloc<PayEvent, PayState>
 
       final current = _currentPaymentState;
       if (current == null) return;
+      if (current.payOrder.orderId != requestedOrderId) return;
       if (!current.isPayinBroadcast) {
         try {
           validatePayOrderDepositAddress(

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -119,6 +119,8 @@ class PayBloc extends Bloc<PayEvent, PayState>
   final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   Timer? _pollingTimer;
+  bool _isOrderRequestInFlight = false;
+  String? _pendingOrderStatusUpdateId;
   StreamSubscription<PayjoinSession>? _payjoinSubscription;
   String? _activePayjoinSessionId;
 
@@ -772,12 +774,16 @@ class PayBloc extends Bloc<PayEvent, PayState>
     PayPollOrderStatus event,
     Emitter<PayState> emit,
   ) async {
-    final payPaymentState = _currentPaymentState;
-    if (payPaymentState == null) return;
+    if (_isOrderRequestInFlight) return;
+    _isOrderRequestInFlight = true;
 
     try {
+      final payPaymentState = _currentPaymentState;
+      if (payPaymentState == null) return;
+      final requestedOrderId = payPaymentState.payOrder.orderId;
+
       final latestOrder = await _getOrderUsecase.execute(
-        orderId: payPaymentState.payOrder.orderId,
+        orderId: requestedOrderId,
       );
 
       if (latestOrder is! FiatPaymentOrder) {
@@ -821,6 +827,13 @@ class PayBloc extends Bloc<PayEvent, PayState>
       }
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
+    } finally {
+      _isOrderRequestInFlight = false;
+      final pendingOrderId = _pendingOrderStatusUpdateId;
+      _pendingOrderStatusUpdateId = null;
+      if (pendingOrderId != null && !emit.isDone) {
+        await _refreshOrderStatusForSuccess(pendingOrderId, emit);
+      }
     }
   }
 
@@ -888,28 +901,55 @@ class PayBloc extends Bloc<PayEvent, PayState>
     PayUpdateOrderStatus event,
     Emitter<PayState> emit,
   ) async {
-    try {
-      final orderSummary = await _getOrderUsecase.execute(
-        orderId: event.orderId,
-      );
+    if (_isOrderRequestInFlight) {
+      _pendingOrderStatusUpdateId = event.orderId;
+      return;
+    }
 
-      // Update the order in the current state if we're in success state
-      if (state is PaySuccessState) {
-        final currentState = state as PaySuccessState;
-        // Convert Order to FiatPaymentOrder if needed
-        if (orderSummary is FiatPaymentOrder) {
-          emit(currentState.copyWith(payOrder: orderSummary));
-        } else {
-          log.severe(
-            error:
-                'Expected FiatPaymentOrder for order ${event.orderId} but received ${orderSummary.runtimeType}',
-            trace: StackTrace.current,
-          );
+    await _refreshOrderStatusForSuccess(event.orderId, emit);
+  }
+
+  Future<void> _refreshOrderStatusForSuccess(
+    String initialOrderId,
+    Emitter<PayState> emit,
+  ) async {
+    var orderId = initialOrderId;
+
+    while (true) {
+      _isOrderRequestInFlight = true;
+
+      try {
+        final orderSummary = await _getOrderUsecase.execute(orderId: orderId);
+
+        // Update the order in the current state if we're in success state
+        if (state is PaySuccessState) {
+          final currentState = state as PaySuccessState;
+          // Convert Order to FiatPaymentOrder if needed
+          if (orderSummary is FiatPaymentOrder) {
+            emit(currentState.copyWith(payOrder: orderSummary));
+          } else {
+            log.severe(
+              error:
+                  'Expected FiatPaymentOrder for order $orderId but received ${orderSummary.runtimeType}',
+              trace: StackTrace.current,
+            );
+          }
         }
+      } catch (e) {
+        log.severe(error: e, trace: StackTrace.current);
+        // Don't emit error state for refresh failures in success screen
+      } finally {
+        _isOrderRequestInFlight = false;
       }
-    } catch (e) {
-      log.severe(error: e, trace: StackTrace.current);
-      // Don't emit error state for refresh failures in success screen
+
+      if (emit.isDone) {
+        _pendingOrderStatusUpdateId = null;
+        return;
+      }
+      final pendingOrderId = _pendingOrderStatusUpdateId;
+      _pendingOrderStatusUpdateId = null;
+      if (pendingOrderId == null) return;
+      orderId = pendingOrderId;
     }
   }
 

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -103,7 +103,9 @@ class SendCubit extends Cubit<SendState>
     required this._checkLiquidConsolidationUsecase,
     required this._getSendPayjoinEnabledUsecase,
     required this._verifySignedTxUsecase,
-  }) : super(const SendState());
+    Future<PaymentRequest> Function(String)? parsePaymentRequest,
+  }) : _parsePaymentRequest = parsePaymentRequest ?? PaymentRequest.parse,
+       super(const SendState());
 
   /// Distinct user-defined labels for the suggestion chips in the label
   /// bottom sheet. Wraps [LabelsFacade.fetchDistinctLabels] so widgets
@@ -155,6 +157,7 @@ class SendCubit extends Cubit<SendState>
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
   final VerifySignedTxUsecase _verifySignedTxUsecase;
+  final Future<PaymentRequest> Function(String) _parsePaymentRequest;
 
   StreamSubscription<Result<OrderSwapRecord, SendFailure>>?
   _orderSwapSubscription;
@@ -169,6 +172,7 @@ class SendCubit extends Cubit<SendState>
   /// re-populating an emptied cache (which could otherwise stage a PSBT
   /// built for the previous tx shape for broadcast).
   int _bitcoinPreviewEpoch = 0;
+  int _paymentRequestInputGeneration = 0;
 
   @override
   Future<void> close() async {
@@ -215,6 +219,14 @@ class SendCubit extends Cubit<SendState>
 
   void clearFailure() => emit(state.copyWith(failure: null));
 
+  int _startNewPaymentRequestInput() {
+    final generation = ++_paymentRequestInputGeneration;
+    if (state.loadingBestWallet) {
+      emit(state.copyWith(loadingBestWallet: false));
+    }
+    return generation;
+  }
+
   void backClicked() {
     _invalidateSignedTransaction();
     if (state.step == SendStep.address) {
@@ -246,6 +258,7 @@ class SendCubit extends Cubit<SendState>
     String scannedRawPaymentRequest,
     PaymentRequest? paymentRequest,
   ) async {
+    _startNewPaymentRequestInput();
     clearFailure();
     _invalidateSignedTransaction();
     final sanitizedText = scannedRawPaymentRequest.trim().replaceAll(
@@ -273,6 +286,7 @@ class SendCubit extends Cubit<SendState>
 
   /// Called when text is pasted or entered manually
   Future<void> onChangedText(String text) async {
+    final inputGeneration = _startNewPaymentRequestInput();
     try {
       clearFailure();
       _invalidateSignedTransaction();
@@ -283,6 +297,7 @@ class SendCubit extends Cubit<SendState>
       final paymentRequest = await _detectBitcoinStringUsecase.execute(
         data: sanitizedText,
       );
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final recipientChanged = state.paymentRequest != paymentRequest;
       emit(
         state.copyWith(
@@ -295,6 +310,7 @@ class SendCubit extends Cubit<SendState>
       // changed. Skip when paste/typing resolves to the same paymentRequest.
       if (recipientChanged) clearBitcoinFeePreviews();
     } catch (e) {
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final recipientCleared = state.paymentRequest != null;
       emit(
         state.copyWith(
@@ -312,9 +328,11 @@ class SendCubit extends Cubit<SendState>
   }
 
   Future<void> continueOnAddressConfirmed() async {
+    final inputGeneration = _paymentRequestInputGeneration;
     try {
       emit(state.copyWith(loadingBestWallet: true));
-      await unifiedBip21Prioritization();
+      await unifiedBip21Prioritization(inputGeneration: inputGeneration);
+      if (inputGeneration != _paymentRequestInputGeneration) return;
 
       if (!state.hasValidPaymentRequest) {
         emit(
@@ -2196,14 +2214,17 @@ class SendCubit extends Cubit<SendState>
         });
   }
 
-  Future<void> unifiedBip21Prioritization() async {
+  Future<void> unifiedBip21Prioritization({
+    required int inputGeneration,
+  }) async {
     final request = state.paymentRequest;
     if (request == null) return;
     if (request is! Bip21PaymentRequest) return;
     if (request.lightning.isEmpty) return;
 
     try {
-      final lightning = await PaymentRequest.parse(request.lightning);
+      final lightning = await _parsePaymentRequest(request.lightning);
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final wallet = _bestWalletUsecase.execute(
         wallets: state.wallets,
         request: lightning,
@@ -2211,6 +2232,7 @@ class SendCubit extends Cubit<SendState>
       );
       emit(state.copyWith(selectedWallet: wallet, paymentRequest: lightning));
     } catch (_) {
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final wallet = _bestWalletUsecase.execute(
         wallets: state.wallets,
         request: request,

--- a/lib/features/transactions/application/usecases/get_transactions_usecase.dart
+++ b/lib/features/transactions/application/usecases/get_transactions_usecase.dart
@@ -87,6 +87,38 @@ class GetTransactionsUsecase {
         secondaryOrderSwapLegs.addAll(secondaryOrderSwapWalletLegs(orderSwap));
       }
 
+      final swapBuckets = <String, List<int>>{};
+      for (var index = 0; index < swaps.length; index++) {
+        final swap = swaps[index];
+        for (final txId in {swap.sendTxId, swap.receiveTxId, swap.refundTxId}) {
+          if (txId != null) swapBuckets.putIfAbsent(txId, () => []).add(index);
+        }
+      }
+      final payjoinBuckets = <String, List<int>>{};
+      for (var index = 0; index < payjoins.length; index++) {
+        final payjoin = payjoins[index];
+        for (final txId in {payjoin.txId, payjoin.originalTxId}) {
+          if (txId != null) {
+            payjoinBuckets.putIfAbsent(txId, () => []).add(index);
+          }
+        }
+      }
+      final orderBuckets = <String, List<int>>{};
+      for (var index = 0; index < orders.length; index++) {
+        final txId = orders[index].transactionId;
+        if (txId != null) orderBuckets.putIfAbsent(txId, () => []).add(index);
+      }
+      final consumedPayjoinIndices = <int>{};
+      final consumedOrderIndices = <int>{};
+      final consumedOrderSwapIndices = <int>{};
+      final orderSwapIndexQueues = <OrderSwapRecord, List<int>>{};
+      final nextOrderSwapQueueIndices = <OrderSwapRecord, int>{};
+      for (var index = 0; index < orderSwaps.length; index++) {
+        orderSwapIndexQueues
+            .putIfAbsent(orderSwaps[index], () => [])
+            .add(index);
+      }
+
       // Add related payjoins, swaps and orders to the broadcasted wallet transactions
       //  as they should be linked and form a single Transaction entity.
       // In the future if swaps or orders can also be payjoins, we should do the same
@@ -98,66 +130,64 @@ class GetTransactionsUsecase {
       final broadcastedTransactions = walletTransactions
           .map((wt) {
             Swap? swap;
-            try {
-              swap = swaps.firstWhere((s) {
-                final claimedLeg =
-                    (wt.isOutgoing && s.sendTxId == wt.txId) ||
-                    (wt.isIncoming &&
-                        (s.receiveTxId == wt.txId || s.refundTxId == wt.txId));
-                return claimedLeg &&
-                    s.walletId == wt.walletId &&
-                    (s.amountSat == 0 || wt.amountSat <= s.amountSat) &&
-                    _transactionPaysSwapAddress(wt, s);
-              });
-            } catch (_) {
-              // If no swap is found, it means the transaction is not a swap
-              swap = null;
+            for (final index in swapBuckets[wt.txId] ?? const <int>[]) {
+              final s = swaps[index];
+              final claimedLeg =
+                  (wt.isOutgoing && s.sendTxId == wt.txId) ||
+                  (wt.isIncoming &&
+                      (s.receiveTxId == wt.txId || s.refundTxId == wt.txId));
+              if (claimedLeg &&
+                  s.walletId == wt.walletId &&
+                  (s.amountSat == 0 || wt.amountSat <= s.amountSat) &&
+                  _transactionPaysSwapAddress(wt, s)) {
+                swap = s;
+                break;
+              }
             }
             final orderSwap =
                 canonicalOrderSwaps[(txId: wt.txId, walletId: wt.walletId)];
             if (orderSwap != null) {
-              orderSwaps.remove(orderSwap);
+              final queue = orderSwapIndexQueues[orderSwap];
+              final queueIndex = nextOrderSwapQueueIndices[orderSwap] ?? 0;
+              if (queue != null && queueIndex < queue.length) {
+                consumedOrderSwapIndices.add(queue[queueIndex]);
+                nextOrderSwapQueueIndices[orderSwap] = queueIndex + 1;
+              }
             }
             PayjoinSession? payjoin;
-            try {
-              payjoin = payjoins.firstWhere(
-                (pj) =>
-                    [pj.txId, pj.originalTxId].contains(wt.txId) &&
-                    // Make sure to match the direction of the payjoin, since
-                    //  both a sender and receiver payjoin can exist for the
-                    //  same transaction if it was done between two wallets in
-                    //  the app.
-                    wt.isOutgoing == pj is PayjoinSenderSession,
-              );
-              // Remove the payjoin from the list of payjoins to avoid duplication
-              //  since it's already included in the broadcasted transaction
-              payjoins.remove(payjoin);
-            } catch (_) {
-              // If no payjoin is found, it means the transaction is not a payjoin
-              payjoin = null;
+            for (final index in payjoinBuckets[wt.txId] ?? const <int>[]) {
+              if (consumedPayjoinIndices.contains(index)) continue;
+              final candidate = payjoins[index];
+              if ((candidate.txId == wt.txId ||
+                      candidate.originalTxId == wt.txId) &&
+                  // Make sure to match the direction of the payjoin, since
+                  //  both a sender and receiver payjoin can exist for the
+                  //  same transaction if it was done between two wallets in
+                  //  the app.
+                  wt.isOutgoing == candidate is PayjoinSenderSession) {
+                payjoin = candidate;
+                consumedPayjoinIndices.add(index);
+                break;
+              }
             }
 
             Order? order;
-            try {
-              order = orders.firstWhere((o) {
-                if (o.transactionId != wt.txId) return false;
-                if (o.toAddress != null && o.toAddress != wt.toAddress) {
-                  return false;
-                }
-                final expectedDirection = o is BuyOrder
-                    ? wt.isIncoming
-                    : o is SellOrder
-                    ? wt.isOutgoing
-                    : true;
-                return expectedDirection &&
-                    _transactionCoversOrderAmount(wt, o);
-              });
-              // Remove the order from the list of orders to avoid duplication
-              //  since it's already included in the broadcasted transaction
-              orders.remove(order);
-            } catch (_) {
-              // If no order is found, it means the transaction is not an order
-              order = null;
+            for (final index in orderBuckets[wt.txId] ?? const <int>[]) {
+              if (consumedOrderIndices.contains(index)) continue;
+              final o = orders[index];
+              if (o.toAddress != null && o.toAddress != wt.toAddress) {
+                continue;
+              }
+              final expectedDirection = o is BuyOrder
+                  ? wt.isIncoming
+                  : o is SellOrder
+                  ? wt.isOutgoing
+                  : true;
+              if (expectedDirection && _transactionCoversOrderAmount(wt, o)) {
+                order = o;
+                consumedOrderIndices.add(index);
+                break;
+              }
             }
 
             return Transaction(
@@ -210,9 +240,23 @@ class GetTransactionsUsecase {
       // incoming and outgoing transactions). We want to make sure the swap is
       // associated with both the incoming as outgoing transaction, so we do it
       // after the broadcasted transactions are created with any associated swaps.
+      final consumedSwapIndices = <int>{};
+      final swapIndexQueues = <Swap, List<int>>{};
+      final nextSwapQueueIndices = <Swap, int>{};
+      for (var index = 0; index < swaps.length; index++) {
+        swapIndexQueues.putIfAbsent(swaps[index], () => []).add(index);
+      }
       for (final tx in dedupedBroadcastedTransactions) {
         if (tx.isSwap) {
-          swaps.remove(tx.swap);
+          final swap = tx.swap;
+          if (swap == null) continue;
+          final queue = swapIndexQueues[swap];
+          if (queue == null) continue;
+          final queueIndex = nextSwapQueueIndices[swap] ?? 0;
+          if (queueIndex < queue.length) {
+            consumedSwapIndices.add(queue[queueIndex]);
+            nextSwapQueueIndices[swap] = queueIndex + 1;
+          }
         }
       }
 
@@ -224,7 +268,14 @@ class GetTransactionsUsecase {
         // A resolved recovered swap with no wallet tx here was only associated
         // via a default/counterpart wallet id; don't show it on that chain.
         ...swaps
-            .where((s) => !(s.recovered && s.status.isTerminal))
+            .asMap()
+            .entries
+            .where(
+              (entry) =>
+                  !consumedSwapIndices.contains(entry.key) &&
+                  !(entry.value.recovered && entry.value.status.isTerminal),
+            )
+            .map((entry) => entry.value)
             .map((s) => Transaction(swap: s)),
         // An aborted Payjoin means its original transaction was successfully
         // broadcast or observed. If that wallet transaction is not visible in
@@ -232,9 +283,20 @@ class GetTransactionsUsecase {
         // standalone `0 sats / pending` row; the real transaction will be
         // joined through originalTxId once wallet sync catches up.
         ...payjoins
-            .where((p) => !p.isAborted)
+            .asMap()
+            .entries
+            .where(
+              (entry) =>
+                  !consumedPayjoinIndices.contains(entry.key) &&
+                  !entry.value.isAborted,
+            )
+            .map((entry) => entry.value)
             .map((p) => Transaction(payjoin: p)),
-        ...orderSwaps.map((orderSwap) => Transaction(orderSwap: orderSwap)),
+        ...orderSwaps
+            .asMap()
+            .entries
+            .where((entry) => !consumedOrderSwapIndices.contains(entry.key))
+            .map((entry) => Transaction(orderSwap: entry.value)),
         // If walletId is not null, the orders should be linked to a wallet transaction.
         // TODO: We could still check on the address of the order to see if it
         // is related to the wallet id, even without a wallet transaction yet.
@@ -243,7 +305,11 @@ class GetTransactionsUsecase {
         //  most efficient and robust way for the future. But for now we assume that
         //  orders without a wallet transaction are not relevant for a specific wallet yet.
         ...(walletId == null
-            ? orders.map((o) => Transaction(order: o))
+            ? orders
+                  .asMap()
+                  .entries
+                  .where((entry) => !consumedOrderIndices.contains(entry.key))
+                  .map((entry) => Transaction(order: entry.value))
             : <Transaction>[]),
       ];
     } catch (e, stackTrace) {
@@ -275,6 +341,7 @@ class GetTransactionsUsecase {
       default:
         return true;
     }
+    if (!declared.isFinite) return false;
     final declaredSat = ConvertAmount.btcToSats(declared);
     if (declaredSat <= 0) return true;
     return wt.amountSat >= declaredSat;

--- a/packages/bull_ui/lib/src/feedback/bull_fading_linear_progress.dart
+++ b/packages/bull_ui/lib/src/feedback/bull_fading_linear_progress.dart
@@ -33,21 +33,19 @@ class BullFadingLinearProgress extends StatefulWidget {
 }
 
 class _BullFadingLinearProgressState extends State<BullFadingLinearProgress> {
-  bool isVisible = false;
+  late bool _tickerEnabled;
 
   @override
   void initState() {
     super.initState();
-    isVisible = widget.trigger;
+    _tickerEnabled = widget.trigger;
   }
 
   @override
   void didUpdateWidget(BullFadingLinearProgress oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.trigger != oldWidget.trigger) {
-      setState(() {
-        isVisible = widget.trigger;
-      });
+    if (widget.trigger && !oldWidget.trigger) {
+      setState(() => _tickerEnabled = true);
     }
   }
 
@@ -56,11 +54,19 @@ class _BullFadingLinearProgressState extends State<BullFadingLinearProgress> {
     return SizedBox(
       height: widget.height,
       child: AnimatedOpacity(
-        opacity: isVisible ? 1.0 : 0.0,
+        opacity: widget.trigger ? 1.0 : 0.0,
         duration: widget.duration,
-        child: LinearProgressIndicator(
-          backgroundColor: widget.backgroundColor,
-          color: widget.foregroundColor,
+        onEnd: () {
+          if (!widget.trigger && _tickerEnabled) {
+            setState(() => _tickerEnabled = false);
+          }
+        },
+        child: TickerMode(
+          enabled: _tickerEnabled,
+          child: LinearProgressIndicator(
+            backgroundColor: widget.backgroundColor,
+            color: widget.foregroundColor,
+          ),
         ),
       ),
     );

--- a/packages/bull_ui/test/bull_fading_linear_progress_test.dart
+++ b/packages/bull_ui/test/bull_fading_linear_progress_test.dart
@@ -1,0 +1,195 @@
+import 'package:bull_ui/bull_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_app.dart';
+
+void main() {
+  const key = ValueKey('bull-fading-linear-progress');
+  const duration = Duration(milliseconds: 100);
+
+  double opacityOf(WidgetTester tester) {
+    return tester
+        .widget<FadeTransition>(
+          find.descendant(
+            of: find.byKey(key),
+            matching: find.byType(FadeTransition),
+          ),
+        )
+        .opacity
+        .value;
+  }
+
+  testWidgets('false trigger preserves layout and becomes scheduler-idle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: false,
+          height: 7,
+          duration: duration,
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(key)).height, 7);
+    expect(
+      tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+      0,
+    );
+
+    await tester.pump(duration);
+
+    expect(opacityOf(tester), 0);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('true trigger keeps transient callbacks active', (tester) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: true,
+          duration: duration,
+        ),
+      ),
+    );
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+
+    await tester.pump(const Duration(milliseconds: 40));
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+
+  testWidgets('true to false fades through an intermediate opacity', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: true,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: false,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+
+    expect(opacityOf(tester), greaterThan(0));
+    expect(opacityOf(tester), lessThan(1));
+
+    await tester.pump(const Duration(milliseconds: 70));
+
+    expect(opacityOf(tester), 0);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('keeps ticker enabled during fade-out', (tester) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: true,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: false,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
+    await tester.pump(duration);
+    await tester.pump();
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isFalse,
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('does not disable a ticker re-enabled before fade-out ends', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: true,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: false,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.pumpWidget(
+      wrapWithTheme(
+        const BullFadingLinearProgress(
+          key: key,
+          trigger: true,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(duration);
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+}

--- a/test/core_test/widgets/loading/fading_linear_progress_test.dart
+++ b/test/core_test/widgets/loading/fading_linear_progress_test.dart
@@ -1,0 +1,197 @@
+import 'package:bb_mobile/core/widgets/loading/fading_linear_progress.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const key = ValueKey('fading-linear-progress');
+  const duration = Duration(milliseconds: 100);
+
+  double opacityOf(WidgetTester tester) {
+    return tester
+        .widget<FadeTransition>(
+          find.descendant(
+            of: find.byKey(key),
+            matching: find.byType(FadeTransition),
+          ),
+        )
+        .opacity
+        .value;
+  }
+
+  testWidgets('false trigger preserves layout and becomes scheduler-idle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: false,
+            height: 7,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(key)).height, 7);
+    expect(
+      tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+      0,
+    );
+
+    await tester.pump(duration);
+
+    expect(opacityOf(tester), 0);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('true trigger keeps transient callbacks active', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: true,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+
+    await tester.pump(const Duration(milliseconds: 40));
+
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+
+  testWidgets('true to false fades through an intermediate opacity', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: true,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: false,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+
+    expect(opacityOf(tester), greaterThan(0));
+    expect(opacityOf(tester), lessThan(1));
+
+    await tester.pump(const Duration(milliseconds: 70));
+
+    expect(opacityOf(tester), 0);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('keeps ticker enabled during fade-out', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: true,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FadingLinearProgress(
+            key: key,
+            trigger: false,
+            duration: duration,
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
+    await tester.pump(duration);
+    await tester.pump();
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isFalse,
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('does not disable a ticker re-enabled before fade-out ends', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: FadingLinearProgress(key: key, trigger: true, duration: duration),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 10));
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: FadingLinearProgress(
+          key: key,
+          trigger: false,
+          duration: duration,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: FadingLinearProgress(key: key, trigger: true, duration: duration),
+      ),
+    );
+    await tester.pump(duration);
+    expect(
+      tester
+          .widget<TickerMode>(
+            find.descendant(
+              of: find.byKey(key),
+              matching: find.byType(TickerMode),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+  });
+}

--- a/test/features/bitcoin_price/ui/price_chart_widget_test.dart
+++ b/test/features/bitcoin_price/ui/price_chart_widget_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/exchange/domain/entity/rate.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/get_price_history_usecase.dart';
+import 'package:bb_mobile/core/exchange/domain/usecases/refresh_price_history_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/watch_currency_changes_usecase.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/bitcoin_price/presentation/bloc/bitcoin_price_bloc.dart';
+import 'package:bb_mobile/features/bitcoin_price/presentation/cubit/price_chart_cubit.dart';
+import 'package:bb_mobile/features/bitcoin_price/ui/price_chart_widget.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockConvertSatsToCurrencyAmountUsecase extends Mock
+    implements ConvertSatsToCurrencyAmountUsecase {}
+
+class _MockGetAvailableCurrenciesUsecase extends Mock
+    implements GetAvailableCurrenciesUsecase {}
+
+class _MockGetPriceHistoryUsecase extends Mock
+    implements GetPriceHistoryUsecase {}
+
+class _MockRefreshPriceHistoryUsecase extends Mock
+    implements RefreshPriceHistoryUsecase {}
+
+class _MockGetSettingsUsecase extends Mock implements GetSettingsUsecase {}
+
+class _MockWatchCurrencyChangesUsecase extends Mock
+    implements WatchCurrencyChangesUsecase {}
+
+Rate _rate(double price, int day) => Rate(
+  fromCurrency: 'BTC',
+  toCurrency: 'CAD',
+  interval: RateTimelineInterval.day,
+  createdAt: DateTime(2026, 1, day),
+  price: price,
+);
+
+void main() {
+  testWidgets('settles after the chart animations finish', (tester) async {
+    final watchCurrencyChanges = _MockWatchCurrencyChangesUsecase();
+    when(
+      () => watchCurrencyChanges.execute(),
+    ).thenAnswer((_) => const Stream<String>.empty());
+
+    final bitcoinPriceBloc = BitcoinPriceBloc(
+      getAvailableCurrenciesUsecase: _MockGetAvailableCurrenciesUsecase(),
+      getSettingsUsecase: _MockGetSettingsUsecase(),
+      convertSatsToCurrencyAmountUsecase:
+          _MockConvertSatsToCurrencyAmountUsecase(),
+      watchCurrencyChangesUsecase: watchCurrencyChanges,
+    );
+    final priceChartCubit =
+        PriceChartCubit(
+          getPriceHistoryUsecase: _MockGetPriceHistoryUsecase(),
+          refreshPriceHistoryUsecase: _MockRefreshPriceHistoryUsecase(),
+          getSettingsUsecase: _MockGetSettingsUsecase(),
+        )..emit(
+          PriceChartState(
+            prices: [_rate(100, 1), _rate(120, 2), _rate(110, 3)],
+            currency: 'CAD',
+            selectedDataPointIndex: 1,
+          ),
+        );
+    addTearDown(bitcoinPriceBloc.close);
+    addTearDown(priceChartCubit.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider.value(value: bitcoinPriceBloc),
+              BlocProvider.value(value: priceChartCubit),
+            ],
+            child: const PriceChartWidget(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CustomPaint), findsWidgets);
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 2),
+    );
+    expect(tester.binding.hasScheduledFrame, isFalse);
+    expect(tester.binding.transientCallbackCount, 0);
+
+    final chart = find.byType(CustomPaint).last;
+    final chartRect = tester.getRect(chart);
+    await tester.tapAt(Offset(chartRect.right - 1, chartRect.center.dy));
+    await tester.pump();
+
+    expect(priceChartCubit.state.selectedDataPointIndex, 2);
+    expect(tester.binding.transientCallbackCount, greaterThan(0));
+
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpAndSettle();
+    expect(tester.binding.hasScheduledFrame, isFalse);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+}

--- a/test/features/bitcoin_price/ui/price_chart_widget_test.dart
+++ b/test/features/bitcoin_price/ui/price_chart_widget_test.dart
@@ -106,7 +106,7 @@ void main() {
     await tester.pump();
 
     expect(priceChartCubit.state.selectedDataPointIndex, 2);
-    expect(tester.binding.transientCallbackCount, greaterThan(0));
+    expect(tester.binding.transientCallbackCount, 0);
 
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpAndSettle();

--- a/test/features/pay/presentation/pay_bloc_test.dart
+++ b/test/features/pay/presentation/pay_bloc_test.dart
@@ -670,6 +670,52 @@ void main() {
       expect(state.isConfirmingPayment, isTrue);
     });
 
+    test('an old order poll cannot overwrite a replacement order', () async {
+      final poll = Completer<Order>();
+      when(
+        () => getOrder.execute(orderId: any(named: 'orderId')),
+      ).thenAnswer((_) => poll.future);
+      when(
+        () => payOrder.payinStatus,
+      ).thenReturn(OrderPayinStatus.awaitingPayment);
+      final replacementOrder = _MockPayOrder();
+      when(() => replacementOrder.orderId).thenReturn('order-2');
+      when(() => replacementOrder.toAddress).thenReturn(payinAddress);
+
+      bloc.add(const PayEvent.pollOrderStatus());
+      await untilCalled(() => getOrder.execute(orderId: 'order-1'));
+      bloc.seed(paymentState().copyWith(payOrder: replacementOrder));
+      poll.complete(payOrder);
+      await pumpEventQueue();
+
+      final state = bloc.state as PayPaymentState;
+      expect(state.payOrder, same(replacementOrder));
+    });
+
+    test('poll and screen update share one in-flight order request', () async {
+      final request = Completer<Order>();
+      var requestCount = 0;
+      when(() => getOrder.execute(orderId: any(named: 'orderId'))).thenAnswer((
+        _,
+      ) {
+        requestCount++;
+        return request.future;
+      });
+
+      bloc.add(const PayEvent.pollOrderStatus());
+      await untilCalled(() => getOrder.execute(orderId: any(named: 'orderId')));
+
+      bloc.add(const PayEvent.updateOrderStatus(orderId: 'order-1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(requestCount, 1);
+
+      request.complete(payOrder);
+      await pumpEventQueue();
+
+      expect(requestCount, 2);
+    });
+
     test('absolute custom fees pass their actual rate to Payjoin', () async {
       const bip21 =
           'bitcoin:bc1q0000000000000000000000000000000000000'

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -205,6 +205,7 @@ class _TestableSendCubit extends SendCubit {
     required super.checkLiquidConsolidationUsecase,
     required super.getSendPayjoinEnabledUsecase,
     required super.verifySignedTxUsecase,
+    super.parsePaymentRequest,
   });
 
   void setStateForTest(SendState state) => emit(state);
@@ -293,7 +294,9 @@ void main() {
 
   late StreamController<PayjoinSession> payjoinEvents;
 
-  _TestableSendCubit buildCubit() => _TestableSendCubit(
+  _TestableSendCubit buildCubit({
+    Future<PaymentRequest> Function(String)? parsePaymentRequest,
+  }) => _TestableSendCubit(
     labelsFacade: labelsFacade,
     bestWalletUsecase: bestWalletUsecase,
     detectBitcoinStringUsecase: detectBitcoinStringUsecase,
@@ -332,6 +335,7 @@ void main() {
     checkLiquidConsolidationUsecase: checkLiquidConsolidationUsecase,
     getSendPayjoinEnabledUsecase: _MockGetSendPayjoinEnabledUsecase(),
     verifySignedTxUsecase: verifySignedTxUsecase,
+    parsePaymentRequest: parsePaymentRequest,
   );
 
   /// Precondition state that makes [SendState.willAttemptPayjoin] true and
@@ -357,6 +361,9 @@ void main() {
     registerFallbackValue(_FakeNewLabel());
     registerFallbackValue(_bitcoinLocalWallet());
     registerFallbackValue(BigInt.zero);
+    registerFallbackValue(
+      const PaymentRequest.bitcoin(address: 'fallback', isTestnet: true),
+    );
   });
 
   setUp(() {
@@ -809,5 +816,136 @@ void main() {
       expect(stored.reference, 'broadcast-txid');
       expect(stored.label, 'coffee');
     });
+  });
+
+  group('SendCubit.onChangedText stale detection results', () {
+    const oldText = 'old payment request';
+    const newText = 'new payment request';
+    const oldPaymentRequest = PaymentRequest.bitcoin(
+      address: 'old-address',
+      isTestnet: true,
+    );
+    const newPaymentRequest = PaymentRequest.bitcoin(
+      address: 'new-address',
+      isTestnet: true,
+    );
+
+    test('ignores an old success that resolves after a new success', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      final newResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: any(named: 'data')),
+      ).thenAnswer((invocation) {
+        final data = invocation.namedArguments[#data] as String;
+        return data == oldText ? oldResult.future : newResult.future;
+      });
+
+      final oldInput = cubit.onChangedText(oldText);
+      final newInput = cubit.onChangedText(newText);
+      newResult.complete(newPaymentRequest);
+      await newInput;
+      oldResult.complete(oldPaymentRequest);
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, newText);
+      expect(cubit.state.paymentRequest, newPaymentRequest);
+      expect(cubit.state.failure, isNull);
+    });
+
+    test('ignores an old error that resolves after a new success', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      final newResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: any(named: 'data')),
+      ).thenAnswer((invocation) {
+        final data = invocation.namedArguments[#data] as String;
+        return data == oldText ? oldResult.future : newResult.future;
+      });
+
+      final oldInput = cubit.onChangedText(oldText);
+      final newInput = cubit.onChangedText(newText);
+      newResult.complete(newPaymentRequest);
+      await newInput;
+      oldResult.completeError(StateError('old parse failed'));
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, newText);
+      expect(cubit.state.paymentRequest, newPaymentRequest);
+      expect(cubit.state.failure, isNull);
+    });
+
+    test('ignores an old success that resolves after a scan', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: oldText),
+      ).thenAnswer((_) => oldResult.future);
+
+      final oldInput = cubit.onChangedText(oldText);
+      await cubit.onScannedPaymentRequest('scanned payment request', null);
+      oldResult.complete(oldPaymentRequest);
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, 'scanned payment request');
+      expect(cubit.state.paymentRequest, isNull);
+    });
+
+    test(
+      'ignores a stale scan after a newer paste during Lightning parsing',
+      () async {
+        final parsing = Completer<PaymentRequest>();
+        final cubit = buildCubit(parsePaymentRequest: (_) => parsing.future);
+        addTearDown(cubit.close);
+        when(
+          () => detectBitcoinStringUsecase.execute(data: 'new payment request'),
+        ).thenAnswer(
+          (_) async => const PaymentRequest.bitcoin(
+            address: 'new-address',
+            isTestnet: true,
+          ),
+        );
+        when(
+          () => bestWalletUsecase.execute(
+            wallets: any(named: 'wallets'),
+            request: any(named: 'request'),
+            amountSat: any(named: 'amountSat'),
+          ),
+        ).thenReturn(_bitcoinLocalWallet());
+        const bip21 = PaymentRequest.bip21(
+          network: Network.bitcoinMainnet,
+          uri: 'bitcoin:old-address?lightning=old-invoice',
+          address: 'old-address',
+          lightning: 'old-invoice',
+        );
+
+        final oldScan = cubit.onScannedPaymentRequest('old scan', bip21);
+        await Future<void>.delayed(Duration.zero);
+        await cubit.onChangedText('new payment request');
+        parsing.complete(
+          PaymentRequest.bolt11(
+            invoice: 'stale-invoice',
+            amountSat: 1000,
+            paymentHash: 'stale-hash',
+            expiresAt: DateTime(2030).millisecondsSinceEpoch ~/ 1000,
+            isTestnet: true,
+          ),
+        );
+        await oldScan;
+
+        expect(cubit.state.copiedRawPaymentRequest, 'new payment request');
+        expect(
+          cubit.state.paymentRequest,
+          const PaymentRequest.bitcoin(address: 'new-address', isTestnet: true),
+        );
+        expect(cubit.state.selectedWallet, isNull);
+        expect(cubit.state.step, SendStep.address);
+        expect(cubit.state.loadingBestWallet, isFalse);
+      },
+    );
   });
 }

--- a/test/features/transactions/application/usecases/get_transactions_usecase_test.dart
+++ b/test/features/transactions/application/usecases/get_transactions_usecase_test.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
@@ -32,6 +34,34 @@ class _MockLabelExchangeOrdersUsecase extends Mock
 
 class _MockGetTransactionOrderSwapsUsecase extends Mock
     implements GetTransactionOrderSwapsUsecase {}
+
+class _CountingList<T> extends ListBase<T> {
+  final List<T> _items;
+  int accesses = 0;
+
+  _CountingList(Iterable<T> items) : _items = [...items];
+
+  @override
+  T operator [](int index) {
+    accesses++;
+    return _items[index];
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    accesses++;
+    _items[index] = value;
+  }
+
+  @override
+  int get length => _items.length;
+
+  @override
+  set length(int value) {
+    accesses++;
+    _items.length = value;
+  }
+}
 
 void main() {
   late _MockSettingsRepository settingsRepository;
@@ -212,6 +242,148 @@ void main() {
     expect(transactions.single.walletTransaction?.txId, 'payin-tx');
     expect(transactions.single.orderSwap?.localId, 'chain-order');
   });
+
+  test(
+    'matches unique order txids with linearly bounded source accesses',
+    () async {
+      const count = 1000;
+      final walletTransactions = [
+        for (var i = 0; i < count; i++)
+          _walletTransaction(
+            txId: 'tx-$i',
+            walletId: 'wallet-$i',
+            isIncoming: false,
+          ),
+      ];
+      final countedOrders = _CountingList<Order>([
+        for (var i = 0; i < count; i++) _sellOrder('tx-$i'),
+      ]);
+      orders = countedOrders;
+      when(
+        () => labelExchangeOrdersUsecase.execute(orders: any(named: 'orders')),
+      ).thenAnswer((_) async {});
+      when(
+        () => walletTransactionRepository.getWalletTransactions(
+          walletId: any(named: 'walletId'),
+          sync: any(named: 'sync'),
+          environment: any(named: 'environment'),
+        ),
+      ).thenAnswer((_) async => walletTransactions);
+      when(
+        () => payjoinSessions.list(any()),
+      ).thenAnswer((_) async => const Ok([]));
+
+      final transactions = await usecase.execute();
+
+      expect(transactions, hasLength(count));
+      expect(
+        transactions.every((transaction) => transaction.order != null),
+        isTrue,
+      );
+      expect(
+        countedOrders.accesses,
+        lessThanOrEqualTo(count * 30),
+        reason:
+            'unique txids should not scan the source order list quadratically',
+      );
+    },
+  );
+
+  test('consumes exchange orders independently from order swaps', () async {
+    final walletTransaction = _walletTransaction(
+      txId: 'exchange-tx',
+      walletId: 'wallet-1',
+      isIncoming: false,
+    );
+
+    orders = [_sellOrder('exchange-tx')];
+    when(
+      () => labelExchangeOrdersUsecase.execute(orders: any(named: 'orders')),
+    ).thenAnswer((_) async {});
+    when(
+      () => payjoinSessions.list(any()),
+    ).thenAnswer((_) async => const Ok([]));
+    when(
+      () => getOrderSwaps.execute(walletId: any(named: 'walletId')),
+    ).thenAnswer((_) async => []);
+    when(
+      () => walletTransactionRepository.getWalletTransactions(
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+        environment: any(named: 'environment'),
+      ),
+    ).thenAnswer((_) async => [walletTransaction]);
+    when(
+      () => payjoinSessions.list(any()),
+    ).thenAnswer((_) async => const Ok([]));
+    when(
+      () => getOrderSwaps.execute(walletId: any(named: 'walletId')),
+    ).thenAnswer((_) async => [_receiveOrderSwap()]);
+
+    final transactions = await usecase.execute();
+
+    expect(transactions, hasLength(2));
+    expect(transactions.singleWhere((tx) => tx.order != null).order, orders[0]);
+    expect(
+      transactions.singleWhere((tx) => tx.orderSwap != null).orderSwap?.localId,
+      'receive-order',
+    );
+  });
+
+  test(
+    'does not let a non-finite BTC amount abort valid associations',
+    () async {
+      final malformed = _sellOrder(
+        'malformed-tx',
+        payinAmount: double.infinity,
+      );
+      final valid = _sellOrder('valid-tx', payinAmount: 0.000005);
+      orders = [malformed, valid];
+      when(
+        () => labelExchangeOrdersUsecase.execute(orders: any(named: 'orders')),
+      ).thenAnswer((_) async {});
+      when(
+        () => payjoinSessions.list(any()),
+      ).thenAnswer((_) async => const Ok([]));
+      when(
+        () => getOrderSwaps.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => []);
+      final validTransaction = _walletTransaction(
+        txId: 'valid-tx',
+        walletId: 'wallet-1',
+        isIncoming: false,
+      );
+      final malformedTransaction = _walletTransaction(
+        txId: 'malformed-tx',
+        walletId: 'wallet-1',
+        isIncoming: false,
+      );
+      when(
+        () => walletTransactionRepository.getWalletTransactions(
+          walletId: any(named: 'walletId'),
+          sync: any(named: 'sync'),
+          environment: any(named: 'environment'),
+        ),
+      ).thenAnswer((_) async => [malformedTransaction, validTransaction]);
+
+      final transactions = await usecase.execute();
+
+      expect(transactions, hasLength(3));
+      expect(transactions.singleWhere((tx) => tx.order == valid).order, valid);
+      expect(
+        transactions
+            .singleWhere((tx) => tx.order == malformed)
+            .walletTransaction,
+        isNull,
+      );
+      expect(
+        transactions
+            .singleWhere((tx) => tx.walletTransaction == malformedTransaction)
+            .order,
+        isNull,
+      );
+    },
+  );
 }
 
 WalletTransaction _walletTransaction({
@@ -258,6 +430,25 @@ OrderSwapRecord _receiveOrderSwap() => OrderSwapRecord(
   ),
   createdAt: DateTime.utc(2026),
   localStatus: OrderSwapLocalStatus.completed,
+);
+
+Order _sellOrder(String txId, {double payinAmount = 0}) => Order.sell(
+  orderId: 'order-$txId',
+  orderType: OrderType.sell,
+  message: OrderMessage(code: '', message: ''),
+  orderNumber: 1,
+  payinAmount: payinAmount,
+  payinCurrency: 'BTC',
+  payoutAmount: 1,
+  payoutCurrency: 'CAD',
+  payinMethod: OrderPaymentMethod.bitcoin,
+  payoutMethod: OrderPaymentMethod.cadBalance,
+  orderStatus: OrderStatus.completed,
+  payinStatus: OrderPayinStatus.completed,
+  payoutStatus: OrderPayoutStatus.completed,
+  createdAt: DateTime.utc(2026),
+  bitcoinTransactionId: txId,
+  isTestnet: false,
 );
 
 OrderSwapRecord _chainOrderSwap() => OrderSwapRecord(


### PR DESCRIPTION
This PR contains the 14 mobile-performance optimization commits rebased onto `develop`.

It removes idle rendering work, bounds chart activity, instruments startup, serializes stale asynchronous flows, indexes transaction associations, and adds an isolated Android benchmark profile.

The included report documents the audit and the measured results.

## Changes

### Idle rendering and chart work

- Stop inactive progress indicators from driving tickers and rendering.
- Bound the Bitcoin price chart pulse and avoid unnecessary repaint work.

### Async correctness and startup

- Ignore stale Send input and Pay order-poll results.
- Instrument startup phases without delaying startup, while preserving the current Tor initialization flow.

### Transaction and workload performance

- Add transaction-association indexing and cover large transaction, coin, swap, and refresh workloads.

### Benchmarking

- Add isolated benchmark flavor wiring and the corresponding build checks.

## Measured impact on Pixel 6a

- Home with the chart hidden changed from 60.25 fps and 79.1% CPU to zero frames over 10 seconds and 0.2% CPU after the fixes settled.
- Send address changed from 60.24 fps and 66.6% CPU to zero frames over 10 seconds and 0.1% CPU after the fixes settled.
- Wallet detail changed from 57.49–60.28 fps and 75.8–90.0% CPU to zero frames over 10 seconds and 0.1% CPU after the fixes settled.
- The source-matched profile measurements stayed within the 60 Hz frame budget, with Home chart-hidden UI-frame p50/p90/p99/max of 3.84/5.16/5.95/8.73 ms and Send p50/p90/p99/max of 1.50/2.68/3.03/3.35 ms.
- The profile APK was measured before the two final non-graphical safeguards for stale Send input and Pay order polling; focused tests cover those final safeguards.
- The benchmark wallet used an isolated funded testnet fixture and did not open or copy production wallet data.