### PR TITLE
feat(payjoin): Bull Bitcoin directory + OHTTP relay with non-collusion rule

### DIFF
--- a/lib/features/settings/ui/screens/bitcoin/payjoin_advanced_settings_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/payjoin_advanced_settings_screen.dart
@@ -243,10 +243,8 @@ class _PayjoinAdvancedSettingsScreenState
                       color: context.appColors.onSurfaceVariant,
                     ),
                   ),
-                  BBText(
-                    PayjoinConstants.directoryUrl,
-                    style: context.font.bodyMedium,
-                  ),
+                  for (final directory in PayjoinConstants.directoryUrls)
+                    BBText(directory, style: context.font.bodyMedium),
                   const Gap(12),
                   BBText(
                     context.loc.settingsPayjoinRelaysLabel,

--- a/packages/bull_payjoin/lib/src/engine/payjoin_constants.dart
+++ b/packages/bull_payjoin/lib/src/engine/payjoin_constants.dart
@@ -1,18 +1,70 @@
 import 'dart:math';
 
 abstract final class PayjoinConstants {
+  static const bullBitcoinDirectoryUrl = 'https://payjoin.bullbitcoin.com';
+  static const publicDirectoryUrl = 'https://payjo.in';
+
+  /// Payjoin directories in preference order: the Bull Bitcoin directory is
+  /// the default, and the public one is only used when it is unreachable
+  /// (see PdkPayjoinDatasource.fetchOhttpKeyRelayAndDirectory).
+  static const directoryUrls = [bullBitcoinDirectoryUrl, publicDirectoryUrl];
+
+  static const bullBitcoinOhttpRelayUrl = 'https://ohttp.bullbitcoin.com';
+
   static const ohttpRelayUrlsBase = [
+    bullBitcoinOhttpRelayUrl,
     'https://ohttp.achow101.com',
     'https://pj.bobspacebkk.com',
     'https://ohttp.cakewallet.com',
   ];
 
-  static List<String> get ohttpRelayUrls {
-    final relays = [...ohttpRelayUrlsBase]..shuffle(Random.secure());
+  /// The OHTTP relays allowed for a session on [directoryUrl], shuffled.
+  ///
+  /// HARD RULE: a relay run by the same operator as the directory must NEVER
+  /// be used — the OHTTP privacy model assumes the relay (which sees the
+  /// client IP) and the directory (which sees the payjoin mailbox) do not
+  /// collude, so pairing ohttp.bullbitcoin.com with payjoin.bullbitcoin.com
+  /// would let Bull Bitcoin link both ends on its own. Operator identity is
+  /// approximated by the registrable domain (last two host labels), so any
+  /// future *.bullbitcoin.com relay/directory pair stays excluded too. When
+  /// the directory cannot be determined, fail closed: the Bull Bitcoin relay
+  /// is dropped rather than risk pairing it with the Bull Bitcoin directory.
+  static List<String> ohttpRelayUrlsFor(String? directoryUrl) {
+    final directoryDomain = _registrableDomain(directoryUrl);
+    final bullBitcoinDomain = _registrableDomain(bullBitcoinDirectoryUrl)!;
+    final relays = [
+      for (final relay in ohttpRelayUrlsBase)
+        if (_registrableDomain(relay) != (directoryDomain ?? bullBitcoinDomain))
+          relay,
+    ]..shuffle(Random.secure());
     return relays;
   }
 
-  static const directoryUrl = 'https://payjo.in';
+  /// Relays allowed for the session behind [bip21]: the directory is whatever
+  /// the URI's `pj` endpoint points at. Used on every poll/post after session
+  /// creation, where the directory choice is already baked into the URI.
+  static List<String> ohttpRelayUrlsForBip21(String? bip21) {
+    return ohttpRelayUrlsFor(_pjEndpoint(bip21));
+  }
+
+  // BIP21 URIs are commonly uppercased wholesale for QR efficiency, so the
+  // `pj` key is matched case-insensitively.
+  static String? _pjEndpoint(String? bip21) {
+    final params = bip21 == null ? null : Uri.tryParse(bip21)?.queryParameters;
+    if (params == null) return null;
+    for (final entry in params.entries) {
+      if (entry.key.toLowerCase() == 'pj') return entry.value;
+    }
+    return null;
+  }
+
+  static String? _registrableDomain(String? url) {
+    final host = url == null ? null : Uri.tryParse(url)?.host.toLowerCase();
+    if (host == null || host.isEmpty) return null;
+    final parts = host.split('.');
+    return parts.length <= 2 ? host : parts.sublist(parts.length - 2).join('.');
+  }
+
   static const directoryPollingInterval = 5;
   static const defaultExpireAfterSec = 60 * 60 * 24;
   static const defaultMinAmountSat = 10000;

--- a/packages/bull_payjoin/lib/src/engine/payjoin_engine.dart
+++ b/packages/bull_payjoin/lib/src/engine/payjoin_engine.dart
@@ -11,7 +11,6 @@ import 'package:bull_payjoin/src/engine/payjoin.dart';
 import 'package:bull_payjoin/src/engine/payjoin_engine_contract.dart';
 import 'package:bull_payjoin/src/engine/payjoin_engine_exception.dart';
 import 'package:bull_payjoin/src/engine/payjoin_logger.dart';
-import 'package:bull_payjoin/src/engine/payjoin_constants.dart';
 import 'package:bull_payjoin/src/engine/pdk_payjoin_datasource.dart';
 import 'package:meta/meta.dart';
 import 'package:synchronized/synchronized.dart';
@@ -188,9 +187,12 @@ class PayjoinRepositoryImpl implements PayjoinRepository {
 
   @override
   Future<bool> checkOhttpRelayHealth() async {
-    final (ohttpKeys, ohttpRelay) = await _pdkPayjoinDatasource
-        .fetchOhttpKeyAndRelay(payjoinDirectory: PayjoinConstants.directoryUrl);
-    return ohttpKeys != null && ohttpRelay != null;
+    // Healthy as long as ANY directory (Bull Bitcoin first, public fallback
+    // second) is reachable through an allowed relay — the same resolution a
+    // new session would perform.
+    final (ohttpKeys, ohttpRelay, directory) = await _pdkPayjoinDatasource
+        .fetchOhttpKeyRelayAndDirectory();
+    return ohttpKeys != null && ohttpRelay != null && directory != null;
   }
 
   // TODO: Remove this and use the general frozen utxo datasource

--- a/packages/bull_payjoin/lib/src/engine/pdk_payjoin_datasource.dart
+++ b/packages/bull_payjoin/lib/src/engine/pdk_payjoin_datasource.dart
@@ -27,7 +27,7 @@ typedef OhttpKeysFetcher =
     });
 
 class PdkPayjoinDatasource {
-  final String _payjoinDirectoryUrl;
+  final List<String> _payjoinDirectoryUrls;
   final Dio _dio;
   final logger.PayjoinLogger _log;
   final OhttpKeysFetcher _fetchOhttpKeys;
@@ -49,7 +49,7 @@ class PdkPayjoinDatasource {
   bool _disposed = false;
 
   PdkPayjoinDatasource({
-    this._payjoinDirectoryUrl = PayjoinConstants.directoryUrl,
+    this._payjoinDirectoryUrls = PayjoinConstants.directoryUrls,
     required this._dio,
     required this._log,
     OhttpKeysFetcher ohttpKeysFetcher = fetchOhttpKeys,
@@ -106,10 +106,31 @@ class PdkPayjoinDatasource {
     await _expiredController.close();
   }
 
+  /// Resolves the first reachable payjoin directory in preference order
+  /// (Bull Bitcoin first, public fallback second) together with its OHTTP
+  /// keys and a working relay. A directory whose keys can't be fetched
+  /// through any of its allowed relays is treated as down.
+  Future<(OhttpKeys?, String?, String?)>
+  fetchOhttpKeyRelayAndDirectory() async {
+    for (final directory in _payjoinDirectoryUrls) {
+      final (ohttpKeys, ohttpRelay) = await fetchOhttpKeyAndRelay(
+        payjoinDirectory: directory,
+      );
+      if (ohttpKeys != null && ohttpRelay != null) {
+        return (ohttpKeys, ohttpRelay, directory);
+      }
+      _log.info('Payjoin directory unreachable, trying next');
+    }
+    return (null, null, null);
+  }
+
   Future<(OhttpKeys?, String?)> fetchOhttpKeyAndRelay({
     required String payjoinDirectory,
   }) async {
-    for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrls) {
+    // ohttpRelayUrlsFor enforces the relay/directory non-collusion rule.
+    for (final ohttpRelayUrl in PayjoinConstants.ohttpRelayUrlsFor(
+      payjoinDirectory,
+    )) {
       try {
         final ohttpKeys = await _fetchOhttpKeys(
           ohttpRelayUrl: ohttpRelayUrl,
@@ -141,18 +162,17 @@ class PdkPayjoinDatasource {
     int? amountSat,
   }) async {
     try {
-      final (ohttpKeys, ohttpRelay) = await fetchOhttpKeyAndRelay(
-        payjoinDirectory: _payjoinDirectoryUrl,
-      );
+      final (ohttpKeys, ohttpRelay, directory) =
+          await fetchOhttpKeyRelayAndDirectory();
 
-      if (ohttpRelay == null || ohttpKeys == null) {
-        throw Exception('All OHTTP relays failed');
+      if (ohttpRelay == null || ohttpKeys == null || directory == null) {
+        throw Exception('All payjoin directories/OHTTP relays failed');
       }
 
       var receiverBuilder =
           ReceiverBuilder(
                 address: address,
-                directory: _payjoinDirectoryUrl,
+                directory: directory,
                 ohttpKeys: ohttpKeys,
               )
               .withExpiration(expirationSecs: expireAfterSec)
@@ -259,7 +279,11 @@ class PdkPayjoinDatasource {
     // published and the creation aborts cleanly.
     await persistBeforePost(model);
 
-    await postOriginalProposal(withReplyKey, persister);
+    await postOriginalProposal(
+      withReplyKey,
+      persister,
+      PayjoinConstants.ohttpRelayUrlsForBip21(model.uri),
+    );
     _log.info('[sender] original proposal posted for $senderLogRef');
 
     // The POST transitioned the session to PollingForProposal, but `model`
@@ -281,10 +305,11 @@ class PdkPayjoinDatasource {
   Future<void> postOriginalProposal(
     WithReplyKey withReplyKey,
     InMemoryJsonSenderSessionPersister persister,
+    List<String> ohttpRelays,
   ) async {
     Object? lastError;
     var posted = false;
-    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+    for (final relay in ohttpRelays) {
       try {
         final reqCtx = withReplyKey.createV2PostRequest(ohttpRelay: relay);
         final body = await postBytes(
@@ -483,9 +508,14 @@ class PdkPayjoinDatasource {
           processPsbt,
         );
       case ProvisionalProposalReceiveSession():
-        return _finalizeProposal(state.inner, persister, processPsbt);
+        return _finalizeProposal(
+          state.inner,
+          persister,
+          receiverModel,
+          processPsbt,
+        );
       case PayjoinProposalReceiveSession():
-        return _sendPayjoinProposal(state.inner, persister);
+        return _sendPayjoinProposal(state.inner, persister, receiverModel);
       case HasReplyableExceptionReceiveSession():
         throw StateError('Receive session has a replyable exception');
       case MonitorReceiveSession():
@@ -640,26 +670,30 @@ class PdkPayjoinDatasource {
           maxEffectiveFeeRateSatPerVb: receiverModel.maxFeeRateSatPerVb.toInt(),
         )
         .save(persister: persister);
-    return _finalizeProposal(next, persister, processPsbt);
+    return _finalizeProposal(next, persister, receiverModel, processPsbt);
   }
 
   Future<({Monitor monitor, String psbt})> _finalizeProposal(
     ProvisionalProposal inner,
     InMemoryJsonReceiverSessionPersister persister,
+    PayjoinReceiverModel receiverModel,
     String Function(String) processPsbt,
   ) async {
     final next = inner
         .finalizeProposal(processPsbt: _ProcessPsbt(processPsbt))
         .save(persister: persister);
-    return _sendPayjoinProposal(next, persister);
+    return _sendPayjoinProposal(next, persister, receiverModel);
   }
 
   Future<({Monitor monitor, String psbt})> _sendPayjoinProposal(
     PayjoinProposal proposal,
     InMemoryJsonReceiverSessionPersister persister,
+    PayjoinReceiverModel receiverModel,
   ) async {
     Object? lastError;
-    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+    for (final relay in PayjoinConstants.ohttpRelayUrlsForBip21(
+      receiverModel.pjUri,
+    )) {
       try {
         final req = proposal.createPostRequest(ohttpRelay: relay);
         final body = await postBytes(
@@ -773,6 +807,7 @@ class PdkPayjoinDatasource {
       final unchecked = await _getUncheckedOriginalPayload(
         state.inner,
         persister,
+        PayjoinConstants.ohttpRelayUrlsForBip21(receiverModel.pjUri),
       );
       if (unchecked == null) {
         _log.info('Receiver request not ready');
@@ -848,7 +883,11 @@ class PdkPayjoinDatasource {
       }
       if (state is! PollingForProposalSendSession) return;
 
-      final proposalPsbt = await _getProposalPsbt(state.inner, persister);
+      final proposalPsbt = await _getProposalPsbt(
+        state.inner,
+        persister,
+        PayjoinConstants.ohttpRelayUrlsForBip21(senderModel.uri),
+      );
       if (proposalPsbt == null) return;
 
       _log.info('[sender poll] proposal found for $senderLogRef');
@@ -881,9 +920,10 @@ class PdkPayjoinDatasource {
   Future<UncheckedOriginalPayload?> _getUncheckedOriginalPayload(
     Initialized initialized,
     InMemoryJsonReceiverSessionPersister persister,
+    List<String> ohttpRelays,
   ) async {
     Object? lastError;
-    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+    for (final relay in ohttpRelays) {
       try {
         final poll = initialized.createPollRequest(ohttpRelay: relay);
         final body = await postBytes(
@@ -916,9 +956,10 @@ class PdkPayjoinDatasource {
   Future<String?> _getProposalPsbt(
     PollingForProposal polling,
     InMemoryJsonSenderSessionPersister persister,
+    List<String> ohttpRelays,
   ) async {
     Object? lastError;
-    for (final relay in PayjoinConstants.ohttpRelayUrls) {
+    for (final relay in ohttpRelays) {
       try {
         final poll = polling.createPollRequest(ohttpRelay: relay);
         final body = await postBytes(

--- a/packages/bull_payjoin/test/pdk_payjoin_datasource_test.dart
+++ b/packages/bull_payjoin/test/pdk_payjoin_datasource_test.dart
@@ -173,11 +173,168 @@ void main() {
 
       expect(
         await datasource.fetchOhttpKeyAndRelay(
-          payjoinDirectory: PayjoinConstants.directoryUrl,
+          payjoinDirectory: PayjoinConstants.publicDirectoryUrl,
         ),
         (null, null),
       );
       expect(attempted, PayjoinConstants.ohttpRelayUrlsBase.toSet());
+      await datasource.dispose();
+    });
+
+    test(
+      'NEVER pairs the Bull Bitcoin relay with the Bull Bitcoin directory',
+      () async {
+        final attempted = <String>{};
+        final datasource = PdkPayjoinDatasource(
+          log: PayjoinLogger.silent,
+          dio: Dio(),
+          ohttpKeysFetcher:
+              ({required ohttpRelayUrl, required directoryUrl}) async {
+                attempted.add(ohttpRelayUrl);
+                throw StateError('relay unavailable');
+              },
+        );
+
+        expect(
+          await datasource.fetchOhttpKeyAndRelay(
+            payjoinDirectory: PayjoinConstants.bullBitcoinDirectoryUrl,
+          ),
+          (null, null),
+        );
+        expect(
+          attempted,
+          PayjoinConstants.ohttpRelayUrlsBase.toSet()
+            ..remove(PayjoinConstants.bullBitcoinOhttpRelayUrl),
+        );
+        expect(
+          attempted,
+          isNot(contains(PayjoinConstants.bullBitcoinOhttpRelayUrl)),
+        );
+        await datasource.dispose();
+      },
+    );
+  });
+
+  group('ohttpRelayUrlsFor', () {
+    test('excludes the Bull Bitcoin relay for the Bull Bitcoin directory', () {
+      final relays = PayjoinConstants.ohttpRelayUrlsFor(
+        PayjoinConstants.bullBitcoinDirectoryUrl,
+      );
+      expect(
+        relays,
+        isNot(contains(PayjoinConstants.bullBitcoinOhttpRelayUrl)),
+      );
+      expect(
+        relays.toSet(),
+        PayjoinConstants.ohttpRelayUrlsBase.toSet()
+          ..remove(PayjoinConstants.bullBitcoinOhttpRelayUrl),
+      );
+    });
+
+    test('allows every relay for the public directory', () {
+      expect(
+        PayjoinConstants.ohttpRelayUrlsFor(
+          PayjoinConstants.publicDirectoryUrl,
+        ).toSet(),
+        PayjoinConstants.ohttpRelayUrlsBase.toSet(),
+      );
+    });
+
+    test('fails closed when the directory is unknown or unparseable', () {
+      for (final directory in [null, '', 'not a url']) {
+        expect(
+          PayjoinConstants.ohttpRelayUrlsFor(directory),
+          isNot(contains(PayjoinConstants.bullBitcoinOhttpRelayUrl)),
+          reason: 'directory: $directory',
+        );
+      }
+    });
+
+    test('applies the rule from a BIP21 pj endpoint, case-insensitively', () {
+      final bullBitcoinBip21 =
+          'bitcoin:BC1QEXAMPLE?amount=0.001'
+          '&pj=HTTPS://PAYJOIN.BULLBITCOIN.COM/ABC123%23OH1QYPM5'
+          '&pjos=0';
+      expect(
+        PayjoinConstants.ohttpRelayUrlsForBip21(bullBitcoinBip21),
+        isNot(contains(PayjoinConstants.bullBitcoinOhttpRelayUrl)),
+      );
+
+      final publicBip21 =
+          'bitcoin:bc1qexample?amount=0.001&pj=https://payjo.in/abc123';
+      expect(
+        PayjoinConstants.ohttpRelayUrlsForBip21(publicBip21).toSet(),
+        PayjoinConstants.ohttpRelayUrlsBase.toSet(),
+      );
+
+      // No pj endpoint at all: fail closed.
+      expect(
+        PayjoinConstants.ohttpRelayUrlsForBip21('bitcoin:bc1qexample'),
+        isNot(contains(PayjoinConstants.bullBitcoinOhttpRelayUrl)),
+      );
+    });
+  });
+
+  group('fetchOhttpKeyRelayAndDirectory', () {
+    test('prefers the Bull Bitcoin directory when reachable', () async {
+      final keys = _fakeOhttpKeys();
+      final datasource = PdkPayjoinDatasource(
+        log: PayjoinLogger.silent,
+        dio: Dio(),
+        ohttpKeysFetcher:
+            ({required ohttpRelayUrl, required directoryUrl}) async => keys,
+      );
+
+      final (resultKeys, relay, directory) = await datasource
+          .fetchOhttpKeyRelayAndDirectory();
+
+      expect(resultKeys, same(keys));
+      expect(directory, PayjoinConstants.bullBitcoinDirectoryUrl);
+      expect(relay, isNot(PayjoinConstants.bullBitcoinOhttpRelayUrl));
+      await datasource.dispose();
+    });
+
+    test(
+      'falls back to the public directory when Bull Bitcoin is down',
+      () async {
+        final keys = _fakeOhttpKeys();
+        final datasource = PdkPayjoinDatasource(
+          log: PayjoinLogger.silent,
+          dio: Dio(),
+          ohttpKeysFetcher:
+              ({required ohttpRelayUrl, required directoryUrl}) async {
+                if (directoryUrl == PayjoinConstants.bullBitcoinDirectoryUrl) {
+                  throw StateError('directory unavailable');
+                }
+                return keys;
+              },
+        );
+
+        final (resultKeys, relay, directory) = await datasource
+            .fetchOhttpKeyRelayAndDirectory();
+
+        expect(resultKeys, same(keys));
+        expect(directory, PayjoinConstants.publicDirectoryUrl);
+        expect(relay, isNotNull);
+        await datasource.dispose();
+      },
+    );
+
+    test('returns nulls when every directory is down', () async {
+      final datasource = PdkPayjoinDatasource(
+        log: PayjoinLogger.silent,
+        dio: Dio(),
+        ohttpKeysFetcher:
+            ({required ohttpRelayUrl, required directoryUrl}) async {
+              throw StateError('unavailable');
+            },
+      );
+
+      expect(await datasource.fetchOhttpKeyRelayAndDirectory(), (
+        null,
+        null,
+        null,
+      ));
       await datasource.dispose();
     });
   });


### PR DESCRIPTION
## What

- Adds **payjoin.bullbitcoin.com** as the default payjoin directory. **payjo.in** remains as fallback and is only used when the Bull Bitcoin directory is unreachable (its OHTTP keys can't be fetched through any allowed relay).
- Adds **ohttp.bullbitcoin.com** to the OHTTP relay pool.

## Hard rule: relay/directory non-collusion

A session using the Bull Bitcoin directory must **never** go through the Bull Bitcoin OHTTP relay. The OHTTP privacy model assumes the relay (which sees the client IP) and the directory (which sees the payjoin mailbox) do not collude — pairing them would let a single operator link both ends.

Enforcement:

- The global `ohttpRelayUrls` getter is gone; relay lists are derived per directory via `PayjoinConstants.ohttpRelayUrlsFor(directory)`, which excludes any relay sharing the directory's registrable domain (so any future `*.bullbitcoin.com` pair stays excluded too).
- Every relay loop (key fetch, sender original-PSBT post, sender proposal poll, receiver request poll, receiver proposal post) takes its relay list from **that session's own directory**, parsed from the BIP21 `pj` endpoint (case-insensitive key) — this also protects a sender paying into someone else's Bull-Bitcoin-directory session.
- If the directory can't be determined, it **fails closed**: the Bull Bitcoin relay is dropped.
- The `PayjoinConstants.directoryUrl` alias is removed so no call site can bypass the rule.

## Notes

- "Directory down" is detected as OHTTP keys unfetchable through every allowed relay, so if all non-BB relays were down but the BB directory was up, the wallet falls back to payjo.in (where the BB relay is allowed) rather than break the rule — privacy over directory preference.
- `checkOhttpRelayHealth` now reports healthy if **any** directory is reachable, matching what a new session would resolve.
- Advanced payjoin settings screen lists both directories and the new relay.

## Testing

- `dart analyze` clean; pre-commit `flutter analyze --fatal-warnings --fatal-infos` passed.
- 81/81 `bull_payjoin` tests pass, including new tests asserting: the BB relay is never attempted against the BB directory, all relays are allowed for payjo.in, fail-closed on unknown/unparseable directories and BIP21s without a `pj` endpoint, directory preference order, and fallback when the BB directory is down.