### PR TITLE
feat(payjoin): ownership fragment on mempool tx URLs

### DIFF
--- a/lib/core/mempool/domain/services/mempool_url_builder.dart
+++ b/lib/core/mempool/domain/services/mempool_url_builder.dart
@@ -7,9 +7,13 @@ class MempoolUrlBuilder {
 
   const MempoolUrlBuilder({required this._getActiveMempoolServerUsecase});
 
-  Future<String> bitcoinTxid(String txid, {required bool isTestnet}) async {
+  Future<String> bitcoinTxid(
+    String txid, {
+    required bool isTestnet,
+    String? fragment,
+  }) async {
     final server = await _activeServer(isTestnet: isTestnet, isLiquid: false);
-    return '${server.fullUrl}/tx/$txid';
+    return '${server.fullUrl}/tx/$txid${fragment == null ? '' : '?showDetails=true#$fragment'}';
   }
 
   Future<String> liquidTxid(

--- a/lib/core/widgets/transaction_viewer.dart
+++ b/lib/core/widgets/transaction_viewer.dart
@@ -29,6 +29,7 @@ class TransactionViewer extends StatelessWidget {
     this.color,
     this.clipboardText,
     required this._isTestnet,
+    this.explorerUrlFragment,
   }) : _network = _TransactionNetwork.bitcoin,
        _unblindedUrl = null;
 
@@ -40,7 +41,8 @@ class TransactionViewer extends StatelessWidget {
     this.clipboardText,
     required this._isTestnet,
     this._unblindedUrl,
-  }) : _network = _TransactionNetwork.liquid;
+  }) : explorerUrlFragment = null,
+       _network = _TransactionNetwork.liquid;
 
   final String data;
   final TextStyle? style;
@@ -52,6 +54,7 @@ class TransactionViewer extends StatelessWidget {
   final _TransactionNetwork _network;
   final bool _isTestnet;
   final String? _unblindedUrl;
+  final String? explorerUrlFragment;
 
   @override
   Widget build(BuildContext context) {
@@ -122,7 +125,11 @@ class TransactionViewer extends StatelessWidget {
     switch (_network) {
       case _TransactionNetwork.bitcoin:
         final builder = locator<MempoolUrlBuilder>();
-        return builder.bitcoinTxid(data, isTestnet: _isTestnet);
+        return builder.bitcoinTxid(
+          data,
+          isTestnet: _isTestnet,
+          fragment: explorerUrlFragment,
+        );
       case _TransactionNetwork.liquid:
         final builder = locator<MempoolUrlBuilder>();
         return builder.liquidTxid(

--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -94,6 +94,20 @@ sealed class Transaction with _$Transaction {
     return pj.status;
   }
 
+  /// Returns ownership only when it describes the displayed payjoin proposal.
+  String? get payjoinOwnershipFragment {
+    final p = payjoin;
+    final ownership = p?.ownership;
+    if (p == null || !isBitcoin || ownership == null) {
+      return null;
+    }
+    if (p.txId == null || p.txId != txId) return null;
+
+    String codes(List<PayjoinParty> parties) =>
+        parties.map((party) => party == PayjoinParty.sender ? 's' : 'r').join();
+    return 'pj=1:${codes(ownership.inputs)}:${codes(ownership.outputs)}';
+  }
+
   /// The mining fee (sats) deducted from a completed payjoin receive,
   /// paying for the input the receiver contributed to the transaction
   /// (BIP78). `null` unless this is a payjoin actually reflected in a

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -108,6 +108,7 @@ class TransactionDetailsTable extends StatelessWidget {
                     txId,
                     style: TextStyle(color: context.appColors.primary),
                     isTestnet: isTestnet,
+                    explorerUrlFragment: transaction?.payjoinOwnershipFragment,
                   ),
           ),
 

--- a/packages/bull_payjoin/lib/bull_payjoin.dart
+++ b/packages/bull_payjoin/lib/bull_payjoin.dart
@@ -41,6 +41,8 @@ export 'src/domain/payjoin_session.dart'
         PayjoinSession,
         PayjoinSenderSession,
         PayjoinReceiverSession,
+        PayjoinOwnership,
+        PayjoinParty,
         PayjoinStatus;
 export 'src/domain/payjoin_session_window.dart' show PayjoinSessionWindow;
 export 'src/public/payjoin.dart' show Payjoin;

--- a/packages/bull_payjoin/lib/src/domain/payjoin_session.dart
+++ b/packages/bull_payjoin/lib/src/domain/payjoin_session.dart
@@ -5,6 +5,15 @@ import 'package:primitives/primitives.dart';
 
 enum PayjoinStatus { started, requested, proposed, completed, aborted, expired }
 
+enum PayjoinParty { sender, recipient }
+
+final class PayjoinOwnership {
+  final List<PayjoinParty> inputs;
+  final List<PayjoinParty> outputs;
+
+  const PayjoinOwnership({required this.inputs, required this.outputs});
+}
+
 sealed class PayjoinSession {
   final PayjoinStatus status;
   final String id;
@@ -16,6 +25,7 @@ sealed class PayjoinSession {
   final String? originalTransactionId;
   final String? transactionId;
   final bool hasProposal;
+  final PayjoinOwnership? ownership;
 
   PayjoinSession({
     required this.status,
@@ -28,6 +38,7 @@ sealed class PayjoinSession {
     this.originalTransactionId,
     this.transactionId,
     this.hasProposal = false,
+    this.ownership,
   }) {
     if (id.trim().isEmpty) {
       throw ArgumentError.value(id, 'id', 'must not be blank');
@@ -92,6 +103,7 @@ final class PayjoinReceiverSession extends PayjoinSession {
     super.originalTransactionId,
     super.transactionId,
     super.hasProposal,
+    super.ownership,
   }) {
     if (payjoinUri.trim().isEmpty) {
       throw ArgumentError.value(payjoinUri, 'payjoinUri', 'must not be blank');
@@ -114,6 +126,7 @@ final class PayjoinSenderSession extends PayjoinSession {
     required super.originalTransactionId,
     super.transactionId,
     super.hasProposal,
+    super.ownership,
   }) : super(id: uri);
 
   String get uri => id;

--- a/packages/bull_payjoin/lib/src/engine/bitcoin_tx.dart
+++ b/packages/bull_payjoin/lib/src/engine/bitcoin_tx.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:bull_payjoin/src/domain/payjoin_session.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 
 final class BitcoinTx {
@@ -14,6 +15,10 @@ final class BitcoinTx {
   });
 
   static Future<BitcoinTx> fromBytes(List<int> bytes) async {
+    return fromBytesSync(bytes);
+  }
+
+  static BitcoinTx fromBytesSync(List<int> bytes) {
     final transaction = bdk.Transaction(
       transactionBytes: Uint8List.fromList(bytes),
     );
@@ -37,6 +42,11 @@ final class BitcoinTx {
   static Future<BitcoinTx> fromPsbt(String psbtBase64) {
     final psbt = bdk.Psbt(psbtBase64: psbtBase64);
     return fromBytes(psbt.extractTx().serialize());
+  }
+
+  static BitcoinTx fromPsbtSync(String psbtBase64) {
+    final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+    return fromBytesSync(psbt.extractTx().serialize());
   }
 
   Future<int> getAmountReceived({
@@ -67,4 +77,82 @@ final class TxOutput {
   final Uint8List scriptPubkey;
 
   const TxOutput({required this.value, required this.scriptPubkey});
+}
+
+PayjoinOwnership? derivePayjoinOwnership({
+  required BitcoinTx original,
+  required BitcoinTx proposal,
+  required Uint8List paymentScript,
+}) {
+  final senderOutpoints = {
+    for (final input in original.inputs) (input.txid, input.vout),
+  };
+  final proposalOutpoints = [
+    for (final input in proposal.inputs) (input.txid, input.vout),
+  ];
+  final proposalOutpointSet = proposalOutpoints.toSet();
+  if (senderOutpoints.isEmpty ||
+      senderOutpoints.length != original.inputs.length ||
+      proposalOutpointSet.length != proposalOutpoints.length ||
+      !proposalOutpointSet.containsAll(senderOutpoints)) {
+    return null;
+  }
+
+  final inputOwners = proposalOutpoints
+      .map(
+        (outpoint) => senderOutpoints.contains(outpoint)
+            ? PayjoinParty.sender
+            : PayjoinParty.recipient,
+      )
+      .toList();
+  if (!inputOwners.contains(PayjoinParty.sender) ||
+      !inputOwners.contains(PayjoinParty.recipient)) {
+    return null;
+  }
+
+  final paymentOutputs = original.outputs
+      .where((output) => _sameScript(output.scriptPubkey, paymentScript))
+      .toList();
+  if (paymentOutputs.length != 1 || proposal.outputs.isEmpty) return null;
+
+  final senderOutputIndexes = <int>{};
+  for (final output in original.outputs) {
+    if (_sameScript(output.scriptPubkey, paymentScript)) continue;
+    final matches = [
+      for (final (index, candidate) in proposal.outputs.indexed)
+        if (_sameScript(output.scriptPubkey, candidate.scriptPubkey)) index,
+    ];
+    if (matches.length != 1 || !senderOutputIndexes.add(matches.single)) {
+      return null;
+    }
+  }
+
+  final outputOwners = [
+    for (final (index, _) in proposal.outputs.indexed)
+      senderOutputIndexes.contains(index)
+          ? PayjoinParty.sender
+          : PayjoinParty.recipient,
+  ];
+  return PayjoinOwnership(inputs: inputOwners, outputs: outputOwners);
+}
+
+Uint8List? paymentScriptFromBip21(String bip21, {required bool isTestnet}) {
+  try {
+    final address = Uri.parse(bip21).path;
+    if (address.isEmpty) return null;
+    return bdk.Address(
+      address: address,
+      network: isTestnet ? bdk.Network.testnet : bdk.Network.bitcoin,
+    ).scriptPubkey().toBytes();
+  } catch (_) {
+    return null;
+  }
+}
+
+bool _sameScript(Uint8List left, Uint8List right) {
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    if (left[i] != right[i]) return false;
+  }
+  return true;
 }

--- a/packages/bull_payjoin/lib/src/engine/payjoin_runtime.dart
+++ b/packages/bull_payjoin/lib/src/engine/payjoin_runtime.dart
@@ -9,6 +9,7 @@ import 'package:bull_payjoin/src/domain/payjoin_policy.dart';
 import 'package:bull_payjoin/src/domain/payjoin_ports.dart';
 import 'package:bull_payjoin/src/domain/payjoin_requests.dart';
 import 'package:bull_payjoin/src/domain/payjoin_session.dart';
+import 'package:bull_payjoin/src/engine/bitcoin_tx.dart';
 import 'package:bull_payjoin/src/engine/payjoin.dart' as engine;
 import 'package:bull_payjoin/src/engine/payjoin_engine.dart';
 import 'package:bull_payjoin/src/engine/payjoin_fee_cap.dart';
@@ -643,6 +644,7 @@ PayjoinSession _toSession(engine.Payjoin value) {
       ? BitcoinNetwork.testnet
       : BitcoinNetwork.mainnet;
   final status = PayjoinStatus.values.byName(value.status.name);
+  final ownership = _deriveOwnership(value);
   return switch (value) {
     engine.PayjoinSender() => PayjoinSenderSession(
       status: status,
@@ -655,6 +657,7 @@ PayjoinSession _toSession(engine.Payjoin value) {
       originalTransactionId: value.originalTxId,
       transactionId: value.txId,
       hasProposal: value.proposalPsbt != null,
+      ownership: ownership,
     ),
     engine.PayjoinReceiver() => PayjoinReceiverSession(
       status: status,
@@ -669,6 +672,45 @@ PayjoinSession _toSession(engine.Payjoin value) {
       transactionId: value.txId,
       hasProposal: value.proposalPsbt != null,
       hasOriginalTransaction: value.originalTxBytes != null,
+      ownership: ownership,
     ),
   };
+}
+
+PayjoinOwnership? _deriveOwnership(engine.Payjoin payjoin) {
+  final proposalPsbt = payjoin.proposalPsbt;
+  final txId = payjoin.txId;
+  if (proposalPsbt == null || txId == null) return null;
+
+  try {
+    final proposal = BitcoinTx.fromPsbtSync(proposalPsbt);
+    if (proposal.txid != txId) return null;
+
+    final (original, bip21) = switch (payjoin) {
+      engine.PayjoinSender(:final originalPsbt, :final uri) => (
+        BitcoinTx.fromPsbtSync(originalPsbt),
+        uri,
+      ),
+      engine.PayjoinReceiver(:final originalTxBytes, :final pjUri) => (
+        originalTxBytes == null
+            ? null
+            : BitcoinTx.fromBytesSync(originalTxBytes),
+        pjUri,
+      ),
+    };
+    if (original == null || original.txid != payjoin.originalTxId) return null;
+
+    final paymentScript = paymentScriptFromBip21(
+      bip21,
+      isTestnet: payjoin.isTestnet,
+    );
+    if (paymentScript == null) return null;
+    return derivePayjoinOwnership(
+      original: original,
+      proposal: proposal,
+      paymentScript: paymentScript,
+    );
+  } catch (_) {
+    return null;
+  }
 }

--- a/packages/bull_payjoin/test/payjoin_session_test.dart
+++ b/packages/bull_payjoin/test/payjoin_session_test.dart
@@ -1,6 +1,14 @@
+import 'dart:typed_data';
+
 import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:bull_payjoin/src/engine/bitcoin_tx.dart';
 import 'package:primitives/primitives.dart';
 import 'package:test/test.dart';
+
+TxInput _input(String txid, [int vout = 0]) => TxInput(txid: txid, vout: vout);
+
+TxOutput _output(int script, [int value = 1000]) =>
+    TxOutput(value: value, scriptPubkey: Uint8List.fromList([script]));
 
 void main() {
   final createdAt = DateTime.utc(2026, 7, 30);
@@ -97,5 +105,76 @@ void main() {
       ),
       throwsArgumentError,
     );
+  });
+
+  test('derives both parties from the original and proposal', () {
+    final paymentScript = paymentScriptFromBip21(
+      'bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?amount=0.0005',
+      isTestnet: false,
+    );
+    expect(paymentScript, isNotNull);
+
+    final original = BitcoinTx(
+      txid: 'original',
+      inputs: [_input('a'), _input('b', 1)],
+      outputs: [
+        TxOutput(value: 50000, scriptPubkey: paymentScript!),
+        _output(2, 40000),
+      ],
+    );
+    final proposal = BitcoinTx(
+      txid: 'proposal',
+      inputs: [_input('receiver'), _input('a'), _input('b', 1)],
+      outputs: [_output(3, 49000), _output(2, 39500), _output(4, 500)],
+    );
+
+    final ownership = derivePayjoinOwnership(
+      original: original,
+      proposal: proposal,
+      paymentScript: paymentScript,
+    );
+
+    expect(ownership?.inputs, [
+      PayjoinParty.recipient,
+      PayjoinParty.sender,
+      PayjoinParty.sender,
+    ]);
+    expect(ownership?.outputs, [
+      PayjoinParty.recipient,
+      PayjoinParty.sender,
+      PayjoinParty.recipient,
+    ]);
+  });
+
+  test('does not guess when the comparison is ambiguous', () {
+    final original = BitcoinTx(
+      txid: 'original',
+      inputs: [_input('sender')],
+      outputs: [_output(1, 50000), _output(2, 40000)],
+    );
+    final paymentScript = Uint8List.fromList([1]);
+
+    for (final proposal in [
+      BitcoinTx(
+        txid: 'no receiver input',
+        inputs: original.inputs,
+        outputs: original.outputs,
+      ),
+      BitcoinTx(
+        txid: 'ambiguous sender output',
+        inputs: [_input('sender'), _input('receiver')],
+        outputs: [_output(2, 39500), _output(2, 500)],
+      ),
+    ]) {
+      expect(
+        derivePayjoinOwnership(
+          original: original,
+          proposal: proposal,
+          paymentScript: paymentScript,
+        ),
+        isNull,
+        reason: proposal.txid,
+      );
+    }
   });
 }

--- a/test/core_test/mempool/mempool_url_builder_test.dart
+++ b/test/core_test/mempool/mempool_url_builder_test.dart
@@ -1,0 +1,39 @@
+import 'package:bb_mobile/core/mempool/application/usecases/get_active_mempool_server_usecase.dart';
+import 'package:bb_mobile/core/mempool/domain/entities/mempool_server.dart';
+import 'package:bb_mobile/core/mempool/domain/services/mempool_url_builder.dart';
+import 'package:bb_mobile/core/mempool/domain/value_objects/mempool_server_network.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockActiveServerUsecase extends Mock
+    implements GetActiveMempoolServerUsecase {}
+
+void main() {
+  test(
+    'Payjoin transaction links open details and preserve ownership',
+    () async {
+      final activeServer = _MockActiveServerUsecase();
+      when(
+        () => activeServer.execute(isTestnet: false, isLiquid: false),
+      ).thenAnswer(
+        (_) async => Ok(
+          MempoolServer.existing(
+            url: 'mempool.bullbitcoin.com',
+            network: MempoolServerNetwork.bitcoinMainnet,
+            isCustom: false,
+          ),
+        ),
+      );
+
+      final url = await MempoolUrlBuilder(
+        getActiveMempoolServerUsecase: activeServer,
+      ).bitcoinTxid('txid', isTestnet: false, fragment: 'pj=1:rss:rs');
+
+      expect(
+        url,
+        'https://mempool.bullbitcoin.com/tx/txid?showDetails=true#pj=1:rss:rs',
+      );
+    },
+  );
+}

--- a/test/features/transactions/domain/entities/transaction_test.dart
+++ b/test/features/transactions/domain/entities/transaction_test.dart
@@ -30,6 +30,7 @@ PayjoinSession _senderPayjoin({
   String originalTxId = 'orig-txid',
   String? txId,
   int amountSat = 50000,
+  PayjoinOwnership? ownership,
 }) => PayjoinSenderSession(
   status: status,
   uri: 'bitcoin:tb1qsender?pj=https://payjo.in',
@@ -40,9 +41,37 @@ PayjoinSession _senderPayjoin({
   createdAt: DateTime(2026),
   expiresAt: DateTime(2026, 1, 1, 0, 5),
   transactionId: txId,
+  ownership: ownership,
 );
 
 void main() {
+  test('exposes ownership only for the displayed payjoin proposal', () {
+    const ownership = PayjoinOwnership(
+      inputs: [PayjoinParty.sender, PayjoinParty.recipient],
+      outputs: [PayjoinParty.recipient, PayjoinParty.sender],
+    );
+    final payjoin = _senderPayjoin(txId: 'payjoin-txid', ownership: ownership);
+
+    expect(
+      Transaction(
+        walletTransaction: _walletTx(txId: 'payjoin-txid'),
+        payjoin: payjoin,
+      ).payjoinOwnershipFragment,
+      'pj=1:sr:rs',
+    );
+    expect(
+      Transaction(payjoin: payjoin).payjoinOwnershipFragment,
+      'pj=1:sr:rs',
+    );
+    expect(
+      Transaction(
+        walletTransaction: _walletTx(txId: 'orig-txid'),
+        payjoin: payjoin,
+      ).payjoinOwnershipFragment,
+      isNull,
+    );
+  });
+
   group('Transaction swap wallet direction', () {
     test('identifies Bitcoin to Liquid transfer wallets', () {
       final transaction = Transaction(


### PR DESCRIPTION
## What

Every mempool transaction link generated for a Payjoin — both **Copy link** and **View in explorer** — carries the ownership fragment understood by the Bull Bitcoin mempool fork and opens mempool's existing transaction details view:

```
https://<mempool>/tx/<txid>?showDetails=true#pj=1:<inputCodes>:<outputCodes>
```

There is one `s`/`r` code per input and output in final transaction order (`s` = sender-owned, `r` = recipient-owned). This lets mempool label the participants and calculate their contributed, returned, and net amounts. Plain transactions and failed Payjoin fallback transactions keep their plain explorer URLs.

The production default remains `mempool.bullbitcoin.com`; custom mempool settings continue to be honored.

## How

- `bull_payjoin` derives canonical ownership from the protocol artifacts already held by the session. Original-transaction inputs are sender-owned; inputs added to the proposal are recipient-owned. Original non-payment outputs identify sender outputs in the proposal; the remaining outputs belong to the recipient. Ambiguous or inconsistent transactions produce no ownership.
- `Transaction.payjoinOwnershipFragment` emits the fragment only for Bitcoin and only when the displayed transaction is the proposal txid, never the original fallback txid.
- The optional fragment is passed through the existing `TransactionViewer` and `MempoolUrlBuilder` funnel. Both explorer actions already share this path, so there is no second URL implementation.
- `?showDetails=true` is added only when the Payjoin fragment exists. Plain Bitcoin and all Liquid explorer URLs are unchanged.

Ownership is derived locally from the original and proposed transactions, not from the exchange API. This works for ordinary sends and receives as well as Bull Bitcoin trades because all of them use the same Payjoin session and transaction-details path.

## Testing

- `flutter analyze --fatal-warnings --fatal-infos` is clean.
- Focused tests cover ownership derivation, proposal/fallback gating, and the exact explorer URL including both `showDetails=true` and the ownership fragment.
- Manually verified with a real mainnet Payjoin: the fragment labels every input/output, renders the Payjoin summary, and `showDetails=true` exposes the input/output script details without pressing **Details**.

## Deployment dependency

The Payjoin display requires the counterpart mempool frontend to be deployed at `mempool.bullbitcoin.com`. Until that deployment is live, production-domain links retain the fragment but the current frontend ignores it.

