### PR TITLE
add webview support to the linux app

### DIFF
--- a/.github/workflows/analyze_and_test.yml
+++ b/.github/workflows/analyze_and_test.yml
@@ -153,7 +153,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             clang lld cmake ninja-build pkg-config \
-            libgtk-3-dev liblzma-dev libstdc++-12-dev \
+            libgtk-3-dev liblzma-dev libstdc++-12-dev libwpewebkit-1.0-dev \
             libsecret-1-dev libsecret-tools libcurl4-openssl-dev \
             dbus gnome-keyring \
             xdg-desktop-portal xdg-desktop-portal-gtk \

--- a/Containerfile.tools
+++ b/Containerfile.tools
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install -y \
 #   clang, lld, cmake, ninja, pkg-config — Flutter Linux toolchain
 #   libgtk-3-dev, liblzma-dev, libstdc++-12-dev — Flutter Linux runtime libs
 #   libsecret-1-dev — required by flutter_secure_storage_linux plugin
+#   libwpewebkit-2.0-dev — required by webview_flutter_linux
 #   libsecret-tools — provides `secret-tool`, used by init-keyring.sh to bootstrap
 #     a default keyring on first run
 #   libcurl4-openssl-dev — required by sentry-native (sentry_flutter) HTTP transport
@@ -82,6 +83,7 @@ RUN apt-get update && apt-get install -y \
     liblzma-dev \
     libstdc++-12-dev \
     libsecret-1-dev \
+    libwpewebkit-2.0-dev \
     libsecret-tools \
     libcurl4-openssl-dev \
     dbus \

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,8 +11,6 @@ PODS:
   - universal_ble (0.0.1):
     - Flutter
     - FlutterMacOS
-  - webview_cookie_manager (0.0.1):
-    - Flutter
 
 DEPENDENCIES:
   - bull_tor (from `.symlinks/plugins/bull_tor/ios`)
@@ -21,7 +19,6 @@ DEPENDENCIES:
   - rust_lib_bull_sdk (from `.symlinks/plugins/rust_lib_bull_sdk/ios`)
   - onion (from `.symlinks/plugins/onion/ios`)
   - universal_ble (from `.symlinks/plugins/universal_ble/darwin`)
-  - webview_cookie_manager (from `.symlinks/plugins/webview_cookie_manager/ios`)
 
 EXTERNAL SOURCES:
   bull_tor:
@@ -36,8 +33,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/onion/ios"
   universal_ble:
     :path: ".symlinks/plugins/universal_ble/darwin"
-  webview_cookie_manager:
-    :path: ".symlinks/plugins/webview_cookie_manager/ios"
 
 SPEC CHECKSUMS:
   bull_tor: effca429a77cc1dd71ee148fa65903a325d79d33
@@ -46,7 +41,6 @@ SPEC CHECKSUMS:
   rust_lib_bull_sdk: 6bdd9a2254b376e910a31340e03bf2db56c637db
   onion: 4876b9b0120d40a2817eac0903dfb9bd59832755
   universal_ble: 65e1257dffc557cc7991a93d253beeddc7c1dc92
-  webview_cookie_manager: eaf920722b493bd0f7611b5484771ca53fed03f7
 
 PODFILE CHECKSUM: b9aa080c2a42d4d61d216015adddd3850778d844
 

--- a/lib/features/exchange/presentation/exchange_cubit.dart
+++ b/lib/features/exchange/presentation/exchange_cubit.dart
@@ -11,7 +11,7 @@ import 'package:bb_mobile/core/exchange/domain/usecases/send_support_chat_messag
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:webview_cookie_manager/webview_cookie_manager.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class ExchangeCubit extends Cubit<ExchangeState> {
   ExchangeCubit({
@@ -163,7 +163,7 @@ class ExchangeCubit extends Cubit<ExchangeState> {
       emit(state.copyWith(deleteApiKeyException: null));
       await _deleteExchangeApiKeyUsecase.execute();
 
-      final cookieManager = WebviewCookieManager();
+      final cookieManager = WebViewCookieManager();
       await cookieManager.clearCookies();
 
       emit(

--- a/lib/features/exchange/ui/screens/exchange_auth_screen.dart
+++ b/lib/features/exchange/ui/screens/exchange_auth_screen.dart
@@ -12,7 +12,6 @@ import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:webview_cookie_manager/webview_cookie_manager.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
@@ -26,7 +25,7 @@ class ExchangeAuthScreen extends StatefulWidget {
 
 class _ExchangeAuthScreenState extends State<ExchangeAuthScreen> {
   late final WebViewController _controller = WebViewController();
-  late final WebviewCookieManager _cookieManager = WebviewCookieManager();
+  late final WebViewCookieManager _cookieManager = WebViewCookieManager();
   late final String _bbAuthUrl;
   String? _basicAuthUsername;
   String? _basicAuthPassword;
@@ -251,7 +250,7 @@ class _ExchangeAuthScreenState extends State<ExchangeAuthScreen> {
   }
 
   Future<String?> _tryGetBBSessionCookie(String url) async {
-    final cookies = await _cookieManager.getCookies(url);
+    final cookies = await _cookieManager.getCookies(domain: Uri.parse(url));
     String? bbSessionCookie;
     for (final cookie in cookies) {
       if (cookie.name == 'bb_session') {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <webview_flutter_linux/flutter_inappwebview_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
@@ -32,4 +33,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) webview_flutter_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterInappwebviewLinuxPlugin");
+  flutter_inappwebview_linux_plugin_register_with_registrar(webview_flutter_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   sentry_flutter
   sqlite3_flutter_libs
   url_launcher_linux
+  webview_flutter_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -720,6 +720,23 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  flutter_inappwebview_internal_annotations:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_internal_annotations
+      sha256: e30fba942e3debea7b7e6cdd4f0f59ce89dd403a9865193e3221293b6d1544c6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  flutter_inappwebview_platform_interface:
+    dependency: transitive
+    description:
+      path: flutter_inappwebview_platform_interface
+      ref: "17527cae5a3371c1e87f9c1df4281a7710debf28"
+      resolved-ref: "17527cae5a3371c1e87f9c1df4281a7710debf28"
+      url: "https://github.com/pichillilorenzo/flutter_inappwebview.git"
+    source: git
+    version: "1.4.0-beta.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -2264,15 +2281,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  webview_cookie_manager:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: e03954491a6952e04d7fceeae4c4d074392c0fe2
-      resolved-ref: e03954491a6952e04d7fceeae4c4d074392c0fe2
-      url: "https://github.com/fryette/webview_cookie_manager.git"
-    source: git
-    version: "2.0.7"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -2289,6 +2297,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.14.0"
+  webview_flutter_linux:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: "0cae2b66f68ebf426fba81c3fb43347d2c5f0345"
+      resolved-ref: "0cae2b66f68ebf426fba81c3fb43347d2c5f0345"
+      url: "https://github.com/basantagoswami/webview_flutter_linux.git"
+    source: git
+    version: "0.0.1"
   webview_flutter_platform_interface:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,12 +96,12 @@ dependencies:
       url: https://github.com/SatoshiPortal/recoverbull-client-dart.git
       ref: 92925c959f219fa4dfd0fe0f40392ddf868e2774
   flutter_zxing: ^2.2.1
-  webview_cookie_manager:
-    git:
-      url: https://github.com/fryette/webview_cookie_manager.git
-      ref: e03954491a6952e04d7fceeae4c4d074392c0fe2
-  webview_flutter: ^4.13.0
+  webview_flutter: ^4.14.1
   webview_flutter_android: ^4.10.10
+  webview_flutter_linux:
+    git:
+      url: https://github.com/basantagoswami/webview_flutter_linux.git
+      ref: 0cae2b66f68ebf426fba81c3fb43347d2c5f0345
   webview_flutter_wkwebview: ^3.23.4
   async: ^2.11.0
   drift: ^2.29.0


### PR DESCRIPTION
- Removed `webview_cookie_manager` and switched exchange authentication to the cookie APIs provided by the official `webview_flutter` package.

  - Added [webview_flutter_linux](https://github.com/basantagoswami/webview_flutter_linux), our Linux implementation of webview_flutter, enabling the existing WebView integration on Linux without affecting Android or iOS