### PR TITLE
feat: add purpose-scoped Nostr backup identity

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,6 +23,7 @@ graph TB
     BTC_PRICE[Bitcoin Price]
     NETWORK[Network]
     BIP85[BIP85]
+    NOSTR_IDENTITY[Nostr Identity]
     FEES[Fees]
     WALLETS[Wallets]
     EXCHANGE[Exchange]

--- a/integration_test/bip85_derivation_test.dart
+++ b/integration_test/bip85_derivation_test.dart
@@ -3,13 +3,12 @@ import 'dart:typed_data';
 import 'package:bb_mobile/core/bip85/data/bip85_datasource.dart';
 import 'package:bb_mobile/core/bip85/data/bip85_repository.dart';
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/storage/tables/bip85_derivations_table.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_usecase.dart';
 import 'package:bb_mobile/locator.dart';
@@ -24,8 +23,6 @@ Future<void> main({bool isInitialized = false}) async {
   if (!isInitialized) await Bull.init();
 
   final sqlite = locator<SqliteDatabase>();
-  final seedRepository = locator<SeedRepository>();
-  final walletRepository = locator<WalletRepository>();
   final bip85Datasource = locator<Bip85Datasource>();
   final bip85Repository = locator<Bip85Repository>();
   final createDefaultWalletsUsecase = locator<CreateDefaultWalletsUsecase>();
@@ -49,9 +46,8 @@ Future<void> main({bool isInitialized = false}) async {
 
   final usecase = DeriveNextBip85MnemonicFromDefaultWalletUsecase(
     bip85Repository: bip85Repository,
-    walletRepository: walletRepository,
-    seedRepository: seedRepository,
-    settingsRepository: locator<SettingsRepository>(),
+    getDefaultSeedUsecase: locator<GetDefaultSeedUsecase>(),
+    getSettingsUsecase: locator<GetSettingsUsecase>(),
   );
 
   setUpAll(() async {

--- a/lib/core/bip85/bip85_locator.dart
+++ b/lib/core/bip85/bip85_locator.dart
@@ -5,10 +5,9 @@ import 'package:bb_mobile/core/bip85/domain/alias_bip85_derivation_usecase.dart'
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_hex_from_default_wallet_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/revoke_bip85_derivation_usecase.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:get_it/get_it.dart';
 
 class Bip85DerivationsLocator {
@@ -28,18 +27,16 @@ class Bip85DerivationsLocator {
     locator.registerFactory<DeriveNextBip85HexFromDefaultWalletUsecase>(
       () => DeriveNextBip85HexFromDefaultWalletUsecase(
         bip85Repository: locator<Bip85Repository>(),
-        walletRepository: locator<WalletRepository>(),
-        seedRepository: locator<SeedRepository>(),
-        settingsRepository: locator<SettingsRepository>(),
+        getDefaultSeedUsecase: locator<GetDefaultSeedUsecase>(),
+        getSettingsUsecase: locator<GetSettingsUsecase>(),
       ),
     );
 
     locator.registerFactory<DeriveNextBip85MnemonicFromDefaultWalletUsecase>(
       () => DeriveNextBip85MnemonicFromDefaultWalletUsecase(
         bip85Repository: locator<Bip85Repository>(),
-        walletRepository: locator<WalletRepository>(),
-        seedRepository: locator<SeedRepository>(),
-        settingsRepository: locator<SettingsRepository>(),
+        getDefaultSeedUsecase: locator<GetDefaultSeedUsecase>(),
+        getSettingsUsecase: locator<GetSettingsUsecase>(),
       ),
     );
 

--- a/lib/core/bip85/data/bip85_datasource.dart
+++ b/lib/core/bip85/data/bip85_datasource.dart
@@ -18,34 +18,24 @@ class Bip85Datasource {
     required int index,
     String? alias,
   }) async {
-    try {
-      const application = Bip85ApplicationColumn.hex;
-      final derivationPath = "${application.number}'/$length'/$index'";
-
-      // Ensure the xprv is valid.
-      final xprv = bip32.Bip32Keys.fromBase58(xprvBase58);
-
-      final bip85Hex = bip85.Bip85Entropy.deriveHex(
-        xprvBase58: xprvBase58,
-        numBytes: length,
-        index: index,
-      );
-
-      // store the derivation into sqlite
-      await _store(
-        Bip85DerivationModel(
-          path: derivationPath,
-          xprvFingerprint: hex.encode(xprv.fingerprint),
-          alias: alias,
-          status: Bip85StatusColumn.active,
-          application: application,
-        ),
-      );
-
-      return (derivation: derivationPath, hex: bip85Hex);
-    } catch (e) {
-      rethrow;
-    }
+    const application = Bip85ApplicationColumn.hex;
+    final derivationPath = "${application.number}'/$length'/$index'";
+    final xprv = bip32.Bip32Keys.fromBase58(xprvBase58);
+    final derived = bip85.Bip85Entropy.deriveHex(
+      xprvBase58: xprvBase58,
+      numBytes: length,
+      index: index,
+    );
+    await _store(
+      Bip85DerivationModel(
+        path: derivationPath,
+        xprvFingerprint: hex.encode(xprv.fingerprint),
+        alias: alias,
+        status: Bip85StatusColumn.active,
+        application: application,
+      ),
+    );
+    return (derivation: derivationPath, hex: derived);
   }
 
   Future<({String derivation, bip39.Mnemonic mnemonic})> deriveMnemonic({
@@ -55,36 +45,37 @@ class Bip85Datasource {
     String? alias,
     bip39.Language language = bip39.Language.english,
   }) async {
-    try {
-      const application = Bip85ApplicationColumn.bip39;
-      final derivationPath =
-          "${application.number}'/${language.toBip85Code()}'/${length.toBip85Code()}'/$index'";
+    final derived = _deriveMnemonic(
+      xprvBase58: xprvBase58,
+      length: length,
+      index: index,
+      language: language,
+    );
+    await _store(
+      Bip85DerivationModel(
+        path: derived.derivation,
+        xprvFingerprint: derived.xprvFingerprint,
+        alias: alias,
+        status: Bip85StatusColumn.active,
+        application: Bip85ApplicationColumn.bip39,
+      ),
+    );
+    return (derivation: derived.derivation, mnemonic: derived.mnemonic);
+  }
 
-      // Ensure the xprv is valid.
-      final xprv = bip32.Bip32Keys.fromBase58(xprvBase58);
-
-      final bip85Mnemonic = bip85.Bip85Entropy.deriveMnemonic(
-        xprvBase58: xprvBase58,
-        language: language,
-        length: length,
-        index: index,
-      );
-
-      // store the derivation into sqlite
-      await _store(
-        Bip85DerivationModel(
-          path: derivationPath,
-          xprvFingerprint: hex.encode(xprv.fingerprint),
-          alias: alias,
-          status: Bip85StatusColumn.active,
-          application: application,
-        ),
-      );
-
-      return (derivation: derivationPath, mnemonic: bip85Mnemonic);
-    } catch (e) {
-      rethrow;
-    }
+  ({String derivation, bip39.Mnemonic mnemonic}) deriveMnemonicPreview({
+    required String xprvBase58,
+    required bip39.MnemonicLength length,
+    required int index,
+    bip39.Language language = bip39.Language.english,
+  }) {
+    final derived = _deriveMnemonic(
+      xprvBase58: xprvBase58,
+      length: length,
+      index: index,
+      language: language,
+    );
+    return (derivation: derived.derivation, mnemonic: derived.mnemonic);
   }
 
   Future<Bip85DerivationModel?> fetch(String path) async {
@@ -96,8 +87,9 @@ class Bip85Datasource {
   }
 
   Future<int> fetchNextIndexForApplication(
-    Bip85ApplicationColumn application,
-  ) async {
+    Bip85ApplicationColumn application, {
+    Set<int> excludedIndices = const {},
+  }) async {
     final rows = await _sqlite.managers.bip85Derivations
         .filter((b) => b.application(application))
         .get();
@@ -111,62 +103,75 @@ class Bip85Datasource {
       if (model.index >= nextIndex) nextIndex = model.index + 1;
     }
 
+    while (excludedIndices.contains(nextIndex)) {
+      nextIndex++;
+    }
+
     return nextIndex;
   }
 
   Future<List<Bip85DerivationModel>> fetchAll() async {
-    try {
-      final rows = await _sqlite.managers.bip85Derivations.get();
-      return rows.map((row) => Bip85DerivationModel.fromSqlite(row)).toList();
-    } catch (e) {
-      rethrow;
-    }
+    final rows = await _sqlite.managers.bip85Derivations.get();
+    return rows.map(Bip85DerivationModel.fromSqlite).toList();
   }
 
   Future<void> revoke(String path) async {
-    try {
-      await _sqlite.managers.bip85Derivations
-          .filter((b) => b.path(path))
-          .update((b) => b(status: const Value(Bip85StatusColumn.revoked)));
-    } catch (e) {
-      rethrow;
-    }
+    await _sqlite.managers.bip85Derivations
+        .filter((b) => b.path(path))
+        .update((b) => b(status: const Value(Bip85StatusColumn.revoked)));
   }
 
   Future<void> activate(String path) async {
-    try {
-      await _sqlite.managers.bip85Derivations
-          .filter((b) => b.path(path))
-          .update((b) => b(status: const Value(Bip85StatusColumn.active)));
-    } catch (e) {
-      rethrow;
-    }
+    await _sqlite.managers.bip85Derivations
+        .filter((b) => b.path(path))
+        .update((b) => b(status: const Value(Bip85StatusColumn.active)));
   }
 
   Future<void> alias(String path, String alias) async {
-    try {
-      await _sqlite.managers.bip85Derivations
-          .filter((b) => b.path(path))
-          .update((b) => b(alias: Value(alias)));
-    } catch (e) {
-      rethrow;
-    }
+    await _sqlite.managers.bip85Derivations
+        .filter((b) => b.path(path))
+        .update((b) => b(alias: Value(alias)));
   }
 
-  // We should not use _store without properly formatting the derivation path.
-  Future<void> _store(Bip85DerivationModel bip85) async {
-    try {
-      await _sqlite.managers.bip85Derivations.create(
-        (b) => b(
-          path: bip85.path,
-          xprvFingerprint: bip85.xprvFingerprint,
-          alias: Value(bip85.alias),
-          status: bip85.status,
-          application: bip85.application,
-        ),
-      );
-    } catch (e) {
-      rethrow;
-    }
+  Future<void> _store(Bip85DerivationModel derivation) async {
+    final existing = await _sqlite.managers.bip85Derivations
+        .filter((row) => row.path(derivation.path))
+        .getSingleOrNull();
+    await _sqlite.managers.bip85Derivations.create(
+      (row) => row(
+        path: derivation.path,
+        xprvFingerprint: derivation.xprvFingerprint,
+        alias: Value(derivation.alias),
+        status: derivation.status,
+        application: derivation.application,
+      ),
+      mode:
+          existing != null &&
+              existing.xprvFingerprint != derivation.xprvFingerprint
+          ? InsertMode.insertOrReplace
+          : InsertMode.insert,
+    );
+  }
+
+  ({String derivation, bip39.Mnemonic mnemonic, String xprvFingerprint})
+  _deriveMnemonic({
+    required String xprvBase58,
+    required bip39.MnemonicLength length,
+    required int index,
+    required bip39.Language language,
+  }) {
+    const application = Bip85ApplicationColumn.bip39;
+    final xprv = bip32.Bip32Keys.fromBase58(xprvBase58);
+    return (
+      derivation:
+          "${application.number}'/${language.toBip85Code()}'/${length.toBip85Code()}'/$index'",
+      mnemonic: bip85.Bip85Entropy.deriveMnemonic(
+        xprvBase58: xprvBase58,
+        language: language,
+        length: length,
+        index: index,
+      ),
+      xprvFingerprint: hex.encode(xprv.fingerprint),
+    );
   }
 }

--- a/lib/core/bip85/data/bip85_repository.dart
+++ b/lib/core/bip85/data/bip85_repository.dart
@@ -30,10 +30,10 @@ class Bip85Repository {
     } catch (e, st) {
       log.severe(
         message: 'Bip85Repository.deriveHex failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85DerivationFailure(e.toString()));
+      return const Err(Bip85DerivationFailure('BIP85 hex derivation failed'));
     }
   }
 
@@ -56,30 +56,75 @@ class Bip85Repository {
     } catch (e, st) {
       log.severe(
         message: 'Bip85Repository.deriveMnemonic failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85DerivationFailure(e.toString()));
+      return const Err(
+        Bip85DerivationFailure('BIP85 mnemonic derivation failed'),
+      );
+    }
+  }
+
+  @useResult
+  Future<Result<({String derivation, bip39.Mnemonic mnemonic}), Bip85Failure>>
+  deriveMnemonicPreview({
+    required String xprvBase58,
+    required bip39.MnemonicLength length,
+    required int index,
+  }) async {
+    try {
+      return Ok(
+        _datasource.deriveMnemonicPreview(
+          xprvBase58: xprvBase58,
+          length: length,
+          index: index,
+        ),
+      );
+    } on Exception catch (error, trace) {
+      log.severe(
+        message: 'Bip85Repository.deriveMnemonicPreview failed',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(Bip85DerivationFailure('BIP85 mnemonic preview failed'));
+    }
+  }
+
+  @useResult
+  Future<Result<Bip85DerivationEntity?, Bip85Failure>> fetch(
+    String path,
+  ) async {
+    try {
+      return Ok((await _datasource.fetch(path))?.toEntity());
+    } on Exception catch (error, trace) {
+      log.severe(
+        message: 'Bip85Repository.fetch failed',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(Bip85StorageFailure('BIP85 derivation lookup failed'));
     }
   }
 
   @useResult
   Future<Result<int, Bip85Failure>> fetchNextIndexForApplication(
-    Bip85Application application,
-  ) async {
+    Bip85Application application, {
+    Set<int> excludedIndices = const {},
+  }) async {
     try {
       final applicationColumn = Bip85ApplicationColumn.fromEntity(application);
       final index = await _datasource.fetchNextIndexForApplication(
         applicationColumn,
+        excludedIndices: excludedIndices,
       );
       return Ok(index);
     } catch (e, st) {
       log.severe(
         message: 'Bip85Repository.fetchNextIndexForApplication failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85StorageFailure(e.toString()));
+      return const Err(Bip85StorageFailure('BIP85 index lookup failed'));
     }
   }
 
@@ -91,10 +136,10 @@ class Bip85Repository {
     } catch (e, st) {
       log.severe(
         message: 'Bip85Repository.fetchAll failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85StorageFailure(e.toString()));
+      return const Err(Bip85StorageFailure('BIP85 derivation listing failed'));
     }
   }
 
@@ -106,8 +151,12 @@ class Bip85Repository {
       await _datasource.revoke(derivation.path);
       return const Ok(null);
     } catch (e, st) {
-      log.severe(message: 'Bip85Repository.revoke failed', error: e, trace: st);
-      return Err(Bip85StorageFailure(e.toString()));
+      log.severe(
+        message: 'Bip85Repository.revoke failed',
+        error: e.runtimeType,
+        trace: st,
+      );
+      return const Err(Bip85StorageFailure('BIP85 revocation failed'));
     }
   }
 
@@ -121,10 +170,10 @@ class Bip85Repository {
     } catch (e, st) {
       log.severe(
         message: 'Bip85Repository.activate failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85StorageFailure(e.toString()));
+      return const Err(Bip85StorageFailure('BIP85 activation failed'));
     }
   }
 
@@ -137,8 +186,12 @@ class Bip85Repository {
       await _datasource.alias(derivation.path, alias);
       return const Ok(null);
     } catch (e, st) {
-      log.severe(message: 'Bip85Repository.alias failed', error: e, trace: st);
-      return Err(Bip85StorageFailure(e.toString()));
+      log.severe(
+        message: 'Bip85Repository.alias failed',
+        error: e.runtimeType,
+        trace: st,
+      );
+      return const Err(Bip85StorageFailure('BIP85 alias update failed'));
     }
   }
 }

--- a/lib/core/bip85/domain/bip85_reservations.dart
+++ b/lib/core/bip85/domain/bip85_reservations.dart
@@ -1,0 +1,161 @@
+import 'package:bb_mobile/core/utils/recoverbull_bip85.dart';
+
+enum Bip85ReservationPurpose {
+  walletSeed,
+  nonWalletNostrKey,
+  backupEncryptionKey,
+}
+
+final class Bip85Reservation {
+  final String id;
+  final String deterministicAlias;
+  final Bip85ReservationPurpose purpose;
+  final String path;
+  final int index;
+
+  const Bip85Reservation({
+    required this.id,
+    required this.deterministicAlias,
+    required this.purpose,
+    required this.path,
+    required this.index,
+  });
+
+  bool get isWalletSeed => purpose == Bip85ReservationPurpose.walletSeed;
+
+  int get walletIndex {
+    if (!isWalletSeed) throw StateError('Reservation is not a wallet seed');
+    return index;
+  }
+}
+
+abstract final class Bip85Reservations {
+  static const nostrApplicationNumber = 128002;
+  static const nostrUserKeyReservationId = 'nostr_user_key';
+  static const nostrUserIdentityStart = 1;
+  static const nostrUserIdentityEnd = 0x7fffffff;
+  static const nostrUserAccount = 1;
+  static const nostrAppReservedIdentityStart = 100;
+  static const nostrAppReservedIdentityEnd = 199;
+
+  static const btcpayWalletSeed = Bip85Reservation(
+    id: 'btcpay_wallet_seed',
+    deterministicAlias: 'BTCPay',
+    purpose: Bip85ReservationPurpose.walletSeed,
+    path: "39'/0'/12'/100'",
+    index: 100,
+  );
+  static const lightningAddressWalletSeed = Bip85Reservation(
+    id: 'lightning_address_wallet_seed',
+    deterministicAlias: 'Lightning Address',
+    purpose: Bip85ReservationPurpose.walletSeed,
+    path: "39'/0'/12'/101'",
+    index: 101,
+  );
+  static const paymentPageWalletSeed = Bip85Reservation(
+    id: 'payment_page_wallet_seed',
+    deterministicAlias: 'Payment Page',
+    purpose: Bip85ReservationPurpose.walletSeed,
+    path: "39'/0'/12'/102'",
+    index: 102,
+  );
+  static const pointOfSaleWalletSeed = Bip85Reservation(
+    id: 'pos_wallet_seed',
+    deterministicAlias: 'Point of Sale',
+    purpose: Bip85ReservationPurpose.walletSeed,
+    path: "39'/0'/12'/103'",
+    index: 103,
+  );
+  static const nostrWalletBackupKey = Bip85Reservation(
+    id: 'nostr_wallet_backup_key',
+    deterministicAlias: 'Nostr Wallet Backup',
+    purpose: Bip85ReservationPurpose.nonWalletNostrKey,
+    path: "128002'/100'/1'",
+    index: 100,
+  );
+  static const nostrBullnymServerAuthKey = Bip85Reservation(
+    id: 'nostr_bullnym_server_auth_key',
+    deterministicAlias: 'Nostr Bullnym Auth',
+    purpose: Bip85ReservationPurpose.nonWalletNostrKey,
+    path: "128002'/101'/1'",
+    index: 101,
+  );
+  static const nostrNip05PublicNymVerificationKey = Bip85Reservation(
+    id: 'nostr_nip05_public_nym_verification_key',
+    deterministicAlias: 'Nostr NIP-05 Public Nym Verification',
+    purpose: Bip85ReservationPurpose.nonWalletNostrKey,
+    path: "128002'/102'/1'",
+    index: 102,
+  );
+  static const walletBackupEncryptionKey = Bip85Reservation(
+    id: 'wallet_backup_encryption_key',
+    deterministicAlias: 'Wallet Backup Encryption',
+    purpose: Bip85ReservationPurpose.backupEncryptionKey,
+    path: "1642'/0'/1'",
+    index: 1,
+  );
+
+  static const all = <Bip85Reservation>[
+    btcpayWalletSeed,
+    lightningAddressWalletSeed,
+    paymentPageWalletSeed,
+    pointOfSaleWalletSeed,
+    nostrWalletBackupKey,
+    nostrBullnymServerAuthKey,
+    nostrNip05PublicNymVerificationKey,
+    walletBackupEncryptionKey,
+  ];
+
+  static final reservedWalletSeedIndices = Set<int>.unmodifiable(
+    all.where((item) => item.isWalletSeed).map((item) => item.walletIndex),
+  );
+  static final reservedPaths = Set<String>.unmodifiable(
+    all.map((item) => item.path),
+  );
+  static final reservedPathPrefixes = Set<String>.unmodifiable({
+    RecoverbullBip85Utils.vaultKeyPathPrefix,
+  });
+
+  static bool isNostrAppReservedIdentity(int identity) =>
+      identity >= nostrAppReservedIdentityStart &&
+      identity <= nostrAppReservedIdentityEnd;
+
+  static String nostrUserKeyPath(int identity) {
+    if (identity < nostrUserIdentityStart ||
+        identity > nostrUserIdentityEnd ||
+        isNostrAppReservedIdentity(identity)) {
+      throw ArgumentError.value(identity, 'identity');
+    }
+    return "$nostrApplicationNumber'/$identity'/$nostrUserAccount'";
+  }
+
+  static int? nostrUserKeyIdentity(String path) {
+    final candidate = path.trim();
+    final parts = candidate.split('/');
+    if (parts.length != 3 ||
+        parts.first != "$nostrApplicationNumber'" ||
+        parts.last != "$nostrUserAccount'") {
+      return null;
+    }
+    final middle = parts[1];
+    final identity = middle.endsWith("'")
+        ? int.tryParse(middle.substring(0, middle.length - 1))
+        : null;
+    if (identity == null ||
+        identity < nostrUserIdentityStart ||
+        identity > nostrUserIdentityEnd ||
+        isNostrAppReservedIdentity(identity)) {
+      return null;
+    }
+    return nostrUserKeyPath(identity) == candidate ? identity : null;
+  }
+
+  static bool isNostrUserKeyPath(String path) =>
+      nostrUserKeyIdentity(path) != null;
+
+  static Bip85Reservation? reservationById(String id) =>
+      all.where((item) => item.id == id).firstOrNull;
+
+  static Bip85Reservation? reservationByExactPath(String path) =>
+      all.where((item) => item.path == path.trim()).firstOrNull;
+}

--- a/lib/core/bip85/domain/derive_next_bip85_hex_from_default_wallet_usecase.dart
+++ b/lib/core/bip85/domain/derive_next_bip85_hex_from_default_wallet_usecase.dart
@@ -1,26 +1,25 @@
 import 'package:bb_mobile/core/bip85/data/bip85_repository.dart';
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:meta/meta.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 
 class DeriveNextBip85HexFromDefaultWalletUsecase {
   final Bip85Repository _bip85Repository;
-  final WalletRepository _walletRepository;
-  final SeedRepository _seedRepository;
-  final SettingsRepository _settingsRepository;
+  final GetDefaultSeedUsecase _getDefaultSeed;
+  final GetSettingsUsecase _getSettings;
 
   DeriveNextBip85HexFromDefaultWalletUsecase({
     required this._bip85Repository,
-    required this._walletRepository,
-    required this._seedRepository,
-    required this._settingsRepository,
-  });
+    required GetDefaultSeedUsecase getDefaultSeedUsecase,
+    required GetSettingsUsecase getSettingsUsecase,
+  }) : _getDefaultSeed = getDefaultSeedUsecase,
+       _getSettings = getSettingsUsecase;
 
   @useResult
   Future<Result<({String derivation, String hex}), Bip85Failure>> execute({
@@ -28,24 +27,20 @@ class DeriveNextBip85HexFromDefaultWalletUsecase {
     String? alias,
   }) async {
     try {
-      // Derive from the default wallet of the environment the app is actually
-      // running in: a hardcoded mainnet lookup finds no wallet on testnet.
-      final settings = await _settingsRepository.fetch();
-      final wallets = await _walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
+      final settings = await _getSettings.execute();
+      final seedResult = await _getDefaultSeed.execute(
         environment: settings.environment,
       );
-      if (wallets.isEmpty) return const Err(Bip85NoDefaultWalletFailure());
-      final defaultWallet = wallets.first;
+      final Seed defaultSeed;
+      switch (seedResult) {
+        case Ok(:final value):
+          defaultSeed = value;
+        case Err(:final failure):
+          return Err(bip85FailureFromDefaultSeed(failure));
+      }
 
-      final defaultSeed = await _seedRepository.get(
-        defaultWallet.masterFingerprint,
-      );
-
-      final xprv = Bip32Derivation.getXprvFromSeed(
+      final xprv = Bip32Derivation.getCanonicalRootXprvFromSeed(
         defaultSeed.bytes,
-        defaultWallet.network,
       );
 
       const application = Bip85Application.hex;
@@ -63,13 +58,15 @@ class DeriveNextBip85HexFromDefaultWalletUsecase {
             alias: alias,
           );
       }
-    } catch (e, st) {
+    } on Exception catch (e, st) {
       log.severe(
         message: 'DeriveNextBip85HexFromDefaultWalletUsecase failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85UnexpectedFailure(e.toString()));
+      return const Err(
+        Bip85UnexpectedFailure('BIP85 next-hex derivation failed'),
+      );
     }
   }
 }

--- a/lib/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart
+++ b/lib/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart
@@ -1,58 +1,55 @@
 import 'package:bb_mobile/core/bip85/data/bip85_repository.dart';
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:meta/meta.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 
 class DeriveNextBip85MnemonicFromDefaultWalletUsecase {
   final Bip85Repository _bip85Repository;
-  final WalletRepository _walletRepository;
-  final SeedRepository _seedRepository;
-  final SettingsRepository _settingsRepository;
+  final GetDefaultSeedUsecase _getDefaultSeed;
+  final GetSettingsUsecase _getSettings;
 
   DeriveNextBip85MnemonicFromDefaultWalletUsecase({
     required this._bip85Repository,
-    required this._walletRepository,
-    required this._seedRepository,
-    required this._settingsRepository,
-  });
+    required GetDefaultSeedUsecase getDefaultSeedUsecase,
+    required GetSettingsUsecase getSettingsUsecase,
+  }) : _getDefaultSeed = getDefaultSeedUsecase,
+       _getSettings = getSettingsUsecase;
 
   @useResult
   Future<Result<({String derivation, bip39.Mnemonic mnemonic}), Bip85Failure>>
   execute({
     bip39.MnemonicLength length = bip39.MnemonicLength.words12,
     String? alias,
+    Set<int> excludedIndices = const {},
   }) async {
     try {
-      // Derive from the default wallet of the environment the app is actually
-      // running in: a hardcoded mainnet lookup finds no wallet on testnet.
-      final settings = await _settingsRepository.fetch();
-      final wallets = await _walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
+      final settings = await _getSettings.execute();
+      final seedResult = await _getDefaultSeed.execute(
         environment: settings.environment,
       );
-      if (wallets.isEmpty) return const Err(Bip85NoDefaultWalletFailure());
-      final defaultWallet = wallets.first;
+      final Seed defaultSeed;
+      switch (seedResult) {
+        case Ok(:final value):
+          defaultSeed = value;
+        case Err(:final failure):
+          return Err(bip85FailureFromDefaultSeed(failure));
+      }
 
-      final defaultSeed = await _seedRepository.get(
-        defaultWallet.masterFingerprint,
-      );
-
-      final xprv = Bip32Derivation.getXprvFromSeed(
+      final xprv = Bip32Derivation.getCanonicalRootXprvFromSeed(
         defaultSeed.bytes,
-        defaultWallet.network,
       );
 
       const application = Bip85Application.bip39;
       final indexResult = await _bip85Repository.fetchNextIndexForApplication(
         application,
+        excludedIndices: excludedIndices,
       );
       switch (indexResult) {
         case Err(:final failure):
@@ -65,13 +62,15 @@ class DeriveNextBip85MnemonicFromDefaultWalletUsecase {
             alias: alias,
           );
       }
-    } catch (e, st) {
+    } on Exception catch (e, st) {
       log.severe(
         message: 'DeriveNextBip85MnemonicFromDefaultWalletUsecase failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85UnexpectedFailure(e.toString()));
+      return const Err(
+        Bip85UnexpectedFailure('BIP85 next-mnemonic derivation failed'),
+      );
     }
   }
 }

--- a/lib/core/bip85/domain/errors/bip85_failure.dart
+++ b/lib/core/bip85/domain/errors/bip85_failure.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/failures/failure.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
 
 sealed class Bip85Failure extends Failure {
   const Bip85Failure([super.logMessage]);
@@ -8,8 +9,16 @@ final class Bip85NoDefaultWalletFailure extends Bip85Failure {
   const Bip85NoDefaultWalletFailure([super.logMessage]);
 }
 
+final class Bip85DefaultWalletAmbiguousFailure extends Bip85Failure {
+  const Bip85DefaultWalletAmbiguousFailure([super.logMessage]);
+}
+
 final class Bip85DerivationFailure extends Bip85Failure {
   const Bip85DerivationFailure([super.logMessage]);
+}
+
+final class Bip85DerivationConflictFailure extends Bip85Failure {
+  const Bip85DerivationConflictFailure([super.logMessage]);
 }
 
 final class Bip85StorageFailure extends Bip85Failure {
@@ -19,3 +28,11 @@ final class Bip85StorageFailure extends Bip85Failure {
 final class Bip85UnexpectedFailure extends Bip85Failure {
   const Bip85UnexpectedFailure([super.logMessage]);
 }
+
+Bip85Failure bip85FailureFromDefaultSeed(SeedFailure failure) =>
+    switch (failure) {
+      DefaultSeedNotFoundFailure() => const Bip85NoDefaultWalletFailure(),
+      DefaultSeedAmbiguousFailure() =>
+        const Bip85DefaultWalletAmbiguousFailure(),
+      _ => const Bip85UnexpectedFailure('Default seed unavailable'),
+    };

--- a/lib/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart
+++ b/lib/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart
@@ -2,10 +2,11 @@ import 'package:bb_mobile/core/bip85/data/bip85_repository.dart';
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
 import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
 import 'package:meta/meta.dart';
 import 'package:convert/convert.dart';
@@ -14,10 +15,12 @@ import 'package:bip32_keys/bip32_keys.dart' as bip32;
 class FetchAllBip85DerivationsWithEntropyUsecase {
   final Bip85Repository _bip85Repository;
   final GetDefaultSeedUsecase _getDefaultSeedUsecase;
+  final GetSettingsUsecase _getSettingsUsecase;
 
   FetchAllBip85DerivationsWithEntropyUsecase({
     required this._bip85Repository,
     required this._getDefaultSeedUsecase,
+    required this._getSettingsUsecase,
   });
 
   @useResult
@@ -27,12 +30,24 @@ class FetchAllBip85DerivationsWithEntropyUsecase {
       Bip85Failure
     >
   >
-  execute() async {
+  execute({
+    Set<String> excludedPaths = const {},
+    Set<String> excludedPathPrefixes = const {},
+  }) async {
     try {
-      final defaultSeed = await _getDefaultSeedUsecase.execute();
-      final xprvBase58 = Bip32Derivation.getXprvFromSeed(
+      final settings = await _getSettingsUsecase.execute();
+      final seedResult = await _getDefaultSeedUsecase.execute(
+        environment: settings.environment,
+      );
+      final Seed defaultSeed;
+      switch (seedResult) {
+        case Ok(:final value):
+          defaultSeed = value;
+        case Err(:final failure):
+          return Err(bip85FailureFromDefaultSeed(failure));
+      }
+      final xprvBase58 = Bip32Derivation.getCanonicalRootXprvFromSeed(
         defaultSeed.bytes,
-        Network.bitcoinMainnet,
       );
 
       switch (await _bip85Repository.fetchAll()) {
@@ -45,8 +60,10 @@ class FetchAllBip85DerivationsWithEntropyUsecase {
                 // no longer available, never show a value derived from another
                 // wallet in its place.
                 final key = bip32.Bip32Keys.fromBase58(xprvBase58);
-                return e.xprvFingerprint.toLowerCase() ==
-                    hex.encode(key.fingerprint).toLowerCase();
+                return !excludedPaths.contains(e.path) &&
+                    !excludedPathPrefixes.any(e.path.startsWith) &&
+                    e.xprvFingerprint.toLowerCase() ==
+                        hex.encode(key.fingerprint).toLowerCase();
               })
               .map((e) {
                 final entropy = bip85.Bip85Entropy.deriveFromHardenedPath(
@@ -58,13 +75,13 @@ class FetchAllBip85DerivationsWithEntropyUsecase {
               .toList();
           return Ok(derivationsWithEntropy);
       }
-    } catch (e, st) {
+    } on Exception catch (e, st) {
       log.severe(
         message: 'FetchAllBip85DerivationsWithEntropyUsecase failed',
-        error: e,
+        error: e.runtimeType,
         trace: st,
       );
-      return Err(Bip85UnexpectedFailure(e.toString()));
+      return const Err(Bip85UnexpectedFailure('BIP85 entropy lookup failed'));
     }
   }
 }

--- a/lib/core/seed/domain/seed_failure.dart
+++ b/lib/core/seed/domain/seed_failure.dart
@@ -8,6 +8,26 @@ final class SeedFetchFailure extends SeedFailure {
   const SeedFetchFailure([super.logMessage]);
 }
 
+final class DefaultSeedWalletLookupFailure extends SeedFailure {
+  const DefaultSeedWalletLookupFailure();
+}
+
+final class DefaultSeedNotFoundFailure extends SeedFailure {
+  const DefaultSeedNotFoundFailure();
+}
+
+final class DefaultSeedAmbiguousFailure extends SeedFailure {
+  const DefaultSeedAmbiguousFailure();
+}
+
+final class DefaultSeedUnavailableFailure extends SeedFailure {
+  const DefaultSeedUnavailableFailure();
+}
+
+final class DefaultSeedFingerprintMismatchFailure extends SeedFailure {
+  const DefaultSeedFingerprintMismatchFailure();
+}
+
 final class SeedDeleteFailure extends SeedFailure {
   const SeedDeleteFailure([super.logMessage]);
 }

--- a/lib/core/seed/domain/usecases/get_default_seed_usecase.dart
+++ b/lib/core/seed/domain/usecases/get_default_seed_usecase.dart
@@ -1,7 +1,14 @@
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bip32_keys/bip32_keys.dart' as bip32;
+import 'package:convert/convert.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
 
 class GetDefaultSeedUsecase {
   final WalletRepository _walletRepository;
@@ -12,18 +19,50 @@ class GetDefaultSeedUsecase {
     required this._seedRepository,
   });
 
-  Future<Seed> execute() async {
+  @useResult
+  Future<Result<Seed, SeedFailure>> execute({Environment? environment}) async {
+    final List<String> fingerprints;
     try {
-      final wallets = await _walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
+      fingerprints = await _walletRepository
+          .getDefaultBitcoinWalletFingerprints(environment: environment);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Default wallet lookup failed',
+        error: error.runtimeType,
+        trace: trace,
       );
-      if (wallets.isEmpty) throw 'No default wallet found';
-      final defaultWallet = wallets.first;
-      return await _seedRepository.get(defaultWallet.masterFingerprint);
-    } catch (e) {
-      log.severe(error: e, trace: StackTrace.current);
-      rethrow;
+      return const Err(DefaultSeedWalletLookupFailure());
     }
+    if (fingerprints.isEmpty) return const Err(DefaultSeedNotFoundFailure());
+    if (fingerprints.length > 1) {
+      return const Err(DefaultSeedAmbiguousFailure());
+    }
+
+    final walletFingerprint = Fingerprint.tryParse(fingerprints.single);
+    if (walletFingerprint == null) {
+      return const Err(DefaultSeedFingerprintMismatchFailure());
+    }
+
+    final Seed seed;
+    try {
+      seed = await _seedRepository.get(walletFingerprint.hex);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Default seed unavailable',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(DefaultSeedUnavailableFailure());
+    }
+
+    final storedFingerprint = Fingerprint.tryParse(seed.masterFingerprint);
+    final derivedFingerprint = Fingerprint.tryParse(
+      hex.encode(bip32.Bip32Keys.fromSeed(seed.bytes).fingerprint),
+    );
+    if (storedFingerprint != walletFingerprint ||
+        derivedFingerprint != walletFingerprint) {
+      return const Err(DefaultSeedFingerprintMismatchFailure());
+    }
+    return Ok(seed);
   }
 }

--- a/lib/core/utils/bip32_derivation.dart
+++ b/lib/core/utils/bip32_derivation.dart
@@ -30,6 +30,11 @@ class Bip32Derivation {
     return root.toBase58();
   }
 
+  /// BIP85 is seed-bound rather than Bitcoin-network-bound. Always serialize
+  /// its root with canonical xprv bytes, including for testnet wallets.
+  static String getCanonicalRootXprvFromSeed(Uint8List seedBytes) =>
+      bip32.Bip32Keys.fromSeed(seedBytes).toBase58();
+
   static bip32.Bip32Keys getBip32Xpub(String xpub) {
     final decoded = base58.decode(xpub);
     final keyBytes = decoded.sublist(4); // Remove xpub version bytes

--- a/lib/core/utils/nostr_bech32.dart
+++ b/lib/core/utils/nostr_bech32.dart
@@ -1,0 +1,37 @@
+import 'package:bech32/bech32.dart';
+
+abstract final class NostrBech32 {
+  static String npub(List<int> publicKeyBytes) =>
+      _encode('npub', publicKeyBytes);
+
+  static String nsec(List<int> privateKeyBytes) =>
+      _encode('nsec', privateKeyBytes);
+
+  static String _encode(String prefix, List<int> bytes) {
+    if (bytes.length != 32) {
+      throw ArgumentError.value(bytes.length, 'bytes.length', 'Must be 32');
+    }
+    return bech32.encode(Bech32(prefix, _convertBits(bytes)));
+  }
+
+  static List<int> _convertBits(List<int> bytes) {
+    var accumulator = 0;
+    var bitCount = 0;
+    final output = <int>[];
+    const outputBits = 5;
+    const mask = (1 << outputBits) - 1;
+    const maxAccumulator = (1 << (8 + outputBits - 1)) - 1;
+    for (final byte in bytes) {
+      accumulator = ((accumulator << 8) | byte) & maxAccumulator;
+      bitCount += 8;
+      while (bitCount >= outputBits) {
+        bitCount -= outputBits;
+        output.add((accumulator >> bitCount) & mask);
+      }
+    }
+    if (bitCount > 0) {
+      output.add((accumulator << (outputBits - bitCount)) & mask);
+    }
+    return output;
+  }
+}

--- a/lib/core/utils/recoverbull_bip85.dart
+++ b/lib/core/utils/recoverbull_bip85.dart
@@ -6,6 +6,11 @@ import 'package:convert/convert.dart' as convert;
 class RecoverbullBip85Utils {
   static final CustomApplication recoverbullApplication =
       CustomApplication.fromNumber(1608);
+  static const vaultKeyNamespace = 0;
+  static const maxVaultKeyIndex = (1 << 31) - 2;
+
+  static String get vaultKeyPathPrefix =>
+      "${recoverbullApplication.number}'/$vaultKeyNamespace'/";
 
   static int findApplicationNumber(String path) {
     // Old format was using `m/` prefix, which was unnecessarirly added by rust-bip85 before I forked it.
@@ -24,7 +29,7 @@ class RecoverbullBip85Utils {
   }
 
   static Bip85HardenedPath formatRecoverBullPath(int index) {
-    return Bip85HardenedPath("${recoverbullApplication.number}'/0'/$index'");
+    return Bip85HardenedPath('$vaultKeyPathPrefix$index\'');
   }
 
   // m/1608'/0'/586053381' -> 0'/586053381
@@ -48,6 +53,6 @@ class RecoverbullBip85Utils {
 
   static int _getRandomIndex() {
     final random = Random.secure();
-    return random.nextInt((1 << 31) - 1);
+    return random.nextInt(maxVaultKeyIndex + 1);
   }
 }

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -316,6 +316,22 @@ class WalletRepository {
         .toList();
   }
 
+  Future<List<String>> getDefaultBitcoinWalletFingerprints({
+    Environment? environment,
+  }) async {
+    final metadatas = await _walletMetadataDatasource.fetchAll();
+    return metadatas
+        .where(
+          (wallet) =>
+              wallet.isDefault &&
+              wallet.isBitcoin &&
+              (environment == null ||
+                  wallet.isMainnet == environment.isMainnet),
+        )
+        .map((wallet) => wallet.masterFingerprint)
+        .toList(growable: false);
+  }
+
   Future<void> updateEncryptedBackupTime({
     required DateTime? time,
     required String walletId,

--- a/lib/features/bip85_entropy/domain/can_access_bip85_entropy_usecase.dart
+++ b/lib/features/bip85_entropy/domain/can_access_bip85_entropy_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+
+class CanAccessBip85EntropyUsecase {
+  final GetSettingsUsecase _getSettings;
+
+  const CanAccessBip85EntropyUsecase(this._getSettings);
+
+  Future<bool> execute() async {
+    try {
+      final settings = await _getSettings.execute();
+      return settings.isSuperuser == true && settings.isDevModeEnabled == true;
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Could not evaluate BIP85 entropy access',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return false;
+    }
+  }
+}

--- a/lib/features/bip85_entropy/domain/derive_next_unreserved_bip85_mnemonic_usecase.dart
+++ b/lib/features/bip85_entropy/domain/derive_next_unreserved_bip85_mnemonic_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:meta/meta.dart';
+
+class DeriveNextUnreservedBip85MnemonicUsecase {
+  final DeriveNextBip85MnemonicFromDefaultWalletUsecase _deriveNext;
+
+  const DeriveNextUnreservedBip85MnemonicUsecase(this._deriveNext);
+
+  @useResult
+  Future<Result<({String derivation, bip39.Mnemonic mnemonic}), Bip85Failure>>
+  execute({
+    bip39.MnemonicLength length = bip39.MnemonicLength.words12,
+    String? alias,
+  }) => _deriveNext.execute(
+    length: length,
+    alias: alias,
+    excludedIndices: Bip85Reservations.reservedWalletSeedIndices,
+  );
+}

--- a/lib/features/bip85_entropy/domain/fetch_unreserved_bip85_derivations_with_entropy_usecase.dart
+++ b/lib/features/bip85_entropy/domain/fetch_unreserved_bip85_derivations_with_entropy_usecase.dart
@@ -1,0 +1,24 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
+import 'package:bb_mobile/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:meta/meta.dart';
+
+class FetchUnreservedBip85DerivationsWithEntropyUsecase {
+  final FetchAllBip85DerivationsWithEntropyUsecase _fetchAll;
+
+  const FetchUnreservedBip85DerivationsWithEntropyUsecase(this._fetchAll);
+
+  @useResult
+  Future<
+    Result<
+      List<({Bip85DerivationEntity derivation, String entropy})>,
+      Bip85Failure
+    >
+  >
+  execute() => _fetchAll.execute(
+    excludedPaths: Bip85Reservations.reservedPaths,
+    excludedPathPrefixes: Bip85Reservations.reservedPathPrefixes,
+  );
+}

--- a/lib/features/bip85_entropy/locator.dart
+++ b/lib/features/bip85_entropy/locator.dart
@@ -6,6 +6,10 @@ import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_defa
 import 'package:bb_mobile/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/revoke_bip85_derivation_usecase.dart';
 import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/can_access_bip85_entropy_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/derive_next_unreserved_bip85_mnemonic_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/fetch_unreserved_bip85_derivations_with_entropy_usecase.dart';
 import 'package:bb_mobile/features/bip85_entropy/presentation/cubit.dart';
 import 'package:get_it/get_it.dart';
 
@@ -15,15 +19,30 @@ class Bip85EntropyLocator {
       () => FetchAllBip85DerivationsWithEntropyUsecase(
         bip85Repository: locator<Bip85Repository>(),
         getDefaultSeedUsecase: locator<GetDefaultSeedUsecase>(),
+        getSettingsUsecase: locator<GetSettingsUsecase>(),
       ),
+    );
+
+    locator.registerFactory<FetchUnreservedBip85DerivationsWithEntropyUsecase>(
+      () => FetchUnreservedBip85DerivationsWithEntropyUsecase(
+        locator<FetchAllBip85DerivationsWithEntropyUsecase>(),
+      ),
+    );
+    locator.registerFactory<DeriveNextUnreservedBip85MnemonicUsecase>(
+      () => DeriveNextUnreservedBip85MnemonicUsecase(
+        locator<DeriveNextBip85MnemonicFromDefaultWalletUsecase>(),
+      ),
+    );
+    locator.registerFactory<CanAccessBip85EntropyUsecase>(
+      () => CanAccessBip85EntropyUsecase(locator<GetSettingsUsecase>()),
     );
 
     locator.registerFactory<Bip85EntropyCubit>(
       () => Bip85EntropyCubit(
-        fetchAllBip85DerivationsWithEntropyUsecase:
-            locator<FetchAllBip85DerivationsWithEntropyUsecase>(),
-        deriveNextBip85MnemonicFromDefaultWalletUsecase:
-            locator<DeriveNextBip85MnemonicFromDefaultWalletUsecase>(),
+        fetchUnreservedBip85DerivationsWithEntropyUsecase:
+            locator<FetchUnreservedBip85DerivationsWithEntropyUsecase>(),
+        deriveNextUnreservedBip85MnemonicUsecase:
+            locator<DeriveNextUnreservedBip85MnemonicUsecase>(),
         deriveNextBip85HexFromDefaultWalletUsecase:
             locator<DeriveNextBip85HexFromDefaultWalletUsecase>(),
         aliasBip85DerivationUsecase: locator<AliasBip85DerivationUsecase>(),

--- a/lib/features/bip85_entropy/presentation/bip85_failure_l10n.dart
+++ b/lib/features/bip85_entropy/presentation/bip85_failure_l10n.dart
@@ -5,7 +5,9 @@ import 'package:flutter/widgets.dart';
 extension Bip85FailureL10n on Bip85Failure {
   String toTranslated(BuildContext context) => switch (this) {
     Bip85NoDefaultWalletFailure() => context.loc.bip85NoDefaultWalletError,
+    Bip85DefaultWalletAmbiguousFailure() => context.loc.oopsSomethingWentWrong,
     Bip85DerivationFailure() => context.loc.oopsSomethingWentWrong,
+    Bip85DerivationConflictFailure() => context.loc.oopsSomethingWentWrong,
     Bip85StorageFailure() => context.loc.oopsSomethingWentWrong,
     Bip85UnexpectedFailure() => context.loc.oopsSomethingWentWrong,
   };

--- a/lib/features/bip85_entropy/presentation/cubit.dart
+++ b/lib/features/bip85_entropy/presentation/cubit.dart
@@ -2,19 +2,19 @@ import 'package:bb_mobile/core/bip85/domain/activate_bip85_derivation_usecase.da
 import 'package:bb_mobile/core/bip85/domain/alias_bip85_derivation_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_hex_from_default_wallet_usecase.dart';
-import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
-import 'package:bb_mobile/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/revoke_bip85_derivation_usecase.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/derive_next_unreserved_bip85_mnemonic_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/fetch_unreserved_bip85_derivations_with_entropy_usecase.dart';
 import 'package:bb_mobile/features/bip85_entropy/presentation/state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class Bip85EntropyCubit extends Cubit<Bip85EntropyState> {
   bool _derivationInProgress = false;
-  final FetchAllBip85DerivationsWithEntropyUsecase
-  _fetchAllBip85DerivationsWithEntropyUsecase;
-  final DeriveNextBip85MnemonicFromDefaultWalletUsecase
-  _deriveNextBip85MnemonicFromDefaultWalletUsecase;
+  final FetchUnreservedBip85DerivationsWithEntropyUsecase
+  _fetchUnreservedBip85DerivationsWithEntropyUsecase;
+  final DeriveNextUnreservedBip85MnemonicUsecase
+  _deriveNextUnreservedBip85MnemonicUsecase;
   final DeriveNextBip85HexFromDefaultWalletUsecase
   _deriveNextBip85HexFromDefaultWalletUsecase;
   final AliasBip85DerivationUsecase _aliasBip85DerivationUsecase;
@@ -22,8 +22,8 @@ class Bip85EntropyCubit extends Cubit<Bip85EntropyState> {
   final ActivateBip85DerivationUsecase _activateBip85DerivationUsecase;
 
   Bip85EntropyCubit({
-    required this._fetchAllBip85DerivationsWithEntropyUsecase,
-    required this._deriveNextBip85MnemonicFromDefaultWalletUsecase,
+    required this._fetchUnreservedBip85DerivationsWithEntropyUsecase,
+    required this._deriveNextUnreservedBip85MnemonicUsecase,
     required this._deriveNextBip85HexFromDefaultWalletUsecase,
     required this._aliasBip85DerivationUsecase,
     required this._revokeBip85DerivationUsecase,
@@ -38,7 +38,8 @@ class Bip85EntropyCubit extends Cubit<Bip85EntropyState> {
 
   Future<void> fetchAllDerivations() async {
     emit(state.copyWith(isLoading: true));
-    switch (await _fetchAllBip85DerivationsWithEntropyUsecase.execute()) {
+    switch (await _fetchUnreservedBip85DerivationsWithEntropyUsecase
+        .execute()) {
       case Err(:final failure):
         emit(state.copyWith(failure: failure, isLoading: false));
       case Ok(:final value):
@@ -52,7 +53,7 @@ class Bip85EntropyCubit extends Cubit<Bip85EntropyState> {
     if (_derivationInProgress) return;
     _derivationInProgress = true;
     emit(state.copyWith(isLoading: true, failure: null));
-    switch (await _deriveNextBip85MnemonicFromDefaultWalletUsecase.execute()) {
+    switch (await _deriveNextUnreservedBip85MnemonicUsecase.execute()) {
       case Err(:final failure):
         emit(state.copyWith(failure: failure, isLoading: false));
       case Ok():

--- a/lib/features/bip85_entropy/router.dart
+++ b/lib/features/bip85_entropy/router.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/features/bip85_entropy/bip85_home_page.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/can_access_bip85_entropy_usecase.dart';
 import 'package:bb_mobile/features/bip85_entropy/presentation/cubit.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -20,6 +21,10 @@ class Bip85EntropyRouter {
       GoRoute(
         name: Bip85EntropyRoute.bip85Home.name,
         path: Bip85EntropyRoute.bip85Home.path,
+        redirect: (context, state) async =>
+            await locator<CanAccessBip85EntropyUsecase>().execute()
+            ? null
+            : '/wallet',
         builder: (context, state) => const Bip85HomePage(),
         routes: const [],
       ),

--- a/lib/features/nostr_identity/domain/get_nostr_public_key_usecase.dart
+++ b/lib/features/nostr_identity/domain/get_nostr_public_key_usecase.dart
@@ -1,0 +1,14 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_failure.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:meta/meta.dart';
+
+class GetNostrPublicKeyUsecase {
+  final NostrIdentityKeyResolver _resolver;
+
+  const GetNostrPublicKeyUsecase(this._resolver);
+
+  @useResult
+  Future<Result<String, NostrIdentityFailure>> execute() async =>
+      (await _resolver.resolve()).map((key) => key.publicKeyHex);
+}

--- a/lib/features/nostr_identity/domain/nostr_identity_failure.dart
+++ b/lib/features/nostr_identity/domain/nostr_identity_failure.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/core/failures/failure.dart';
+
+sealed class NostrIdentityFailure extends Failure {
+  const NostrIdentityFailure([super.logMessage]);
+}
+
+final class NostrIdentityUnavailableFailure extends NostrIdentityFailure {
+  const NostrIdentityUnavailableFailure();
+}
+
+final class NostrIdentityInvalidHashFailure extends NostrIdentityFailure {
+  const NostrIdentityInvalidHashFailure();
+}

--- a/lib/features/nostr_identity/domain/nostr_identity_key_resolver.dart
+++ b/lib/features/nostr_identity/domain/nostr_identity_key_resolver.dart
@@ -1,0 +1,56 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_failure.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_key.dart';
+import 'package:meta/meta.dart';
+
+class NostrIdentityKeyResolver {
+  final GetSettingsUsecase _settings;
+  final GetDefaultSeedUsecase _defaultSeed;
+
+  const NostrIdentityKeyResolver(this._settings, this._defaultSeed);
+
+  @useResult
+  Future<Result<NostrKey, NostrIdentityFailure>> resolve() async {
+    final SettingsEntity settings;
+    try {
+      settings = await _settings.execute();
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Nostr identity wallet lookup failed',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(NostrIdentityUnavailableFailure());
+    }
+
+    final seedResult = await _defaultSeed.execute(
+      environment: settings.environment,
+    );
+    final Seed seed;
+    switch (seedResult) {
+      case Ok(:final value):
+        seed = value;
+      case Err(:final failure):
+        log.warning(
+          'Nostr identity seed is unavailable',
+          error: failure.runtimeType,
+        );
+        return const Err(NostrIdentityUnavailableFailure());
+    }
+
+    final rootXprv = Bip32Derivation.getCanonicalRootXprvFromSeed(seed.bytes);
+    return Ok(
+      NostrKey.derive(
+        rootXprv: rootXprv,
+        path: Bip85Reservations.nostrWalletBackupKey.path,
+      ),
+    );
+  }
+}

--- a/lib/features/nostr_identity/domain/nostr_key.dart
+++ b/lib/features/nostr_identity/domain/nostr_key.dart
@@ -1,0 +1,27 @@
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:convert/convert.dart';
+
+final class NostrKey {
+  final ECPrivate _privateKey;
+
+  NostrKey._(this._privateKey);
+
+  factory NostrKey.derive({required String rootXprv, required String path}) {
+    final entropy = bip85.Bip85Entropy.deriveFromHardenedPath(
+      xprvBase58: rootXprv,
+      path: bip85.Bip85HardenedPath(path),
+    );
+    return NostrKey._(ECPrivate.fromHex(entropy.substring(0, 64)));
+  }
+
+  late final _publicKeyBytes = _privateKey.getPublic().toXOnly();
+
+  late final String publicKeyHex = hex.encode(_publicKeyBytes);
+
+  String signHash(String hashHex) =>
+      _privateKey.signBip340(hex.decode(hashHex), tweak: false);
+
+  @override
+  String toString() => 'NostrKey(publicKeyHex: $publicKeyHex)';
+}

--- a/lib/features/nostr_identity/domain/sign_nostr_hash_usecase.dart
+++ b/lib/features/nostr_identity/domain/sign_nostr_hash_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_failure.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:meta/meta.dart';
+
+class SignNostrHashUsecase {
+  static final _hashPattern = RegExp(r'^[0-9a-fA-F]{64}$');
+
+  final NostrIdentityKeyResolver _resolver;
+
+  const SignNostrHashUsecase(this._resolver);
+
+  @useResult
+  Future<Result<String, NostrIdentityFailure>> execute(String hashHex) async {
+    if (!_hashPattern.hasMatch(hashHex)) {
+      return const Err(NostrIdentityInvalidHashFailure());
+    }
+    return (await _resolver.resolve()).map((key) => key.signHash(hashHex));
+  }
+}

--- a/lib/features/nostr_identity/nostr_identity_locator.dart
+++ b/lib/features/nostr_identity/nostr_identity_locator.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/get_nostr_public_key_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/sign_nostr_hash_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'package:get_it/get_it.dart';
+
+class NostrIdentityLocator {
+  static void setup(GetIt locator) {
+    locator.registerFactory<NostrIdentityFacade>(() {
+      final resolver = NostrIdentityKeyResolver(
+        locator<GetSettingsUsecase>(),
+        locator<GetDefaultSeedUsecase>(),
+      );
+      return NostrIdentityFacade(
+        GetNostrPublicKeyUsecase(resolver),
+        SignNostrHashUsecase(resolver),
+      );
+    });
+  }
+}

--- a/lib/features/nostr_identity/public/nostr_identity_facade.dart
+++ b/lib/features/nostr_identity/public/nostr_identity_facade.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/get_nostr_public_key_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_failure.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/sign_nostr_hash_usecase.dart';
+import 'package:meta/meta.dart';
+
+export 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_failure.dart';
+
+class NostrIdentityFacade {
+  final GetNostrPublicKeyUsecase _getPublicKey;
+  final SignNostrHashUsecase _signHash;
+
+  const NostrIdentityFacade(this._getPublicKey, this._signHash);
+
+  @useResult
+  Future<Result<String, NostrIdentityFailure>> walletBackupPublicKey() =>
+      _getPublicKey.execute();
+
+  @useResult
+  Future<Result<String, NostrIdentityFailure>> signWalletBackupHash(
+    String hashHex,
+  ) => _signHash.execute(hashHex);
+}

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -25,6 +25,7 @@ import 'package:bb_mobile/features/electrum_settings/electrum_settings_locator.d
 import 'package:bb_mobile/features/exchange/exchange_locator.dart';
 import 'package:bb_mobile/features/exchange_settings/exchange_settings_locator.dart';
 import 'package:bb_mobile/features/mempool_settings/mempool_settings_locator.dart';
+import 'package:bb_mobile/features/nostr_identity/nostr_identity_locator.dart';
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_locator.dart';
 import 'package:bb_mobile/features/import_mnemonic/locator.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_locator.dart';
@@ -168,6 +169,7 @@ class AppLocator {
     ImportMnemonicLocator.setup(locator);
     DcaLocator.setup(locator);
     ReplaceByFeeLocator.setup(locator);
+    NostrIdentityLocator.setup(locator);
     Bip85EntropyLocator.setup(locator);
     LedgerLocator.setup(locator);
     RecipientsLocator.setup(locator);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -107,7 +107,7 @@ packages:
     source: git
     version: "1.0.0-rc.3"
   bech32:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: bech32
       sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   no_screenshot: ^1.1.0
   freezed_annotation: ^3.1.0
   convert: ^3.1.2
+  bech32: ^0.2.2
   crypto: ^3.0.7
   synchronized: ^3.4.0
   json_annotation: ^4.9.0

--- a/test/core_test/bip85/bip85_reservations_test.dart
+++ b/test/core_test/bip85/bip85_reservations_test.dart
@@ -1,0 +1,69 @@
+import 'package:bb_mobile/core/bip85/data/bip85_datasource.dart';
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _masterXprv =
+    'xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb';
+
+void main() {
+  test('locks unique first-party paths and wallet indices', () {
+    expect(Bip85Reservations.all.map((item) => item.id), [
+      'btcpay_wallet_seed',
+      'lightning_address_wallet_seed',
+      'payment_page_wallet_seed',
+      'pos_wallet_seed',
+      'nostr_wallet_backup_key',
+      'nostr_bullnym_server_auth_key',
+      'nostr_nip05_public_nym_verification_key',
+      'wallet_backup_encryption_key',
+    ]);
+    expect(Bip85Reservations.reservedWalletSeedIndices, {100, 101, 102, 103});
+    expect(
+      Bip85Reservations.reservedPaths,
+      Bip85Reservations.all.map((item) => item.path).toSet(),
+    );
+    expect(Bip85Reservations.reservedPathPrefixes, {"1608'/0'/"});
+    expect(
+      () => Bip85Reservations.reservedWalletSeedIndices.add(104),
+      throwsA(isA<UnsupportedError>()),
+    );
+    expect(
+      Bip85Reservations.all.map((item) => item.path).toSet(),
+      hasLength(Bip85Reservations.all.length),
+    );
+  });
+
+  test('separates user Nostr identities from the app-owned range', () {
+    expect(Bip85Reservations.nostrUserKeyPath(1), "128002'/1'/1'");
+    expect(Bip85Reservations.nostrUserKeyIdentity("128002'/99'/1'"), 99);
+    expect(Bip85Reservations.isNostrUserKeyPath("128002'/200'/1'"), isTrue);
+    expect(Bip85Reservations.nostrUserKeyIdentity("128002'/100'/1'"), isNull);
+    expect(Bip85Reservations.nostrUserKeyIdentity("128002'/05'/1'"), isNull);
+    expect(() => Bip85Reservations.nostrUserKeyPath(100), throwsArgumentError);
+    expect(
+      Bip85Reservations.reservationByExactPath("1642'/0'/1'")?.id,
+      'wallet_backup_encryption_key',
+    );
+  });
+
+  test('reserved index 100 keeps the pinned BIP85 derivation', () async {
+    final database = SqliteDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final datasource = Bip85Datasource(sqlite: database);
+
+    final preview = datasource.deriveMnemonicPreview(
+      xprvBase58: _masterXprv,
+      length: bip39.MnemonicLength.words12,
+      index: Bip85Reservations.btcpayWalletSeed.walletIndex,
+    );
+
+    expect(preview.derivation, Bip85Reservations.btcpayWalletSeed.path);
+    expect(
+      preview.mnemonic.sentence,
+      'nurse knock brief chronic category music mosquito sell clean proud useful soon',
+    );
+  });
+}

--- a/test/core_test/bip85/derive_next_bip85_usecase_test.dart
+++ b/test/core_test/bip85/derive_next_bip85_usecase_test.dart
@@ -3,58 +3,31 @@ import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_hex_from_default_w
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
 import 'package:bb_mobile/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart';
-import 'package:bb_mobile/core/entities/signer_entity.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
 import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockBip85Repository extends Mock implements Bip85Repository {}
 
-class _MockWalletRepository extends Mock implements WalletRepository {}
-
-class _MockSeedRepository extends Mock implements SeedRepository {}
-
 class _MockGetDefaultSeedUsecase extends Mock
     implements GetDefaultSeedUsecase {}
 
-class _MockSettingsRepository extends Mock implements SettingsRepository {}
-
-final _fakeWallet = Wallet(
-  origin: 'test-id',
-  label: 'Test',
-  network: Network.bitcoinMainnet,
-  isDefault: true,
-  masterFingerprint: 'abcd1234',
-  xpubFingerprint: 'abcd1234',
-  scriptType: ScriptType.bip84,
-  xpub: 'xpub',
-  externalPublicDescriptor: 'desc',
-  internalPublicDescriptor: 'desc',
-  signer: SignerEntity.local,
-  signerDevice: null,
-  balanceSat: BigInt.zero,
-);
+class _MockGetSettingsUsecase extends Mock implements GetSettingsUsecase {}
 
 void main() {
   late _MockBip85Repository bip85Repository;
-  late _MockWalletRepository walletRepository;
-  late _MockSeedRepository seedRepository;
-  late _MockGetDefaultSeedUsecase getDefaultSeedUsecase;
-  late _MockSettingsRepository settingsRepository;
+  late _MockGetDefaultSeedUsecase getDefaultSeed;
+  late _MockGetSettingsUsecase getSettings;
 
   setUp(() {
     bip85Repository = _MockBip85Repository();
-    walletRepository = _MockWalletRepository();
-    seedRepository = _MockSeedRepository();
-    getDefaultSeedUsecase = _MockGetDefaultSeedUsecase();
-    settingsRepository = _MockSettingsRepository();
-    when(() => settingsRepository.fetch()).thenAnswer(
+    getDefaultSeed = _MockGetDefaultSeedUsecase();
+    getSettings = _MockGetSettingsUsecase();
+    when(() => getSettings.execute()).thenAnswer(
       (_) async => const SettingsEntity(
         environment: Environment.mainnet,
         bitcoinUnit: BitcoinUnit.sats,
@@ -69,51 +42,35 @@ void main() {
     setUp(() {
       usecase = DeriveNextBip85MnemonicFromDefaultWalletUsecase(
         bip85Repository: bip85Repository,
-        walletRepository: walletRepository,
-        seedRepository: seedRepository,
-        settingsRepository: settingsRepository,
+        getDefaultSeedUsecase: getDefaultSeed,
+        getSettingsUsecase: getSettings,
       );
     });
 
-    test(
-      'returns Bip85NoDefaultWalletFailure when no default wallet exists',
-      () async {
-        when(
-          () => walletRepository.getWallets(
-            onlyDefaults: any(named: 'onlyDefaults'),
-            onlyBitcoin: any(named: 'onlyBitcoin'),
-            environment: any(named: 'environment'),
-          ),
-        ).thenAnswer((_) async => []);
+    test('maps a missing default wallet', () async {
+      when(
+        () => getDefaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => const Err(DefaultSeedNotFoundFailure()));
 
-        final result = await usecase.execute();
+      final result = await usecase.execute();
 
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        final failure = (result as Err).failure;
-        expect(failure, isA<Bip85NoDefaultWalletFailure>());
-        expect(failure.logMessage, isNull);
-      },
-    );
+      expect(result, isA<Err<dynamic, Bip85Failure>>());
+      expect((result as Err).failure, isA<Bip85NoDefaultWalletFailure>());
+    });
 
-    test(
-      'returns Bip85UnexpectedFailure when wallet repository throws',
-      () async {
-        when(
-          () => walletRepository.getWallets(
-            onlyDefaults: any(named: 'onlyDefaults'),
-            onlyBitcoin: any(named: 'onlyBitcoin'),
-            environment: any(named: 'environment'),
-          ),
-        ).thenThrow(Exception('internal db error with secret path /data/user'));
+    test('maps an ambiguous default wallet', () async {
+      when(
+        () => getDefaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => const Err(DefaultSeedAmbiguousFailure()));
 
-        final result = await usecase.execute();
+      final result = await usecase.execute();
 
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        final failure = (result as Err).failure;
-        expect(failure, isA<Bip85UnexpectedFailure>());
-        expect(failure.logMessage, isNotNull);
-      },
-    );
+      expect(result, isA<Err<dynamic, Bip85Failure>>());
+      expect(
+        (result as Err).failure,
+        isA<Bip85DefaultWalletAmbiguousFailure>(),
+      );
+    });
   });
 
   group('DeriveNextBip85HexFromDefaultWalletUsecase', () {
@@ -122,80 +79,32 @@ void main() {
     setUp(() {
       usecase = DeriveNextBip85HexFromDefaultWalletUsecase(
         bip85Repository: bip85Repository,
-        walletRepository: walletRepository,
-        seedRepository: seedRepository,
-        settingsRepository: settingsRepository,
+        getDefaultSeedUsecase: getDefaultSeed,
+        getSettingsUsecase: getSettings,
       );
     });
 
-    test(
-      'returns Bip85NoDefaultWalletFailure when no default wallet exists',
-      () async {
-        when(
-          () => walletRepository.getWallets(
-            onlyDefaults: any(named: 'onlyDefaults'),
-            onlyBitcoin: any(named: 'onlyBitcoin'),
-            environment: any(named: 'environment'),
-          ),
-        ).thenAnswer((_) async => []);
+    test('maps a missing default wallet', () async {
+      when(
+        () => getDefaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => const Err(DefaultSeedNotFoundFailure()));
 
-        final result = await usecase.execute(length: 30);
+      final result = await usecase.execute(length: 30);
 
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        expect((result as Err).failure, isA<Bip85NoDefaultWalletFailure>());
-      },
-    );
+      expect(result, isA<Err<dynamic, Bip85Failure>>());
+      expect((result as Err).failure, isA<Bip85NoDefaultWalletFailure>());
+    });
 
-    test(
-      'returns Bip85UnexpectedFailure when seed repository throws',
-      () async {
-        when(
-          () => walletRepository.getWallets(
-            onlyDefaults: any(named: 'onlyDefaults'),
-            onlyBitcoin: any(named: 'onlyBitcoin'),
-            environment: any(named: 'environment'),
-          ),
-        ).thenAnswer((_) async => [_fakeWallet]);
+    test('sanitizes an unavailable default seed', () async {
+      when(
+        () => getDefaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => const Err(DefaultSeedUnavailableFailure()));
 
-        when(
-          () => seedRepository.get(any()),
-        ).thenThrow(Exception('seed not found'));
+      final result = await usecase.execute(length: 30);
 
-        final result = await usecase.execute(length: 30);
-
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        final failure = (result as Err).failure;
-        expect(failure, isA<Bip85UnexpectedFailure>());
-        expect(failure.logMessage, isNotNull);
-      },
-    );
-
-    test(
-      'forwards Bip85StorageFailure from repository fetchNextIndex',
-      () async {
-        when(
-          () => walletRepository.getWallets(
-            onlyDefaults: any(named: 'onlyDefaults'),
-            onlyBitcoin: any(named: 'onlyBitcoin'),
-            environment: any(named: 'environment'),
-          ),
-        ).thenAnswer((_) async => [_fakeWallet]);
-
-        when(
-          () => seedRepository.get(any()),
-        ).thenThrow(Exception('seed not found'));
-
-        final result = await usecase.execute(length: 30);
-
-        // The seed lookup throws (a shared core repo), so the use-case maps it
-        // to the sanitized catch-all — never a raw exception, never the typed
-        // no-default-wallet failure.
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        final failure = (result as Err).failure;
-        expect(failure, isA<Bip85UnexpectedFailure>());
-        expect(failure, isNot(isA<Bip85NoDefaultWalletFailure>()));
-      },
-    );
+      expect(result, isA<Err<dynamic, Bip85Failure>>());
+      expect((result as Err).failure, isA<Bip85UnexpectedFailure>());
+    });
   });
 
   group('FetchAllBip85DerivationsWithEntropyUsecase', () {
@@ -204,25 +113,20 @@ void main() {
     setUp(() {
       usecase = FetchAllBip85DerivationsWithEntropyUsecase(
         bip85Repository: bip85Repository,
-        getDefaultSeedUsecase: getDefaultSeedUsecase,
+        getDefaultSeedUsecase: getDefaultSeed,
+        getSettingsUsecase: getSettings,
       );
     });
 
-    test(
-      'returns Bip85UnexpectedFailure when default seed lookup throws',
-      () async {
-        when(
-          () => getDefaultSeedUsecase.execute(),
-        ).thenThrow(Exception('internal db error with secret path /data/user'));
+    test('sanitizes a default-wallet lookup failure', () async {
+      when(
+        () => getDefaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => const Err(DefaultSeedWalletLookupFailure()));
 
-        final result = await usecase.execute();
+      final result = await usecase.execute();
 
-        expect(result, isA<Err<dynamic, Bip85Failure>>());
-        final failure = (result as Err).failure;
-        expect(failure, isA<Bip85UnexpectedFailure>());
-        // logMessage is for Sentry only — never surfaced to UI.
-        expect(failure.logMessage, isNotNull);
-      },
-    );
+      expect(result, isA<Err<dynamic, Bip85Failure>>());
+      expect((result as Err).failure, isA<Bip85UnexpectedFailure>());
+    });
   });
 }

--- a/test/core_test/seed/get_default_seed_usecase_test.dart
+++ b/test/core_test/seed/get_default_seed_usecase_test.dart
@@ -1,0 +1,103 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bip32_keys/bip32_keys.dart' as bip32;
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _Wallets extends Mock implements WalletRepository {}
+
+class _Seeds extends Mock implements SeedRepository {}
+
+void main() {
+  final bytes = Uint8List.fromList(List.generate(16, (index) => index));
+  final fingerprint = hex.encode(bip32.Bip32Keys.fromSeed(bytes).fingerprint);
+  late _Wallets wallets;
+  late _Seeds seeds;
+  late GetDefaultSeedUsecase usecase;
+
+  setUp(() {
+    wallets = _Wallets();
+    seeds = _Seeds();
+    usecase = GetDefaultSeedUsecase(
+      walletRepository: wallets,
+      seedRepository: seeds,
+    );
+  });
+
+  test('returns the verified seed without loading wallet balances', () async {
+    final seed = Seed.bytes(bytes: bytes, masterFingerprint: fingerprint);
+    when(
+      () => wallets.getDefaultBitcoinWalletFingerprints(
+        environment: Environment.mainnet,
+      ),
+    ).thenAnswer((_) async => [fingerprint]);
+    when(() => seeds.get(fingerprint)).thenAnswer((_) async => seed);
+
+    final result = await usecase.execute(environment: Environment.mainnet);
+
+    expect(result, isA<Ok<Seed, SeedFailure>>());
+    verifyNever(
+      () => wallets.getWallets(
+        environment: any(named: 'environment'),
+        onlyDefaults: any(named: 'onlyDefaults'),
+        onlyBitcoin: any(named: 'onlyBitcoin'),
+      ),
+    );
+  });
+
+  test('rejects an ambiguous default-wallet trust root', () async {
+    when(
+      () => wallets.getDefaultBitcoinWalletFingerprints(
+        environment: Environment.mainnet,
+      ),
+    ).thenAnswer((_) async => [fingerprint, fingerprint]);
+
+    final result = await usecase.execute(environment: Environment.mainnet);
+
+    expect(result, isA<Err<Seed, SeedFailure>>());
+    expect((result as Err).failure, isA<DefaultSeedAmbiguousFailure>());
+    verifyNever(() => seeds.get(any()));
+  });
+
+  test('rejects seed bytes that do not match the wallet fingerprint', () async {
+    final otherBytes = Uint8List.fromList(
+      List.generate(16, (index) => index + 1),
+    );
+    final seed = Seed.bytes(bytes: otherBytes, masterFingerprint: fingerprint);
+    when(
+      () => wallets.getDefaultBitcoinWalletFingerprints(
+        environment: Environment.mainnet,
+      ),
+    ).thenAnswer((_) async => [fingerprint]);
+    when(() => seeds.get(fingerprint)).thenAnswer((_) async => seed);
+
+    final result = await usecase.execute(environment: Environment.mainnet);
+
+    expect(result, isA<Err<Seed, SeedFailure>>());
+    expect(
+      (result as Err).failure,
+      isA<DefaultSeedFingerprintMismatchFailure>(),
+    );
+  });
+
+  test('does not catch programmer errors', () async {
+    when(
+      () => wallets.getDefaultBitcoinWalletFingerprints(
+        environment: Environment.mainnet,
+      ),
+    ).thenThrow(StateError('programmer error'));
+
+    await expectLater(
+      usecase.execute(environment: Environment.mainnet),
+      throwsStateError,
+    );
+  });
+}

--- a/test/core_test/utils/nostr_bech32_test.dart
+++ b/test/core_test/utils/nostr_bech32_test.dart
@@ -1,0 +1,29 @@
+import 'package:bb_mobile/core/utils/nostr_bech32.dart';
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('encodes frozen Nostr public and private keys', () {
+    expect(
+      NostrBech32.npub(
+        hex.decode(
+          '4fb85384f3a52baadbadc3f9bcb7fd59691e323293160b58959dadd6195c7981',
+        ),
+      ),
+      'npub1f7u98p8n55464kadc0umedlat953uv3jjvtqkky4nkkavx2u0xqsvsgq2t',
+    );
+    expect(
+      NostrBech32.nsec(
+        hex.decode(
+          'f4141af5b1b85b1343cf8400a311b27fb5c16ace5537ee6fe9552e2dd97f311b',
+        ),
+      ),
+      'nsec17s2p4ad3hpd3xs70ssq2xydj076uz6kw25m7umlf25hzmktlxydsw2t3sg',
+    );
+  });
+
+  test('rejects values that are not 32 bytes', () {
+    expect(() => NostrBech32.npub([0]), throwsArgumentError);
+    expect(() => NostrBech32.nsec(List.filled(33, 0)), throwsArgumentError);
+  });
+}

--- a/test/features/bip85_entropy/domain/bip85_entropy_policy_test.dart
+++ b/test/features/bip85_entropy/domain/bip85_entropy_policy_test.dart
@@ -1,0 +1,103 @@
+import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
+import 'package:bb_mobile/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/can_access_bip85_entropy_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/derive_next_unreserved_bip85_mnemonic_usecase.dart';
+import 'package:bb_mobile/features/bip85_entropy/domain/fetch_unreserved_bip85_derivations_with_entropy_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _GetSettings extends Mock implements GetSettingsUsecase {}
+
+class _DeriveMnemonic extends Mock
+    implements DeriveNextBip85MnemonicFromDefaultWalletUsecase {}
+
+class _FetchDerivations extends Mock
+    implements FetchAllBip85DerivationsWithEntropyUsecase {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<int>{});
+    registerFallbackValue(<String>{});
+  });
+
+  test('entropy access requires both privileged settings', () async {
+    final settings = _GetSettings();
+    final usecase = CanAccessBip85EntropyUsecase(settings);
+
+    for (final flags in [
+      (superuser: true, devMode: true, allowed: true),
+      (superuser: true, devMode: false, allowed: false),
+      (superuser: false, devMode: true, allowed: false),
+      (superuser: false, devMode: false, allowed: false),
+    ]) {
+      reset(settings);
+      when(settings.execute).thenAnswer(
+        (_) async => SettingsEntity(
+          environment: Environment.mainnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+          isSuperuser: flags.superuser,
+          isDevModeEnabled: flags.devMode,
+        ),
+      );
+      expect(await usecase.execute(), flags.allowed);
+    }
+  });
+
+  test('entropy access fails closed when settings cannot load', () async {
+    final settings = _GetSettings();
+    when(settings.execute).thenThrow(Exception('unavailable'));
+
+    expect(await CanAccessBip85EntropyUsecase(settings).execute(), isFalse);
+  });
+
+  test('manual derivation skips every reserved wallet index', () async {
+    final derive = _DeriveMnemonic();
+    when(
+      () => derive.execute(excludedIndices: any(named: 'excludedIndices')),
+    ).thenAnswer((_) async => const Err(Bip85NoDefaultWalletFailure()));
+
+    final result = await DeriveNextUnreservedBip85MnemonicUsecase(
+      derive,
+    ).execute();
+    expect(result, isA<Err>());
+
+    final excluded =
+        verify(
+              () => derive.execute(
+                excludedIndices: captureAny(named: 'excludedIndices'),
+              ),
+            ).captured.single
+            as Set<int>;
+    expect(excluded, Bip85Reservations.reservedWalletSeedIndices);
+  });
+
+  test('entropy listing hides every reserved path and namespace', () async {
+    final fetch = _FetchDerivations();
+    when(
+      () => fetch.execute(
+        excludedPaths: any(named: 'excludedPaths'),
+        excludedPathPrefixes: any(named: 'excludedPathPrefixes'),
+      ),
+    ).thenAnswer((_) async => const Ok([]));
+
+    final result = await FetchUnreservedBip85DerivationsWithEntropyUsecase(
+      fetch,
+    ).execute();
+    expect(result, isA<Ok>());
+
+    final captured = verify(
+      () => fetch.execute(
+        excludedPaths: captureAny(named: 'excludedPaths'),
+        excludedPathPrefixes: captureAny(named: 'excludedPathPrefixes'),
+      ),
+    ).captured;
+    expect(captured[0], Bip85Reservations.reservedPaths);
+    expect(captured[1], Bip85Reservations.reservedPathPrefixes);
+  });
+}

--- a/test/features/nostr_identity/nostr_identity_facade_test.dart
+++ b/test/features/nostr_identity/nostr_identity_facade_test.dart
@@ -1,0 +1,250 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/nostr_bech32.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/get_nostr_public_key_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_key.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/sign_nostr_hash_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/nostr_identity_locator.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'package:bip32_keys/bip32_keys.dart' as bip32;
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSettings extends Mock implements GetSettingsUsecase {}
+
+class _MockDefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+const _mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const _hash =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+void main() {
+  late Seed seed;
+  late _MockSettings settings;
+  late _MockDefaultSeed defaultSeed;
+  late NostrIdentityFacade facade;
+
+  setUpAll(() {
+    final bytes = Uint8List.fromList(
+      bip39.Mnemonic.fromSentence(_mnemonic, bip39.Language.english).seed,
+    );
+    seed = Seed.bytes(
+      bytes: bytes,
+      masterFingerprint: hex.encode(
+        bip32.Bip32Keys.fromSeed(bytes).fingerprint,
+      ),
+    );
+  });
+
+  setUp(() {
+    settings = _MockSettings();
+    defaultSeed = _MockDefaultSeed();
+    when(() => settings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'CRC',
+      ),
+    );
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(seed));
+    facade = _facade(settings, defaultSeed);
+  });
+
+  test('derives the wallet backup identity from its frozen path', () async {
+    final backup = await facade.walletBackupPublicKey();
+
+    expect(
+      backup,
+      isA<Ok<String, NostrIdentityFailure>>().having(
+        (result) => result.value,
+        'wallet backup public key',
+        '4fb85384f3a52baadbadc3f9bcb7fd59691e323293160b58959dadd6195c7981',
+      ),
+    );
+    expect(
+      NostrBech32.npub(
+        hex.decode((backup as Ok<String, NostrIdentityFailure>).value),
+      ),
+      'npub1f7u98p8n55464kadc0umedlat953uv3jjvtqkky4nkkavx2u0xqsvsgq2t',
+    );
+  });
+
+  test('pins reserved payment identity vectors without runtime APIs', () {
+    final rootXprv = Bip32Derivation.getCanonicalRootXprvFromSeed(seed.bytes);
+    final auth = NostrKey.derive(
+      rootXprv: rootXprv,
+      path: Bip85Reservations.nostrBullnymServerAuthKey.path,
+    );
+    final verification = NostrKey.derive(
+      rootXprv: rootXprv,
+      path: Bip85Reservations.nostrNip05PublicNymVerificationKey.path,
+    );
+
+    expect(
+      auth.publicKeyHex,
+      '1d11451fdea6a9e291265e6ebf0eba04145f4bd2a15e7cea11978430f1011cf3',
+    );
+    expect(
+      verification.publicKeyHex,
+      'f1b86d6ed23fbdebf687a2d4f39c7e35d6cee5a38f8959c27a4454ce1b494b1b',
+    );
+  });
+
+  test('signs the frozen digest without exposing a private key', () async {
+    final publicKey = await facade.walletBackupPublicKey();
+    final signature = await facade.signWalletBackupHash(_hash);
+
+    final publicKeyHex = (publicKey as Ok<String, NostrIdentityFailure>).value;
+    final signatureHex = (signature as Ok<String, NostrIdentityFailure>).value;
+    expect(
+      signatureHex,
+      'da19ff41d148b058411c1df044f8595f0e6f05261eec000e8446461d185d739b'
+      'f74262ec740930f36fad2ca58e8c0026978d27a0035832403d8bfa37e5c712fd',
+    );
+    expect(
+      ECPublic.fromHex('02$publicKeyHex').verifyBip340Signature(
+        digest: hex.decode(_hash),
+        signature: hex.decode(signatureHex),
+        tweak: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('rejects a malformed digest before loading wallet secrets', () async {
+    expect(
+      await facade.signWalletBackupHash('abcd'),
+      isA<Err<String, NostrIdentityFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<NostrIdentityInvalidHashFailure>(),
+      ),
+    );
+    verifyNever(() => settings.execute());
+    verifyNever(
+      () => defaultSeed.execute(environment: any(named: 'environment')),
+    );
+  });
+
+  final failureCases = <({String name, SeedFailure source})>[
+    (
+      name: 'reports a missing default wallet',
+      source: const DefaultSeedNotFoundFailure(),
+    ),
+    (
+      name: 'reports ambiguous default wallets',
+      source: const DefaultSeedAmbiguousFailure(),
+    ),
+    (
+      name: 'reports wallet lookup failure',
+      source: const DefaultSeedWalletLookupFailure(),
+    ),
+    (
+      name: 'reports an unavailable seed',
+      source: const DefaultSeedUnavailableFailure(),
+    ),
+    (
+      name: 'reports a default-seed fingerprint mismatch',
+      source: const DefaultSeedFingerprintMismatchFailure(),
+    ),
+  ];
+  for (final failureCase in failureCases) {
+    test(failureCase.name, () async {
+      when(
+        () => defaultSeed.execute(environment: Environment.mainnet),
+      ).thenAnswer((_) async => Err<Seed, SeedFailure>(failureCase.source));
+
+      expect(
+        await facade.walletBackupPublicKey(),
+        isA<Err<String, NostrIdentityFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<NostrIdentityUnavailableFailure>(),
+        ),
+      );
+    });
+  }
+
+  test('maps settings lookup exceptions without exposing details', () async {
+    when(() => settings.execute()).thenThrow(Exception('storage detail'));
+
+    expect(
+      await facade.walletBackupPublicKey(),
+      isA<Err<String, NostrIdentityFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<NostrIdentityUnavailableFailure>(),
+      ),
+    );
+  });
+
+  test('uses the active environment when resolving the default seed', () async {
+    when(() => settings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.testnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'CRC',
+      ),
+    );
+    when(
+      () => defaultSeed.execute(environment: Environment.testnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(seed));
+
+    expect(
+      await facade.walletBackupPublicKey(),
+      isA<Ok<String, NostrIdentityFailure>>(),
+    );
+    verify(
+      () => defaultSeed.execute(environment: Environment.testnet),
+    ).called(1);
+  });
+
+  test('registers only the facade in the application container', () {
+    final getIt = GetIt.asNewInstance()
+      ..registerSingleton<GetSettingsUsecase>(settings)
+      ..registerSingleton<GetDefaultSeedUsecase>(defaultSeed);
+    addTearDown(getIt.reset);
+
+    NostrIdentityLocator.setup(getIt);
+
+    expect(getIt.isRegistered<NostrIdentityFacade>(), isTrue);
+    expect(getIt.isRegistered<NostrIdentityKeyResolver>(), isFalse);
+    expect(getIt.isRegistered<GetNostrPublicKeyUsecase>(), isFalse);
+    expect(getIt.isRegistered<SignNostrHashUsecase>(), isFalse);
+  });
+
+  test('does not catch programmer errors', () async {
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenThrow(StateError('programmer bug'));
+
+    expect(facade.walletBackupPublicKey, throwsA(isA<StateError>()));
+  });
+}
+
+NostrIdentityFacade _facade(
+  GetSettingsUsecase settings,
+  GetDefaultSeedUsecase defaultSeed,
+) {
+  final resolver = NostrIdentityKeyResolver(settings, defaultSeed);
+  return NostrIdentityFacade(
+    GetNostrPublicKeyUsecase(resolver),
+    SignNostrHashUsecase(resolver),
+  );
+}

--- a/test/security_audit/behavior/bip85_active_environment_test.dart
+++ b/test/security_audit/behavior/bip85_active_environment_test.dart
@@ -11,47 +11,27 @@ import 'package:bb_mobile/core/bip85/domain/bip85_derivation_entity.dart';
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_hex_from_default_wallet_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart';
 import 'package:bb_mobile/core/bip85/domain/errors/bip85_failure.dart';
-import 'package:bb_mobile/core/entities/signer_entity.dart';
-import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
-import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
-import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class _MockBip85Repository extends Mock implements Bip85Repository {}
 
-class _MockWalletRepository extends Mock implements WalletRepository {}
+class _MockGetDefaultSeedUsecase extends Mock
+    implements GetDefaultSeedUsecase {}
 
-class _MockSeedRepository extends Mock implements SeedRepository {}
-
-class _MockSettingsRepository extends Mock implements SettingsRepository {}
-
-final _testnetWallet = Wallet(
-  origin: 'testnet-default',
-  label: 'Secure Bitcoin',
-  network: Network.bitcoinTestnet,
-  isDefault: true,
-  masterFingerprint: 'aabbccdd',
-  xpubFingerprint: 'aabbccdd',
-  scriptType: ScriptType.bip84,
-  xpub: 'tpub',
-  externalPublicDescriptor: 'desc',
-  internalPublicDescriptor: 'desc',
-  signer: SignerEntity.local,
-  signerDevice: null,
-  balanceSat: BigInt.zero,
-);
+class _MockGetSettingsUsecase extends Mock implements GetSettingsUsecase {}
 
 void main() {
   late _MockBip85Repository bip85Repository;
-  late _MockWalletRepository walletRepository;
-  late _MockSeedRepository seedRepository;
-  late _MockSettingsRepository settingsRepository;
+  late _MockGetDefaultSeedUsecase getDefaultSeed;
+  late _MockGetSettingsUsecase getSettings;
 
   final seed = MnemonicSeed(
     mnemonicWords: const [
@@ -79,12 +59,11 @@ void main() {
 
   setUp(() {
     bip85Repository = _MockBip85Repository();
-    walletRepository = _MockWalletRepository();
-    seedRepository = _MockSeedRepository();
-    settingsRepository = _MockSettingsRepository();
+    getDefaultSeed = _MockGetDefaultSeedUsecase();
+    getSettings = _MockGetSettingsUsecase();
 
     // The app is running on testnet.
-    when(() => settingsRepository.fetch()).thenAnswer(
+    when(() => getSettings.execute()).thenAnswer(
       (_) async => const SettingsEntity(
         environment: Environment.testnet,
         bitcoinUnit: BitcoinUnit.sats,
@@ -92,23 +71,9 @@ void main() {
       ),
     );
 
-    // Only a testnet default wallet exists — the app is running on testnet.
     when(
-      () => walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
-        environment: Environment.mainnet,
-      ),
-    ).thenAnswer((_) async => <Wallet>[]);
-    when(
-      () => walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
-        environment: Environment.testnet,
-      ),
-    ).thenAnswer((_) async => <Wallet>[_testnetWallet]);
-
-    when(() => seedRepository.get(any())).thenAnswer((_) async => seed);
+      () => getDefaultSeed.execute(environment: Environment.testnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(seed));
     when(
       () => bip85Repository.fetchNextIndexForApplication(any()),
     ).thenAnswer((_) async => const Ok(0));
@@ -158,9 +123,8 @@ void main() {
     () async {
       final usecase = DeriveNextBip85MnemonicFromDefaultWalletUsecase(
         bip85Repository: bip85Repository,
-        walletRepository: walletRepository,
-        seedRepository: seedRepository,
-        settingsRepository: settingsRepository,
+        getDefaultSeedUsecase: getDefaultSeed,
+        getSettingsUsecase: getSettings,
       );
 
       final result = await usecase.execute();
@@ -176,9 +140,8 @@ void main() {
   test('hex derivation uses the active-environment default wallet', () async {
     final usecase = DeriveNextBip85HexFromDefaultWalletUsecase(
       bip85Repository: bip85Repository,
-      walletRepository: walletRepository,
-      seedRepository: seedRepository,
-      settingsRepository: settingsRepository,
+      getDefaultSeedUsecase: getDefaultSeed,
+      getSettingsUsecase: getSettings,
     );
 
     final result = await usecase.execute(length: 30);

--- a/test/security_audit/issue_2613_test.dart
+++ b/test/security_audit/issue_2613_test.dart
@@ -13,7 +13,11 @@ void main() {
         'lib/core/bip85/domain/fetch_all_bip85_derivations_with_entropy_usecase.dart',
       ).readAsStringSync();
 
-      expect(source, contains('final defaultSeed = await'));
+      expect(
+        source,
+        contains('final seedResult = await _getDefaultSeedUsecase.execute('),
+      );
+      expect(source, contains('final Seed defaultSeed'));
       expect(source, contains('Bip85HardenedPath(e.path)'));
       expect(source, contains('xprvFingerprint'));
       expect(source, contains('fingerprint'));

--- a/test/security_audit/issue_2645_test.dart
+++ b/test/security_audit/issue_2645_test.dart
@@ -8,18 +8,17 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Security audit #2645 network-specific default wallet', () {
-    test('derive-next requests defaults without filtering environment', () {
+    test('derive-next resolves the default seed for the active environment', () {
       final source = File(
         'lib/core/bip85/domain/derive_next_bip85_mnemonic_from_default_wallet_usecase.dart',
       ).readAsStringSync();
-      final call = source.substring(
-        source.indexOf('walletRepository.getWallets'),
-        source.indexOf(');', source.indexOf('walletRepository.getWallets')) + 2,
-      );
 
-      expect(call, contains('onlyDefaults: true'));
-      expect(call, contains('onlyBitcoin: true'));
-      expect(call, contains('environment:'));
+      expect(source, contains('final settings = await _getSettings.execute()'));
+      expect(
+        source,
+        contains('final seedResult = await _getDefaultSeed.execute('),
+      );
+      expect(source, contains('environment: settings.environment'));
     });
   });
 }


### PR DESCRIPTION
## What this adds

This adds a purpose-scoped Nostr identity used to authenticate wallet backup operations.

- Derives a stable backup public key from the default wallet seed at a fixed BIP85 path.
- Signs only validated 32-byte hashes for the permitted backup purpose.
- Exposes no raw private key, reusable key handle, or generic signing service.
- Uses a shared Nostr bech32 encoder for frozen public-key vectors.

## Approach

Only the facade is registered in the application container. Key resolution and signing remain private implementation details composed inside the facade. Seed lookup uses the balance-free default-wallet path and validates both stored and derived root fingerprints.

## Verification

Tests pin the derivation and signature vectors and cover missing or ambiguous defaults, locked seeds, environment selection, fingerprint mismatches, invalid hashes, sanitized logging, and programmer-error propagation.