### PR TITLE
fix(mempool): support self-hosted TLS servers

### DIFF
--- a/lib/core/electrum/application/usecases/add_custom_server_usecase.dart
+++ b/lib/core/electrum/application/usecases/add_custom_server_usecase.dart
@@ -54,9 +54,9 @@ class AddCustomServerUsecase {
         return const Err(ElectrumServerAlreadyExistsFailure());
       }
 
-      // Probe with the user's own validateDomain setting: accepting a
-      // certificate the sync would refuse saves a server that can never be
-      // used, and the failure only surfaces later as a broken sync.
+      // The timeout and retry policy still comes from the active settings.
+      // Domain validation is relaxed below because adding a custom server
+      // also persists that custom-server policy atomically.
       final ElectrumSettings electrumSettings;
       switch (await _electrumSettingsRepository.fetchByNetwork(
         server.network,
@@ -99,7 +99,7 @@ class AddCustomServerUsecase {
         final protocolStatus = await _serverStatusPort.checkElectrum(
           url: server.url,
           network: server.network,
-          validateDomain: electrumSettings.validateDomain,
+          validateDomain: false,
           timeout: effectiveTimeout,
           retry: electrumSettings.retry,
           proxyEndpoint: route?.endpoint,
@@ -111,9 +111,34 @@ class AddCustomServerUsecase {
         await route?.close();
       }
 
-      // Both checks passed — persist the server.
-      final saveResult = await _electrumServerRepository.save(server);
-      return saveResult.map((_) => ElectrumServerStatus.online);
+      switch (await _electrumServerRepository.save(server)) {
+        case Ok():
+          break;
+        case Err(:final failure):
+          return Err(failure);
+      }
+
+      if (electrumSettings.validateDomain) {
+        electrumSettings.update(newValidateDomain: false);
+        switch (await _electrumSettingsRepository.save(electrumSettings)) {
+          case Ok():
+            break;
+          case Err(:final failure):
+            final rollback = await _electrumServerRepository.delete(
+              url: server.url,
+            );
+            if (rollback case Err(:final failure)) {
+              log.severe(
+                message: 'Failed to roll back custom electrum server',
+                error: failure,
+                trace: StackTrace.current,
+              );
+            }
+            return Err(failure);
+        }
+      }
+
+      return const Ok(ElectrumServerStatus.online);
     } on OnionServerWithoutTorException catch (error, st) {
       log.severe(
         message: 'External Tor unavailable for custom onion server',

--- a/lib/core/fees/data/fees_datasource.dart
+++ b/lib/core/fees/data/fees_datasource.dart
@@ -1,28 +1,38 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/data/models/mempool_fees_model.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 
 class FeesDatasource {
   /// Builds the HTTP client for a resolved base URL. Injected so tests can
   /// supply a mock; defaults to a real Dio.
-  final Dio Function(String baseUrl) _dioBuilder;
+  final Dio Function(String baseUrl, bool validateDomain) _dioBuilder;
 
-  FeesDatasource({Dio Function(String baseUrl)? dioBuilder})
-    : _dioBuilder = dioBuilder ?? _defaultDioBuilder;
+  FeesDatasource({
+    Dio Function(String baseUrl, bool validateDomain)? dioBuilder,
+  }) : _dioBuilder = dioBuilder ?? _defaultDioBuilder;
 
-  static Dio _defaultDioBuilder(String baseUrl) => Dio(
-    BaseOptions(
-      baseUrl: baseUrl,
-      connectTimeout: const Duration(seconds: 10),
-      sendTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 15),
-      followRedirects: false,
-      validateStatus: (status) => status == 200,
-    ),
-  );
+  static Dio _defaultDioBuilder(String baseUrl, bool validateDomain) {
+    final http = Dio(
+      BaseOptions(
+        baseUrl: baseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        sendTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 15),
+        followRedirects: false,
+        validateStatus: (status) => status == 200,
+      ),
+    );
+    if (!validateDomain) {
+      (http.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () =>
+          HttpClient()..badCertificateCallback = (_, _, _) => true;
+    }
+    return http;
+  }
 
   /// Fetches precise (sub-1 sat/vByte) fee rates from the mempool API.
   ///
@@ -34,9 +44,10 @@ class FeesDatasource {
   /// neither endpoint yields a usable response.
   Future<MempoolFeesModel> fetchBitcoinNetworkFees({
     required String baseUrl,
+    bool validateDomain = true,
   }) async {
     // Fees and mempool are application traffic and intentionally remain direct.
-    final http = _dioBuilder(baseUrl);
+    final http = _dioBuilder(baseUrl, validateDomain);
 
     final fees =
         await _getFees(http, ApiServiceConstants.mempoolPreciseFeesPath) ??

--- a/lib/core/fees/data/fees_repository_impl.dart
+++ b/lib/core/fees/data/fees_repository_impl.dart
@@ -23,8 +23,12 @@ class FeesRepositoryImpl implements FeesRepository {
   @override
   Future<FeeOptions> getNetworkFees({required Network network}) async {
     if (network.isBitcoin) {
+      final server = await _resolveBitcoinMempoolServer(
+        isTestnet: network.isTestnet,
+      );
       final fees = await _feesDatasource.fetchBitcoinNetworkFees(
-        baseUrl: await _resolveBitcoinMempoolUrl(isTestnet: network.isTestnet),
+        baseUrl: server.baseUrl,
+        validateDomain: server.validateDomain,
       );
       return MempoolFeesMapper.toFeeOptions(fees);
     }
@@ -41,7 +45,9 @@ class FeesRepositoryImpl implements FeesRepository {
     );
   }
 
-  Future<String> _resolveBitcoinMempoolUrl({required bool isTestnet}) async {
+  Future<({String baseUrl, bool validateDomain})> _resolveBitcoinMempoolServer({
+    required bool isTestnet,
+  }) async {
     final network = MempoolServerNetwork.fromEnvironment(
       isTestnet: isTestnet,
       isLiquid: false,
@@ -54,7 +60,10 @@ class FeesRepositoryImpl implements FeesRepository {
       Err() => throw MempoolFeesException('Failed to fetch mempool settings'),
     };
     if (!settings.useForFeeEstimation) {
-      return _bbMempoolUrl(isTestnet: isTestnet);
+      return (
+        baseUrl: _bbMempoolUrl(isTestnet: isTestnet),
+        validateDomain: true,
+      );
     }
 
     final customResult = await _mempoolServerRepository.fetchCustomServer(
@@ -66,7 +75,12 @@ class FeesRepositoryImpl implements FeesRepository {
         'Failed to fetch custom mempool server',
       ),
     };
-    if (customServer != null) return customServer.fullUrl;
+    if (customServer != null) {
+      return (
+        baseUrl: customServer.fullUrl,
+        validateDomain: customServer.validateDomain,
+      );
+    }
 
     final defaultResult = await _mempoolServerRepository.fetchDefaultServer(
       network,
@@ -77,7 +91,10 @@ class FeesRepositoryImpl implements FeesRepository {
         'Failed to fetch default mempool server',
       ),
     };
-    return defaultServer.fullUrl;
+    return (
+      baseUrl: defaultServer.fullUrl,
+      validateDomain: defaultServer.validateDomain,
+    );
   }
 
   String _bbMempoolUrl({required bool isTestnet}) => isTestnet

--- a/lib/core/mempool/application/dtos/mempool_server_dto.dart
+++ b/lib/core/mempool/application/dtos/mempool_server_dto.dart
@@ -7,6 +7,7 @@ class MempoolServerDto {
   final bool isTestnet;
   final bool isLiquid;
   final bool enableSsl;
+  final bool validateDomain;
   final MempoolServerStatus status;
 
   MempoolServerDto({
@@ -15,6 +16,7 @@ class MempoolServerDto {
     required this.isTestnet,
     required this.isLiquid,
     this.enableSsl = true,
+    this.validateDomain = true,
     this.status = MempoolServerStatus.unknown,
   });
 
@@ -25,6 +27,7 @@ class MempoolServerDto {
       isTestnet: entity.isTestnet,
       isLiquid: entity.isLiquid,
       enableSsl: entity.enableSsl,
+      validateDomain: entity.validateDomain,
     );
   }
 
@@ -36,6 +39,7 @@ class MempoolServerDto {
     bool? isTestnet,
     bool? isLiquid,
     bool? enableSsl,
+    bool? validateDomain,
     MempoolServerStatus? status,
   }) {
     return MempoolServerDto(
@@ -44,6 +48,7 @@ class MempoolServerDto {
       isTestnet: isTestnet ?? this.isTestnet,
       isLiquid: isLiquid ?? this.isLiquid,
       enableSsl: enableSsl ?? this.enableSsl,
+      validateDomain: validateDomain ?? this.validateDomain,
       status: status ?? this.status,
     );
   }
@@ -58,6 +63,7 @@ class MempoolServerDto {
           isTestnet == other.isTestnet &&
           isLiquid == other.isLiquid &&
           enableSsl == other.enableSsl &&
+          validateDomain == other.validateDomain &&
           status == other.status;
 
   @override
@@ -67,9 +73,10 @@ class MempoolServerDto {
       isTestnet.hashCode ^
       isLiquid.hashCode ^
       enableSsl.hashCode ^
+      validateDomain.hashCode ^
       status.hashCode;
 
   @override
   String toString() =>
-      'MempoolServerDto(url: $url, isCustom: $isCustom, isTestnet: $isTestnet, isLiquid: $isLiquid, enableSsl: $enableSsl, status: $status)';
+      'MempoolServerDto(url: $url, isCustom: $isCustom, isTestnet: $isTestnet, isLiquid: $isLiquid, enableSsl: $enableSsl, validateDomain: $validateDomain, status: $status)';
 }

--- a/lib/core/mempool/application/dtos/requests/set_custom_mempool_server_request.dart
+++ b/lib/core/mempool/application/dtos/requests/set_custom_mempool_server_request.dart
@@ -8,6 +8,6 @@ class SetCustomMempoolServerRequest {
     required this.url,
     required this.isLiquid,
     this.enableSsl = true,
-    this.validateDomain = true,
+    this.validateDomain = false,
   });
 }

--- a/lib/core/mempool/application/dtos/requests/set_custom_mempool_server_request.dart
+++ b/lib/core/mempool/application/dtos/requests/set_custom_mempool_server_request.dart
@@ -2,10 +2,12 @@ class SetCustomMempoolServerRequest {
   final String url;
   final bool isLiquid;
   final bool enableSsl;
+  final bool validateDomain;
 
   SetCustomMempoolServerRequest({
     required this.url,
     required this.isLiquid,
     this.enableSsl = true,
+    this.validateDomain = true,
   });
 }

--- a/lib/core/mempool/application/usecases/set_custom_mempool_server_usecase.dart
+++ b/lib/core/mempool/application/usecases/set_custom_mempool_server_usecase.dart
@@ -45,6 +45,7 @@ class SetCustomMempoolServerUsecase {
       url: request.url,
       network: network,
       enableSsl: request.enableSsl,
+      validateDomain: request.validateDomain,
     )) {
       case Ok(:final value):
         server = value;
@@ -76,6 +77,7 @@ class SetCustomMempoolServerUsecase {
         url: request.url,
         network: network,
         enableSsl: request.enableSsl,
+        validateDomain: request.validateDomain,
       );
       if (validation case Err(:final failure)) {
         return Err(failure);

--- a/lib/core/mempool/domain/entities/mempool_server.dart
+++ b/lib/core/mempool/domain/entities/mempool_server.dart
@@ -8,12 +8,14 @@ class MempoolServer {
   final MempoolServerNetwork _network;
   final bool _isCustom;
   final bool _enableSsl;
+  final bool _validateDomain;
 
   MempoolServer._({
     required this._url,
     required this._network,
     required this._isCustom,
     required this._enableSsl,
+    required this._validateDomain,
   });
 
   /// Validates [url] and builds a custom server, returning a typed failure
@@ -22,6 +24,7 @@ class MempoolServer {
     required String url,
     required MempoolServerNetwork network,
     bool enableSsl = true,
+    bool validateDomain = true,
   }) {
     final parsed = MempoolUrlParser.tryParse(url);
     if (parsed == null) {
@@ -33,6 +36,7 @@ class MempoolServer {
         network: network,
         isCustom: true,
         enableSsl: enableSsl,
+        validateDomain: validateDomain,
       ),
     );
   }
@@ -42,12 +46,14 @@ class MempoolServer {
     required MempoolServerNetwork network,
     required bool isCustom,
     bool enableSsl = true,
+    bool validateDomain = true,
   }) {
     return MempoolServer._(
       url: url,
       network: network,
       isCustom: isCustom,
       enableSsl: enableSsl,
+      validateDomain: validateDomain,
     );
   }
 
@@ -55,6 +61,7 @@ class MempoolServer {
   MempoolServerNetwork get network => _network;
   bool get isCustom => _isCustom;
   bool get enableSsl => _enableSsl;
+  bool get validateDomain => _validateDomain;
   bool get canUseForFeeEstimation => _enableSsl;
   String get fullUrl => _enableSsl ? 'https://$_url' : 'http://$_url';
 
@@ -69,16 +76,18 @@ class MempoolServer {
           _url == other._url &&
           _network == other._network &&
           _isCustom == other._isCustom &&
-          _enableSsl == other._enableSsl;
+          _enableSsl == other._enableSsl &&
+          _validateDomain == other._validateDomain;
 
   @override
   int get hashCode =>
       _url.hashCode ^
       _network.hashCode ^
       _isCustom.hashCode ^
-      _enableSsl.hashCode;
+      _enableSsl.hashCode ^
+      _validateDomain.hashCode;
 
   @override
   String toString() =>
-      'MempoolServer(url: $_url, network: $_network, isCustom: $_isCustom, enableSsl: $_enableSsl)';
+      'MempoolServer(url: $_url, network: $_network, isCustom: $_isCustom, enableSsl: $_enableSsl, validateDomain: $_validateDomain)';
 }

--- a/lib/core/mempool/domain/entities/mempool_server.dart
+++ b/lib/core/mempool/domain/entities/mempool_server.dart
@@ -24,7 +24,7 @@ class MempoolServer {
     required String url,
     required MempoolServerNetwork network,
     bool enableSsl = true,
-    bool validateDomain = true,
+    bool validateDomain = false,
   }) {
     final parsed = MempoolUrlParser.tryParse(url);
     if (parsed == null) {

--- a/lib/core/mempool/domain/ports/mempool_server_validator_port.dart
+++ b/lib/core/mempool/domain/ports/mempool_server_validator_port.dart
@@ -11,5 +11,6 @@ abstract class MempoolServerValidatorPort {
     required String url,
     required MempoolServerNetwork network,
     bool enableSsl = true,
+    bool validateDomain = true,
   });
 }

--- a/lib/core/mempool/frameworks/drift/models/mempool_server_model.dart
+++ b/lib/core/mempool/frameworks/drift/models/mempool_server_model.dart
@@ -8,6 +8,7 @@ class MempoolServerModel {
   final bool isLiquid;
   final bool isCustom;
   final bool enableSsl;
+  final bool validateDomain;
 
   MempoolServerModel({
     required this.url,
@@ -15,6 +16,7 @@ class MempoolServerModel {
     required this.isLiquid,
     required this.isCustom,
     this.enableSsl = true,
+    this.validateDomain = true,
   });
 
   factory MempoolServerModel.fromSqlite(MempoolServerRow row) {
@@ -24,6 +26,7 @@ class MempoolServerModel {
       isLiquid: row.isLiquid,
       isCustom: row.isCustom,
       enableSsl: row.enableSsl,
+      validateDomain: row.validateDomain,
     );
   }
 
@@ -34,6 +37,7 @@ class MempoolServerModel {
       isLiquid: isLiquid,
       isCustom: isCustom,
       enableSsl: enableSsl,
+      validateDomain: validateDomain,
     );
   }
 
@@ -44,6 +48,7 @@ class MempoolServerModel {
       isLiquid: entity.isLiquid,
       isCustom: entity.isCustom,
       enableSsl: entity.enableSsl,
+      validateDomain: entity.validateDomain,
     );
   }
 
@@ -58,6 +63,7 @@ class MempoolServerModel {
       network: network,
       isCustom: isCustom,
       enableSsl: enableSsl,
+      validateDomain: validateDomain,
     );
   }
 
@@ -70,7 +76,8 @@ class MempoolServerModel {
           isTestnet == other.isTestnet &&
           isLiquid == other.isLiquid &&
           isCustom == other.isCustom &&
-          enableSsl == other.enableSsl;
+          enableSsl == other.enableSsl &&
+          validateDomain == other.validateDomain;
 
   @override
   int get hashCode =>
@@ -78,9 +85,10 @@ class MempoolServerModel {
       isTestnet.hashCode ^
       isLiquid.hashCode ^
       isCustom.hashCode ^
-      enableSsl.hashCode;
+      enableSsl.hashCode ^
+      validateDomain.hashCode;
 
   @override
   String toString() =>
-      'MempoolServerModel(url: $url, isTestnet: $isTestnet, isLiquid: $isLiquid, isCustom: $isCustom, enableSsl: $enableSsl)';
+      'MempoolServerModel(url: $url, isTestnet: $isTestnet, isLiquid: $isLiquid, isCustom: $isCustom, enableSsl: $enableSsl, validateDomain: $validateDomain)';
 }

--- a/lib/core/mempool/interface_adapters/validators/http_mempool_server_validator.dart
+++ b/lib/core/mempool/interface_adapters/validators/http_mempool_server_validator.dart
@@ -36,6 +36,7 @@ class HttpMempoolServerValidator implements MempoolServerValidatorPort {
     required String url,
     required MempoolServerNetwork network,
     bool enableSsl = true,
+    bool validateDomain = true,
   }) async {
     MempoolTorRoute? route;
     HttpClient? torClient;
@@ -50,7 +51,10 @@ class HttpMempoolServerValidator implements MempoolServerValidatorPort {
           if (route == null) {
             return const Err(MempoolValidationTorNotRunningFailure());
           }
-          torClient = _torHttpClientFactory.create(route.endpoint);
+          torClient = _torHttpClientFactory.create(
+            route.endpoint,
+            allowBadCertificate: !validateDomain,
+          );
         } on Exception catch (error, stackTrace) {
           log.severe(
             message: 'Tor route setup failed',
@@ -69,9 +73,12 @@ class HttpMempoolServerValidator implements MempoolServerValidatorPort {
           sendTimeout: _timeout,
         ),
       );
+      final adapter = dio.httpClientAdapter as IOHttpClientAdapter;
       if (torClient != null) {
-        (dio.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () =>
-            torClient!;
+        adapter.createHttpClient = () => torClient!;
+      } else if (!validateDomain) {
+        adapter.createHttpClient = () =>
+            HttpClient()..badCertificateCallback = (_, _, _) => true;
       }
 
       // Use a simple endpoint to verify the server is a valid mempool instance.

--- a/lib/core/storage/database_seeds.dart
+++ b/lib/core/storage/database_seeds.dart
@@ -134,6 +134,7 @@ class DatabaseSeeds {
         isLiquid: isLiquid,
         isCustom: false,
         enableSsl: true,
+        validateDomain: true,
       );
 
       await db.into(db.mempoolServers).insertOnConflictUpdate(server);

--- a/lib/core/storage/migrations/schema_14_to_15.dart
+++ b/lib/core/storage/migrations/schema_14_to_15.dart
@@ -10,6 +10,8 @@ import 'package:drift/drift.dart';
 /// - `screen_capture_protection_enabled` — gates screenshot/recording blocking
 ///   on sensitive screens (defaults to true so installs keep protection until
 ///   the user opts out).
+/// - `mempool_servers.validate_domain` — stores certificate validation per
+///   custom mempool server (defaults to true for existing and default servers).
 class Schema14To15 {
   static Future<void> migrate(Migrator m, Schema15 schema15) async {
     await m.addColumn(schema15.settings, schema15.settings.torTransportMode);
@@ -20,6 +22,10 @@ class Schema14To15 {
     await m.addColumn(
       schema15.settings,
       schema15.settings.screenCaptureProtectionEnabled,
+    );
+    await m.addColumn(
+      schema15.mempoolServers,
+      schema15.mempoolServers.validateDomain,
     );
   }
 }

--- a/lib/core/storage/schemas/bull_database/drift_schema_v15.json
+++ b/lib/core/storage/schemas/bull_database/drift_schema_v15.json
@@ -1216,6 +1216,20 @@
             "default_dart": "const CustomExpression('1')",
             "default_client_dart": null,
             "dsl_features": []
+          },
+          {
+            "name": "validate_domain",
+            "getter_name": "validateDomain",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"validate_domain\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"validate_domain\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('1')",
+            "default_client_dart": null,
+            "dsl_features": []
           }
         ],
         "is_virtual": false,
@@ -2721,7 +2735,7 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"mempool_servers\" (\"url\" TEXT NOT NULL, \"is_testnet\" INTEGER NOT NULL CHECK (\"is_testnet\" IN (0, 1)), \"is_liquid\" INTEGER NOT NULL CHECK (\"is_liquid\" IN (0, 1)), \"is_custom\" INTEGER NOT NULL CHECK (\"is_custom\" IN (0, 1)), \"enable_ssl\" INTEGER NOT NULL DEFAULT 1 CHECK (\"enable_ssl\" IN (0, 1)), PRIMARY KEY (\"url\", \"is_testnet\", \"is_liquid\"));"
+          "sql": "CREATE TABLE IF NOT EXISTS \"mempool_servers\" (\"url\" TEXT NOT NULL, \"is_testnet\" INTEGER NOT NULL CHECK (\"is_testnet\" IN (0, 1)), \"is_liquid\" INTEGER NOT NULL CHECK (\"is_liquid\" IN (0, 1)), \"is_custom\" INTEGER NOT NULL CHECK (\"is_custom\" IN (0, 1)), \"enable_ssl\" INTEGER NOT NULL DEFAULT 1 CHECK (\"enable_ssl\" IN (0, 1)), \"validate_domain\" INTEGER NOT NULL DEFAULT 1 CHECK (\"validate_domain\" IN (0, 1)), PRIMARY KEY (\"url\", \"is_testnet\", \"is_liquid\"));"
         }
       ]
     },

--- a/lib/core/storage/sqlite_database.steps.dart
+++ b/lib/core/storage/sqlite_database.steps.dart
@@ -7371,7 +7371,7 @@ final class Schema15 extends i0.VersionedSchema {
     ),
     alias: null,
   );
-  late final Shape36 mempoolServers = Shape36(
+  late final Shape43 mempoolServers = Shape43(
     source: i0.VersionedTable(
       entityName: 'mempool_servers',
       withoutRowId: false,
@@ -7383,6 +7383,7 @@ final class Schema15 extends i0.VersionedSchema {
         _column_179,
         _column_181,
         _column_234,
+        _column_288,
       ],
       attachedDatabase: database,
     ),
@@ -7688,6 +7689,33 @@ i1.GeneratedColumn<int> _column_287(
       'NOT NULL DEFAULT 1 CHECK (screen_capture_protection_enabled IN (0, 1))',
   defaultValue: const i1.CustomExpression('1'),
 );
+
+class Shape43 extends i0.VersionedTable {
+  Shape43({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<String> get url =>
+      columnsByName['url']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get isTestnet =>
+      columnsByName['is_testnet']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get isLiquid =>
+      columnsByName['is_liquid']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get isCustom =>
+      columnsByName['is_custom']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get enableSsl =>
+      columnsByName['enable_ssl']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get validateDomain =>
+      columnsByName['validate_domain']! as i1.GeneratedColumn<int>;
+}
+
+i1.GeneratedColumn<int> _column_288(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'validate_domain',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints:
+          'NOT NULL DEFAULT 1 CHECK (validate_domain IN (0, 1))',
+      defaultValue: const i1.CustomExpression('1'),
+    );
 i0.MigrationStepWithVersion migrationSteps({
   required Future<void> Function(i1.Migrator m, Schema2 schema) from1To2,
   required Future<void> Function(i1.Migrator m, Schema3 schema) from2To3,

--- a/lib/core/storage/tables/mempool_servers_table.dart
+++ b/lib/core/storage/tables/mempool_servers_table.dart
@@ -7,6 +7,8 @@ class MempoolServers extends Table {
   BoolColumn get isLiquid => boolean()();
   BoolColumn get isCustom => boolean()();
   BoolColumn get enableSsl => boolean().withDefault(const Constant(true))();
+  BoolColumn get validateDomain =>
+      boolean().withDefault(const Constant(true))();
 
   @override
   Set<Column> get primaryKey => {url, isTestnet, isLiquid};

--- a/lib/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_bloc.dart
+++ b/lib/features/electrum_settings/interface_adapters/presenters/bloc/electrum_settings_bloc.dart
@@ -185,20 +185,15 @@ class ElectrumSettingsBloc
           status: value,
           priority: priority,
         );
-        // Custom servers (self-hosted, Tailscale, etc.) commonly present a
-        // certificate that fails strict domain validation, so switching to
-        // one disables it automatically.
-        final updatedAdvancedOptions = await _setValidateDomain(
-          network: network,
-          validateDomain: false,
-        );
         final hasActiveCustomBitcoinOnionServer =
             await _hasActiveCustomBitcoinOnionServerUsecase.execute();
         emit(
           state.copyWith(
             customServers: [...state.customServers, newServer],
             isAddingCustomServer: false,
-            advancedOptions: updatedAdvancedOptions ?? state.advancedOptions,
+            advancedOptions: state.advancedOptions?.copyWith(
+              validateDomain: false,
+            ),
             hasActiveCustomBitcoinOnionServer:
                 hasActiveCustomBitcoinOnionServer,
           ),
@@ -443,10 +438,9 @@ class ElectrumSettingsBloc
     _loadGeneration++;
   }
 
-  // Auto-toggles validateDomain to match the active server tier (off for
-  // custom, on for defaults). Best-effort: the server list change already
-  // succeeded, so a failure here is logged rather than surfaced as an
-  // add/delete-server error. Returns null when nothing changed.
+  // Restores strict validation when deleting the last custom server returns
+  // the active tier to the defaults. The deletion has already succeeded, so a
+  // settings failure is logged instead of reported as a deletion failure.
   Future<ElectrumAdvancedOptionsViewModel?> _setValidateDomain({
     required ElectrumServerNetwork network,
     required bool validateDomain,

--- a/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
+++ b/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
@@ -83,13 +83,18 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
     }
   }
 
-  Future<bool> setCustomServer(String url, {bool enableSsl = true}) async {
+  Future<bool> setCustomServer(
+    String url, {
+    bool enableSsl = true,
+    bool validateDomain = true,
+  }) async {
     emit(state.copyWith(isSavingServer: true, failure: null));
 
     final request = SetCustomMempoolServerRequest(
       url: url,
       isLiquid: state.isLiquid,
       enableSsl: enableSsl,
+      validateDomain: validateDomain,
     );
 
     switch (await _setCustomServerUsecase.execute(request)) {
@@ -163,6 +168,7 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
       url: server.url,
       network: network,
       enableSsl: server.enableSsl,
+      validateDomain: server.validateDomain,
     )).fold((_) => true, (_) => false);
 
     final finalServer = server.copyWith(

--- a/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
+++ b/lib/features/mempool_settings/presentation/bloc/mempool_settings_cubit.dart
@@ -86,7 +86,7 @@ class MempoolSettingsCubit extends Cubit<MempoolSettingsState> {
   Future<bool> setCustomServer(
     String url, {
     bool enableSsl = true,
-    bool validateDomain = true,
+    bool validateDomain = false,
   }) async {
     emit(state.copyWith(isSavingServer: true, failure: null));
 

--- a/lib/features/mempool_settings/ui/widgets/mempool_server_list.dart
+++ b/lib/features/mempool_settings/ui/widgets/mempool_server_list.dart
@@ -71,6 +71,7 @@ class MempoolServerList extends StatelessWidget {
                   context,
                   customServer.url,
                   customServer.enableSsl,
+                  customServer.validateDomain,
                 ),
               ),
             ],
@@ -105,11 +106,13 @@ class MempoolServerList extends StatelessWidget {
     BuildContext context,
     String currentUrl,
     bool enableSsl,
+    bool validateDomain,
   ) {
     SetCustomServerBottomSheet.show(
       context,
       initialUrl: currentUrl,
       initialEnableSsl: enableSsl,
+      initialValidateDomain: validateDomain,
     );
   }
 

--- a/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
+++ b/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
@@ -14,17 +14,20 @@ import 'package:bull_ui/bull_ui.dart' show Gap;
 class SetCustomServerBottomSheet extends StatefulWidget {
   final String? initialUrl;
   final bool? initialEnableSsl;
+  final bool? initialValidateDomain;
 
   const SetCustomServerBottomSheet({
     super.key,
     this.initialUrl,
     this.initialEnableSsl,
+    this.initialValidateDomain,
   });
 
   static Future<bool?> show(
     BuildContext context, {
     String? initialUrl,
     bool? initialEnableSsl,
+    bool? initialValidateDomain,
   }) {
     final cubit = context.read<MempoolSettingsCubit>();
 
@@ -35,6 +38,7 @@ class SetCustomServerBottomSheet extends StatefulWidget {
         child: SetCustomServerBottomSheet(
           initialUrl: initialUrl,
           initialEnableSsl: initialEnableSsl,
+          initialValidateDomain: initialValidateDomain,
         ),
       ),
     );
@@ -54,11 +58,13 @@ class _SetCustomServerBottomSheetState
   String? _errorMessage;
   bool _enableSsl = true;
   bool _sslAutoDetected = false;
+  bool _validateDomain = true;
 
   @override
   void initState() {
     super.initState();
     _urlController = TextEditingController(text: widget.initialUrl ?? '');
+    _validateDomain = widget.initialValidateDomain ?? true;
     if (widget.initialEnableSsl != null) {
       _enableSsl = widget.initialEnableSsl!;
       _sslAutoDetected = false;
@@ -107,6 +113,7 @@ class _SetCustomServerBottomSheetState
     final success = await context.read<MempoolSettingsCubit>().setCustomServer(
       url,
       enableSsl: _enableSsl,
+      validateDomain: _validateDomain,
     );
 
     if (!mounted) return;
@@ -138,7 +145,7 @@ class _SetCustomServerBottomSheetState
           padding: EdgeInsets.only(bottom: bottomInset),
           child: Form(
             key: _formKey,
-            child: Padding(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.fromLTRB(20, 12, 20, 16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -297,6 +304,24 @@ class _SetCustomServerBottomSheetState
                       textAlign: TextAlign.start,
                     ),
                   ),
+                  if (_enableSsl) ...[
+                    const Gap(8),
+                    SwitchListTile.adaptive(
+                      shape: const RoundedRectangleBorder(
+                        side: BorderSide.none,
+                      ),
+                      tileColor: context.appColors.transparent,
+                      title: Text(
+                        context.loc.mempoolCustomServerValidateDomain,
+                      ),
+                      contentPadding: EdgeInsets.zero,
+                      value: _validateDomain,
+                      onChanged: (value) {
+                        setState(() => _validateDomain = value);
+                      },
+                    ),
+                    const Gap(8),
+                  ],
                   if (_errorMessage != null) ...[
                     const Gap(16),
                     Container(

--- a/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
+++ b/lib/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart
@@ -58,13 +58,13 @@ class _SetCustomServerBottomSheetState
   String? _errorMessage;
   bool _enableSsl = true;
   bool _sslAutoDetected = false;
-  bool _validateDomain = true;
+  bool _validateDomain = false;
 
   @override
   void initState() {
     super.initState();
     _urlController = TextEditingController(text: widget.initialUrl ?? '');
-    _validateDomain = widget.initialValidateDomain ?? true;
+    _validateDomain = widget.initialValidateDomain ?? false;
     if (widget.initialEnableSsl != null) {
       _enableSsl = widget.initialEnableSsl!;
       _sslAutoDetected = false;

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14705,5 +14705,9 @@
   "sellErrorFeesUnavailable": "Network fees could not be loaded. Check your connection and try again.",
   "@sellErrorFeesUnavailable": {
     "description": "Shown when the network fee rates cannot be fetched, so no sell payin can be built. Wording matches the send equivalent."
+  },
+  "mempoolCustomServerValidateDomain": "Validate Domain",
+  "@mempoolCustomServerValidateDomain": {
+    "description": "Certificate validation switch for a custom mempool server."
   }
 }

--- a/packages/bull_tor/lib/src/data/tor_http_client_factory.dart
+++ b/packages/bull_tor/lib/src/data/tor_http_client_factory.dart
@@ -8,15 +8,20 @@ import '../domain/tor_failure.dart';
 /// Builds an HTTP client for an already-selected Tor route.
 ///
 /// [endpoint] is deliberately non-nullable. Accepting null meant "return a
-/// plain, unproxied client", and the only consumer is the RecoverBull key
-/// server — an onion address. A caller that passed null would have shipped its
-/// request over clearnet to a hidden-service name, so the route is a
-/// requirement the compiler enforces rather than a default the caller can
-/// forget.
+/// plain, unproxied client". A caller that passed null could ship a request over
+/// clearnet, so the route is a requirement the compiler enforces rather than a
+/// default the caller can forget.
 final class TorHttpClientFactory {
   const TorHttpClientFactory();
 
-  HttpClient create(TorProxyEndpoint endpoint) {
+  /// Creates a client that can only connect through [endpoint].
+  ///
+  /// Certificate validation stays enabled unless [allowBadCertificate] is
+  /// explicitly selected for a user-controlled server.
+  HttpClient create(
+    TorProxyEndpoint endpoint, {
+    bool allowBadCertificate = false,
+  }) {
     // The proxy endpoint is loopback by product contract. The destination
     // hostname is intentionally left to socks5_proxy so SOCKS5 can send it as
     // ATYP DOMAINNAME instead of resolving it on the device.
@@ -30,9 +35,9 @@ final class TorHttpClientFactory {
     }
 
     final client = HttpClient();
-    SocksTCPClient.assignToHttpClient(client, [
+    SocksTCPClient.assignToHttpClientWithSecureOptions(client, [
       ProxySettings(address, endpoint.port, password: null),
-    ]);
+    ], onBadCertificate: allowBadCertificate ? (_) => true : null);
     return client;
   }
 }

--- a/test/core_test/electrum/electrum_settings_failure_test.dart
+++ b/test/core_test/electrum/electrum_settings_failure_test.dart
@@ -65,6 +65,7 @@ ElectrumSettings _settings({bool validateDomain = true}) => ElectrumSettings(
 void main() {
   setUpAll(() {
     registerFallbackValue(_network);
+    registerFallbackValue(_settings());
     registerFallbackValue(TorProxyEndpoint(host: '127.0.0.1', port: 9050));
     registerFallbackValue(
       ElectrumServer.existing(
@@ -182,7 +183,7 @@ void main() {
           () => statusPort.checkElectrum(
             url: any(named: 'url'),
             network: _network,
-            validateDomain: true,
+            validateDomain: false,
             timeout: any(named: 'timeout'),
             retry: 1,
             proxyEndpoint: any(named: 'proxyEndpoint'),
@@ -254,48 +255,45 @@ void main() {
       );
     });
 
-    test(
-      'probes with the user validateDomain setting, not a fixed one',
-      () async {
-        when(
-          () => serverRepo.fetchByUrl(any()),
-        ).thenAnswer((_) async => Ok(null));
-        when(
-          () => statusPort.checkSocket(
-            url: any(named: 'url'),
-            timeout: any(named: 'timeout'),
-            proxyEndpoint: any(named: 'proxyEndpoint'),
-          ),
-        ).thenAnswer((_) async => ElectrumServerStatus.online);
-        when(
-          () => electrumSettingsRepo.fetchByNetwork(_network),
-        ).thenAnswer((_) async => Ok(_settings(validateDomain: false)));
-        when(
-          () => statusPort.checkElectrum(
-            url: any(named: 'url'),
-            network: _network,
-            validateDomain: any(named: 'validateDomain'),
-            timeout: any(named: 'timeout'),
-            retry: any(named: 'retry'),
-            proxyEndpoint: any(named: 'proxyEndpoint'),
-          ),
-        ).thenAnswer((_) async => ElectrumServerStatus.offline);
+    test('probes custom servers without domain validation', () async {
+      when(
+        () => serverRepo.fetchByUrl(any()),
+      ).thenAnswer((_) async => Ok(null));
+      when(
+        () => statusPort.checkSocket(
+          url: any(named: 'url'),
+          timeout: any(named: 'timeout'),
+          proxyEndpoint: any(named: 'proxyEndpoint'),
+        ),
+      ).thenAnswer((_) async => ElectrumServerStatus.online);
+      when(
+        () => electrumSettingsRepo.fetchByNetwork(_network),
+      ).thenAnswer((_) async => Ok(_settings()));
+      when(
+        () => statusPort.checkElectrum(
+          url: any(named: 'url'),
+          network: _network,
+          validateDomain: any(named: 'validateDomain'),
+          timeout: any(named: 'timeout'),
+          retry: any(named: 'retry'),
+          proxyEndpoint: any(named: 'proxyEndpoint'),
+        ),
+      ).thenAnswer((_) async => ElectrumServerStatus.offline);
 
-        final result = await usecase.execute(request());
+      final result = await usecase.execute(request());
 
-        expect(result, isA<Err>());
-        verify(
-          () => statusPort.checkElectrum(
-            url: any(named: 'url'),
-            network: _network,
-            validateDomain: false,
-            timeout: 5,
-            retry: 1,
-            proxyEndpoint: any(named: 'proxyEndpoint'),
-          ),
-        ).called(1);
-      },
-    );
+      expect(result, isA<Err>());
+      verify(
+        () => statusPort.checkElectrum(
+          url: any(named: 'url'),
+          network: _network,
+          validateDomain: false,
+          timeout: 5,
+          retry: 1,
+          proxyEndpoint: any(named: 'proxyEndpoint'),
+        ),
+      ).called(1);
+    });
 
     test(
       'propagates the load failure when electrum settings are unreadable',
@@ -330,6 +328,49 @@ void main() {
       },
     );
 
+    test(
+      'rolls back the server when the relaxed policy cannot be saved',
+      () async {
+        when(
+          () => serverRepo.fetchByUrl(any()),
+        ).thenAnswer((_) async => Ok(null));
+        when(
+          () => electrumSettingsRepo.fetchByNetwork(_network),
+        ).thenAnswer((_) async => Ok(_settings()));
+        when(
+          () => statusPort.checkElectrum(
+            url: any(named: 'url'),
+            network: _network,
+            validateDomain: false,
+            timeout: 5,
+            retry: 1,
+            proxyEndpoint: any(named: 'proxyEndpoint'),
+          ),
+        ).thenAnswer((_) async => ElectrumServerStatus.online);
+        when(
+          () => serverRepo.save(any()),
+        ).thenAnswer((_) async => const Ok(null));
+        when(() => electrumSettingsRepo.save(any())).thenAnswer(
+          (_) async => const Err(ElectrumSaveFailure('raw db error')),
+        );
+        when(
+          () => serverRepo.delete(url: any(named: 'url')),
+        ).thenAnswer((_) async => const Ok(null));
+
+        final result = await usecase.execute(request());
+
+        expect(result, isA<Err>());
+        expect((result as Err).failure, isA<ElectrumSaveFailure>());
+        final savedSettings =
+            verify(
+                  () => electrumSettingsRepo.save(captureAny()),
+                ).captured.single
+                as ElectrumSettings;
+        expect(savedSettings.validateDomain, isFalse);
+        verify(() => serverRepo.delete(url: 'ssl://a.example:50002')).called(1);
+      },
+    );
+
     test('checks an onion server through a closed isolated route', () async {
       var routeClosed = false;
       final endpoint = TorProxyEndpoint(host: '127.0.0.1', port: 41001);
@@ -354,7 +395,7 @@ void main() {
         () => statusPort.checkElectrum(
           url: 'ssl://hidden.onion:50002',
           network: _network,
-          validateDomain: true,
+          validateDomain: false,
           timeout: 30,
           retry: 1,
           proxyEndpoint: endpoint,
@@ -378,7 +419,7 @@ void main() {
         () => statusPort.checkElectrum(
           url: 'ssl://hidden.onion:50002',
           network: _network,
-          validateDomain: true,
+          validateDomain: false,
           timeout: 30,
           retry: 1,
           proxyEndpoint: endpoint,
@@ -431,7 +472,7 @@ void main() {
         () => statusPort.checkElectrum(
           url: any(named: 'url'),
           network: _network,
-          validateDomain: true,
+          validateDomain: false,
           timeout: 5,
           retry: 1,
           proxyEndpoint: externalRoute.endpoint,
@@ -439,6 +480,9 @@ void main() {
       ).thenAnswer((_) async => ElectrumServerStatus.online);
       when(
         () => serverRepo.save(any()),
+      ).thenAnswer((_) async => const Ok(null));
+      when(
+        () => electrumSettingsRepo.save(any()),
       ).thenAnswer((_) async => const Ok(null));
 
       final result = await usecase.execute(request());
@@ -465,7 +509,7 @@ void main() {
         () => statusPort.checkElectrum(
           url: any(named: 'url'),
           network: _network,
-          validateDomain: true,
+          validateDomain: false,
           timeout: 5,
           retry: 1,
           proxyEndpoint: externalRoute.endpoint,

--- a/test/core_test/fees/fees_datasource_test.dart
+++ b/test/core_test/fees/fees_datasource_test.dart
@@ -1,8 +1,13 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:bb_mobile/core/fees/data/fees_datasource.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import '../utils/self_signed_certificate_fixture.dart';
 
 class _MockDio extends Mock implements Dio {}
 
@@ -34,10 +39,17 @@ DioException _dioError(String path, {int? statusCode}) => DioException(
 void main() {
   late _MockDio dio;
   late FeesDatasource datasource;
+  late SelfSignedCertificateFixture certificateFixture;
+
+  setUpAll(() async {
+    certificateFixture = await SelfSignedCertificateFixture.create();
+  });
+
+  tearDownAll(() => certificateFixture.dispose());
 
   setUp(() {
     dio = _MockDio();
-    datasource = FeesDatasource(dioBuilder: (_) => dio);
+    datasource = FeesDatasource(dioBuilder: (_, _) => dio);
   });
 
   group('FeesDatasource.fetchBitcoinNetworkFees', () {
@@ -196,5 +208,45 @@ void main() {
         throwsA(isA<MempoolFeesException>()),
       );
     });
+
+    test(
+      'accepts a self-signed custom server only when validation is disabled',
+      () async {
+        final server = await HttpServer.bindSecure(
+          InternetAddress.loopbackIPv4,
+          0,
+          certificateFixture.securityContext,
+        );
+        addTearDown(() => server.close(force: true));
+        server.listen((request) async {
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'fastestFee': 4,
+                'halfHourFee': 3,
+                'hourFee': 2,
+                'economyFee': 1,
+                'minimumFee': 1,
+              }),
+            );
+          await request.response.close();
+        });
+        final liveDatasource = FeesDatasource();
+        final baseUrl = 'https://${server.address.address}:${server.port}';
+
+        await expectLater(
+          liveDatasource.fetchBitcoinNetworkFees(baseUrl: baseUrl),
+          throwsA(isA<MempoolFeesException>()),
+        );
+        final fees = await liveDatasource.fetchBitcoinNetworkFees(
+          baseUrl: baseUrl,
+          validateDomain: false,
+        );
+
+        expect(fees.fastestFee, 4);
+      },
+    );
   });
 }

--- a/test/core_test/fees/fees_repository_impl_test.dart
+++ b/test/core_test/fees/fees_repository_impl_test.dart
@@ -54,7 +54,10 @@ void main() {
       isLiquid: false,
     );
     when(
-      () => datasource.fetchBitcoinNetworkFees(baseUrl: any(named: 'baseUrl')),
+      () => datasource.fetchBitcoinNetworkFees(
+        baseUrl: any(named: 'baseUrl'),
+        validateDomain: any(named: 'validateDomain'),
+      ),
     ).thenAnswer((_) async => _fees);
   });
 
@@ -70,6 +73,7 @@ void main() {
     verify(
       () => datasource.fetchBitcoinNetworkFees(
         baseUrl: 'https://mempool.bullbitcoin.com',
+        validateDomain: true,
       ),
     ).called(1);
     verifyNever(() => serverRepository.fetchCustomServer(any()));
@@ -80,6 +84,7 @@ void main() {
       url: 'custom.example',
       network: network,
       isCustom: true,
+      validateDomain: false,
     );
     when(() => settingsRepository.fetchByNetwork(network)).thenAnswer(
       (_) async => Ok(
@@ -93,8 +98,10 @@ void main() {
     await repository.getNetworkFees(network: Network.bitcoinMainnet);
 
     verify(
-      () =>
-          datasource.fetchBitcoinNetworkFees(baseUrl: 'https://custom.example'),
+      () => datasource.fetchBitcoinNetworkFees(
+        baseUrl: 'https://custom.example',
+        validateDomain: false,
+      ),
     ).called(1);
     verifyNever(() => serverRepository.fetchDefaultServer(any()));
   });
@@ -122,6 +129,7 @@ void main() {
     verify(
       () => datasource.fetchBitcoinNetworkFees(
         baseUrl: 'https://default.example',
+        validateDomain: true,
       ),
     ).called(1);
   });
@@ -136,7 +144,10 @@ void main() {
       throwsA(isA<MempoolFeesException>()),
     );
     verifyNever(
-      () => datasource.fetchBitcoinNetworkFees(baseUrl: any(named: 'baseUrl')),
+      () => datasource.fetchBitcoinNetworkFees(
+        baseUrl: any(named: 'baseUrl'),
+        validateDomain: any(named: 'validateDomain'),
+      ),
     );
   });
 }

--- a/test/core_test/mempool/http_mempool_server_validator_test.dart
+++ b/test/core_test/mempool/http_mempool_server_validator_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/mempool/domain/errors/mempool_failure.dart';
+import 'package:bb_mobile/core/mempool/domain/ports/mempool_tor_session_port.dart';
+import 'package:bb_mobile/core/mempool/domain/value_objects/mempool_server_network.dart';
+import 'package:bb_mobile/core/mempool/interface_adapters/validators/http_mempool_server_validator.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bull_tor/tor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/self_signed_certificate_fixture.dart';
+
+final class _UnusedTorSessionPort implements MempoolTorSessionPort {
+  @override
+  Future<MempoolTorRoute?> open({required String serverUrl}) {
+    throw StateError('Clearnet validation must not open a Tor session');
+  }
+}
+
+void _serveMempoolApi(HttpServer server) {
+  server.listen((request) async {
+    request.response.headers.contentType = ContentType.text;
+    switch (request.uri.path) {
+      case '/api/v1/blocks/tip/height':
+        request.response.write('1');
+      case '/api/block-height/0':
+        request.response.write(
+          '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+        );
+      default:
+        request.response.statusCode = HttpStatus.notFound;
+    }
+    await request.response.close();
+  });
+}
+
+void main() {
+  late SelfSignedCertificateFixture fixture;
+
+  setUpAll(() async => fixture = await SelfSignedCertificateFixture.create());
+  tearDownAll(() => fixture.dispose());
+
+  Future<({HttpMempoolServerValidator validator, String url})>
+  startServer() async {
+    final server = await HttpServer.bindSecure(
+      InternetAddress.loopbackIPv4,
+      0,
+      fixture.securityContext,
+    );
+    addTearDown(() => server.close(force: true));
+    _serveMempoolApi(server);
+    return (
+      validator: HttpMempoolServerValidator(
+        torSessionPort: _UnusedTorSessionPort(),
+        torHttpClientFactory: const TorHttpClientFactory(),
+      ),
+      url: '127.0.0.1:${server.port}',
+    );
+  }
+
+  test('rejects a self-signed certificate by default', () async {
+    final (:validator, :url) = await startServer();
+
+    final result = await validator.validateServer(
+      url: url,
+      network: MempoolServerNetwork.bitcoinMainnet,
+    );
+
+    expect(result, isA<Err<void, MempoolFailure>>());
+  });
+
+  test('accepts a self-signed certificate when explicitly allowed', () async {
+    final (:validator, :url) = await startServer();
+
+    final result = await validator.validateServer(
+      url: url,
+      network: MempoolServerNetwork.bitcoinMainnet,
+      validateDomain: false,
+    );
+
+    expect(result, isA<Ok<void, MempoolFailure>>());
+  });
+}

--- a/test/core_test/mempool/mempool_server_model_test.dart
+++ b/test/core_test/mempool/mempool_server_model_test.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/core/mempool/domain/entities/mempool_server.dart';
+import 'package:bb_mobile/core/mempool/domain/value_objects/mempool_server_network.dart';
+import 'package:bb_mobile/core/mempool/frameworks/drift/models/mempool_server_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('preserves the custom server certificate policy', () {
+    final server = MempoolServer.existing(
+      url: 'mempool.local',
+      network: MempoolServerNetwork.bitcoinMainnet,
+      isCustom: true,
+      validateDomain: false,
+    );
+
+    final row = MempoolServerModel.fromEntity(server).toSqlite();
+    final rehydrated = MempoolServerModel.fromSqlite(row).toEntity();
+
+    expect(rehydrated.validateDomain, isFalse);
+  });
+}

--- a/test/core_test/mempool/mempool_usecases_test.dart
+++ b/test/core_test/mempool/mempool_usecases_test.dart
@@ -96,12 +96,10 @@ void main() {
     late _MockEnvironmentPort env;
     late SetCustomMempoolServerUsecase usecase;
 
-    SetCustomMempoolServerRequest request({bool validateDomain = true}) =>
-        SetCustomMempoolServerRequest(
-          url: 'mempool.example.com',
-          isLiquid: false,
-          validateDomain: validateDomain,
-        );
+    SetCustomMempoolServerRequest request() => SetCustomMempoolServerRequest(
+      url: 'mempool.example.com',
+      isLiquid: false,
+    );
 
     setUp(() {
       repo = _MockServerRepository();
@@ -175,33 +173,36 @@ void main() {
       expect((result as Err).failure, isA<MempoolSaveFailure>());
     });
 
-    test('validates and persists the selected certificate policy', () async {
-      when(
-        () => validator.validateServer(
-          url: any(named: 'url'),
-          network: any(named: 'network'),
-          enableSsl: any(named: 'enableSsl'),
-          validateDomain: any(named: 'validateDomain'),
-        ),
-      ).thenAnswer((_) async => const Ok(null));
-      when(() => repo.save(any())).thenAnswer((_) async => const Ok(null));
+    test(
+      'defaults new custom servers to relaxed certificate validation',
+      () async {
+        when(
+          () => validator.validateServer(
+            url: any(named: 'url'),
+            network: any(named: 'network'),
+            enableSsl: any(named: 'enableSsl'),
+            validateDomain: any(named: 'validateDomain'),
+          ),
+        ).thenAnswer((_) async => const Ok(null));
+        when(() => repo.save(any())).thenAnswer((_) async => const Ok(null));
 
-      final result = await usecase.execute(request(validateDomain: false));
+        final result = await usecase.execute(request());
 
-      expect(result, isA<Ok>());
-      verify(
-        () => validator.validateServer(
-          url: 'mempool.example.com',
-          network: MempoolServerNetwork.bitcoinMainnet,
-          enableSsl: true,
-          validateDomain: false,
-        ),
-      ).called(1);
-      final server =
-          verify(() => repo.save(captureAny())).captured.single
-              as MempoolServer;
-      expect(server.validateDomain, isFalse);
-    });
+        expect(result, isA<Ok>());
+        verify(
+          () => validator.validateServer(
+            url: 'mempool.example.com',
+            network: MempoolServerNetwork.bitcoinMainnet,
+            enableSsl: true,
+            validateDomain: false,
+          ),
+        ).called(1);
+        final server =
+            verify(() => repo.save(captureAny())).captured.single
+                as MempoolServer;
+        expect(server.validateDomain, isFalse);
+      },
+    );
 
     test(
       'returns SameAsDefault failure when custom URL matches the default',

--- a/test/core_test/mempool/mempool_usecases_test.dart
+++ b/test/core_test/mempool/mempool_usecases_test.dart
@@ -96,10 +96,12 @@ void main() {
     late _MockEnvironmentPort env;
     late SetCustomMempoolServerUsecase usecase;
 
-    SetCustomMempoolServerRequest request() => SetCustomMempoolServerRequest(
-      url: 'mempool.example.com',
-      isLiquid: false,
-    );
+    SetCustomMempoolServerRequest request({bool validateDomain = true}) =>
+        SetCustomMempoolServerRequest(
+          url: 'mempool.example.com',
+          isLiquid: false,
+          validateDomain: validateDomain,
+        );
 
     setUp(() {
       repo = _MockServerRepository();
@@ -125,6 +127,7 @@ void main() {
           url: any(named: 'url'),
           network: any(named: 'network'),
           enableSsl: any(named: 'enableSsl'),
+          validateDomain: any(named: 'validateDomain'),
         ),
       ).thenAnswer((_) async => const Err(MempoolValidationTimeoutFailure()));
 
@@ -148,6 +151,7 @@ void main() {
           url: any(named: 'url'),
           network: any(named: 'network'),
           enableSsl: any(named: 'enableSsl'),
+          validateDomain: any(named: 'validateDomain'),
         ),
       );
     });
@@ -158,6 +162,7 @@ void main() {
           url: any(named: 'url'),
           network: any(named: 'network'),
           enableSsl: any(named: 'enableSsl'),
+          validateDomain: any(named: 'validateDomain'),
         ),
       ).thenAnswer((_) async => const Ok(null));
       when(
@@ -168,6 +173,34 @@ void main() {
 
       expect(result, isA<Err>());
       expect((result as Err).failure, isA<MempoolSaveFailure>());
+    });
+
+    test('validates and persists the selected certificate policy', () async {
+      when(
+        () => validator.validateServer(
+          url: any(named: 'url'),
+          network: any(named: 'network'),
+          enableSsl: any(named: 'enableSsl'),
+          validateDomain: any(named: 'validateDomain'),
+        ),
+      ).thenAnswer((_) async => const Ok(null));
+      when(() => repo.save(any())).thenAnswer((_) async => const Ok(null));
+
+      final result = await usecase.execute(request(validateDomain: false));
+
+      expect(result, isA<Ok>());
+      verify(
+        () => validator.validateServer(
+          url: 'mempool.example.com',
+          network: MempoolServerNetwork.bitcoinMainnet,
+          enableSsl: true,
+          validateDomain: false,
+        ),
+      ).called(1);
+      final server =
+          verify(() => repo.save(captureAny())).captured.single
+              as MempoolServer;
+      expect(server.validateDomain, isFalse);
     });
 
     test(

--- a/test/core_test/utils/self_signed_certificate_fixture.dart
+++ b/test/core_test/utils/self_signed_certificate_fixture.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+/// Generates a short-lived self-signed certificate for TLS behavior tests.
+final class SelfSignedCertificateFixture {
+  final Directory _directory;
+  final SecurityContext securityContext;
+
+  SelfSignedCertificateFixture._(this._directory, this.securityContext);
+
+  static Future<SelfSignedCertificateFixture> create() async {
+    final directory = Directory.systemTemp.createTempSync('bb_self_signed');
+    final result = await Process.run('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      '${directory.path}/key.pem',
+      '-out',
+      '${directory.path}/cert.pem',
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=localhost',
+      '-addext',
+      'subjectAltName=DNS:localhost,IP:127.0.0.1',
+      '-addext',
+      'basicConstraints=critical,CA:FALSE',
+    ]);
+    if (result.exitCode != 0) {
+      throw StateError('openssl failed to build a test cert: ${result.stderr}');
+    }
+    return SelfSignedCertificateFixture._(
+      directory,
+      SecurityContext()
+        ..useCertificateChain('${directory.path}/cert.pem')
+        ..usePrivateKey('${directory.path}/key.pem'),
+    );
+  }
+
+  void dispose() => _directory.deleteSync(recursive: true);
+}

--- a/test/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet_test.dart
+++ b/test/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet_test.dart
@@ -32,6 +32,10 @@ void main() {
       expect(find.byType(SingleChildScrollView), findsOneWidget);
       expect(find.text('Validate Domain'), findsOneWidget);
       expect(
+        tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+        isFalse,
+      );
+      expect(
         tester.getTopLeft(find.textContaining('For local')).dy,
         lessThan(tester.getTopLeft(find.text('Validate Domain')).dy),
       );

--- a/test/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet_test.dart
+++ b/test/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet_test.dart
@@ -1,0 +1,41 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/mempool_settings/ui/widgets/set_custom_server_bottom_sheet.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'lays out TLS controls on a compact screen with the keyboard open',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.themeData(AppThemeType.light),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const MediaQuery(
+            data: MediaQueryData(
+              size: Size(320, 480),
+              viewInsets: EdgeInsets.only(bottom: 240),
+            ),
+            child: Scaffold(
+              body: SetCustomServerBottomSheet(
+                initialUrl: 'mempool.local',
+                initialEnableSsl: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      expect(find.text('Validate Domain'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.textContaining('For local')).dy,
+        lessThan(tester.getTopLeft(find.text('Validate Domain')).dy),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/test/migrations_test/bull_database/generated/schema_v15.dart
+++ b/test/migrations_test/bull_database/generated/schema_v15.dart
@@ -4651,6 +4651,15 @@ class MempoolServers extends Table
     $customConstraints: 'NOT NULL DEFAULT 1 CHECK (enable_ssl IN (0, 1))',
     defaultValue: const CustomExpression('1'),
   );
+  late final GeneratedColumn<int> validateDomain = GeneratedColumn<int>(
+    'validate_domain',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 1 CHECK (validate_domain IN (0, 1))',
+    defaultValue: const CustomExpression('1'),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     url,
@@ -4658,6 +4667,7 @@ class MempoolServers extends Table
     isLiquid,
     isCustom,
     enableSsl,
+    validateDomain,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -4690,6 +4700,10 @@ class MempoolServers extends Table
         DriftSqlType.int,
         data['${effectivePrefix}enable_ssl'],
       )!,
+      validateDomain: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}validate_domain'],
+      )!,
     );
   }
 
@@ -4713,12 +4727,14 @@ class MempoolServersData extends DataClass
   final int isLiquid;
   final int isCustom;
   final int enableSsl;
+  final int validateDomain;
   const MempoolServersData({
     required this.url,
     required this.isTestnet,
     required this.isLiquid,
     required this.isCustom,
     required this.enableSsl,
+    required this.validateDomain,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -4728,6 +4744,7 @@ class MempoolServersData extends DataClass
     map['is_liquid'] = Variable<int>(isLiquid);
     map['is_custom'] = Variable<int>(isCustom);
     map['enable_ssl'] = Variable<int>(enableSsl);
+    map['validate_domain'] = Variable<int>(validateDomain);
     return map;
   }
 
@@ -4738,6 +4755,7 @@ class MempoolServersData extends DataClass
       isLiquid: Value(isLiquid),
       isCustom: Value(isCustom),
       enableSsl: Value(enableSsl),
+      validateDomain: Value(validateDomain),
     );
   }
 
@@ -4752,6 +4770,7 @@ class MempoolServersData extends DataClass
       isLiquid: serializer.fromJson<int>(json['isLiquid']),
       isCustom: serializer.fromJson<int>(json['isCustom']),
       enableSsl: serializer.fromJson<int>(json['enableSsl']),
+      validateDomain: serializer.fromJson<int>(json['validateDomain']),
     );
   }
   @override
@@ -4763,6 +4782,7 @@ class MempoolServersData extends DataClass
       'isLiquid': serializer.toJson<int>(isLiquid),
       'isCustom': serializer.toJson<int>(isCustom),
       'enableSsl': serializer.toJson<int>(enableSsl),
+      'validateDomain': serializer.toJson<int>(validateDomain),
     };
   }
 
@@ -4772,12 +4792,14 @@ class MempoolServersData extends DataClass
     int? isLiquid,
     int? isCustom,
     int? enableSsl,
+    int? validateDomain,
   }) => MempoolServersData(
     url: url ?? this.url,
     isTestnet: isTestnet ?? this.isTestnet,
     isLiquid: isLiquid ?? this.isLiquid,
     isCustom: isCustom ?? this.isCustom,
     enableSsl: enableSsl ?? this.enableSsl,
+    validateDomain: validateDomain ?? this.validateDomain,
   );
   MempoolServersData copyWithCompanion(MempoolServersCompanion data) {
     return MempoolServersData(
@@ -4786,6 +4808,9 @@ class MempoolServersData extends DataClass
       isLiquid: data.isLiquid.present ? data.isLiquid.value : this.isLiquid,
       isCustom: data.isCustom.present ? data.isCustom.value : this.isCustom,
       enableSsl: data.enableSsl.present ? data.enableSsl.value : this.enableSsl,
+      validateDomain: data.validateDomain.present
+          ? data.validateDomain.value
+          : this.validateDomain,
     );
   }
 
@@ -4796,14 +4821,21 @@ class MempoolServersData extends DataClass
           ..write('isTestnet: $isTestnet, ')
           ..write('isLiquid: $isLiquid, ')
           ..write('isCustom: $isCustom, ')
-          ..write('enableSsl: $enableSsl')
+          ..write('enableSsl: $enableSsl, ')
+          ..write('validateDomain: $validateDomain')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode =>
-      Object.hash(url, isTestnet, isLiquid, isCustom, enableSsl);
+  int get hashCode => Object.hash(
+    url,
+    isTestnet,
+    isLiquid,
+    isCustom,
+    enableSsl,
+    validateDomain,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4812,7 +4844,8 @@ class MempoolServersData extends DataClass
           other.isTestnet == this.isTestnet &&
           other.isLiquid == this.isLiquid &&
           other.isCustom == this.isCustom &&
-          other.enableSsl == this.enableSsl);
+          other.enableSsl == this.enableSsl &&
+          other.validateDomain == this.validateDomain);
 }
 
 class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
@@ -4821,6 +4854,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
   final Value<int> isLiquid;
   final Value<int> isCustom;
   final Value<int> enableSsl;
+  final Value<int> validateDomain;
   final Value<int> rowid;
   const MempoolServersCompanion({
     this.url = const Value.absent(),
@@ -4828,6 +4862,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
     this.isLiquid = const Value.absent(),
     this.isCustom = const Value.absent(),
     this.enableSsl = const Value.absent(),
+    this.validateDomain = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   MempoolServersCompanion.insert({
@@ -4836,6 +4871,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
     required int isLiquid,
     required int isCustom,
     this.enableSsl = const Value.absent(),
+    this.validateDomain = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : url = Value(url),
        isTestnet = Value(isTestnet),
@@ -4847,6 +4883,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
     Expression<int>? isLiquid,
     Expression<int>? isCustom,
     Expression<int>? enableSsl,
+    Expression<int>? validateDomain,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -4855,6 +4892,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
       if (isLiquid != null) 'is_liquid': isLiquid,
       if (isCustom != null) 'is_custom': isCustom,
       if (enableSsl != null) 'enable_ssl': enableSsl,
+      if (validateDomain != null) 'validate_domain': validateDomain,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -4865,6 +4903,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
     Value<int>? isLiquid,
     Value<int>? isCustom,
     Value<int>? enableSsl,
+    Value<int>? validateDomain,
     Value<int>? rowid,
   }) {
     return MempoolServersCompanion(
@@ -4873,6 +4912,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
       isLiquid: isLiquid ?? this.isLiquid,
       isCustom: isCustom ?? this.isCustom,
       enableSsl: enableSsl ?? this.enableSsl,
+      validateDomain: validateDomain ?? this.validateDomain,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -4895,6 +4935,9 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
     if (enableSsl.present) {
       map['enable_ssl'] = Variable<int>(enableSsl.value);
     }
+    if (validateDomain.present) {
+      map['validate_domain'] = Variable<int>(validateDomain.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -4909,6 +4952,7 @@ class MempoolServersCompanion extends UpdateCompanion<MempoolServersData> {
           ..write('isLiquid: $isLiquid, ')
           ..write('isCustom: $isCustom, ')
           ..write('enableSsl: $enableSsl, ')
+          ..write('validateDomain: $validateDomain, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();

--- a/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
+++ b/test/migrations_test/bull_database/schema_v14_to_v15_test.dart
@@ -13,8 +13,7 @@ void main() {
 
   setUpAll(() => verifier = SchemaVerifier(GeneratedHelper()));
 
-  test('v14 to v15 adds Tor transport and screen-capture settings with '
-      'defaults', () async {
+  test('v14 to v15 adds settings with secure defaults', () async {
     final schema = await verifier.schemaAt(14);
     final oldDb = v14.DatabaseAtV14(schema.newConnection());
     await oldDb
@@ -27,6 +26,17 @@ void main() {
             currency: 'USD',
             hideAmounts: 0,
             isSuperuser: 0,
+          ),
+        );
+    await oldDb
+        .into(oldDb.mempoolServers)
+        .insert(
+          v14.MempoolServersCompanion.insert(
+            url: 'mempool.local',
+            isTestnet: 0,
+            isLiquid: 0,
+            isCustom: 1,
+            enableSsl: const Value(1),
           ),
         );
     await oldDb.close();
@@ -44,6 +54,13 @@ void main() {
     // Screen-capture protection is added in this step and defaults to enabled
     // (1) so existing installs keep protection until the user opts out.
     expect(settings.single.screenCaptureProtectionEnabled, 1);
+
+    final mempoolServers = await migratedDb
+        .select(migratedDb.mempoolServers)
+        .get();
+    expect(mempoolServers, hasLength(1));
+    expect(mempoolServers.single.url, 'mempool.local');
+    expect(mempoolServers.single.validateDomain, 1);
     await migratedDb.close();
   });
 }


### PR DESCRIPTION
## Summary

Self-hosted Mempool and Electrum servers on platforms such as StartOS can use certificates that the app cannot validate, preventing secure connections.

This PR:

- Adds the same **Validate Domain** option already available for custom Electrum servers
- Defaults domain validation to off for newly added custom Mempool servers
- Probes newly added custom Electrum servers with relaxed domain validation
- Keeps Bull/default Mempool and Electrum servers strict
- Preserves existing saved Mempool server and Electrum settings on upgrades
- Shows the option only when SSL is enabled
- Applies the setting to server validation and fee fetching over direct HTTPS and Tor/SOCKS
- Persists the Mempool setting through the database

## Testing

- Full `make checks` passes
- Covered strict and relaxed certificate validation
- Covered direct HTTPS and Tor/SOCKS connections
- Covered the relaxed policy for new custom Mempool and Electrum servers
- Covered database migration and persistence
- Verified the UI on a dedicated Android emulator
