### PR TITLE
fix(qr): accept fountain parts with seqnum above sequence count

### DIFF
--- a/lib/core/urqr/urqr.dart
+++ b/lib/core/urqr/urqr.dart
@@ -138,8 +138,12 @@ class UrQrReader {
 
     final sequenceNumber = int.parse(match.group(1)!);
     final sequenceCount = int.parse(match.group(2)!);
+    // Note: sequenceNumber may legitimately exceed sequenceCount. Animated
+    // URs are fountain-coded (BCR-2020-005): once the pure fragments 1..N
+    // have played, the stream keeps emitting mixed parts N+1, N+2, ... so a
+    // decoder that missed frames can still recover. Rejecting those parts
+    // breaks scanning of any stream the camera joins mid-animation.
     if (sequenceNumber < 1 ||
-        sequenceNumber > sequenceCount ||
         sequenceCount > maxMultipartParts ||
         data.length > maxMultipartMessageSize) {
       throw UrSequenceLimitExceeded();

--- a/test/core_test/urqr/ur_qr_reader_test.dart
+++ b/test/core_test/urqr/ur_qr_reader_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/urqr/urqr.dart';
+import 'package:cbor/cbor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ur/ur.dart';
+import 'package:ur/ur_encoder.dart';
+
+void main() {
+  group('UrQrReader', () {
+    // Animated URs are fountain-coded (BCR-2020-005): once the pure
+    // fragments 1..N have played, the stream keeps emitting mixed parts
+    // N+1, N+2, ... The reader must accept them, or any scan that joins
+    // the animation mid-stream fails immediately.
+    test('decodes a stream the camera joins mid-animation', () {
+      final payload = cbor.encode(CborBytes(utf8.encode('x' * 100)));
+      final encoder = UREncoder(UR('bytes', Uint8List.fromList(payload)), 20);
+      final pureParts = <String>[];
+      while (!encoder.isComplete) {
+        pureParts.add(encoder.nextPart());
+      }
+      final mixedPart = encoder.nextPart(); // seqNum N+1 of N
+
+      final reader = UrQrReader();
+      reader.receive(mixedPart); // first captured frame is a mixed part
+      for (final part in pureParts) {
+        reader.receive(part);
+      }
+
+      expect(reader.isComplete, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

URQR scanning is broken in v6.13.0 (current Latest release): scanning any animated UR fails immediately with "UR processing failed", typically on the first captured frame. Regression introduced by ef78955e7 (the security-audit hardening for #2608), first shipped in v6.13.0 — 6.12.x is unaffected.

## Root cause

The #2608 hardening added a multipart frame validation that rejects frames whose sequence number exceeds the declared sequence count (`sequenceNumber > sequenceCount`).

Animated URs are fountain-coded (BCR-2020-005): after the pure fragments `1..N` have played, the stream keeps emitting mixed parts `N+1`, `N+2`, … indefinitely — that unbounded sequence is exactly what allows a decoder that missed frames (or joined mid-animation) to recover. Since the animation has usually been looping before the camera points at it, nearly every captured frame has `seqNum > seqCount`, so the very first frame threw `UrSequenceLimitExceeded`, the reader reset in the catch path, and the scan could never complete.

The existing roundtrip test didn't catch this because it feeds parts `1..N` in order, where `seqNum ≤ seqCount` always holds.

## Fix

Drop the `sequenceNumber > sequenceCount` condition in `UrQrReader._validateMultipartFrame`. The guards that actually bound the decoder's resources stay in place:

- `sequenceCount > maxMultipartParts` (1000) — caps the part count
- `data.length > maxMultipartMessageSize` (1 MB) — caps frame size
- `sequenceNumber < 1` — rejects malformed frames

So the #2608 DoS protection is preserved; only the spec-violating check is removed.

## Tests

- New regression test `test/core_test/urqr/ur_qr_reader_test.dart`: builds a genuine fountain stream with the real `UREncoder` (including mixed parts past `isComplete`, which `UrQrGenerator` cannot produce) and decodes a stream the camera joins mid-animation — the exact reported scenario. Verified to fail against the pre-fix code and pass with the fix.
- All existing `test/core_test/urqr` and `test/security_audit` tests pass (106 tests), including the #2608 sequence-bound test.
- `make analyze` clean, `dart fix --dry-run` clean.