### PR TITLE
feat(wallet): analyze and sign descriptor policies

### DIFF
--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -78,10 +78,16 @@ Future<void> main({bool isInitialized = false}) async {
       drain: true,
       networkFee: NetworkFee.relativeFromSatPerVbyte(testnetFeeRate),
     );
-    final signed = await signBitcoinTx.execute(
+    final signingResult = await signBitcoinTx.execute(
       psbt: prepared.unsignedPsbt,
       walletId: walletId,
     );
+    final signed = switch (signingResult) {
+      Ok(:final value) => value,
+      Err(:final failure) => throw StateError(
+        'Failed to sign consolidation transaction: ${failure.runtimeType}',
+      ),
+    };
     await broadcastBitcoinTx.execute(signed.signedPsbt, isPsbt: true);
     await Future<void>.delayed(const Duration(seconds: 3));
     await walletRepository.getWallets(sync: true);

--- a/lib/core/bbqr/bbqr.dart
+++ b/lib/core/bbqr/bbqr.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:bb_mobile/core/bbqr/bbqr_options.dart';
 import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
@@ -101,7 +102,7 @@ class Bbqr {
   static Future<List<String>> splitPsbt(String psbt) async {
     try {
       // check if the PSBT is valid, will throw if not
-      final parsedPsbt = bdk.Psbt(psbtBase64: psbt);
+      final parsedPsbt = bdk.Psbt(psbtBase64: normalizeBitcoinPsbt(psbt));
       final validPstb = parsedPsbt.serialize();
       final psbtBytes = base64.decode(validPstb);
 

--- a/lib/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart
+++ b/lib/core/blockchain/data/datasources/bdk_bitcoin_blockchain_datasource.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 
 class BdkBitcoinBlockchainDatasource {
@@ -11,7 +12,7 @@ class BdkBitcoinBlockchainDatasource {
     required ElectrumConnection connection,
   }) async {
     final blockchain = await _createClient(connection);
-    final psbt = bdk.Psbt(psbtBase64: finalizedPsbt);
+    final psbt = bdk.Psbt(psbtBase64: normalizeBitcoinPsbt(finalizedPsbt));
     final tx = psbt.extractTx();
     final txId = blockchain.transactionBroadcast(tx: tx);
     return txId.toString();

--- a/lib/core/exchange/domain/errors/pay_error.dart
+++ b/lib/core/exchange/domain/errors/pay_error.dart
@@ -28,6 +28,12 @@ sealed class PayError with _$PayError {
   /// operation, so the refreshed order is refused rather than paid.
   const factory PayError.depositAddressChanged() =
       DepositAddressChangedPayError;
+  const factory PayError.transactionSigningFailed() =
+      TransactionSigningFailedPayError;
+  const factory PayError.selectedCoinsUnavailable() =
+      SelectedCoinsUnavailablePayError;
+  const factory PayError.selectedCoinsInsufficient() =
+      SelectedCoinsInsufficientPayError;
   const factory PayError.unexpected({required String message}) =
       UnexpectedPayError;
 
@@ -42,6 +48,11 @@ sealed class PayError with _$PayError {
     orderNotFound: () => context.loc.payOrderNotFound,
     orderAlreadyConfirmed: () => context.loc.payOrderAlreadyConfirmed,
     depositAddressChanged: () => context.loc.payDepositAddressChangedError,
+    transactionSigningFailed: () => context.loc.oopsSomethingWentWrong,
+    selectedCoinsUnavailable: () =>
+        context.loc.sendErrorSelectedCoinsUnavailable,
+    selectedCoinsInsufficient: () =>
+        context.loc.sendErrorSelectedCoinsInsufficient,
     unexpected: (message) => message,
   );
 }

--- a/lib/core/exchange/domain/errors/sell_error.dart
+++ b/lib/core/exchange/domain/errors/sell_error.dart
@@ -27,6 +27,12 @@ sealed class SellError with _$SellError {
   /// operation, so the refreshed order is refused rather than paid.
   const factory SellError.depositAddressChanged() =
       DepositAddressChangedSellError;
+  const factory SellError.transactionSigningFailed() =
+      TransactionSigningFailedSellError;
+  const factory SellError.selectedCoinsUnavailable() =
+      SelectedCoinsUnavailableSellError;
+  const factory SellError.selectedCoinsInsufficient() =
+      SelectedCoinsInsufficientSellError;
   const factory SellError.unexpected({required String message}) =
       UnexpectedSellError;
   const factory SellError.insufficientBalance({
@@ -43,6 +49,11 @@ sealed class SellError with _$SellError {
     orderNotFound: () => context.loc.sellOrderNotFoundError,
     orderAlreadyConfirmed: () => context.loc.sellOrderAlreadyConfirmedError,
     depositAddressChanged: () => context.loc.sellDepositAddressChangedError,
+    transactionSigningFailed: () => context.loc.oopsSomethingWentWrong,
+    selectedCoinsUnavailable: () =>
+        context.loc.sendErrorSelectedCoinsUnavailable,
+    selectedCoinsInsufficient: () =>
+        context.loc.sendErrorSelectedCoinsInsufficient,
     unexpected: (message) => message,
     insufficientBalance: (_) => context.loc.sellInsufficientBalanceError,
   );

--- a/lib/core/utils/bitcoin_signer_result.dart
+++ b/lib/core/utils/bitcoin_signer_result.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+const int maxBitcoinPsbtDecodedBytes = 2 * 1024 * 1024;
+const int maxBitcoinPsbtTransportBytes = 3 * 1024 * 1024;
+
+const _psbtMagic = <int>[0x70, 0x73, 0x62, 0x74, 0xff];
+
+String normalizeBitcoinPsbt(String value) {
+  if (value.length > maxBitcoinPsbtTransportBytes) {
+    throw const FormatException('PSBT exceeds the maximum supported size');
+  }
+  final normalized = value.replaceAll(RegExp(r'\s'), '');
+  if (normalized.length > maxBitcoinPsbtTransportBytes) {
+    throw const FormatException('PSBT exceeds the maximum supported size');
+  }
+
+  final Uint8List decoded;
+  try {
+    decoded = base64.decode(normalized);
+  } on FormatException {
+    throw const FormatException('Invalid PSBT encoding');
+  }
+  return encodeBitcoinPsbtBytes(decoded);
+}
+
+String encodeBitcoinPsbtBytes(List<int> bytes) {
+  if (bytes.length > maxBitcoinPsbtDecodedBytes) {
+    throw const FormatException('PSBT exceeds the maximum supported size');
+  }
+  if (bytes.length < _psbtMagic.length ||
+      !Iterable<int>.generate(
+        _psbtMagic.length,
+      ).every((index) => bytes[index] == _psbtMagic[index])) {
+    throw const FormatException('Invalid PSBT data');
+  }
+  return base64.encode(bytes);
+}

--- a/lib/core/utils/bitcoin_tx.dart
+++ b/lib/core/utils/bitcoin_tx.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -59,15 +60,16 @@ class BitcoinTx {
   }
 
   static Future<BitcoinTx> fromPsbt(String psbtBase64) async {
+    final normalized = normalizeBitcoinPsbt(psbtBase64);
     // BDK extraction needs input metadata to compute fees, so finalized
     // PSBTs stripped of it must fall back to the bitcoin_base path, which
     // does not require that metadata (issue #2654).
     try {
-      final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+      final psbt = bdk.Psbt(psbtBase64: normalized);
       final txBytes = psbt.extractTx().serialize();
       return fromBytes(txBytes);
     } catch (_) {
-      final psbt = Psbt.fromBase64(psbtBase64);
+      final psbt = Psbt.fromBase64(normalized);
       final txBytes = PsbtBuilder.fromPsbt(psbt).finalizeAll().toBytes();
       return fromBytes(txBytes);
     }

--- a/lib/core/utils/payment_request.dart
+++ b/lib/core/utils/payment_request.dart
@@ -1,7 +1,8 @@
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
-import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bb_mobile/core/utils/msats.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bull_logger/bull_logger.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:bip21_uri/bip21_uri.dart';
 import 'package:bull_sdk/boltz.dart' as boltz;
@@ -330,7 +331,7 @@ sealed class PaymentRequest with _$PaymentRequest {
 
   static Future<PaymentRequest?> _tryParsePsbt(String psbtBase64) async {
     try {
-      final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+      final psbt = bdk.Psbt(psbtBase64: normalizeBitcoinPsbt(psbtBase64));
       return PaymentRequest.psbt(psbt: psbt.toString());
     } catch (e) {
       log.warning(e.toString());

--- a/lib/core/wallet/data/datasources/bdk_facade.dart
+++ b/lib/core/wallet/data/datasources/bdk_facade.dart
@@ -143,43 +143,71 @@ class BdkFacade {
       password: walletModel.passphrase,
     );
 
-    bdk.Descriptor? external;
-    bdk.Descriptor? internal;
+    late final bdk.Descriptor external;
+    late final bdk.Descriptor internal;
 
-    switch (walletModel.scriptType) {
-      case ScriptType.bip84:
-        external = bdk.Descriptor.newBip84(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.external_,
+    if (walletModel.account == 0) {
+      switch (walletModel.scriptType) {
+        case ScriptType.bip84:
+          external = bdk.Descriptor.newBip84(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.external_,
+            networkKind: networkKind,
+          );
+          internal = bdk.Descriptor.newBip84(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.internal,
+            networkKind: networkKind,
+          );
+        case ScriptType.bip49:
+          external = bdk.Descriptor.newBip49(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.external_,
+            networkKind: networkKind,
+          );
+          internal = bdk.Descriptor.newBip49(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.internal,
+            networkKind: networkKind,
+          );
+        case ScriptType.bip44:
+          external = bdk.Descriptor.newBip44(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.external_,
+            networkKind: networkKind,
+          );
+          internal = bdk.Descriptor.newBip44(
+            secretKey: secretKey,
+            keychainKind: bdk.KeychainKind.internal,
+            networkKind: networkKind,
+          );
+      }
+    } else {
+      final path = bdk.DerivationPath(
+        path:
+            "m/${walletModel.scriptType.purpose}'/"
+            "${walletModel.isTestnet ? 1 : 0}'/${walletModel.account}'",
+      );
+      final accountKey = secretKey.derive(path: path);
+      try {
+        external = bdk.Descriptor(
+          descriptor: _singleSignatureDescriptor(
+            walletModel.scriptType,
+            '$accountKey/0/*',
+          ),
           networkKind: networkKind,
         );
-        internal = bdk.Descriptor.newBip84(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.internal,
+        internal = bdk.Descriptor(
+          descriptor: _singleSignatureDescriptor(
+            walletModel.scriptType,
+            '$accountKey/1/*',
+          ),
           networkKind: networkKind,
         );
-      case ScriptType.bip49:
-        external = bdk.Descriptor.newBip49(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.external_,
-          networkKind: networkKind,
-        );
-        internal = bdk.Descriptor.newBip49(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.internal,
-          networkKind: networkKind,
-        );
-      case ScriptType.bip44:
-        external = bdk.Descriptor.newBip44(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.external_,
-          networkKind: networkKind,
-        );
-        internal = bdk.Descriptor.newBip44(
-          secretKey: secretKey,
-          keychainKind: bdk.KeychainKind.internal,
-          networkKind: networkKind,
-        );
+      } finally {
+        accountKey.dispose();
+        path.dispose();
+      }
     }
 
     // Get the database path
@@ -219,6 +247,58 @@ class BdkFacade {
         persister: dbPersister,
         lookahead: _lookahead,
       );
+    }
+  }
+
+  static String _singleSignatureDescriptor(ScriptType scriptType, String key) =>
+      switch (scriptType) {
+        ScriptType.bip44 => 'pkh($key)',
+        ScriptType.bip49 => 'sh(wpkh($key))',
+        ScriptType.bip84 => 'wpkh($key)',
+      };
+
+  /// Creates an in-memory wallet from arbitrary Bitcoin descriptors.
+  ///
+  /// Callers must never persist or log descriptors containing private keys.
+  static bdk.Wallet createEphemeralDescriptorWallet({
+    required String descriptor,
+    required bool isTestnet,
+  }) {
+    final network = isTestnet ? bdk.Network.testnet : bdk.Network.bitcoin;
+    final networkKind = isTestnet ? bdk.NetworkKind.test : bdk.NetworkKind.main;
+    final descriptors = _expandTwoPathDescriptor(
+      descriptor: descriptor,
+      networkKind: networkKind,
+    );
+    final external = bdk.Descriptor(
+      descriptor: descriptors.external,
+      networkKind: networkKind,
+    );
+    try {
+      external.sanityCheck();
+      final internal = bdk.Descriptor(
+        descriptor: descriptors.internal,
+        networkKind: networkKind,
+      );
+      try {
+        internal.sanityCheck();
+        final persister = bdk.Persister.newInMemory();
+        try {
+          return bdk.Wallet(
+            descriptor: external,
+            changeDescriptor: internal,
+            network: network,
+            persister: persister,
+            lookahead: _lookahead,
+          );
+        } finally {
+          persister.dispose();
+        }
+      } finally {
+        internal.dispose();
+      }
+    } finally {
+      external.dispose();
     }
   }
 
@@ -321,6 +401,19 @@ class BdkFacade {
     identities.sort();
     return identities.join(':');
   }
+
+  static String descriptorForPolicyAnalysis(String descriptor) =>
+      descriptor.split('#').first.replaceAllMapped(
+        RegExp(
+          r'\[([0-9a-fA-F]{8})([^\]]*)\]'
+          r'((?:xpub|tpub)[1-9A-HJ-NP-Za-km-z]+)',
+        ),
+        (match) {
+          final xpub = match.group(3)!;
+          final fingerprint = Bip32Derivation.getBip32Xpub(xpub).fingerprintHex;
+          return '[$fingerprint${match.group(2)!}]$xpub';
+        },
+      );
 
   static List<BdkDescriptorKey> _descriptorKeys(String descriptor) {
     final keys = <BdkDescriptorKey>[];
@@ -473,6 +566,87 @@ class BdkFacade {
       );
     }
     return parsed.descriptor;
+  }
+
+  static ({String external, String internal}) _expandTwoPathDescriptor({
+    required String descriptor,
+    required bdk.NetworkKind networkKind,
+  }) {
+    final withoutChecksum = descriptor.split('#').first;
+    if (withoutChecksum.contains('xprv') || withoutChecksum.contains('tprv')) {
+      return _expandPrivateTwoPathDescriptor(
+        descriptor: withoutChecksum,
+        networkKind: networkKind,
+      );
+    }
+    final multipath = bdk.Descriptor(
+      descriptor: withoutChecksum,
+      networkKind: networkKind,
+    );
+    try {
+      multipath.sanityCheck();
+      if (!multipath.isMultipath()) {
+        throw const FormatException(
+          'Descriptor must define receiving and change paths',
+        );
+      }
+      final descriptors = multipath.toSingleDescriptors();
+      try {
+        if (descriptors.length != 2) {
+          throw const FormatException(
+            'Descriptor must define exactly two wallet paths',
+          );
+        }
+        return (
+          external: descriptors.first.toStringWithSecret(),
+          internal: descriptors.last.toStringWithSecret(),
+        );
+      } finally {
+        for (final descriptor in descriptors) {
+          descriptor.dispose();
+        }
+      }
+    } finally {
+      multipath.dispose();
+    }
+  }
+
+  static ({String external, String internal}) _expandPrivateTwoPathDescriptor({
+    required String descriptor,
+    required bdk.NetworkKind networkKind,
+  }) {
+    final multipath = RegExp(r'<([0-9]+);([0-9]+)>');
+    if (!multipath.hasMatch(descriptor)) {
+      throw const FormatException(
+        'Descriptor must define receiving and change paths',
+      );
+    }
+
+    String expand(int branch) =>
+        descriptor.replaceAllMapped(multipath, (match) => match.group(branch)!);
+
+    final external = bdk.Descriptor(
+      descriptor: expand(1),
+      networkKind: networkKind,
+    );
+    try {
+      external.sanityCheck();
+      final internal = bdk.Descriptor(
+        descriptor: expand(2),
+        networkKind: networkKind,
+      );
+      try {
+        internal.sanityCheck();
+        return (
+          external: external.toStringWithSecret(),
+          internal: internal.toStringWithSecret(),
+        );
+      } finally {
+        internal.dispose();
+      }
+    } finally {
+      external.dispose();
+    }
   }
 
   static String _normalizePublicSingleDescriptor({

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -4,20 +4,31 @@ import 'dart:math';
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/utils/address_script_conversions.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bb_mobile/core/utils/generic_extensions.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_psbt_review_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_wallet_policy_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/balance_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/transaction_input_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/transaction_output_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_transaction_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:bitcoin_base/bitcoin_base.dart' as bitcoin_base;
 import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:convert/convert.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:primitives/primitives.dart' show Outpoint;
@@ -190,7 +201,7 @@ class BdkWalletDatasource {
   }) async {
     final bdkWallet = await BdkFacade.createPrivateWallet(wallet);
     return (String psbtBase64) {
-      final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+      final psbt = _parsePsbt(psbtBase64);
       // Unlike signPsbt (the sender signing a complete transaction, where a
       // non-finalized result is a genuine anomaly), this signs only the
       // receiver's own contributed input into a multi-party payjoin
@@ -234,6 +245,7 @@ class BdkWalletDatasource {
     bool? drain,
     List<WalletUtxoModel>? selected,
     bool replaceByFee = true,
+    BitcoinPolicyPath? policyPath,
     required WalletModel wallet,
   }) async {
     final bdkWallet = await BdkFacade.createWallet(wallet);
@@ -259,27 +271,25 @@ class BdkWalletDatasource {
       );
     }
 
-    if (selected != null && selected.isNotEmpty) {
-      final selectableOutPoints = selected
-          .map(
-            (utxo) => bdk.OutPoint(
-              txid: bdk.Txid.fromString(hex: utxo.txId),
-              vout: utxo.vout,
-            ),
-          )
-          .toList();
-      // bdk_dart's TxBuilder is immutable — every method returns a NEW
-      // builder instance rather than mutating in place. Discarding the
-      // return value (as this call did before) silently drops the manual
-      // UTXO selection and leaves BDK to pick inputs automatically.
-      txBuilder = txBuilder.addUtxos(outpoints: selectableOutPoints);
-    }
-
     // bdk_dart always has RBF (nSequence = 0xFFFFFFFD) enabled by default,
     // so we set the sequence to 0xFFFFFFFE if replaceByFee is explicitly set to false to disable RBF.
-    // Same immutable-builder pitfall as addUtxos above — must reassign.
-    if (!replaceByFee) {
+    if (!replaceByFee && policyPath?.requiresRelativeTimelock != true) {
       txBuilder = txBuilder.setExactSequence(nsequence: 0xFFFFFFFE);
+    }
+
+    if (policyPath != null) {
+      if (policyPath.external.isNotEmpty) {
+        txBuilder = txBuilder.policyPath(
+          policyPath: policyPath.external,
+          keychain: bdk.KeychainKind.external_,
+        );
+      }
+      if (policyPath.internal.isNotEmpty) {
+        txBuilder = txBuilder.policyPath(
+          policyPath: policyPath.internal,
+          keychain: bdk.KeychainKind.internal,
+        );
+      }
     }
 
     switch (networkFee) {
@@ -296,9 +306,63 @@ class BdkWalletDatasource {
         );
     }
 
-    // Make sure utxos that are unspendable are not used
-    final unspendableOutPoints = unspendable
-        ?.map(
+    // Keep policy-ineligible coins out of automatic and manual coin selection.
+    // Relative timelocks are per UTXO, so a wallet can have a mix of eligible
+    // and ineligible coins for the same selected descriptor path.
+    final unspendableByKey = {
+      for (final input in unspendable ?? const <({String txId, int vout})>[])
+        '${input.txId}:${input.vout}': input,
+    };
+    final unspents = bdkWallet.listUnspent();
+    if (policyPath != null) {
+      for (final utxo in unspents) {
+        final key = '${utxo.outpoint.txid}:${utxo.outpoint.vout}';
+        final eligible = utxo.keychain == bdk.KeychainKind.external_
+            ? policyPath.eligibleExternalOutpoints
+            : policyPath.eligibleInternalOutpoints;
+        if (eligible != null && !eligible.contains(key)) {
+          unspendableByKey[key] = (
+            txId: utxo.outpoint.txid.toString(),
+            vout: utxo.outpoint.vout,
+          );
+        }
+      }
+    }
+
+    final selectedKeys = {
+      for (final utxo in selected ?? const <WalletUtxoModel>[])
+        '${utxo.txId}:${utxo.vout}',
+    };
+    final hasManualSelection = selectedKeys.isNotEmpty;
+    if (hasManualSelection) {
+      final unspentKeys = {
+        for (final utxo in unspents)
+          '${utxo.outpoint.txid}:${utxo.outpoint.vout}',
+      };
+      final hasDuplicateSelection = selectedKeys.length != selected!.length;
+      final hasUnavailableSelection =
+          hasDuplicateSelection ||
+          !unspentKeys.containsAll(selectedKeys) ||
+          selectedKeys.any(unspendableByKey.containsKey);
+      if (hasUnavailableSelection) {
+        throw SelectedBitcoinCoinsUnavailableException();
+      }
+
+      final selectedOutpoints = selected
+          .map(
+            (utxo) => bdk.OutPoint(
+              txid: bdk.Txid.fromString(hex: utxo.txId),
+              vout: utxo.vout,
+            ),
+          )
+          .toList();
+      txBuilder = txBuilder
+          .addUtxos(outpoints: selectedOutpoints)
+          .manuallySelectedOnly();
+    }
+
+    final unspendableOutPoints = unspendableByKey.values
+        .map(
           (input) => bdk.OutPoint(
             txid: bdk.Txid.fromString(hex: input.txId),
             vout: input.vout,
@@ -308,7 +372,7 @@ class BdkWalletDatasource {
 
     // TODO: MOVE THIS TO THE TRANSACTION REPOSITORY, the repository should check the unspendable and spendable inputs
     // and build the transaction accordingly or return an error
-    if (unspendableOutPoints != null && unspendableOutPoints.isNotEmpty) {
+    if (unspendableOutPoints.isNotEmpty) {
       // Check if there are unspents that are not in the unspendable set so a
       // transaction can be built. Compare by (txId, vout) value, NOT by
       // bdk.OutPoint identity: OutPoint/Txid are opaque Rust handles with no
@@ -316,13 +380,9 @@ class BdkWalletDatasource {
       // Set.contains on the objects would always miss, leaving the all-frozen
       // case undetected (BDK would then fail with "insufficient funds" instead
       // of NoSpendableUtxoException).
-      final unspents = bdkWallet.listUnspent();
-      final unspendableKeys = unspendable!
-          .map((o) => '${o.txId}:${o.vout}')
-          .toSet();
       final spendableUtxos = unspents.where((utxo) {
         final key = '${utxo.outpoint.txid}:${utxo.outpoint.vout}';
-        return !unspendableKeys.contains(key);
+        return !unspendableByKey.containsKey(key);
       }).toList();
 
       if (spendableUtxos.isEmpty) {
@@ -332,31 +392,191 @@ class BdkWalletDatasource {
       txBuilder = txBuilder.unspendable(unspendable: unspendableOutPoints);
     }
 
-    // Finish the transaction building process
-    final bdk.Psbt psbt;
+    late final bdk.Psbt psbt;
     try {
       psbt = txBuilder.finish(wallet: bdkWallet);
     } on bdk.InsufficientFundsCreateTxException catch (e) {
-      // Mapped here so callers don't depend on a BDK type.
+      if (hasManualSelection) {
+        throw SelectedBitcoinCoinsInsufficientException();
+      }
       throw InsufficientFundsException(e.toString());
     } on bdk.CoinSelectionCreateTxException catch (e) {
-      // The same situation reported through a different variant: BDK raises
-      // this one when the selection can't cover the outputs plus the fee,
-      // which is what hand-picked coins hit.
+      if (hasManualSelection) {
+        throw SelectedBitcoinCoinsInsufficientException();
+      }
       throw InsufficientFundsException(e.errorMessage);
+    }
+
+    if (hasManualSelection) {
+      final transaction = psbt.extractTx();
+      try {
+        final actualInputKeys = {
+          for (final input in transaction.input())
+            '${input.previousOutput.txid}:${input.previousOutput.vout}',
+        };
+        if (actualInputKeys.length != selectedKeys.length ||
+            !actualInputKeys.containsAll(selectedKeys)) {
+          throw SelectedBitcoinCoinsUnavailableException();
+        }
+      } finally {
+        transaction.dispose();
+      }
     }
 
     return psbt.serialize();
   }
 
-  Future<int> decodeTxSize(String psbtString) async {
-    final psbt = bdk.Psbt(psbtBase64: psbtString);
-    final size = psbt.extractTx().vsize();
-    return size.toInt();
+  int decodeTxSize(String psbtString, {required PublicBdkWalletModel wallet}) {
+    final psbt = _parsePsbt(psbtString);
+    try {
+      final transaction = psbt.extractTx();
+      try {
+        final transactionInputs = transaction.input();
+        final psbtInputs = psbt.input();
+        if (transactionInputs.length != psbtInputs.length) {
+          throw const InvalidBitcoinPsbtException();
+        }
+        if (psbtInputs.every(_isFinalizedInput)) return transaction.vsize();
+        final descriptorWallet = BdkFacade.createEphemeralDescriptorWallet(
+          descriptor: wallet.descriptor,
+          isTestnet: wallet.isTestnet,
+        );
+        try {
+          final keychains = <BitcoinPolicyKeychain>[];
+          for (final (index, input) in psbtInputs.indexed) {
+            final utxo = _inputUtxo(
+              input,
+              transactionInputs[index].previousOutput,
+            );
+            final ownership = _descriptorOwnership(
+              descriptorWallet,
+              script: utxo.scriptPubkey,
+              keySources: input.bip32Derivation.values,
+            );
+            if (ownership == null) {
+              throw const BitcoinPsbtWalletMismatchException();
+            }
+            keychains.add(ownership.keychain);
+          }
+          return _completedTransactionVsize(
+            transaction: transaction,
+            inputs: psbtInputs,
+            inputKeychains: keychains,
+            wallet: wallet,
+          );
+        } finally {
+          descriptorWallet.dispose();
+        }
+      } finally {
+        transaction.dispose();
+      }
+    } finally {
+      psbt.dispose();
+    }
+  }
+
+  bool validatePolicyPreimage(BitcoinPolicyPreimage preimage) {
+    final input = _psbtPreimage(preimage);
+    return hex.encode(_preimageHash(input)) == preimage.hash;
+  }
+
+  String applyPolicyPreimages(
+    String psbtBase64,
+    List<BitcoinPolicyPreimage> preimages,
+  ) {
+    final parsed = _parsePsbt(psbtBase64);
+    final String normalizedPsbt;
+    try {
+      normalizedPsbt = parsed.serialize();
+    } finally {
+      parsed.dispose();
+    }
+    if (preimages.isEmpty) return normalizedPsbt;
+    final psbt = bitcoin_base.Psbt.fromBase64(normalizedPsbt);
+    final inputs = [for (final preimage in preimages) _psbtPreimage(preimage)];
+    for (var index = 0; index < psbt.input.length; index++) {
+      psbt.input.updateInputs(index, inputs);
+    }
+    return psbt.toBase64();
+  }
+
+  ({String transaction, int txSize}) verifyFinalTransaction({
+    required String psbtBase64,
+    required String transactionHex,
+  }) {
+    final psbt = _parsePsbt(psbtBase64);
+    try {
+      final prepared = psbt.extractTx();
+      try {
+        final signed = bdk.Transaction(
+          transactionBytes: Uint8List.fromList(hex.decode(transactionHex)),
+        );
+        try {
+          final preparedInputs = prepared.input();
+          final psbtInputs = psbt.input();
+          final signedInputs = signed.input();
+          final preparedOutputs = prepared.output();
+          final signedOutputs = signed.output();
+
+          final sameHeader =
+              prepared.version() == signed.version() &&
+              prepared.lockTime() == signed.lockTime();
+          final sameInputs =
+              preparedInputs.length == signedInputs.length &&
+              Iterable<int>.generate(preparedInputs.length).every((index) {
+                final expected = preparedInputs[index];
+                final actual = signedInputs[index];
+                return expected.previousOutput.txid.toString() ==
+                        actual.previousOutput.txid.toString() &&
+                    expected.previousOutput.vout ==
+                        actual.previousOutput.vout &&
+                    expected.sequence == actual.sequence;
+              });
+          final sameOutputs =
+              preparedOutputs.length == signedOutputs.length &&
+              Iterable<int>.generate(preparedOutputs.length).every((index) {
+                final expected = preparedOutputs[index];
+                final actual = signedOutputs[index];
+                return expected.value.toSat() == actual.value.toSat() &&
+                    listEquals(
+                      expected.scriptPubkey.toBytes(),
+                      actual.scriptPubkey.toBytes(),
+                    );
+              });
+          final hasOnlyCommittedSignatures =
+              psbtInputs.length == signedInputs.length &&
+              Iterable<int>.generate(signedInputs.length).every(
+                (index) => _hasOnlyCommittedSignatures(
+                  signedInputs[index],
+                  psbtInputs[index],
+                ),
+              );
+          if (!sameHeader ||
+              !sameInputs ||
+              !sameOutputs ||
+              !hasOnlyCommittedSignatures) {
+            throw const FormatException(
+              'Signed transaction does not match the prepared PSBT',
+            );
+          }
+
+          return (
+            transaction: hex.encode(signed.serialize()),
+            txSize: signed.vsize(),
+          );
+        } finally {
+          signed.dispose();
+        }
+      } finally {
+        prepared.dispose();
+      }
+    } finally {
+      psbt.dispose();
+    }
   }
 
   Future<int> getFeeAmount(String psbtString) async {
-    final psbt = bdk.Psbt(psbtBase64: psbtString);
+    final psbt = _parsePsbt(psbtString);
     final fee = psbt.fee();
     return fee;
   }
@@ -366,7 +586,7 @@ class BdkWalletDatasource {
     String address, {
     required bool isTestnet,
   }) async {
-    final psbt = bdk.Psbt(psbtBase64: psbtString);
+    final psbt = _parsePsbt(psbtString);
     final tx = psbt.extractTx();
     final outputs = tx.output();
     int totalAmount = 0;
@@ -384,31 +604,624 @@ class BdkWalletDatasource {
   }
   // 25000 - 988
 
-  Future<String> signPsbt(
+  Future<({String psbt, bool isFinalized})> signPsbt(
     String unsignedPsbt, {
     required PrivateBdkWalletModel wallet,
+    bool allowFinalizedForeignInputs = false,
   }) async {
-    final psbt = bdk.Psbt(psbtBase64: unsignedPsbt);
-    final bdkWallet = await BdkFacade.createPrivateWallet(wallet);
+    final psbt = _parsePsbt(unsignedPsbt);
+    try {
+      final inputs = psbt.input();
+      _validatePartialSignatures(
+        unsignedPsbt,
+        inputs: inputs,
+        allowFinalizedTaprootInputs: allowFinalizedForeignInputs,
+      );
+      final bdkWallet = await BdkFacade.createPrivateWallet(wallet);
+      try {
+        if (allowFinalizedForeignInputs) {
+          _rejectFinalizedWalletInputs(psbt, inputs, bdkWallet);
+        } else {
+          _rejectFinalizedInputs(inputs);
+        }
+        bdkWallet.sign(
+          psbt: psbt,
+          signOptions: bdk.SignOptions(
+            trustWitnessUtxo: true,
+            assumeHeight: null,
+            allowAllSighashes: false,
+            tryFinalize: false,
+            signWithTapInternalKey: false,
+            allowGrinding: true,
+          ),
+        );
+        final signed = inputs.every(_isFinalizedInput)
+            ? (psbt: psbt.serialize(), isFinalized: true)
+            : _finalizeCompletePsbt(psbt);
+        if (!signed.isFinalized) {
+          log.info('Signed PSBT is not finalized');
+        } else {
+          log.info('Signed PSBT is finalized');
+        }
+        return signed;
+      } finally {
+        bdkWallet.dispose();
+      }
+    } finally {
+      psbt.dispose();
+    }
+  }
 
-    final isFinalized = bdkWallet.sign(
-      psbt: psbt,
-      signOptions: bdk.SignOptions(
-        trustWitnessUtxo: true,
-        assumeHeight: null,
-        allowAllSighashes: false,
-        tryFinalize: true,
-        signWithTapInternalKey: false,
-        allowGrinding: true,
-      ),
+  BitcoinWalletPolicyModel analyzePolicy({
+    required PublicBdkWalletModel wallet,
+    List<WalletDescriptorKeyModel> descriptorKeys = const [],
+  }) {
+    final bdkWallet = BdkFacade.createEphemeralDescriptorWallet(
+      descriptor: wallet.descriptor,
+      isTestnet: wallet.isTestnet,
     );
-    if (!isFinalized) {
-      log.info('Signed PSBT is not finalized');
-    } else {
-      log.info('Signed PSBT is finalized');
+    final keyIdentityWallet = descriptorKeys.isEmpty
+        ? null
+        : BdkFacade.createEphemeralDescriptorWallet(
+            descriptor: BdkFacade.descriptorForPolicyAnalysis(
+              wallet.descriptor,
+            ),
+            isTestnet: wallet.isTestnet,
+          );
+    try {
+      final external = bdkWallet.policies(keychain: bdk.KeychainKind.external_);
+      final internal = bdkWallet.policies(keychain: bdk.KeychainKind.internal);
+      final externalKeyIdentities =
+          keyIdentityWallet?.policies(keychain: bdk.KeychainKind.external_) ??
+          external;
+      final internalKeyIdentities =
+          keyIdentityWallet?.policies(keychain: bdk.KeychainKind.internal) ??
+          internal;
+      if (external == null ||
+          internal == null ||
+          externalKeyIdentities == null ||
+          internalKeyIdentities == null) {
+        throw StateError('Wallet descriptor has no spend policy');
+      }
+
+      return BitcoinWalletPolicyMapper.fromBdk(
+        external: external,
+        internal: internal,
+        externalKeyIdentities: externalKeyIdentities,
+        internalKeyIdentities: internalKeyIdentities,
+        descriptorKeys: descriptorKeys,
+      );
+    } finally {
+      keyIdentityWallet?.dispose();
+      bdkWallet.dispose();
+    }
+  }
+
+  Future<BitcoinPsbtReviewModel> inspectPsbt(
+    String psbtBase64, {
+    required PublicBdkWalletModel wallet,
+    required Set<String> walletFingerprints,
+  }) async {
+    final psbt = _parsePsbt(psbtBase64);
+    try {
+      final transaction = psbt.extractTx();
+      try {
+        final transactionInputs = transaction.input();
+        final transactionOutputs = transaction.output();
+        final psbtInputs = psbt.input();
+        final psbtOutputs = psbt.output();
+        if (transactionInputs.length != psbtInputs.length ||
+            transactionOutputs.length != psbtOutputs.length) {
+          throw const InvalidBitcoinPsbtException();
+        }
+        _validatePartialSignatures(psbtBase64, inputs: psbtInputs);
+
+        final descriptorWallet = await BdkFacade.createWallet(wallet);
+        try {
+          final normalizedWalletFingerprints = walletFingerprints
+              .map((fingerprint) => fingerprint.toLowerCase())
+              .toSet();
+          final inputs = <BitcoinPsbtInputReviewRecord>[];
+          for (final (index, input) in psbtInputs.indexed) {
+            final previousOutput = transactionInputs[index].previousOutput;
+            final utxo = _inputUtxo(input, previousOutput);
+            final ownership = _descriptorOwnership(
+              descriptorWallet,
+              script: utxo.scriptPubkey,
+              keySources: input.bip32Derivation.values,
+            );
+            if (ownership == null) {
+              throw const BitcoinPsbtWalletMismatchException();
+            }
+
+            final originKeySources = [
+              for (final entry in input.bip32Derivation.entries)
+                (
+                  publicKey: entry.key.toString().toLowerCase(),
+                  fingerprint: entry.value.fingerprint.toLowerCase(),
+                  derivationPath: entry.value.path.toString(),
+                ),
+            ];
+            final signedKeySources = [
+              for (final publicKey in input.partialSigs.keys)
+                (
+                  publicKey: publicKey.toString().toLowerCase(),
+                  fingerprint: input.bip32Derivation[publicKey]?.fingerprint
+                      .toLowerCase(),
+                  derivationPath: input.bip32Derivation[publicKey]?.path
+                      .toString(),
+                ),
+            ];
+            inputs.add((
+              amountSat: BigInt.from(utxo.value.toSat()),
+              keychain: ownership.keychain == BitcoinPolicyKeychain.external
+                  ? BitcoinPolicyKeychainModel.external
+                  : BitcoinPolicyKeychainModel.internal,
+              originKeySources: originKeySources,
+              outpoint: '${previousOutput.txid}:${previousOutput.vout}',
+              sequence: transactionInputs[index].sequence,
+              signedKeySources: signedKeySources,
+            ));
+          }
+
+          final outputs = <BitcoinPsbtOutputReviewRecord>[];
+          for (final (index, txOut) in transactionOutputs.indexed) {
+            final output = psbtOutputs[index];
+            final ownership = _descriptorOwnership(
+              descriptorWallet,
+              script: txOut.scriptPubkey,
+              keySources: output.bip32Derivation.values,
+            );
+            final originFingerprints = output.bip32Derivation.values
+                .map((source) => source.fingerprint.toLowerCase())
+                .toSet();
+            if (ownership == null &&
+                originFingerprints
+                    .intersection(normalizedWalletFingerprints)
+                    .isNotEmpty) {
+              throw const BitcoinPsbtWalletMismatchException();
+            }
+            outputs.add((
+              address: _addressFromScript(
+                txOut.scriptPubkey,
+                isTestnet: wallet.isTestnet,
+              ),
+              amountSat: BigInt.from(txOut.value.toSat()),
+              index: index,
+              isWalletOwned: ownership != null,
+              scriptHex: hex.encode(txOut.scriptPubkey.toBytes()),
+            ));
+          }
+
+          return BitcoinPsbtReviewModel(
+            transactionId: transaction.computeTxid().toString(),
+            inputs: inputs,
+            outputs: outputs,
+            feeSat: BigInt.from(psbt.fee()),
+            estimatedTransactionVsize: _completedTransactionVsize(
+              transaction: transaction,
+              inputs: psbtInputs,
+              inputKeychains: inputs
+                  .map(
+                    (input) =>
+                        input.keychain == BitcoinPolicyKeychainModel.external
+                        ? BitcoinPolicyKeychain.external
+                        : BitcoinPolicyKeychain.internal,
+                  )
+                  .toList(),
+              wallet: wallet,
+            ),
+            lockTime: transaction.lockTime(),
+            version: transaction.version(),
+          );
+        } finally {
+          descriptorWallet.dispose();
+        }
+      } finally {
+        transaction.dispose();
+      }
+    } on bdk.MissingInputValueExtractTxException {
+      throw const BitcoinPsbtMissingUtxoException();
+    } finally {
+      psbt.dispose();
+    }
+  }
+
+  Future<void> validateWalletPsbtInputs(
+    String psbtBase64, {
+    required PublicBdkWalletModel wallet,
+    Set<String> frozenOutpoints = const {},
+    String? replacingTxid,
+  }) async {
+    final psbt = _parsePsbt(psbtBase64);
+    try {
+      final transaction = psbt.extractTx();
+      try {
+        final transactionInputs = transaction.input();
+        final psbtInputs = psbt.input();
+        if (transactionInputs.length != psbtInputs.length) {
+          throw const InvalidBitcoinPsbtException();
+        }
+
+        final bdkWallet = await BdkFacade.createWallet(wallet);
+        try {
+          final replacedOutpoints = replacingTxid == null
+              ? const <String>{}
+              : _transactionInputOutpoints(bdkWallet, replacingTxid);
+          final outputs = {
+            for (final output in bdkWallet.listOutput())
+              '${output.outpoint.txid}:${output.outpoint.vout}': output,
+          };
+          final seenOutpoints = <String>{};
+          for (final (index, transactionInput) in transactionInputs.indexed) {
+            final previousOutput = transactionInput.previousOutput;
+            final outpoint = '${previousOutput.txid}:${previousOutput.vout}';
+            if (!seenOutpoints.add(outpoint)) {
+              throw const InvalidBitcoinPsbtException();
+            }
+            if (frozenOutpoints.contains(outpoint)) {
+              throw const BitcoinPsbtFrozenUtxoException();
+            }
+            final localOutput = outputs[outpoint];
+            if (localOutput == null ||
+                (localOutput.isSpent &&
+                    !replacedOutpoints.contains(outpoint))) {
+              throw const BitcoinPsbtMissingUtxoException();
+            }
+            final expected = localOutput.txout;
+            final supplied = _inputUtxo(psbtInputs[index], previousOutput);
+            if (supplied.value.toSat() != expected.value.toSat() ||
+                !_sameBytes(
+                  supplied.scriptPubkey.toBytes(),
+                  expected.scriptPubkey.toBytes(),
+                )) {
+              throw const InvalidBitcoinPsbtException();
+            }
+          }
+        } finally {
+          bdkWallet.dispose();
+        }
+      } finally {
+        transaction.dispose();
+      }
+    } finally {
+      psbt.dispose();
+    }
+  }
+
+  Set<String> _transactionInputOutpoints(bdk.Wallet wallet, String txid) {
+    final parsedTxid = bdk.Txid.fromString(hex: txid);
+    try {
+      final transaction = wallet.getTx(txid: parsedTxid)?.transaction;
+      if (transaction == null) {
+        throw const BitcoinPsbtMissingUtxoException();
+      }
+      try {
+        return {
+          for (final input in transaction.input())
+            '${input.previousOutput.txid}:${input.previousOutput.vout}',
+        };
+      } finally {
+        transaction.dispose();
+      }
+    } finally {
+      parsedTxid.dispose();
+    }
+  }
+
+  Future<BitcoinPolicyMaturityModel> getPolicyMaturity({
+    required PublicBdkWalletModel wallet,
+    ElectrumConnection? electrumServer,
+    required bool includeTimeBasedLocks,
+  }) async {
+    final bdkWallet = await BdkFacade.createWallet(wallet);
+    try {
+      final unspents = bdkWallet.listUnspent();
+      var tipHeight = bdkWallet.latestCheckpoint().height;
+      int? medianTimePast;
+      final confirmationMedianTimes = <int, int>{};
+
+      if (electrumServer != null) {
+        final referenceHeights = includeTimeBasedLocks
+            ? unspents
+                  .map((utxo) => utxo.chainPosition)
+                  .whereType<bdk.ConfirmedChainPosition>()
+                  .map(
+                    (position) => max(
+                      0,
+                      position.confirmationBlockTime.blockId.height - 1,
+                    ),
+                  )
+                  .toSet()
+                  .toList()
+            : const <int>[];
+        final chainState = await compute(
+          _fetchPolicyChainState,
+          _PolicyChainStateParams(
+            electrumUrl: electrumServer.url,
+            electrumSocks5: electrumServer.socks5,
+            electrumTimeout: electrumServer.timeout,
+            electrumRetry: electrumServer.retry,
+            electrumValidateDomain: electrumServer.validateDomain,
+            includeMedianTimePast: includeTimeBasedLocks,
+            referenceHeights: referenceHeights,
+          ),
+        );
+        tipHeight = chainState.tipHeight;
+        medianTimePast = chainState.medianTimePast;
+        confirmationMedianTimes.addAll(chainState.referenceMedianTimes);
+      }
+
+      return BitcoinPolicyMaturityModel(
+        tipHeight: tipHeight,
+        medianTimePast: medianTimePast,
+        utxos: [
+          for (final utxo in unspents)
+            BitcoinPolicyUtxoMaturityModel(
+              outpoint: '${utxo.outpoint.txid}:${utxo.outpoint.vout}',
+              keychain: utxo.keychain == bdk.KeychainKind.external_
+                  ? BitcoinPolicyKeychainModel.external
+                  : BitcoinPolicyKeychainModel.internal,
+              amountSat: BigInt.from(utxo.txout.value.toSat()),
+              confirmations: confirmationsFromTip(
+                tip: tipHeight,
+                height: utxo.chainPosition is bdk.ConfirmedChainPosition
+                    ? (utxo.chainPosition as bdk.ConfirmedChainPosition)
+                          .confirmationBlockTime
+                          .blockId
+                          .height
+                    : null,
+              ),
+              confirmationMedianTimePast:
+                  utxo.chainPosition is bdk.ConfirmedChainPosition
+                  ? confirmationMedianTimes[max(
+                      0,
+                      (utxo.chainPosition as bdk.ConfirmedChainPosition)
+                              .confirmationBlockTime
+                              .blockId
+                              .height -
+                          1,
+                    )]
+                  : null,
+            ),
+        ],
+      );
+    } finally {
+      bdkWallet.dispose();
+    }
+  }
+
+  /// Partially signs a PSBT with private keys in the supplied descriptors.
+  ///
+  /// The descriptors and wallet are kept in memory only.
+  ({String psbt, bool isFinalized}) signPsbtWithDescriptor(
+    String psbtBase64, {
+    required String descriptor,
+    required bool isTestnet,
+    bool tryFinalize = true,
+  }) {
+    final psbt = _parsePsbt(psbtBase64);
+    try {
+      final inputs = psbt.input();
+      _validatePartialSignatures(psbtBase64, inputs: inputs);
+      _rejectFinalizedInputs(inputs);
+      final wallet = BdkFacade.createEphemeralDescriptorWallet(
+        descriptor: descriptor,
+        isTestnet: isTestnet,
+      );
+      try {
+        wallet.sign(
+          psbt: psbt,
+          signOptions: bdk.SignOptions(
+            trustWitnessUtxo: true,
+            assumeHeight: null,
+            allowAllSighashes: false,
+            tryFinalize: false,
+            signWithTapInternalKey: false,
+            allowGrinding: true,
+          ),
+        );
+        return tryFinalize
+            ? _finalizeCompletePsbt(psbt)
+            : (psbt: psbt.serialize(), isFinalized: false);
+      } finally {
+        wallet.dispose();
+      }
+    } finally {
+      psbt.dispose();
+    }
+  }
+
+  String combinePsbts({required String first, required String second}) {
+    final firstPsbt = _parsePsbt(first);
+    try {
+      final secondPsbt = _parsePsbt(second);
+      try {
+        final combined = firstPsbt.combine(other: secondPsbt);
+        try {
+          return combined.serialize();
+        } finally {
+          combined.dispose();
+        }
+      } finally {
+        secondPsbt.dispose();
+      }
+    } finally {
+      firstPsbt.dispose();
+    }
+  }
+
+  void validateExternalPartialPsbt({
+    required String currentPsbtBase64,
+    required String signedPsbtBase64,
+  }) {
+    final current = _parsePsbt(currentPsbtBase64);
+    try {
+      final signed = _parsePsbt(signedPsbtBase64);
+      try {
+        final currentInputs = current.input();
+        final signedInputs = signed.input();
+        if (currentInputs.length != signedInputs.length ||
+            signedInputs.any(
+              (input) =>
+                  input.finalScriptSig != null ||
+                  input.finalScriptWitness != null,
+            )) {
+          throw const InvalidBitcoinPsbtException();
+        }
+
+        var hasNewSignature = false;
+        for (final (index, input) in signedInputs.indexed) {
+          if (input.tapKeySig != null || input.tapScriptSigs.isNotEmpty) {
+            throw const BitcoinPsbtUnsupportedSighashException();
+          }
+          for (final entry in input.partialSigs.entries) {
+            final signature = entry.value;
+            if (signature.isEmpty || signature.last != 0x01) {
+              throw const BitcoinPsbtUnsupportedSighashException();
+            }
+            final currentSignature =
+                currentInputs[index].partialSigs[entry.key];
+            if (currentSignature == null ||
+                !listEquals(currentSignature, signature)) {
+              hasNewSignature = true;
+            }
+          }
+        }
+        if (!hasNewSignature) throw const InvalidBitcoinPsbtException();
+      } finally {
+        signed.dispose();
+      }
+    } finally {
+      current.dispose();
     }
 
-    return psbt.serialize();
+    final combined = combinePsbts(
+      first: currentPsbtBase64,
+      second: signedPsbtBase64,
+    );
+    _validatePartialSignatures(combined);
+  }
+
+  void _validatePartialSignatures(
+    String psbtBase64, {
+    List<bdk.Input>? inputs,
+    bool allowFinalizedTaprootInputs = false,
+  }) {
+    final parsedPsbt = inputs == null ? _parsePsbt(psbtBase64) : null;
+    try {
+      final bdkInputs = inputs ?? parsedPsbt!.input();
+      for (final input in bdkInputs) {
+        _validateSighash(input.sighashType);
+        if ((input.tapKeySig != null || input.tapScriptSigs.isNotEmpty) &&
+            !(allowFinalizedTaprootInputs && _isFinalizedInput(input))) {
+          throw const BitcoinPsbtUnsupportedSighashException();
+        }
+      }
+      final finalizedInputIndexes = [
+        for (final (index, input) in bdkInputs.indexed)
+          if (_isFinalizedInput(input)) index,
+      ];
+      if (finalizedInputIndexes.isNotEmpty) {
+        final finalizedPsbt = parsedPsbt ?? _parsePsbt(psbtBase64);
+        try {
+          final transaction = finalizedPsbt.extractTx();
+          try {
+            final transactionInputs = transaction.input();
+            if (transactionInputs.length != bdkInputs.length) {
+              throw const InvalidBitcoinPsbtException();
+            }
+            for (final index in finalizedInputIndexes) {
+              _validateFinalizedInputSignatures(
+                transactionInputs[index],
+                bdkInputs[index],
+                allowTaproot: allowFinalizedTaprootInputs,
+              );
+            }
+          } finally {
+            transaction.dispose();
+          }
+        } finally {
+          if (!identical(finalizedPsbt, parsedPsbt)) finalizedPsbt.dispose();
+        }
+      }
+      if (bdkInputs.every((input) => input.partialSigs.isEmpty)) return;
+
+      final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+      final builder = bitcoin_base.PsbtBuilder.fromPsbt(psbt);
+      final txInputs = builder.txInputs();
+      if (txInputs.length != bdkInputs.length) {
+        throw const InvalidBitcoinPsbtException();
+      }
+      final unsignedTransaction = builder.buildUnsignedTransaction();
+      for (final index in Iterable<int>.generate(txInputs.length)) {
+        final inputInfo = bitcoin_base.PsbtUtils.getPsbtInputInfo(
+          psbt: psbt,
+          inputIndex: index,
+          txInputs: txInputs,
+        );
+        final digest = bitcoin_base.PsbtUtils.generateInputTransactionDigest(
+          index: index,
+          unsignedTx: unsignedTransaction,
+          params: inputInfo,
+          tapleafHash: null,
+          input: psbt.input,
+          psbt: psbt,
+        );
+        final partialSignatures =
+            psbt.input.getInputs<bitcoin_base.PsbtInputPartialSig>(
+              index,
+              bitcoin_base.PsbtInputTypes.partialSignature,
+            ) ??
+            const <bitcoin_base.PsbtInputPartialSig>[];
+        final signingScript = inputInfo.isScriptSpending
+            ? inputInfo.witnessScript ?? inputInfo.redeemScript
+            : inputInfo.scriptPubKey;
+        for (final signature in partialSignatures) {
+          if (signature.signature.isEmpty || signature.signature.last != 0x01) {
+            throw const BitcoinPsbtUnsupportedSighashException();
+          }
+          if (!_isBitcoinEcdsaSignature(
+            Uint8List.fromList(signature.signature),
+          )) {
+            throw const InvalidBitcoinPsbtException();
+          }
+          if (!bitcoin_base.PsbtUtils.keyInScript(
+                publicKey: signature.publicKey,
+                script: signingScript,
+                type: inputInfo.type,
+              ) ||
+              !digest.verifyEcdsaSignature(signature)) {
+            throw const InvalidBitcoinPsbtException();
+          }
+        }
+      }
+    } finally {
+      parsedPsbt?.dispose();
+    }
+  }
+
+  ({String psbt, bool isFinalized}) finalizePsbt(String psbtBase64) {
+    final psbt = _parsePsbt(psbtBase64);
+    try {
+      final inputs = psbt.input();
+      _validatePartialSignatures(psbtBase64, inputs: inputs);
+      _rejectFinalizedInputs(inputs);
+      return _finalizeCompletePsbt(psbt);
+    } finally {
+      psbt.dispose();
+    }
+  }
+
+  ({String psbt, bool isFinalized}) _finalizeCompletePsbt(bdk.Psbt psbt) {
+    final result = psbt.finalize();
+    try {
+      return result.couldFinalize
+          ? (psbt: result.psbt.serialize(), isFinalized: true)
+          : (psbt: psbt.serialize(), isFinalized: false);
+    } finally {
+      result.psbt.dispose();
+    }
   }
 
   Future<List<WalletUtxoModel>> getUtxos({required WalletModel wallet}) async {
@@ -792,6 +1605,530 @@ class BdkWalletDatasource {
   }
 }
 
+typedef _DescriptorOwnership = ({int index, BitcoinPolicyKeychain keychain});
+
+bdk.Psbt _parsePsbt(String psbtBase64) {
+  try {
+    return bdk.Psbt(psbtBase64: normalizeBitcoinPsbt(psbtBase64));
+  } on Exception {
+    throw const InvalidBitcoinPsbtException();
+  }
+}
+
+int _completedTransactionVsize({
+  required bdk.Transaction transaction,
+  required List<bdk.Input> inputs,
+  required List<BitcoinPolicyKeychain> inputKeychains,
+  required PublicBdkWalletModel wallet,
+}) {
+  if (inputs.length != inputKeychains.length) {
+    throw const InvalidBitcoinPsbtException();
+  }
+  if (inputs.every(_isFinalizedInput)) return transaction.vsize();
+
+  final networkKind = wallet.isTestnet
+      ? bdk.NetworkKind.test
+      : bdk.NetworkKind.main;
+  final descriptors = BdkFacade.parsePublicTwoPathDescriptor(
+    descriptor: wallet.descriptor,
+    isTestnet: wallet.isTestnet,
+  );
+  final external = bdk.Descriptor(
+    descriptor: descriptors.externalDescriptor,
+    networkKind: networkKind,
+  );
+  final internal = bdk.Descriptor(
+    descriptor: descriptors.internalDescriptor,
+    networkKind: networkKind,
+  );
+  try {
+    final descriptorTypes = [
+      for (final keychain in inputKeychains)
+        (keychain == BitcoinPolicyKeychain.external ? external : internal)
+            .descType(),
+    ];
+    final hasSegwitInput = descriptorTypes.any(_isSegwitDescriptor);
+    final transactionAlreadyHasWitness = transaction.input().any(
+      (input) => input.witness.isNotEmpty,
+    );
+    var completedWeight = transaction.weight();
+    if (hasSegwitInput && !transactionAlreadyHasWitness) {
+      // A legacy-serialized unsigned transaction has neither the SegWit
+      // marker/flag nor each input's empty witness-vector count. Descriptor
+      // maxWeightToSatisfy is measured from a default SegWit TxIn, which
+      // already includes that empty-vector byte.
+      completedWeight += 2 + inputs.length;
+    }
+    for (final index in Iterable<int>.generate(inputs.length)) {
+      if (_isFinalizedInput(inputs[index])) continue;
+      final descriptor = inputKeychains[index] == BitcoinPolicyKeychain.external
+          ? external
+          : internal;
+      var satisfactionWeight = descriptor.maxWeightToSatisfy();
+      if (!hasSegwitInput) satisfactionWeight -= 1;
+      completedWeight += satisfactionWeight;
+    }
+    return (completedWeight + 3) ~/ 4;
+  } finally {
+    external.dispose();
+    internal.dispose();
+  }
+}
+
+bool _isFinalizedInput(bdk.Input input) =>
+    input.finalScriptSig != null || input.finalScriptWitness != null;
+
+void _rejectFinalizedInputs(List<bdk.Input> inputs) {
+  if (inputs.any(_isFinalizedInput)) {
+    throw const InvalidBitcoinPsbtException();
+  }
+}
+
+void _rejectFinalizedWalletInputs(
+  bdk.Psbt psbt,
+  List<bdk.Input> inputs,
+  bdk.Wallet wallet,
+) {
+  final transaction = psbt.extractTx();
+  try {
+    final transactionInputs = transaction.input();
+    if (transactionInputs.length != inputs.length) {
+      throw const InvalidBitcoinPsbtException();
+    }
+    for (final (index, input) in inputs.indexed) {
+      if (!_isFinalizedInput(input)) continue;
+      final utxo = _inputUtxo(
+        input,
+        transactionInputs[index].previousOutput,
+        allowTaprootWitnessUtxo: true,
+      );
+      if (wallet.isMine(script: utxo.scriptPubkey)) {
+        throw const InvalidBitcoinPsbtException();
+      }
+    }
+  } finally {
+    transaction.dispose();
+  }
+}
+
+bool _hasOnlyCommittedSignatures(bdk.TxIn input, bdk.Input psbtInput) {
+  final signatures = _inputEcdsaSignatures(input, psbtInput);
+  return signatures != null &&
+      signatures.isNotEmpty &&
+      signatures.every((signature) => signature.last == 0x01);
+}
+
+void _validateFinalizedInputSignatures(
+  bdk.TxIn input,
+  bdk.Input psbtInput, {
+  bool allowTaproot = false,
+}) {
+  final hasUnlockingData =
+      input.scriptSig.toBytes().isNotEmpty ||
+      input.witness.any((item) => item.isNotEmpty);
+  if (!hasUnlockingData) throw const InvalidBitcoinPsbtException();
+
+  if (allowTaproot) {
+    final signatures = _inputTaprootSignatures(input, psbtInput);
+    if (signatures != null) {
+      if (signatures.isEmpty) throw const InvalidBitcoinPsbtException();
+      if (signatures.any(
+        (signature) => signature.length == 65 && signature.last != 0x01,
+      )) {
+        throw const BitcoinPsbtUnsupportedSighashException();
+      }
+      return;
+    }
+  }
+
+  final signatures = _inputEcdsaSignatures(input, psbtInput);
+  if (signatures == null || signatures.isEmpty) {
+    throw const InvalidBitcoinPsbtException();
+  }
+  if (signatures.any((signature) => signature.last != 0x01)) {
+    throw const BitcoinPsbtUnsupportedSighashException();
+  }
+}
+
+List<Uint8List>? _inputTaprootSignatures(bdk.TxIn input, bdk.Input psbtInput) {
+  final utxo = _inputUtxo(
+    psbtInput,
+    input.previousOutput,
+    allowTaprootWitnessUtxo: true,
+  );
+  if (!_isV1TaprootProgram(utxo.scriptPubkey.toBytes())) return null;
+  final witness = input.witness.toList();
+  if (witness.length >= 2 &&
+      witness.last.isNotEmpty &&
+      witness.last.first == 0x50) {
+    witness.removeLast();
+  }
+  final signatureItems = witness.length <= 1
+      ? witness
+      : witness.sublist(0, witness.length - 2);
+  return signatureItems
+      .where((item) => item.length == 64 || item.length == 65)
+      .toList(growable: false);
+}
+
+List<Uint8List>? _inputEcdsaSignatures(bdk.TxIn input, bdk.Input psbtInput) {
+  final scriptPushes = _scriptPushes(input.scriptSig.toBytes());
+  if (scriptPushes == null) return null;
+  final preimages = <Uint8List>[
+    ...psbtInput.sha256Preimages.values,
+    ...psbtInput.hash256Preimages.values,
+    ...psbtInput.ripemd160Preimages.values,
+    ...psbtInput.hash160Preimages.values,
+  ];
+  final hashlockCommitments = _inputHashlockCommitments(
+    input,
+    psbtInput,
+    scriptPushes,
+  );
+  return <Uint8List>[...input.witness, ...scriptPushes]
+      .where(
+        (item) =>
+            _isBitcoinEcdsaSignature(item) &&
+            !preimages.any((preimage) => listEquals(preimage, item)) &&
+            !_matchesHashlockPreimage(item, hashlockCommitments),
+      )
+      .toList(growable: false);
+}
+
+List<({BitcoinHashlockType type, List<int> hash})> _inputHashlockCommitments(
+  bdk.TxIn input,
+  bdk.Input psbtInput,
+  List<Uint8List> scriptPushes,
+) {
+  final scripts = <List<int>>[
+    if (psbtInput.witnessScript case final script?) script.toBytes(),
+    if (psbtInput.redeemScript case final script?) script.toBytes(),
+    if (input.witness.length > 1) input.witness.last,
+    if (scriptPushes.length > 1) scriptPushes.last,
+  ];
+  final commitments = <({BitcoinHashlockType type, List<int> hash})>[];
+  for (final scriptBytes in scripts) {
+    commitments.addAll(_scriptHashlockCommitments(scriptBytes));
+  }
+  return commitments;
+}
+
+List<({BitcoinHashlockType type, List<int> hash})> _scriptHashlockCommitments(
+  List<int> scriptBytes,
+) {
+  final List<dynamic> tokens;
+  try {
+    tokens = bitcoin_base.Script.deserialize(bytes: scriptBytes).script;
+  } on RangeError {
+    throw const InvalidBitcoinPsbtException();
+  }
+  final commitments = <({BitcoinHashlockType type, List<int> hash})>[];
+  BitcoinHashlockType? pendingType;
+  for (final token in tokens) {
+    final type = switch (token) {
+      'OP_RIPEMD160' => BitcoinHashlockType.ripemd160,
+      'OP_SHA256' => BitcoinHashlockType.sha256,
+      'OP_HASH160' => BitcoinHashlockType.hash160,
+      'OP_HASH256' => BitcoinHashlockType.hash256,
+      _ => null,
+    };
+    if (type != null) {
+      pendingType = type;
+      continue;
+    }
+    final commitmentType = pendingType;
+    if (commitmentType == null || token is! String) continue;
+    final List<int> hash;
+    try {
+      hash = hex.decode(token);
+    } on FormatException {
+      pendingType = null;
+      continue;
+    }
+    final expectedLength = switch (commitmentType) {
+      BitcoinHashlockType.sha256 || BitcoinHashlockType.hash256 => 32,
+      BitcoinHashlockType.ripemd160 || BitcoinHashlockType.hash160 => 20,
+    };
+    if (hash.length == expectedLength) {
+      commitments.add((type: commitmentType, hash: hash));
+    }
+    pendingType = null;
+  }
+  return commitments;
+}
+
+bool _matchesHashlockPreimage(
+  Uint8List item,
+  List<({BitcoinHashlockType type, List<int> hash})> commitments,
+) {
+  for (final commitment in commitments) {
+    final hash = switch (commitment.type) {
+      BitcoinHashlockType.sha256 => bitcoin_base.PsbtInputSha256.fromPreImage(
+        item,
+      ).hash,
+      BitcoinHashlockType.hash256 => bitcoin_base.PsbtInputHash256.fromPreImage(
+        item,
+      ).hash,
+      BitcoinHashlockType.ripemd160 =>
+        bitcoin_base.PsbtInputRipemd160.fromPreImage(item).hash,
+      BitcoinHashlockType.hash160 => bitcoin_base.PsbtInputHash160.fromPreImage(
+        item,
+      ).hash,
+    };
+    if (_sameBytes(hash, commitment.hash)) return true;
+  }
+  return false;
+}
+
+bool _isBitcoinEcdsaSignature(Uint8List bytes) {
+  if (bytes.length < 9 || bytes.length > 73 || bytes[0] != 0x30) return false;
+  if (bytes[1] != bytes.length - 3 || bytes[2] != 0x02) return false;
+  final rLength = bytes[3];
+  if (rLength == 0 || 5 + rLength >= bytes.length) return false;
+  final sLength = bytes[5 + rLength];
+  if (rLength + sLength + 7 != bytes.length) return false;
+  if ((bytes[4] & 0x80) != 0 ||
+      (rLength > 1 && bytes[4] == 0 && (bytes[5] & 0x80) == 0)) {
+    return false;
+  }
+  if (bytes[4 + rLength] != 0x02 || sLength == 0) return false;
+  if ((bytes[6 + rLength] & 0x80) != 0 ||
+      (sLength > 1 &&
+          bytes[6 + rLength] == 0 &&
+          (bytes[7 + rLength] & 0x80) == 0)) {
+    return false;
+  }
+  return true;
+}
+
+List<Uint8List>? _scriptPushes(Uint8List script) {
+  final pushes = <Uint8List>[];
+  var cursor = 0;
+  while (cursor < script.length) {
+    final opcode = script[cursor++];
+    if (opcode == 0) {
+      pushes.add(Uint8List(0));
+      continue;
+    }
+    if (opcode == 0x4f || (opcode >= 0x51 && opcode <= 0x60)) {
+      // OP_1NEGATE and OP_1 through OP_16 are push-only opcodes, but cannot
+      // contain a signature.
+      continue;
+    }
+    final int length;
+    if (opcode <= 75) {
+      length = opcode;
+    } else if (opcode == 76) {
+      if (cursor >= script.length) return null;
+      length = script[cursor++];
+    } else if (opcode == 77) {
+      if (cursor + 2 > script.length) return null;
+      length = script[cursor] | (script[cursor + 1] << 8);
+      cursor += 2;
+    } else if (opcode == 78) {
+      if (cursor + 4 > script.length) return null;
+      length =
+          script[cursor] |
+          (script[cursor + 1] << 8) |
+          (script[cursor + 2] << 16) |
+          (script[cursor + 3] << 24);
+      cursor += 4;
+    } else {
+      return null;
+    }
+    if (length < 0 || cursor + length > script.length) return null;
+    pushes.add(Uint8List.sublistView(script, cursor, cursor + length));
+    cursor += length;
+  }
+  return pushes;
+}
+
+bool _isSegwitDescriptor(bdk.DescriptorType type) => switch (type) {
+  bdk.DescriptorType.wpkh ||
+  bdk.DescriptorType.wsh ||
+  bdk.DescriptorType.shWsh ||
+  bdk.DescriptorType.shWpkh ||
+  bdk.DescriptorType.wshSortedMulti ||
+  bdk.DescriptorType.shWshSortedMulti ||
+  bdk.DescriptorType.tr => true,
+  bdk.DescriptorType.bare ||
+  bdk.DescriptorType.sh ||
+  bdk.DescriptorType.pkh ||
+  bdk.DescriptorType.shSortedMulti => false,
+};
+
+bdk.TxOut _inputUtxo(
+  bdk.Input input,
+  bdk.OutPoint previousOutput, {
+  bool allowTaprootWitnessUtxo = false,
+}) {
+  final witnessUtxo = input.witnessUtxo;
+  final previousTransaction = input.nonWitnessUtxo;
+  if (previousTransaction != null) {
+    if (previousTransaction.computeTxid().toString() !=
+        previousOutput.txid.toString()) {
+      throw const InvalidBitcoinPsbtException();
+    }
+    final outputs = previousTransaction.output();
+    if (previousOutput.vout >= outputs.length) {
+      throw const BitcoinPsbtMissingUtxoException();
+    }
+    final previousTxOut = outputs[previousOutput.vout];
+    if (witnessUtxo != null &&
+        (witnessUtxo.value.toSat() != previousTxOut.value.toSat() ||
+            !_sameBytes(
+              witnessUtxo.scriptPubkey.toBytes(),
+              previousTxOut.scriptPubkey.toBytes(),
+            ))) {
+      throw const InvalidBitcoinPsbtException();
+    }
+    return previousTxOut;
+  }
+
+  if (witnessUtxo == null) {
+    throw const BitcoinPsbtMissingUtxoException();
+  }
+  final script = witnessUtxo.scriptPubkey.toBytes();
+  if (!_isV0WitnessProgram(script) &&
+      !_isNestedSegwitInput(input, script) &&
+      !(allowTaprootWitnessUtxo && _isV1TaprootProgram(script))) {
+    throw const BitcoinPsbtMissingUtxoException();
+  }
+  return witnessUtxo;
+}
+
+bool _isV0WitnessProgram(List<int> script) =>
+    script.length >= 4 &&
+    script.first == 0 &&
+    (script[1] == 20 || script[1] == 32) &&
+    script[1] + 2 == script.length;
+
+bool _isV1TaprootProgram(List<int> script) =>
+    script.length == 34 && script[0] == 0x51 && script[1] == 32;
+
+bool _isNestedSegwitInput(bdk.Input input, List<int> scriptPubkey) {
+  if (scriptPubkey.length != 23 ||
+      scriptPubkey[0] != 0xa9 ||
+      scriptPubkey[1] != 0x14 ||
+      scriptPubkey.last != 0x87) {
+    return false;
+  }
+  final finalScriptSig = input.finalScriptSig;
+  final redeemScript = finalScriptSig == null
+      ? input.redeemScript?.toBytes()
+      : switch (_scriptPushes(finalScriptSig.toBytes())) {
+          [final redeemScript] => redeemScript,
+          _ => null,
+        };
+  if (redeemScript == null || !_isV0WitnessProgram(redeemScript)) {
+    return false;
+  }
+  final redeemHash = bitcoin_base.BitcoinAddressUtils.scriptToHash160Bytes(
+    bitcoin_base.Script.deserialize(bytes: redeemScript),
+  );
+  return _sameBytes(redeemHash, scriptPubkey.sublist(2, 22));
+}
+
+void _validateSighash(String? sighashType) {
+  if (sighashType == null) return;
+  final normalized = sighashType.toUpperCase().replaceFirst('SIGHASH_', '');
+  if (normalized != 'ALL' && normalized != '1') {
+    throw const BitcoinPsbtUnsupportedSighashException();
+  }
+}
+
+_DescriptorOwnership? _descriptorOwnership(
+  bdk.Wallet wallet, {
+  required bdk.Script script,
+  required Iterable<bdk.KeySource> keySources,
+}) {
+  final tracked = wallet.derivationOfSpk(spk: script);
+  if (tracked != null) {
+    return (
+      index: tracked.index,
+      keychain: tracked.keychain == bdk.KeychainKind.external_
+          ? BitcoinPolicyKeychain.external
+          : BitcoinPolicyKeychain.internal,
+    );
+  }
+
+  final scriptBytes = script.toBytes();
+  final candidateIndices = <int>{};
+  for (final source in keySources) {
+    final path = source.path.toU32Vec();
+    if (path.isEmpty) continue;
+    final child = path.last;
+    const hardenedBit = 1 << 31;
+    if (child & hardenedBit != 0) continue;
+    if (child > 10000000) {
+      throw const InvalidBitcoinPsbtException();
+    }
+    candidateIndices.add(child);
+  }
+
+  for (final index in candidateIndices) {
+    final external = wallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: index,
+    );
+    if (_sameBytes(external.address.scriptPubkey().toBytes(), scriptBytes)) {
+      return (index: index, keychain: BitcoinPolicyKeychain.external);
+    }
+    final internal = wallet.peekAddress(
+      keychain: bdk.KeychainKind.internal,
+      index: index,
+    );
+    if (_sameBytes(internal.address.scriptPubkey().toBytes(), scriptBytes)) {
+      return (index: index, keychain: BitcoinPolicyKeychain.internal);
+    }
+  }
+  return null;
+}
+
+String? _addressFromScript(bdk.Script script, {required bool isTestnet}) {
+  try {
+    return bdk.Address.fromScript(
+      script: script,
+      network: isTestnet ? bdk.Network.testnet : bdk.Network.bitcoin,
+    ).toString();
+  } on Exception {
+    return null;
+  }
+}
+
+bool _sameBytes(List<int> left, List<int> right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+bitcoin_base.PsbtInputData _psbtPreimage(BitcoinPolicyPreimage preimage) {
+  final bytes = hex.decode(preimage.preimageHex);
+  return switch (preimage.type) {
+    BitcoinHashlockType.sha256 => bitcoin_base.PsbtInputSha256.fromPreImage(
+      bytes,
+    ),
+    BitcoinHashlockType.hash256 => bitcoin_base.PsbtInputHash256.fromPreImage(
+      bytes,
+    ),
+    BitcoinHashlockType.ripemd160 =>
+      bitcoin_base.PsbtInputRipemd160.fromPreImage(bytes),
+    BitcoinHashlockType.hash160 => bitcoin_base.PsbtInputHash160.fromPreImage(
+      bytes,
+    ),
+  };
+}
+
+List<int> _preimageHash(bitcoin_base.PsbtInputData input) => switch (input) {
+  bitcoin_base.PsbtInputSha256(:final hash) ||
+  bitcoin_base.PsbtInputHash256(:final hash) ||
+  bitcoin_base.PsbtInputRipemd160(:final hash) ||
+  bitcoin_base.PsbtInputHash160(:final hash) => hash,
+  _ => throw ArgumentError.value(input, 'input'),
+};
+
 // Top-level function for isolate execution
 class _SyncParams {
   final String walletId;
@@ -876,6 +2213,93 @@ class UnsupportedBdkNetworkException extends BullException {
 int confirmationsFromTip({required int tip, required int? height}) {
   if (height == null) return 0;
   return max(0, tip - height + 1);
+}
+
+int _medianTimePast({
+  required bdk.ElectrumClient client,
+  required int height,
+  bdk.Header? knownHeader,
+}) {
+  final firstHeight = max(0, height - 10);
+  final times = <int>[];
+  for (
+    var currentHeight = firstHeight;
+    currentHeight <= height;
+    currentHeight++
+  ) {
+    final header = currentHeight == height && knownHeader != null
+        ? knownHeader
+        : client.blockHeader(height: currentHeight);
+    times.add(header.time);
+  }
+  times.sort();
+  return times[times.length ~/ 2];
+}
+
+final class _PolicyChainStateParams {
+  final String electrumUrl;
+  final String? electrumSocks5;
+  final int electrumTimeout;
+  final int electrumRetry;
+  final bool electrumValidateDomain;
+  final bool includeMedianTimePast;
+  final List<int> referenceHeights;
+
+  const _PolicyChainStateParams({
+    required this.electrumUrl,
+    required this.electrumSocks5,
+    required this.electrumTimeout,
+    required this.electrumRetry,
+    required this.electrumValidateDomain,
+    required this.includeMedianTimePast,
+    required this.referenceHeights,
+  });
+}
+
+final class _PolicyChainState {
+  final int tipHeight;
+  final int? medianTimePast;
+  final Map<int, int> referenceMedianTimes;
+
+  const _PolicyChainState({
+    required this.tipHeight,
+    required this.medianTimePast,
+    required this.referenceMedianTimes,
+  });
+}
+
+_PolicyChainState _fetchPolicyChainState(_PolicyChainStateParams params) {
+  final client = _createElectrumClient(
+    url: params.electrumUrl,
+    socks5: params.electrumSocks5,
+    timeout: params.electrumTimeout,
+    retry: params.electrumRetry,
+    validateDomain: params.electrumValidateDomain,
+  );
+  try {
+    final tip = client.blockHeadersSubscribe();
+    final referenceMedianTimes = <int, int>{};
+    for (final requestedHeight in params.referenceHeights) {
+      final height = min(requestedHeight, tip.height);
+      referenceMedianTimes[requestedHeight] = _medianTimePast(
+        client: client,
+        height: height,
+      );
+    }
+    return _PolicyChainState(
+      tipHeight: tip.height,
+      medianTimePast: params.includeMedianTimePast
+          ? _medianTimePast(
+              client: client,
+              height: tip.height,
+              knownHeader: tip.header,
+            )
+          : null,
+      referenceMedianTimes: referenceMedianTimes,
+    );
+  } finally {
+    client.dispose();
+  }
 }
 
 class _DryScanParams {

--- a/lib/core/wallet/data/mappers/bitcoin_policy_maturity_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_policy_maturity_mapper.dart
@@ -1,0 +1,26 @@
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_maturity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+
+class BitcoinPolicyMaturityMapper {
+  static BitcoinPolicyMaturity toEntity(BitcoinPolicyMaturityModel model) =>
+      BitcoinPolicyMaturity(
+        tipHeight: model.tipHeight,
+        medianTimePast: model.medianTimePast,
+        utxos: [
+          for (final utxo in model.utxos)
+            BitcoinPolicyUtxoMaturity(
+              outpoint: utxo.outpoint,
+              keychain: switch (utxo.keychain) {
+                BitcoinPolicyKeychainModel.external =>
+                  BitcoinPolicyKeychain.external,
+                BitcoinPolicyKeychainModel.internal =>
+                  BitcoinPolicyKeychain.internal,
+              },
+              amountSat: utxo.amountSat,
+              confirmations: utxo.confirmations,
+              confirmationMedianTimePast: utxo.confirmationMedianTimePast,
+            ),
+        ],
+      );
+}

--- a/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
@@ -1,0 +1,90 @@
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_psbt_review_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/wallet_descriptor_key_matcher.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+
+class BitcoinPsbtReviewMapper {
+  static BitcoinPsbtReview toEntity(
+    BitcoinPsbtReviewModel model, {
+    required List<WalletDescriptorKeyModel> descriptorKeys,
+    required Set<String> localSignerIds,
+  }) => BitcoinPsbtReview(
+    transactionId: model.transactionId,
+    inputs: [
+      for (final input in model.inputs)
+        _inputToEntity(
+          input,
+          descriptorKeys: descriptorKeys,
+          localSignerIds: localSignerIds,
+        ),
+    ],
+    outputs: [
+      for (final output in model.outputs)
+        BitcoinPsbtOutputReview(
+          index: output.index,
+          amountSat: output.amountSat,
+          address: output.address,
+          scriptHex: output.scriptHex,
+          isWalletOwned: output.isWalletOwned,
+        ),
+    ],
+    feeSat: model.feeSat,
+    estimatedTransactionVsize: model.estimatedTransactionVsize,
+    lockTime: model.lockTime,
+    version: model.version,
+  );
+
+  static BitcoinPsbtInputReview _inputToEntity(
+    BitcoinPsbtInputReviewRecord input, {
+    required List<WalletDescriptorKeyModel> descriptorKeys,
+    required Set<String> localSignerIds,
+  }) {
+    final originKeyIds = _resolveKeyIds(
+      input.originKeySources,
+      descriptorKeys,
+      keychain: input.keychain,
+    );
+    final signedKeyIds = _resolveKeyIds(
+      input.signedKeySources,
+      descriptorKeys,
+      keychain: input.keychain,
+    );
+    final localKeyIds = {
+      for (final key in descriptorKeys)
+        if (originKeyIds.contains(key.id) &&
+            localSignerIds.contains(key.signerId))
+          key.id,
+    };
+    return BitcoinPsbtInputReview(
+      outpoint: input.outpoint,
+      amountSat: input.amountSat,
+      keychain: switch (input.keychain) {
+        BitcoinPolicyKeychainModel.external => BitcoinPolicyKeychain.external,
+        BitcoinPolicyKeychainModel.internal => BitcoinPolicyKeychain.internal,
+        null => null,
+      },
+      localDescriptorKeyIds: localKeyIds,
+      sequence: input.sequence,
+      signedDescriptorKeyIds: signedKeyIds,
+    );
+  }
+
+  static Set<String> _resolveKeyIds(
+    List<BitcoinPsbtKeySourceRecord> sources,
+    List<WalletDescriptorKeyModel> keys, {
+    required BitcoinPolicyKeychainModel? keychain,
+  }) => Set.unmodifiable({
+    for (final source in sources)
+      for (final key in keys)
+        if (walletDescriptorKeyMatches(
+          key: key,
+          publicKey: source.publicKey,
+          fingerprint: source.fingerprint,
+          derivationPath: source.derivationPath,
+          keychain: keychain,
+        ))
+          key.id,
+  });
+}

--- a/lib/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart
@@ -1,0 +1,335 @@
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_wallet_policy_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
+
+class BitcoinWalletPolicyMapper {
+  static BitcoinWalletPolicyModel fromBdk({
+    required bdk.Policy external,
+    required bdk.Policy internal,
+    bdk.Policy? externalKeyIdentities,
+    bdk.Policy? internalKeyIdentities,
+    required List<WalletDescriptorKeyModel> descriptorKeys,
+  }) => BitcoinWalletPolicyModel(
+    external: _spendingPolicy(
+      external,
+      externalKeyIdentities ?? external,
+      _PolicyKeyResolver(descriptorKeys),
+    ),
+    internal: _spendingPolicy(
+      internal,
+      internalKeyIdentities ?? internal,
+      _PolicyKeyResolver(descriptorKeys),
+    ),
+  );
+
+  static BitcoinWalletPolicy toEntity(BitcoinWalletPolicyModel model) =>
+      BitcoinWalletPolicy(
+        external: _spendingPolicyEntity(model.external),
+        internal: _spendingPolicyEntity(model.internal),
+      );
+
+  static BitcoinSpendingPolicyModel _spendingPolicy(
+    bdk.Policy policy,
+    bdk.Policy keyIdentities,
+    _PolicyKeyResolver keys,
+  ) => BitcoinSpendingPolicyModel(
+    root: _node(policy, keyIdentities, keys),
+    requiresPath: policy.requiresPath(),
+  );
+
+  static BitcoinPolicyNodeModel _node(
+    bdk.Policy policy,
+    bdk.Policy keyIdentities,
+    _PolicyKeyResolver keys,
+  ) {
+    final id = policy.id();
+    final item = policy.item();
+    final keyIdentityItem = keyIdentities.item();
+
+    return switch (item) {
+      bdk.EcdsaSignatureSatisfiableItem() => BitcoinPolicyNodeModel(
+        id: id,
+        type: BitcoinPolicyNodeModelType.signature,
+        key: _key(_signatureKey(keyIdentityItem), keys),
+      ),
+      bdk.SchnorrSignatureSatisfiableItem() => BitcoinPolicyNodeModel(
+        id: id,
+        type: BitcoinPolicyNodeModelType.signature,
+        key: _key(_signatureKey(keyIdentityItem), keys),
+      ),
+      bdk.Sha256PreimageSatisfiableItem(:final hash) => BitcoinPolicyNodeModel(
+        id: id,
+        type: BitcoinPolicyNodeModelType.sha256,
+        hash: hash,
+      ),
+      bdk.Hash256PreimageSatisfiableItem(:final hash) => BitcoinPolicyNodeModel(
+        id: id,
+        type: BitcoinPolicyNodeModelType.hash256,
+        hash: hash,
+      ),
+      bdk.Ripemd160PreimageSatisfiableItem(:final hash) =>
+        BitcoinPolicyNodeModel(
+          id: id,
+          type: BitcoinPolicyNodeModelType.ripemd160,
+          hash: hash,
+        ),
+      bdk.Hash160PreimageSatisfiableItem(:final hash) => BitcoinPolicyNodeModel(
+        id: id,
+        type: BitcoinPolicyNodeModelType.hash160,
+        hash: hash,
+      ),
+      bdk.AbsoluteTimelockSatisfiableItem(:final value) => _absoluteTimelock(
+        id: id,
+        value: value,
+      ),
+      bdk.RelativeTimelockSatisfiableItem(:final value) => _relativeTimelock(
+        id: id,
+        sequence: value,
+      ),
+      bdk.MultisigSatisfiableItem(keys: final policyKeys, :final threshold) =>
+        BitcoinPolicyNodeModel(
+          id: id,
+          type: BitcoinPolicyNodeModelType.threshold,
+          threshold: threshold,
+          children: [
+            for (final (index, _) in policyKeys.indexed)
+              BitcoinPolicyNodeModel(
+                id: '$id:$index',
+                type: BitcoinPolicyNodeModelType.signature,
+                key: _key(
+                  _multisigKeys(keyIdentityItem, policyKeys.length)[index],
+                  keys,
+                ),
+              ),
+          ],
+        ),
+      bdk.ThreshSatisfiableItem(:final items, :final threshold) =>
+        BitcoinPolicyNodeModel(
+          id: id,
+          type: BitcoinPolicyNodeModelType.threshold,
+          threshold: threshold,
+          requiresPath: policy.requiresPath(),
+          children: [
+            for (final (index, item) in items.indexed)
+              _node(
+                item,
+                _thresholdItems(keyIdentityItem, items.length)[index],
+                keys,
+              ),
+          ],
+        ),
+      _ => throw StateError('Unsupported BDK policy item'),
+    };
+  }
+
+  static bdk.PkOrF _signatureKey(bdk.SatisfiableItem item) => switch (item) {
+    bdk.EcdsaSignatureSatisfiableItem(:final key) => key,
+    bdk.SchnorrSignatureSatisfiableItem(:final key) => key,
+    _ => throw const UnsupportedBitcoinPolicyPathException(),
+  };
+
+  static List<bdk.PkOrF> _multisigKeys(
+    bdk.SatisfiableItem item,
+    int expectedLength,
+  ) {
+    if (item case bdk.MultisigSatisfiableItem(
+      keys: final keys,
+    ) when keys.length == expectedLength) {
+      return keys;
+    }
+    throw const UnsupportedBitcoinPolicyPathException();
+  }
+
+  static List<bdk.Policy> _thresholdItems(
+    bdk.SatisfiableItem item,
+    int expectedLength,
+  ) {
+    if (item case bdk.ThreshSatisfiableItem(
+      items: final items,
+    ) when items.length == expectedLength) {
+      return items;
+    }
+    throw const UnsupportedBitcoinPolicyPathException();
+  }
+
+  static BitcoinPolicyKeyModel _key(bdk.PkOrF key, _PolicyKeyResolver keys) =>
+      switch (key) {
+        bdk.PubkeyPkOrF(:final value) =>
+          keys.resolvePublicKey(value) ??
+              BitcoinPolicyKeyModel(
+                type: BitcoinPolicyKeyModelType.publicKey,
+                value: value,
+              ),
+        bdk.XOnlyPubkeyPkOrF(:final value) => BitcoinPolicyKeyModel(
+          type: BitcoinPolicyKeyModelType.xOnlyPublicKey,
+          value: value,
+        ),
+        bdk.FingerprintPkOrF(:final value) =>
+          keys.resolveFingerprint(value) ??
+              BitcoinPolicyKeyModel(
+                type: BitcoinPolicyKeyModelType.fingerprint,
+                value: value,
+              ),
+        _ => throw StateError('Unsupported BDK policy key'),
+      };
+
+  static BitcoinPolicyNodeModel _absoluteTimelock({
+    required String id,
+    required bdk.LockTime value,
+  }) => switch (value) {
+    bdk.BlocksLockTime(:final height) => BitcoinPolicyNodeModel(
+      id: id,
+      type: BitcoinPolicyNodeModelType.absoluteBlockHeight,
+      value: height,
+    ),
+    bdk.SecondsLockTime(:final consensusTime) => BitcoinPolicyNodeModel(
+      id: id,
+      type: BitcoinPolicyNodeModelType.absoluteTimestamp,
+      value: consensusTime,
+    ),
+    _ => throw StateError('Unsupported BDK absolute timelock'),
+  };
+
+  static BitcoinPolicyNodeModel _relativeTimelock({
+    required String id,
+    required int sequence,
+  }) {
+    const typeFlag = 1 << 22;
+    const valueMask = 0xffff;
+    final encodedValue = sequence & valueMask;
+    final isTimeBased = sequence & typeFlag != 0;
+    return BitcoinPolicyNodeModel(
+      id: id,
+      type: isTimeBased
+          ? BitcoinPolicyNodeModelType.relativeSeconds
+          : BitcoinPolicyNodeModelType.relativeBlocks,
+      value: isTimeBased ? encodedValue * 512 : encodedValue,
+    );
+  }
+
+  static BitcoinSpendingPolicy _spendingPolicyEntity(
+    BitcoinSpendingPolicyModel model,
+  ) => BitcoinSpendingPolicy(
+    root: _nodeEntity(model.root),
+    requiresPath: model.requiresPath,
+  );
+
+  static BitcoinPolicyNode _nodeEntity(BitcoinPolicyNodeModel model) =>
+      switch (model.type) {
+        BitcoinPolicyNodeModelType.signature => BitcoinSignaturePolicyNode(
+          id: model.id,
+          key: _keyEntity(model.key!),
+        ),
+        BitcoinPolicyNodeModelType.sha256 => BitcoinHashlockPolicyNode(
+          id: model.id,
+          type: BitcoinHashlockType.sha256,
+          hash: model.hash!,
+        ),
+        BitcoinPolicyNodeModelType.hash256 => BitcoinHashlockPolicyNode(
+          id: model.id,
+          type: BitcoinHashlockType.hash256,
+          hash: model.hash!,
+        ),
+        BitcoinPolicyNodeModelType.ripemd160 => BitcoinHashlockPolicyNode(
+          id: model.id,
+          type: BitcoinHashlockType.ripemd160,
+          hash: model.hash!,
+        ),
+        BitcoinPolicyNodeModelType.hash160 => BitcoinHashlockPolicyNode(
+          id: model.id,
+          type: BitcoinHashlockType.hash160,
+          hash: model.hash!,
+        ),
+        BitcoinPolicyNodeModelType.absoluteBlockHeight =>
+          BitcoinAbsoluteTimelockPolicyNode(
+            id: model.id,
+            type: BitcoinAbsoluteTimelockType.blockHeight,
+            value: model.value!,
+          ),
+        BitcoinPolicyNodeModelType.absoluteTimestamp =>
+          BitcoinAbsoluteTimelockPolicyNode(
+            id: model.id,
+            type: BitcoinAbsoluteTimelockType.timestamp,
+            value: model.value!,
+          ),
+        BitcoinPolicyNodeModelType.relativeBlocks =>
+          BitcoinRelativeTimelockPolicyNode(
+            id: model.id,
+            type: BitcoinRelativeTimelockType.blocks,
+            value: model.value!,
+          ),
+        BitcoinPolicyNodeModelType.relativeSeconds =>
+          BitcoinRelativeTimelockPolicyNode(
+            id: model.id,
+            type: BitcoinRelativeTimelockType.seconds,
+            value: model.value!,
+          ),
+        BitcoinPolicyNodeModelType.threshold => BitcoinThresholdPolicyNode(
+          id: model.id,
+          threshold: model.threshold!,
+          requiresPath: model.requiresPath,
+          children: model.children.map(_nodeEntity).toList(),
+        ),
+      };
+
+  static BitcoinPolicyKey _keyEntity(BitcoinPolicyKeyModel model) =>
+      BitcoinPolicyKey(
+        kind: switch (model.type) {
+          BitcoinPolicyKeyModelType.descriptorKey =>
+            BitcoinPolicyKeyKind.descriptorKey,
+          BitcoinPolicyKeyModelType.publicKey => BitcoinPolicyKeyKind.publicKey,
+          BitcoinPolicyKeyModelType.xOnlyPublicKey =>
+            BitcoinPolicyKeyKind.xOnlyPublicKey,
+          BitcoinPolicyKeyModelType.fingerprint =>
+            BitcoinPolicyKeyKind.fingerprint,
+        },
+        value: model.value,
+      );
+}
+
+final class _PolicyKeyResolver {
+  final List<WalletDescriptorKeyModel> descriptorKeys;
+  final Map<String, int> _fingerprintOffsets = {};
+
+  _PolicyKeyResolver(this.descriptorKeys);
+
+  BitcoinPolicyKeyModel? resolveFingerprint(String fingerprint) {
+    final normalized = fingerprint.toLowerCase();
+    final matches = descriptorKeys
+        .where(
+          (key) =>
+              key.masterFingerprint.toLowerCase() == normalized ||
+              key.xpubFingerprint.toLowerCase() == normalized,
+        )
+        .toList();
+    if (matches.isEmpty) return null;
+
+    final offset = _fingerprintOffsets.update(
+      normalized,
+      (value) => value + 1,
+      ifAbsent: () => 0,
+    );
+    if (offset >= matches.length) {
+      throw StateError('Policy contains an unmatched descriptor key');
+    }
+    final match = matches[offset];
+    return BitcoinPolicyKeyModel(
+      type: BitcoinPolicyKeyModelType.descriptorKey,
+      value: match.id,
+    );
+  }
+
+  BitcoinPolicyKeyModel? resolvePublicKey(String publicKey) {
+    final normalized = publicKey.toLowerCase();
+    final match = descriptorKeys
+        .where((key) => key.xpub.toLowerCase() == normalized)
+        .firstOrNull;
+    if (match == null) return null;
+    return BitcoinPolicyKeyModel(
+      type: BitcoinPolicyKeyModelType.descriptorKey,
+      value: match.id,
+    );
+  }
+}

--- a/lib/core/wallet/data/mappers/wallet_descriptor_key_matcher.dart
+++ b/lib/core/wallet/data/mappers/wallet_descriptor_key_matcher.dart
@@ -1,0 +1,101 @@
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/uint_8_list_x.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+
+bool walletDescriptorKeyMatches({
+  required WalletDescriptorKeyModel key,
+  required String publicKey,
+  required String? fingerprint,
+  required String? derivationPath,
+  required BitcoinPolicyKeychainModel? keychain,
+  bool isXOnly = false,
+}) {
+  final normalizedPublicKey = publicKey.toLowerCase();
+  if (key.xpub.toLowerCase() == normalizedPublicKey) {
+    return key.descriptorPath.isEmpty;
+  }
+  if (key.xpub.isEmpty) return false;
+
+  final normalizedFingerprint = fingerprint?.toLowerCase();
+  final masterFingerprint = key.masterFingerprint.toLowerCase();
+  final xpubFingerprint = key.xpubFingerprint.toLowerCase();
+  if (masterFingerprint.isNotEmpty &&
+      normalizedFingerprint != masterFingerprint) {
+    return false;
+  }
+  if (masterFingerprint.isEmpty &&
+      xpubFingerprint.isNotEmpty &&
+      normalizedFingerprint != xpubFingerprint) {
+    return false;
+  }
+
+  final sourcePath = _pathParts(derivationPath);
+  final accountPath = _pathParts(key.derivationPath);
+  if (accountPath.isNotEmpty && !_startsWith(sourcePath, accountPath)) {
+    return false;
+  }
+  final suffix = accountPath.isEmpty
+      ? sourcePath
+      : sourcePath.sublist(accountPath.length);
+  if (suffix.any(_isHardened) ||
+      !_matchesDescriptorPath(suffix, key.descriptorPath, keychain: keychain)) {
+    return false;
+  }
+
+  try {
+    var derived = Bip32Derivation.getBip32Xpub(key.xpub);
+    if (suffix.isNotEmpty) derived = derived.derivePath(suffix.join('/'));
+    final derivedPublicKey = derived.public.toHexString().toLowerCase();
+    return isXOnly
+        ? derivedPublicKey.substring(2) == normalizedPublicKey
+        : derivedPublicKey == normalizedPublicKey;
+  } on Exception {
+    return false;
+  }
+}
+
+bool _matchesDescriptorPath(
+  List<String> actual,
+  String descriptorPath, {
+  required BitcoinPolicyKeychainModel? keychain,
+}) {
+  if (descriptorPath.isEmpty) return true;
+  final expected = _pathParts(descriptorPath);
+  if (actual.length != expected.length) return false;
+  for (var index = 0; index < expected.length; index++) {
+    final component = expected[index];
+    if (component == '*') continue;
+    final branches = RegExp(r'^<(\d+);(\d+)>$').firstMatch(component);
+    if (branches != null) {
+      final branch = switch (keychain) {
+        BitcoinPolicyKeychainModel.external => branches[1],
+        BitcoinPolicyKeychainModel.internal => branches[2],
+        null => null,
+      };
+      if (actual[index] != branch) return false;
+      continue;
+    }
+    if (actual[index] != component) return false;
+  }
+  return true;
+}
+
+List<String> _pathParts(String? path) {
+  if (path == null || path.isEmpty || path == 'm') return const [];
+  return path
+      .replaceAllMapped(RegExp(r'(\d+)[hH]'), (match) => "${match[1]}'")
+      .split('/')
+      .where((part) => part.isNotEmpty && part != 'm')
+      .toList();
+}
+
+bool _startsWith(List<String> path, List<String> prefix) {
+  if (path.length < prefix.length) return false;
+  for (var index = 0; index < prefix.length; index++) {
+    if (path[index] != prefix[index]) return false;
+  }
+  return true;
+}
+
+bool _isHardened(String component) => component.endsWith("'");

--- a/lib/core/wallet/data/models/bitcoin_policy_maturity_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_policy_maturity_model.dart
@@ -1,0 +1,29 @@
+enum BitcoinPolicyKeychainModel { external, internal }
+
+final class BitcoinPolicyUtxoMaturityModel {
+  final String outpoint;
+  final BitcoinPolicyKeychainModel keychain;
+  final BigInt amountSat;
+  final int confirmations;
+  final int? confirmationMedianTimePast;
+
+  const BitcoinPolicyUtxoMaturityModel({
+    required this.outpoint,
+    required this.keychain,
+    required this.amountSat,
+    required this.confirmations,
+    this.confirmationMedianTimePast,
+  });
+}
+
+final class BitcoinPolicyMaturityModel {
+  final int tipHeight;
+  final int? medianTimePast;
+  final List<BitcoinPolicyUtxoMaturityModel> utxos;
+
+  BitcoinPolicyMaturityModel({
+    required this.tipHeight,
+    required this.medianTimePast,
+    required List<BitcoinPolicyUtxoMaturityModel> utxos,
+  }) : utxos = List.unmodifiable(utxos);
+}

--- a/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
@@ -1,0 +1,45 @@
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+
+typedef BitcoinPsbtKeySourceRecord = ({
+  String publicKey,
+  String? fingerprint,
+  String? derivationPath,
+});
+
+typedef BitcoinPsbtInputReviewRecord = ({
+  BigInt amountSat,
+  BitcoinPolicyKeychainModel? keychain,
+  List<BitcoinPsbtKeySourceRecord> originKeySources,
+  List<BitcoinPsbtKeySourceRecord> signedKeySources,
+  String outpoint,
+  int sequence,
+});
+
+typedef BitcoinPsbtOutputReviewRecord = ({
+  String? address,
+  BigInt amountSat,
+  int index,
+  bool isWalletOwned,
+  String scriptHex,
+});
+
+final class BitcoinPsbtReviewModel {
+  final String transactionId;
+  final List<BitcoinPsbtInputReviewRecord> inputs;
+  final List<BitcoinPsbtOutputReviewRecord> outputs;
+  final BigInt feeSat;
+  final int estimatedTransactionVsize;
+  final int lockTime;
+  final int version;
+
+  BitcoinPsbtReviewModel({
+    required this.transactionId,
+    required List<BitcoinPsbtInputReviewRecord> inputs,
+    required List<BitcoinPsbtOutputReviewRecord> outputs,
+    required this.feeSat,
+    required this.estimatedTransactionVsize,
+    required this.lockTime,
+    required this.version,
+  }) : inputs = List.unmodifiable(inputs),
+       outputs = List.unmodifiable(outputs);
+}

--- a/lib/core/wallet/data/models/bitcoin_wallet_policy_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_wallet_policy_model.dart
@@ -1,0 +1,68 @@
+enum BitcoinPolicyNodeModelType {
+  signature,
+  sha256,
+  hash256,
+  ripemd160,
+  hash160,
+  absoluteBlockHeight,
+  absoluteTimestamp,
+  relativeBlocks,
+  relativeSeconds,
+  threshold,
+}
+
+enum BitcoinPolicyKeyModelType {
+  descriptorKey,
+  publicKey,
+  xOnlyPublicKey,
+  fingerprint,
+}
+
+final class BitcoinPolicyKeyModel {
+  final BitcoinPolicyKeyModelType type;
+  final String value;
+
+  const BitcoinPolicyKeyModel({required this.type, required this.value});
+}
+
+final class BitcoinPolicyNodeModel {
+  final String id;
+  final BitcoinPolicyNodeModelType type;
+  final BitcoinPolicyKeyModel? key;
+  final String? hash;
+  final int? value;
+  final int? threshold;
+  final bool requiresPath;
+  final List<BitcoinPolicyNodeModel> children;
+
+  BitcoinPolicyNodeModel({
+    required this.id,
+    required this.type,
+    this.key,
+    this.hash,
+    this.value,
+    this.threshold,
+    this.requiresPath = false,
+    List<BitcoinPolicyNodeModel> children = const [],
+  }) : children = List.unmodifiable(children);
+}
+
+final class BitcoinSpendingPolicyModel {
+  final BitcoinPolicyNodeModel root;
+  final bool requiresPath;
+
+  const BitcoinSpendingPolicyModel({
+    required this.root,
+    required this.requiresPath,
+  });
+}
+
+final class BitcoinWalletPolicyModel {
+  final BitcoinSpendingPolicyModel external;
+  final BitcoinSpendingPolicyModel internal;
+
+  const BitcoinWalletPolicyModel({
+    required this.external,
+    required this.internal,
+  });
+}

--- a/lib/core/wallet/data/models/wallet_model.dart
+++ b/lib/core/wallet/data/models/wallet_model.dart
@@ -21,6 +21,7 @@ sealed class WalletModel with _$WalletModel {
     required ScriptType scriptType,
     required String mnemonic,
     String? passphrase,
+    required int account,
     required bool isTestnet,
   }) = PrivateBdkWalletModel;
   const factory WalletModel.privateLwk({

--- a/lib/core/wallet/data/payjoin_wallet_adapter.dart
+++ b/lib/core/wallet/data/payjoin_wallet_adapter.dart
@@ -27,7 +27,15 @@ final class PayjoinWalletAdapter implements PayjoinWalletPort {
     required String psbt,
   }) async {
     final wallet = await _loadPrivateWallet(walletId, network);
-    return _wallet.signPsbt(psbt, wallet: wallet);
+    final signed = await _wallet.signPsbt(
+      psbt,
+      wallet: wallet,
+      allowFinalizedForeignInputs: true,
+    );
+    if (!signed.isFinalized) {
+      throw StateError('Payjoin PSBT is not fully signed');
+    }
+    return signed.psbt;
   }
 
   @override
@@ -105,25 +113,26 @@ final class PayjoinWalletAdapter implements PayjoinWalletPort {
     if (signer.descriptorKeys.length != 1) {
       throw StateError('Payjoin requires a standard local wallet');
     }
-    final descriptorKey = signer.descriptorKeys.single;
+    final key = signer.descriptorKeys.single;
+    final account = scriptType.standardAccount(
+      key.derivationPath,
+      metadata.network,
+    );
     if (signer.signer != Signer.local ||
-        scriptType.standardAccount(
-              descriptorKey.derivationPath,
-              metadata.network,
-            ) !=
-            0 ||
-        descriptorKey.descriptorPath != standardSingleSignatureDescriptorPath) {
+        account == null ||
+        key.descriptorPath != standardSingleSignatureDescriptorPath) {
       throw StateError('Payjoin requires a standard local wallet');
     }
-    final seed = await _seed.get(descriptorKey.masterFingerprint);
+    final seed = await _seed.get(key.masterFingerprint);
     if (seed is! MnemonicSeedModel) {
-      throw StateError('Payjoin requires a local mnemonic wallet');
+      throw StateError('Payjoin requires a standard local wallet');
     }
     return WalletModel.privateBdk(
           id: walletId,
           scriptType: scriptType,
           mnemonic: seed.mnemonicWords.join(' '),
           passphrase: seed.passphrase,
+          account: account,
           isTestnet: metadata.isTestnet,
         )
         as PrivateBdkWalletModel;

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -1,35 +1,73 @@
 import 'dart:typed_data';
 
+import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_server_network.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/storage/tables/wallet_signer_table.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_policy_maturity_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/mappers/wallet_metadata_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/mappers/wallet_utxo_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_send_port.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
 
-class BitcoinWalletRepository implements BitcoinSendPort {
+class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final SeedDatasource _seed;
   final BdkWalletDatasource _bdkWallet;
   final FrozenWalletUtxoDatasource _frozenUtxos;
+  final ElectrumServersPort? electrumServers;
 
   BitcoinWalletRepository({
     required this._walletMetadataDatasource,
     required SeedDatasource seedDatasource,
     required BdkWalletDatasource bdkWalletDatasource,
     required FrozenWalletUtxoDatasource frozenWalletUtxoDatasource,
+    this.electrumServers,
   }) : _seed = seedDatasource,
        _bdkWallet = bdkWalletDatasource,
        _frozenUtxos = frozenWalletUtxoDatasource;
+
+  Future<({WalletMetadataModel metadata, PublicBdkWalletModel wallet})>
+  _publicWalletContext(String walletId) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+    if (metadata == null) {
+      throw Exception('Wallet metadata not found for walletId: $walletId');
+    }
+    if (!metadata.isBitcoin) {
+      throw Exception('Wallet $walletId is not a Bitcoin wallet');
+    }
+    return (
+      metadata: metadata,
+      wallet:
+          WalletModel.publicBdk(
+                descriptor: metadata.publicDescriptor,
+                isTestnet: metadata.isTestnet,
+                id: metadata.id,
+              )
+              as PublicBdkWalletModel,
+    );
+  }
 
   @override
   Future<String> buildPsbt({
@@ -41,48 +79,23 @@ class BitcoinWalletRepository implements BitcoinSendPort {
     List<({String txId, int vout})>? unspendable,
     List<WalletUtxo>? selected,
     bool? replaceByFee,
+    BitcoinPolicyPath? policyPath,
   }) async {
-    final metadata = await _walletMetadataDatasource.fetch(walletId);
+    final context = await _publicWalletContext(walletId);
+    final wallet = context.wallet;
 
-    if (metadata == null) {
-      throw Exception('Wallet metadata not found for walletId: $walletId');
-    }
-
-    if (!metadata.isBitcoin) {
-      throw Exception('Wallet $walletId is not a Bitcoin wallet');
-    }
-
-    final wallet =
-        WalletModel.publicBdk(
-              descriptor: metadata.publicDescriptor,
-              isTestnet: metadata.isTestnet,
-              id: metadata.id,
-            )
-            as PublicBdkWalletModel;
-
-    // D7 defense in depth: a frozen coin must never be spendable. BDK's
-    // documented semantics are the opposite — a manually added utxo
-    // (TxBuilder.addUtxos) overrides the unspendable filter — and the
-    // datasource deliberately preserves those raw semantics. Enforce the
-    // app-level invariant here at the repository boundary, reading the
-    // frozen store LIVE at build time, so it holds for ANY caller and
-    // any staleness of the caller's earlier utxo fetch — not only for
-    // callers going through PrepareBitcoinSendUsecase (which reads the
-    // same store plus the payjoin-derived set; payjoin exclusion stays
-    // at the usecase because it comes from another repository).
+    // A frozen coin must never be spendable. Read the frozen store at build
+    // time so the invariant holds for every caller and does not depend on an
+    // earlier UTXO snapshot. Payjoin exclusions remain supplied by the use
+    // case because they come from a separate repository.
     //
     // The frozen set read here is:
     //  * merged into `unspendable`, so BDK's automatic selection can
     //    never pick a frozen coin even when the caller passed no
     //    exclusion list at all;
-    //  * used to strip `selected`, so a frozen coin can't be forced in
-    //    as a mandatory input either (the addUtxos override above).
+    //  * checked against `selected` by the datasource, so a frozen coin
+    //    causes manual selection to fail instead of being substituted.
     final frozenRows = await _frozenUtxos.getAllFrozen();
-    final unspendableKeys = {
-      for (final row in frozenRows) '${row.txId}:${row.vout}',
-      for (final outpoint in unspendable ?? const <({String txId, int vout})>[])
-        '${outpoint.txId}:${outpoint.vout}',
-    };
     final mergedUnspendable = [
       for (final outpoint in {
         for (final row in frozenRows) (txId: row.txId, vout: row.vout),
@@ -90,12 +103,6 @@ class BitcoinWalletRepository implements BitcoinSendPort {
       })
         outpoint,
     ];
-    final spendableSelected = selected
-        ?.where(
-          (utxo) => !unspendableKeys.contains('${utxo.txId}:${utxo.vout}'),
-        )
-        .toList();
-
     final psbt = await _bdkWallet.buildPsbt(
       wallet: wallet,
       address: address,
@@ -105,46 +112,319 @@ class BitcoinWalletRepository implements BitcoinSendPort {
       // An empty merged list is equivalent to null for the datasource
       // (it gates on isNotEmpty), so always pass the merge.
       unspendable: mergedUnspendable,
-      selected: spendableSelected
+      selected: selected
           ?.map((utxo) => WalletUtxoMapper.fromEntity(utxo))
           .toList(),
-      // Default to RBF-enabled, matching both the datasource default and
-      // BDK's own default sequence (0xFFFFFFFD). `?? false` would disable
-      // RBF for any caller omitting the flag — harmless while
-      // setExactSequence's result was discarded, wrong now that it works.
+      // Match BDK's default RBF sequence when callers omit the flag.
       replaceByFee: replaceByFee ?? true,
+      policyPath: policyPath,
     );
 
     return psbt;
   }
 
-  Future<String> signPsbt(String psbt, {required String walletId}) async {
-    final wallet = await getPrivateWallet(walletId: walletId);
-    final signedPsbt = await _bdkWallet.signPsbt(wallet: wallet, psbt);
-    return signedPsbt;
+  @override
+  Future<Result<({String psbt, bool isFinalized}), BitcoinSigningFailure>>
+  signPsbt(
+    String psbt, {
+    required String walletId,
+    bool tryFinalize = true,
+    String? signerId,
+  }) => _guardSigning(
+    () => _signPsbt(
+      psbt,
+      walletId: walletId,
+      tryFinalize: tryFinalize,
+      signerId: signerId,
+    ),
+  );
+
+  Future<({String psbt, bool isFinalized})> _signPsbt(
+    String psbt, {
+    required String walletId,
+    bool tryFinalize = true,
+    String? signerId,
+    String? replacingTxid,
+  }) async {
+    final context = await _publicWalletContext(walletId);
+    final metadata = context.metadata;
+    final publicWallet = context.wallet;
+    await _validateWalletPsbtInputs(
+      psbt: psbt,
+      wallet: publicWallet,
+      replacingTxid: replacingTxid,
+    );
+
+    var descriptor = _withoutDescriptorChecksum(metadata.publicDescriptor);
+    var injectedKey = false;
+    final localSigners = metadata.signers.where(
+      (signer) =>
+          signer.signer == Signer.local &&
+          (signerId == null || signer.id == signerId),
+    );
+    final injectedPublicKeys = <String>{};
+    for (final signer in localSigners) {
+      for (final key in signer.descriptorKeys) {
+        final derivationPath = key.derivationPath;
+        if (derivationPath == null) {
+          throw StateError('Local descriptor key has no derivation path');
+        }
+        final seed = await _seed.get(key.masterFingerprint);
+        final rootKey = _descriptorSecretKey(seed, network: metadata.network);
+        try {
+          final path = bdk.DerivationPath(path: derivationPath);
+          try {
+            final accountKey = rootKey.derive(path: path);
+            try {
+              final publicKey = accountKey.asPublic();
+              try {
+                final publicKeyString = publicKey.toString();
+                final privateKeyString = accountKey.toString();
+                if (!injectedPublicKeys.add(publicKeyString)) continue;
+                final descriptorWithKey = descriptor.replaceAll(
+                  publicKeyString,
+                  privateKeyString,
+                );
+                if (descriptorWithKey == descriptor) {
+                  throw StateError(
+                    'Local descriptor key is not present in descriptors',
+                  );
+                }
+                descriptor = descriptorWithKey;
+                injectedKey = true;
+              } finally {
+                publicKey.dispose();
+              }
+            } finally {
+              accountKey.dispose();
+            }
+          } finally {
+            path.dispose();
+          }
+        } finally {
+          rootKey.dispose();
+        }
+      }
+    }
+    if (!injectedKey) throw const BitcoinPsbtMissingLocalOriginException();
+
+    return _bdkWallet.signPsbtWithDescriptor(
+      psbt,
+      descriptor: descriptor,
+      isTestnet: metadata.isTestnet,
+      tryFinalize: tryFinalize,
+    );
   }
+
+  @override
+  Future<Result<BitcoinPsbtReview, BitcoinSigningFailure>> reviewPsbt(
+    String psbt, {
+    required String walletId,
+    bool requireLocalOrigin = true,
+  }) => _guardSigning(
+    () => _reviewPsbt(
+      psbt,
+      walletId: walletId,
+      requireLocalOrigin: requireLocalOrigin,
+    ),
+  );
+
+  Future<BitcoinPsbtReview> _reviewPsbt(
+    String psbt, {
+    required String walletId,
+    bool requireLocalOrigin = true,
+  }) async {
+    final context = await _publicWalletContext(walletId);
+    final metadata = context.metadata;
+    final wallet = context.wallet;
+    final localSignerIds = metadata.signers
+        .where((signer) => signer.signer == Signer.local)
+        .map((signer) => signer.id)
+        .toSet();
+    if (requireLocalOrigin && localSignerIds.isEmpty) {
+      throw const BitcoinPsbtMissingLocalOriginException();
+    }
+
+    await _validateWalletPsbtInputs(psbt: psbt, wallet: wallet);
+    final model = await _bdkWallet.inspectPsbt(
+      psbt,
+      wallet: wallet,
+      walletFingerprints: metadata.signers
+          .expand((signer) => signer.descriptorKeys)
+          .expand((key) => [key.masterFingerprint, key.xpubFingerprint])
+          .where((fingerprint) => fingerprint.isNotEmpty)
+          .map((fingerprint) => fingerprint.toLowerCase())
+          .toSet(),
+    );
+    final review = BitcoinPsbtReviewMapper.toEntity(
+      model,
+      descriptorKeys: metadata.signers
+          .expand((signer) => signer.descriptorKeys)
+          .toList(),
+      localSignerIds: localSignerIds,
+    );
+    if (requireLocalOrigin &&
+        !review.inputs.any((input) => input.hasLocalSignerOrigin)) {
+      throw const BitcoinPsbtMissingLocalOriginException();
+    }
+    return review;
+  }
+
+  @override
+  Future<Result<BitcoinWalletPolicy, BitcoinSigningFailure>> getPolicy({
+    required String walletId,
+  }) => _guardSigning(() => _getPolicy(walletId: walletId));
+
+  Future<BitcoinWalletPolicy> _getPolicy({required String walletId}) async {
+    final context = await _publicWalletContext(walletId);
+    final metadata = context.metadata;
+
+    return BitcoinWalletPolicyMapper.toEntity(
+      _bdkWallet.analyzePolicy(
+        wallet: context.wallet,
+        descriptorKeys: metadata.signers
+            .expand((signer) => signer.descriptorKeys)
+            .toList(),
+      ),
+    );
+  }
+
+  @override
+  Future<Result<BitcoinPolicyMaturity, BitcoinSigningFailure>>
+  getPolicyMaturity({
+    required String walletId,
+    required bool includeTimeBasedLocks,
+  }) => _guardSigning(
+    () => _getPolicyMaturity(
+      walletId: walletId,
+      includeTimeBasedLocks: includeTimeBasedLocks,
+    ),
+  );
+
+  Future<BitcoinPolicyMaturity> _getPolicyMaturity({
+    required String walletId,
+    required bool includeTimeBasedLocks,
+  }) async {
+    final context = await _publicWalletContext(walletId);
+    final metadata = context.metadata;
+    final wallet = context.wallet;
+    final cachedModel = await _bdkWallet.getPolicyMaturity(
+      wallet: wallet,
+      includeTimeBasedLocks: includeTimeBasedLocks,
+    );
+    final servers = electrumServers;
+    if (servers == null) {
+      return BitcoinPolicyMaturityMapper.toEntity(cachedModel);
+    }
+
+    try {
+      final model = await servers.runWithFallback(
+        network: ElectrumServerNetwork.fromEnvironment(
+          isTestnet: metadata.isTestnet,
+          isLiquid: false,
+        ),
+        operation: (connection) => _bdkWallet.getPolicyMaturity(
+          wallet: wallet,
+          electrumServer: connection,
+          includeTimeBasedLocks: includeTimeBasedLocks,
+        ),
+      );
+      return BitcoinPolicyMaturityMapper.toEntity(model);
+    } on Exception {
+      // Cached height remains safe: stale data only keeps a path hidden longer.
+      // Time-based paths stay unavailable until median-time-past is known.
+      return BitcoinPolicyMaturityMapper.toEntity(cachedModel);
+    }
+  }
+
+  @override
+  Future<Result<({String psbt, bool isFinalized}), BitcoinSigningFailure>>
+  combinePsbts({
+    required String currentPsbt,
+    required String signedPsbt,
+    required String walletId,
+    bool tryFinalize = true,
+  }) => _guardSigning(
+    () => _combinePsbts(
+      currentPsbt: currentPsbt,
+      signedPsbt: signedPsbt,
+      walletId: walletId,
+      tryFinalize: tryFinalize,
+    ),
+  );
+
+  Future<({String psbt, bool isFinalized})> _combinePsbts({
+    required String currentPsbt,
+    required String signedPsbt,
+    required String walletId,
+    bool tryFinalize = true,
+  }) async {
+    final context = await _publicWalletContext(walletId);
+    final metadata = context.metadata;
+    final wallet = context.wallet;
+    _bdkWallet.validateExternalPartialPsbt(
+      currentPsbtBase64: currentPsbt,
+      signedPsbtBase64: signedPsbt,
+    );
+    final String combined;
+    try {
+      combined = _bdkWallet.combinePsbts(
+        first: currentPsbt,
+        second: signedPsbt,
+      );
+    } on bdk.PsbtException {
+      throw const InvalidBitcoinPsbtException();
+    }
+    await _validateWalletPsbtInputs(psbt: combined, wallet: wallet);
+    await _bdkWallet.inspectPsbt(
+      combined,
+      wallet: wallet,
+      walletFingerprints: metadata.signers
+          .expand((signer) => signer.descriptorKeys)
+          .expand((key) => [key.masterFingerprint, key.xpubFingerprint])
+          .where((fingerprint) => fingerprint.isNotEmpty)
+          .map((fingerprint) => fingerprint.toLowerCase())
+          .toSet(),
+    );
+    return tryFinalize
+        ? _bdkWallet.finalizePsbt(combined)
+        : (psbt: combined, isFinalized: false);
+  }
+
+  @override
+  Future<Result<bool, BitcoinSigningFailure>> validatePolicyPreimage(
+    BitcoinPolicyPreimage preimage,
+  ) => _guardSigning(() async => _bdkWallet.validatePolicyPreimage(preimage));
+
+  @override
+  Future<Result<String, BitcoinSigningFailure>> applyPolicyPreimages({
+    required String psbt,
+    required List<BitcoinPolicyPreimage> preimages,
+  }) => _guardSigning(
+    () async => _bdkWallet.applyPolicyPreimages(psbt, preimages),
+  );
+
+  @override
+  Future<Result<({String transaction, int txSize}), BitcoinSigningFailure>>
+  verifyFinalTransaction({required String psbt, required String transaction}) =>
+      _guardSigning(() async {
+        try {
+          return _bdkWallet.verifyFinalTransaction(
+            psbtBase64: psbt,
+            transactionHex: transaction,
+          );
+        } on FormatException {
+          throw const InvalidBitcoinPsbtException();
+        } on bdk.TransactionException {
+          throw const InvalidBitcoinPsbtException();
+        }
+      });
 
   Future<bool> isScriptOfWallet({
     required String walletId,
     required Uint8List script,
   }) async {
-    final metadata = await _walletMetadataDatasource.fetch(walletId);
-
-    if (metadata == null) {
-      throw Exception('Wallet metadata not found for walletId: $walletId');
-    }
-
-    if (!metadata.isBitcoin) {
-      throw Exception('Wallet $walletId is not a Bitcoin wallet');
-    }
-
-    final wallet =
-        WalletModel.publicBdk(
-              descriptor: metadata.publicDescriptor,
-              isTestnet: metadata.isTestnet,
-              id: metadata.id,
-            )
-            as PublicBdkWalletModel;
+    final wallet = (await _publicWalletContext(walletId)).wallet;
 
     final isFromWallet = await _bdkWallet.isMine(script, wallet: wallet);
 
@@ -156,23 +436,7 @@ class BitcoinWalletRepository implements BitcoinSendPort {
     String address, {
     required String walletId,
   }) async {
-    final metadata = await _walletMetadataDatasource.fetch(walletId);
-
-    if (metadata == null) {
-      throw Exception('Wallet metadata not found for walletId: $walletId');
-    }
-
-    if (!metadata.isBitcoin) {
-      throw Exception('Wallet $walletId is not a Bitcoin wallet');
-    }
-
-    final wallet =
-        WalletModel.publicBdk(
-              descriptor: metadata.publicDescriptor,
-              isTestnet: metadata.isTestnet,
-              id: metadata.id,
-            )
-            as PublicBdkWalletModel;
+    final wallet = (await _publicWalletContext(walletId)).wallet;
 
     final isFromWallet = await _bdkWallet.isAddressMine(
       address,
@@ -183,9 +447,12 @@ class BitcoinWalletRepository implements BitcoinSendPort {
   }
 
   @override
-  Future<int> getTxSize({required String psbt}) async {
-    final txSize = await _bdkWallet.decodeTxSize(psbt);
-    return txSize;
+  Future<int> getTxSize({
+    required String psbt,
+    required String walletId,
+  }) async {
+    final wallet = (await _publicWalletContext(walletId)).wallet;
+    return _bdkWallet.decodeTxSize(psbt, wallet: wallet);
   }
 
   Future<int> getTxFeeAmount({required String psbt}) async {
@@ -234,17 +501,20 @@ class BitcoinWalletRepository implements BitcoinSendPort {
       throw StateError('Standard local single-signature wallet required');
     }
     final descriptorKey = signer.descriptorKeys.single;
+    final account = scriptType.standardAccount(
+      descriptorKey.derivationPath,
+      metadata.network,
+    );
     if (signer.signer != Signer.local ||
-        scriptType.standardAccount(
-              descriptorKey.derivationPath,
-              metadata.network,
-            ) !=
-            0 ||
+        account == null ||
         descriptorKey.descriptorPath != standardSingleSignatureDescriptorPath) {
       throw StateError('Standard local single-signature wallet required');
     }
-    final seed =
-        await _seed.get(descriptorKey.masterFingerprint) as MnemonicSeedModel;
+
+    final seed = await _seed.get(descriptorKey.masterFingerprint);
+    if (seed is! MnemonicSeedModel) {
+      throw StateError('Standard local single-signature wallet required');
+    }
     final mnemonic = seed.mnemonicWords.join(' ');
 
     final wallet =
@@ -253,6 +523,7 @@ class BitcoinWalletRepository implements BitcoinSendPort {
               mnemonic: mnemonic,
               passphrase: seed.passphrase,
               scriptType: scriptType,
+              account: account,
               isTestnet: metadata.isTestnet,
             )
             as PrivateBdkWalletModel;
@@ -286,7 +557,107 @@ class BitcoinWalletRepository implements BitcoinSendPort {
       txid: txid,
       feeRate: newFeeRate,
     );
-    final signedPsbt = await signPsbt(psbt, walletId: walletId);
-    return signedPsbt;
+    final signed = await _signPsbt(
+      psbt,
+      walletId: walletId,
+      replacingTxid: txid,
+    );
+    if (!signed.isFinalized) {
+      throw StateError('Replacement transaction is not fully signed');
+    }
+    return signed.psbt;
+  }
+
+  bdk.DescriptorSecretKey _descriptorSecretKey(
+    SeedModel seed, {
+    required Network network,
+  }) {
+    if (seed is MnemonicSeedModel) {
+      final mnemonic = bdk.Mnemonic.fromString(
+        mnemonic: seed.mnemonicWords.join(' '),
+      );
+      try {
+        return bdk.DescriptorSecretKey(
+          networkKind: network.isTestnet
+              ? bdk.NetworkKind.test
+              : bdk.NetworkKind.main,
+          mnemonic: mnemonic,
+          password: seed.passphrase,
+        );
+      } finally {
+        mnemonic.dispose();
+      }
+    }
+
+    final xprv = Bip32Derivation.getXprvFromSeed(
+      Uint8List.fromList(seed.bytes),
+      network,
+    );
+    return bdk.DescriptorSecretKey.fromString(privateKey: xprv);
+  }
+
+  String _withoutDescriptorChecksum(String descriptor) =>
+      descriptor.split('#').first;
+
+  Future<void> _validateWalletPsbtInputs({
+    required String psbt,
+    required PublicBdkWalletModel wallet,
+    String? replacingTxid,
+  }) async {
+    final frozenRows = await _frozenUtxos.getAllFrozen();
+    final frozenOutpoints = {
+      for (final row in frozenRows) '${row.txId}:${row.vout}',
+    };
+    if (replacingTxid == null) {
+      await _bdkWallet.validateWalletPsbtInputs(
+        psbt,
+        wallet: wallet,
+        frozenOutpoints: frozenOutpoints,
+      );
+    } else {
+      await _bdkWallet.validateWalletPsbtInputs(
+        psbt,
+        wallet: wallet,
+        frozenOutpoints: frozenOutpoints,
+        replacingTxid: replacingTxid,
+      );
+    }
+  }
+
+  Future<Result<T, BitcoinSigningFailure>> _guardSigning<T>(
+    Future<T> Function() operation,
+  ) async {
+    try {
+      return Ok(await operation());
+    } on BitcoinPsbtReviewException catch (error) {
+      return Err(BitcoinSigningFailure(_signingFailureKind(error)));
+    } on UnsupportedBitcoinPolicyPathException {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unsupportedPolicyPath),
+      );
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Bitcoin signing operation failed',
+        error: error,
+        trace: stackTrace,
+      );
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unexpected),
+      );
+    }
   }
 }
+
+BitcoinSigningFailureKind _signingFailureKind(
+  BitcoinPsbtReviewException exception,
+) => switch (exception) {
+  InvalidBitcoinPsbtException() => BitcoinSigningFailureKind.invalidPsbt,
+  BitcoinPsbtWalletMismatchException() =>
+    BitcoinSigningFailureKind.walletMismatch,
+  BitcoinPsbtMissingLocalOriginException() =>
+    BitcoinSigningFailureKind.missingLocalOrigin,
+  BitcoinPsbtMissingUtxoException() => BitcoinSigningFailureKind.missingUtxo,
+  BitcoinPsbtFrozenUtxoException() => BitcoinSigningFailureKind.frozenUtxo,
+  BitcoinPsbtUnsupportedSighashException() =>
+    BitcoinSigningFailureKind.unsupportedSighash,
+};

--- a/lib/core/wallet/domain/bitcoin_coin_selection_exception.dart
+++ b/lib/core/wallet/domain/bitcoin_coin_selection_exception.dart
@@ -1,0 +1,17 @@
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+
+sealed class BitcoinCoinSelectionException extends BullException {
+  BitcoinCoinSelectionException(super.message);
+}
+
+final class SelectedBitcoinCoinsUnavailableException
+    extends BitcoinCoinSelectionException {
+  SelectedBitcoinCoinsUnavailableException()
+    : super('One or more selected coins are no longer available');
+}
+
+final class SelectedBitcoinCoinsInsufficientException
+    extends BitcoinCoinSelectionException {
+  SelectedBitcoinCoinsInsufficientException()
+    : super('Selected coins do not cover the amount and network fees');
+}

--- a/lib/core/wallet/domain/bitcoin_psbt_review_exception.dart
+++ b/lib/core/wallet/domain/bitcoin_psbt_review_exception.dart
@@ -1,0 +1,30 @@
+sealed class BitcoinPsbtReviewException implements Exception {
+  const BitcoinPsbtReviewException();
+}
+
+final class InvalidBitcoinPsbtException extends BitcoinPsbtReviewException {
+  const InvalidBitcoinPsbtException();
+}
+
+final class BitcoinPsbtWalletMismatchException
+    extends BitcoinPsbtReviewException {
+  const BitcoinPsbtWalletMismatchException();
+}
+
+final class BitcoinPsbtMissingLocalOriginException
+    extends BitcoinPsbtReviewException {
+  const BitcoinPsbtMissingLocalOriginException();
+}
+
+final class BitcoinPsbtMissingUtxoException extends BitcoinPsbtReviewException {
+  const BitcoinPsbtMissingUtxoException();
+}
+
+final class BitcoinPsbtFrozenUtxoException extends BitcoinPsbtReviewException {
+  const BitcoinPsbtFrozenUtxoException();
+}
+
+final class BitcoinPsbtUnsupportedSighashException
+    extends BitcoinPsbtReviewException {
+  const BitcoinPsbtUnsupportedSighashException();
+}

--- a/lib/core/wallet/domain/bitcoin_send_port.dart
+++ b/lib/core/wallet/domain/bitcoin_send_port.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 
 abstract interface class BitcoinSendPort {
@@ -11,9 +12,10 @@ abstract interface class BitcoinSendPort {
     List<({String txId, int vout})>? unspendable,
     List<WalletUtxo>? selected,
     bool? replaceByFee,
+    BitcoinPolicyPath? policyPath,
   });
 
-  Future<int> getTxSize({required String psbt});
+  Future<int> getTxSize({required String psbt, required String walletId});
 
   Future<bool> isAddressOfWallet(String address, {required String walletId});
 }

--- a/lib/core/wallet/domain/bitcoin_signing_port.dart
+++ b/lib/core/wallet/domain/bitcoin_signing_port.dart
@@ -1,0 +1,61 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class BitcoinSigningPort {
+  @useResult
+  Future<Result<BitcoinWalletPolicy, BitcoinSigningFailure>> getPolicy({
+    required String walletId,
+  });
+
+  @useResult
+  Future<Result<BitcoinPolicyMaturity, BitcoinSigningFailure>>
+  getPolicyMaturity({
+    required String walletId,
+    required bool includeTimeBasedLocks,
+  });
+
+  @useResult
+  Future<Result<({String psbt, bool isFinalized}), BitcoinSigningFailure>>
+  signPsbt(
+    String psbt, {
+    required String walletId,
+    bool tryFinalize = true,
+    String? signerId,
+  });
+
+  @useResult
+  Future<Result<BitcoinPsbtReview, BitcoinSigningFailure>> reviewPsbt(
+    String psbt, {
+    required String walletId,
+    bool requireLocalOrigin = true,
+  });
+
+  @useResult
+  Future<Result<({String psbt, bool isFinalized}), BitcoinSigningFailure>>
+  combinePsbts({
+    required String currentPsbt,
+    required String signedPsbt,
+    required String walletId,
+    bool tryFinalize = true,
+  });
+
+  @useResult
+  Future<Result<bool, BitcoinSigningFailure>> validatePolicyPreimage(
+    BitcoinPolicyPreimage preimage,
+  );
+
+  @useResult
+  Future<Result<String, BitcoinSigningFailure>> applyPolicyPreimages({
+    required String psbt,
+    required List<BitcoinPolicyPreimage> preimages,
+  });
+
+  @useResult
+  Future<Result<({String transaction, int txSize}), BitcoinSigningFailure>>
+  verifyFinalTransaction({required String psbt, required String transaction});
+
+  Future<int> getTxSize({required String psbt, required String walletId});
+}

--- a/lib/core/wallet/domain/entities/bitcoin_policy.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy.dart
@@ -1,0 +1,5 @@
+export 'bitcoin_policy_maturity.dart';
+export 'bitcoin_policy_node.dart';
+export 'bitcoin_policy_path.dart';
+export 'bitcoin_signing_plan.dart';
+export 'bitcoin_wallet_policy.dart';

--- a/lib/core/wallet/domain/entities/bitcoin_policy_maturity.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy_maturity.dart
@@ -1,0 +1,88 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+
+final class BitcoinPolicyUtxoMaturity {
+  final String outpoint;
+  final BitcoinPolicyKeychain keychain;
+  final BigInt amountSat;
+  final int confirmations;
+  final int? confirmationMedianTimePast;
+
+  BitcoinPolicyUtxoMaturity({
+    required this.outpoint,
+    required this.keychain,
+    required this.amountSat,
+    required this.confirmations,
+    this.confirmationMedianTimePast,
+  }) {
+    if (outpoint.isEmpty) throw ArgumentError.value(outpoint, 'outpoint');
+    if (amountSat < BigInt.zero) {
+      throw ArgumentError.value(amountSat, 'amountSat');
+    }
+    if (confirmations < 0) {
+      throw ArgumentError.value(confirmations, 'confirmations');
+    }
+  }
+}
+
+final class BitcoinPolicyMaturity {
+  final bool isKnown;
+  final int tipHeight;
+  final int? medianTimePast;
+  final List<BitcoinPolicyUtxoMaturity> utxos;
+
+  const BitcoinPolicyMaturity.empty()
+    : isKnown = false,
+      tipHeight = 0,
+      medianTimePast = null,
+      utxos = const [];
+
+  BitcoinPolicyMaturity({
+    required this.tipHeight,
+    required this.medianTimePast,
+    required List<BitcoinPolicyUtxoMaturity> utxos,
+  }) : isKnown = true,
+       utxos = List.unmodifiable(utxos) {
+    if (tipHeight < 0) throw ArgumentError.value(tipHeight, 'tipHeight');
+  }
+}
+
+enum BitcoinPolicyActivationType {
+  absoluteBlock,
+  absoluteTime,
+  relativeBlocks,
+  relativeTime,
+}
+
+final class BitcoinPolicyActivation {
+  final BitcoinPolicyActivationType type;
+  final int value;
+  final int estimatedSecondsFromNow;
+
+  BitcoinPolicyActivation({
+    required this.type,
+    required this.value,
+    required this.estimatedSecondsFromNow,
+  }) {
+    if (value < 0) throw ArgumentError.value(value, 'value');
+    if (estimatedSecondsFromNow < 0) {
+      throw ArgumentError.value(
+        estimatedSecondsFromNow,
+        'estimatedSecondsFromNow',
+      );
+    }
+  }
+}
+
+final class BitcoinPolicyOptionStatus {
+  final bool available;
+  final BigInt availableAmountSat;
+  final BigInt activatingAmountSat;
+  final BitcoinPolicyActivation? activation;
+
+  const BitcoinPolicyOptionStatus({
+    required this.available,
+    required this.availableAmountSat,
+    required this.activatingAmountSat,
+    this.activation,
+  });
+}

--- a/lib/core/wallet/domain/entities/bitcoin_policy_node.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy_node.dart
@@ -1,0 +1,150 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
+
+enum BitcoinPolicyKeyKind {
+  descriptorKey,
+  publicKey,
+  xOnlyPublicKey,
+  fingerprint,
+}
+
+enum BitcoinPolicyKeychain { external, internal }
+
+final class BitcoinPolicyKey {
+  final BitcoinPolicyKeyKind kind;
+  final String value;
+
+  BitcoinPolicyKey({required this.kind, required String value})
+    : value = value.toLowerCase() {
+    if (value.isEmpty) throw ArgumentError.value(value, 'value');
+  }
+
+  bool matches(WalletDescriptorKey descriptorKey) {
+    final identifiers = switch (kind) {
+      BitcoinPolicyKeyKind.descriptorKey => {descriptorKey.id.toLowerCase()},
+      BitcoinPolicyKeyKind.fingerprint => {
+        descriptorKey.masterFingerprint.toLowerCase(),
+        descriptorKey.xpubFingerprint.toLowerCase(),
+      },
+      BitcoinPolicyKeyKind.publicKey ||
+      BitcoinPolicyKeyKind.xOnlyPublicKey => {descriptorKey.xpub.toLowerCase()},
+    };
+    return identifiers.contains(value);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BitcoinPolicyKey && kind == other.kind && value == other.value;
+
+  @override
+  int get hashCode => Object.hash(kind, value);
+}
+
+sealed class BitcoinPolicyNode {
+  final String id;
+
+  const BitcoinPolicyNode({required this.id});
+}
+
+final class BitcoinSignaturePolicyNode extends BitcoinPolicyNode {
+  final BitcoinPolicyKey key;
+
+  const BitcoinSignaturePolicyNode({required super.id, required this.key});
+}
+
+enum BitcoinHashlockType { sha256, hash256, ripemd160, hash160 }
+
+final class BitcoinPolicyPreimage {
+  final BitcoinHashlockType type;
+  final String hash;
+  final String preimageHex;
+
+  BitcoinPolicyPreimage({
+    required this.type,
+    required String hash,
+    required String preimageHex,
+  }) : hash = hash.toLowerCase(),
+       preimageHex = preimageHex.toLowerCase() {
+    if (!_isHex(this.hash)) throw ArgumentError.value(hash, 'hash');
+    if (this.preimageHex.length != 64 || !_isHex(this.preimageHex)) {
+      throw ArgumentError.value(preimageHex, 'preimageHex');
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BitcoinPolicyPreimage &&
+          type == other.type &&
+          hash == other.hash &&
+          preimageHex == other.preimageHex;
+
+  @override
+  int get hashCode => Object.hash(type, hash, preimageHex);
+
+  static bool _isHex(String value) =>
+      value.isNotEmpty && RegExp(r'^[0-9a-fA-F]+$').hasMatch(value);
+}
+
+final class BitcoinHashlockPolicyNode extends BitcoinPolicyNode {
+  final BitcoinHashlockType type;
+  final String hash;
+
+  BitcoinHashlockPolicyNode({
+    required super.id,
+    required this.type,
+    required this.hash,
+  }) {
+    if (hash.isEmpty) throw ArgumentError.value(hash, 'hash');
+  }
+}
+
+enum BitcoinAbsoluteTimelockType { blockHeight, timestamp }
+
+final class BitcoinAbsoluteTimelockPolicyNode extends BitcoinPolicyNode {
+  final BitcoinAbsoluteTimelockType type;
+  final int value;
+
+  BitcoinAbsoluteTimelockPolicyNode({
+    required super.id,
+    required this.type,
+    required this.value,
+  }) {
+    if (value < 0) throw ArgumentError.value(value, 'value');
+  }
+}
+
+enum BitcoinRelativeTimelockType { blocks, seconds }
+
+final class BitcoinRelativeTimelockPolicyNode extends BitcoinPolicyNode {
+  final BitcoinRelativeTimelockType type;
+  final int value;
+
+  BitcoinRelativeTimelockPolicyNode({
+    required super.id,
+    this.type = BitcoinRelativeTimelockType.blocks,
+    required this.value,
+  }) {
+    if (value < 0) throw ArgumentError.value(value, 'value');
+  }
+}
+
+final class BitcoinThresholdPolicyNode extends BitcoinPolicyNode {
+  final int threshold;
+  final List<BitcoinPolicyNode> children;
+  final bool requiresPath;
+
+  BitcoinThresholdPolicyNode({
+    required super.id,
+    required this.threshold,
+    required List<BitcoinPolicyNode> children,
+    this.requiresPath = false,
+  }) : children = List.unmodifiable(children) {
+    if (children.isEmpty) throw ArgumentError.value(children, 'children');
+    if (threshold < 1 || threshold > children.length) {
+      throw ArgumentError.value(threshold, 'threshold');
+    }
+  }
+
+  bool get requiresSelection => requiresPath && threshold < children.length;
+}

--- a/lib/core/wallet/domain/entities/bitcoin_policy_path.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy_path.dart
@@ -1,0 +1,95 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+
+final class BitcoinPolicyPathRequirement {
+  final BitcoinPolicyKeychain keychain;
+  final String nodePath;
+  final int threshold;
+  final List<BitcoinPolicyNode> options;
+
+  BitcoinPolicyPathRequirement({
+    required this.keychain,
+    required this.nodePath,
+    required this.threshold,
+    required List<BitcoinPolicyNode> options,
+  }) : options = List.unmodifiable(options);
+}
+
+final class BitcoinPolicySelection {
+  final Map<String, List<int>> choices;
+
+  const BitcoinPolicySelection.empty() : choices = const {};
+
+  BitcoinPolicySelection({required Map<String, List<int>> choices})
+    : choices = Map<String, List<int>>.unmodifiable(
+        choices.map((key, value) {
+          if (value.any((index) => index < 0) ||
+              value.toSet().length != value.length) {
+            throw ArgumentError.value(value, key);
+          }
+          final sorted = [...value]..sort();
+          return MapEntry(key, List<int>.unmodifiable(sorted));
+        }),
+      );
+
+  List<int>? choiceFor({
+    required BitcoinPolicyKeychain keychain,
+    required String nodePath,
+  }) => choices['${keychain.name}:$nodePath'];
+
+  bool hasSameChoices(BitcoinPolicySelection other) {
+    if (choices.length != other.choices.length) return false;
+    for (final entry in choices.entries) {
+      final otherChoice = other.choices[entry.key];
+      if (otherChoice == null || otherChoice.length != entry.value.length) {
+        return false;
+      }
+      for (var index = 0; index < entry.value.length; index++) {
+        if (entry.value[index] != otherChoice[index]) return false;
+      }
+    }
+    return true;
+  }
+
+  BitcoinPolicySelection withChoice({
+    required BitcoinPolicyKeychain keychain,
+    required String nodePath,
+    required Iterable<int> selectedIndices,
+  }) {
+    final selected = selectedIndices.toSet().toList()..sort();
+    if (selected.any((index) => index < 0)) {
+      throw ArgumentError.value(selectedIndices, 'selectedIndices');
+    }
+    return BitcoinPolicySelection(
+      choices: {...choices, '${keychain.name}:$nodePath': selected},
+    );
+  }
+}
+
+final class BitcoinPolicyPath {
+  final Map<String, List<int>> external;
+  final Map<String, List<int>> internal;
+  final bool requiresRelativeTimelock;
+  final Set<String>? eligibleExternalOutpoints;
+  final Set<String>? eligibleInternalOutpoints;
+
+  BitcoinPolicyPath({
+    required Map<String, List<int>> external,
+    required Map<String, List<int>> internal,
+    required this.requiresRelativeTimelock,
+    Set<String>? eligibleExternalOutpoints,
+    Set<String>? eligibleInternalOutpoints,
+  }) : external = Map<String, List<int>>.unmodifiable({
+         for (final entry in external.entries)
+           entry.key: List<int>.unmodifiable(entry.value),
+       }),
+       internal = Map<String, List<int>>.unmodifiable({
+         for (final entry in internal.entries)
+           entry.key: List<int>.unmodifiable(entry.value),
+       }),
+       eligibleExternalOutpoints = eligibleExternalOutpoints == null
+           ? null
+           : Set.unmodifiable(eligibleExternalOutpoints),
+       eligibleInternalOutpoints = eligibleInternalOutpoints == null
+           ? null
+           : Set.unmodifiable(eligibleInternalOutpoints);
+}

--- a/lib/core/wallet/domain/entities/bitcoin_psbt_review.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_psbt_review.dart
@@ -1,0 +1,269 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_maturity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+
+final class BitcoinPsbtInputReview {
+  final String outpoint;
+  final BigInt amountSat;
+  final BitcoinPolicyKeychain? keychain;
+  final Set<String> localDescriptorKeyIds;
+  final int sequence;
+  final Set<String> signedDescriptorKeyIds;
+
+  BitcoinPsbtInputReview({
+    required this.outpoint,
+    required this.amountSat,
+    required this.keychain,
+    Set<String> localDescriptorKeyIds = const {},
+    required this.sequence,
+    Set<String> signedDescriptorKeyIds = const {},
+  }) : localDescriptorKeyIds = Set.unmodifiable(localDescriptorKeyIds),
+       signedDescriptorKeyIds = Set.unmodifiable(signedDescriptorKeyIds) {
+    if (outpoint.isEmpty) throw ArgumentError.value(outpoint, 'outpoint');
+    if (amountSat < BigInt.zero) {
+      throw ArgumentError.value(amountSat, 'amountSat');
+    }
+    if (sequence < 0 || sequence > 0xffffffff) {
+      throw ArgumentError.value(sequence, 'sequence');
+    }
+  }
+
+  bool get hasLocalSignerOrigin => localDescriptorKeyIds.isNotEmpty;
+}
+
+final class BitcoinPsbtOutputReview {
+  final int index;
+  final BigInt amountSat;
+  final String? address;
+  final String scriptHex;
+  final bool isWalletOwned;
+
+  BitcoinPsbtOutputReview({
+    required this.index,
+    required this.amountSat,
+    required this.address,
+    required this.scriptHex,
+    required this.isWalletOwned,
+  }) {
+    if (index < 0) throw ArgumentError.value(index, 'index');
+    if (amountSat < BigInt.zero) {
+      throw ArgumentError.value(amountSat, 'amountSat');
+    }
+    if (scriptHex.isEmpty) throw ArgumentError.value(scriptHex, 'scriptHex');
+  }
+}
+
+final class BitcoinPsbtReview {
+  final String transactionId;
+  final List<BitcoinPsbtInputReview> inputs;
+  final List<BitcoinPsbtOutputReview> outputs;
+  final BigInt feeSat;
+  final int estimatedTransactionVsize;
+  final int lockTime;
+  final int version;
+
+  BitcoinPsbtReview({
+    required this.transactionId,
+    required List<BitcoinPsbtInputReview> inputs,
+    required List<BitcoinPsbtOutputReview> outputs,
+    required this.feeSat,
+    required this.estimatedTransactionVsize,
+    required this.lockTime,
+    required this.version,
+  }) : inputs = List.unmodifiable(inputs),
+       outputs = List.unmodifiable(outputs) {
+    if (transactionId.isEmpty) {
+      throw ArgumentError.value(transactionId, 'transactionId');
+    }
+    if (inputs.isEmpty) throw ArgumentError.value(inputs, 'inputs');
+    if (outputs.isEmpty) throw ArgumentError.value(outputs, 'outputs');
+    if (feeSat < BigInt.zero) throw ArgumentError.value(feeSat, 'feeSat');
+    if (estimatedTransactionVsize <= 0) {
+      throw ArgumentError.value(
+        estimatedTransactionVsize,
+        'estimatedTransactionVsize',
+      );
+    }
+    if (lockTime < 0 || lockTime > 0xffffffff) {
+      throw ArgumentError.value(lockTime, 'lockTime');
+    }
+  }
+
+  List<BitcoinPsbtOutputReview> get recipients =>
+      outputs.where((output) => !output.isWalletOwned).toList(growable: false);
+
+  List<BitcoinPsbtOutputReview> get walletOwnedOutputs =>
+      outputs.where((output) => output.isWalletOwned).toList(growable: false);
+
+  BigInt get recipientAmountSat =>
+      recipients.fold(BigInt.zero, (total, output) => total + output.amountSat);
+
+  double get estimatedFeeRateSatPerVbyte =>
+      feeSat.toDouble() / estimatedTransactionVsize;
+
+  Set<String> get outpoints =>
+      Set.unmodifiable(inputs.map((input) => input.outpoint));
+
+  Set<String> get signedDescriptorKeyIds {
+    if (inputs.isEmpty) return const {};
+    return Set.unmodifiable(
+      inputs
+          .map((input) => input.signedDescriptorKeyIds)
+          .reduce((signed, next) => signed.intersection(next)),
+    );
+  }
+
+  Map<BitcoinPolicyKeychain, Set<String>>
+  get signedDescriptorKeyIdsByKeychain => Map.unmodifiable({
+    for (final keychain in BitcoinPolicyKeychain.values)
+      if (inputs.any((input) => input.keychain == keychain))
+        keychain: Set.unmodifiable(
+          inputs
+              .where((input) => input.keychain == keychain)
+              .map((input) => input.signedDescriptorKeyIds)
+              .reduce((signed, next) => signed.intersection(next)),
+        ),
+  });
+
+  Map<String, Set<String>> get signedDescriptorKeyIdsByOutpoint =>
+      Map.unmodifiable({
+        for (final input in inputs)
+          input.outpoint: Set.unmodifiable(input.signedDescriptorKeyIds),
+      });
+
+  bool get hasTimingConstraint =>
+      _hasAbsoluteTimingConstraint ||
+      (version >= 2 &&
+          inputs.any((input) => _relativeValue(input.sequence) > 0));
+
+  bool get hasTimeBasedTimingConstraint =>
+      (_hasAbsoluteTimingConstraint && lockTime >= 500000000) ||
+      (version >= 2 &&
+          inputs.any(
+            (input) =>
+                _relativeValue(input.sequence) > 0 &&
+                input.sequence & _sequenceTypeFlag != 0,
+          ));
+
+  bool timingIsSatisfied(BitcoinPolicyMaturity maturity) {
+    if (!hasTimingConstraint) return true;
+    if (!maturity.isKnown) return false;
+
+    if (_hasAbsoluteTimingConstraint) {
+      final absoluteSatisfied = lockTime < 500000000
+          ? maturity.tipHeight >= lockTime
+          : maturity.medianTimePast != null &&
+                maturity.medianTimePast! > lockTime;
+      if (!absoluteSatisfied) return false;
+    }
+
+    if (version < 2) return true;
+    final maturityByOutpoint = {
+      for (final utxo in maturity.utxos) utxo.outpoint: utxo,
+    };
+    for (final input in inputs) {
+      final value = _relativeValue(input.sequence);
+      if (value == 0) continue;
+      final utxo = maturityByOutpoint[input.outpoint];
+      if (utxo == null) return false;
+      if (input.sequence & _sequenceTypeFlag == 0) {
+        if (utxo.confirmations < value) return false;
+      } else {
+        final confirmationTime = utxo.confirmationMedianTimePast;
+        final currentTime = maturity.medianTimePast;
+        if (confirmationTime == null ||
+            currentTime == null ||
+            currentTime < confirmationTime + value * 512) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  BitcoinPolicyActivation? blockingTimingActivation(
+    BitcoinPolicyMaturity maturity,
+  ) {
+    if (!hasTimingConstraint || !maturity.isKnown) return null;
+
+    final activations = <BitcoinPolicyActivation>[];
+    if (_hasAbsoluteTimingConstraint) {
+      if (lockTime < 500000000 && maturity.tipHeight < lockTime) {
+        activations.add(
+          BitcoinPolicyActivation(
+            type: BitcoinPolicyActivationType.absoluteBlock,
+            value: lockTime,
+            estimatedSecondsFromNow: (lockTime - maturity.tipHeight) * 600,
+          ),
+        );
+      } else if (lockTime >= 500000000) {
+        final medianTimePast = maturity.medianTimePast;
+        if (medianTimePast == null) return null;
+        if (medianTimePast <= lockTime) {
+          activations.add(
+            BitcoinPolicyActivation(
+              type: BitcoinPolicyActivationType.absoluteTime,
+              value: lockTime,
+              estimatedSecondsFromNow: lockTime - medianTimePast + 1,
+            ),
+          );
+        }
+      }
+    }
+
+    if (version >= 2) {
+      final maturityByOutpoint = {
+        for (final utxo in maturity.utxos) utxo.outpoint: utxo,
+      };
+      for (final input in inputs) {
+        final value = _relativeValue(input.sequence);
+        if (value == 0) continue;
+        final utxo = maturityByOutpoint[input.outpoint];
+        if (utxo == null) return null;
+        if (input.sequence & _sequenceTypeFlag == 0) {
+          final remainingBlocks = value - utxo.confirmations;
+          if (remainingBlocks > 0) {
+            activations.add(
+              BitcoinPolicyActivation(
+                type: BitcoinPolicyActivationType.relativeBlocks,
+                value: remainingBlocks,
+                estimatedSecondsFromNow: remainingBlocks * 600,
+              ),
+            );
+          }
+        } else {
+          final confirmationTime = utxo.confirmationMedianTimePast;
+          final medianTimePast = maturity.medianTimePast;
+          if (confirmationTime == null || medianTimePast == null) return null;
+          final target = confirmationTime + value * 512;
+          if (medianTimePast < target) {
+            activations.add(
+              BitcoinPolicyActivation(
+                type: BitcoinPolicyActivationType.relativeTime,
+                value: target,
+                estimatedSecondsFromNow: target - medianTimePast,
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    if (activations.isEmpty) return null;
+    return activations.reduce(
+      (latest, activation) =>
+          activation.estimatedSecondsFromNow > latest.estimatedSecondsFromNow
+          ? activation
+          : latest,
+    );
+  }
+
+  bool get _hasAbsoluteTimingConstraint =>
+      lockTime > 0 && inputs.any((input) => input.sequence != 0xffffffff);
+}
+
+const _sequenceDisableFlag = 1 << 31;
+const _sequenceTypeFlag = 1 << 22;
+const _sequenceValueMask = 0xffff;
+
+int _relativeValue(int sequence) =>
+    sequence & _sequenceDisableFlag != 0 ? 0 : sequence & _sequenceValueMask;

--- a/lib/core/wallet/domain/entities/bitcoin_signing_plan.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_signing_plan.dart
@@ -1,0 +1,346 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_path.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_wallet_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+
+final class BitcoinSigningPlan {
+  final BitcoinWalletPolicy policy;
+  final BitcoinPolicySelection selection;
+  final bool canFinalizeLocally;
+  final Map<BitcoinPolicyKeychain, Set<String>>
+  signedDescriptorKeyIdsByKeychain;
+  final Map<String, Set<String>> signedDescriptorKeyIdsByOutpoint;
+  final Map<String, BitcoinPolicyKeychain> inputKeychainsByOutpoint;
+  final Set<BitcoinPolicyKeychain> inputKeychains;
+  final Set<String> satisfiedPreimageKeys;
+  final List<WalletSigner> eligibleSigners;
+
+  const BitcoinSigningPlan._({
+    required this.policy,
+    this.selection = const BitcoinPolicySelection.empty(),
+    required this.canFinalizeLocally,
+    this.signedDescriptorKeyIdsByKeychain = const {},
+    this.signedDescriptorKeyIdsByOutpoint = const {},
+    this.inputKeychainsByOutpoint = const {},
+    this.inputKeychains = const {
+      BitcoinPolicyKeychain.external,
+      BitcoinPolicyKeychain.internal,
+    },
+    this.satisfiedPreimageKeys = const {},
+    this.eligibleSigners = const [],
+  });
+
+  factory BitcoinSigningPlan.fromPolicy({
+    required BitcoinWalletPolicy policy,
+    required List<WalletSigner> signers,
+    BitcoinPolicySelection selection = const BitcoinPolicySelection.empty(),
+    Map<BitcoinPolicyKeychain, Set<String>> signedDescriptorKeyIdsByKeychain =
+        const {},
+    Map<String, Set<String>> signedDescriptorKeyIdsByOutpoint = const {},
+    Map<String, BitcoinPolicyKeychain> inputKeychainsByOutpoint = const {},
+    Set<BitcoinPolicyKeychain>? inputKeychains,
+    Set<String> satisfiedPreimageKeys = const {},
+  }) {
+    final selectionComplete = policy.pathRequirements(selection).isEmpty;
+    final usedKeychains = inputKeychains == null || inputKeychains.isEmpty
+        ? const {BitcoinPolicyKeychain.external, BitcoinPolicyKeychain.internal}
+        : Set<BitcoinPolicyKeychain>.unmodifiable(inputKeychains);
+    final requiredKeys = policy.signatureKeys(
+      selection,
+      keychains: usedKeychains,
+    );
+    final eligibleSigners = [
+      for (final signer in signers)
+        if (signer.descriptorKeys.any(
+          (descriptorKey) =>
+              requiredKeys.any((key) => key.matches(descriptorKey)),
+        ))
+          signer,
+    ];
+    final signedByKeychain = <BitcoinPolicyKeychain, Set<String>>{
+      for (final keychain in usedKeychains)
+        keychain: Set.unmodifiable(
+          signedDescriptorKeyIdsByKeychain[keychain] ?? const {},
+        ),
+    };
+    final signedByOutpoint = {
+      for (final entry in signedDescriptorKeyIdsByOutpoint.entries)
+        entry.key: Set.unmodifiable(entry.value),
+    };
+    final inputEvidence = inputKeychainsByOutpoint.isEmpty
+        ? [
+            for (final keychain in usedKeychains)
+              (
+                keychain: keychain,
+                signedDescriptorKeyIds: signedByKeychain[keychain] ?? const {},
+              ),
+          ]
+        : [
+            for (final entry in inputKeychainsByOutpoint.entries)
+              (
+                keychain: entry.value,
+                signedDescriptorKeyIds: signedByOutpoint[entry.key] ?? const {},
+              ),
+          ];
+    bool descriptorKeyIsSigned(
+      WalletDescriptorKey descriptorKey,
+      _InputSigningEvidence evidence,
+    ) => evidence.signedDescriptorKeyIds.contains(descriptorKey.id);
+    bool keyIsLocalOrSigned(
+      BitcoinPolicyKey key,
+      _InputSigningEvidence evidence,
+    ) => eligibleSigners.any(
+      (signer) => signer.descriptorKeys.any(
+        (descriptorKey) =>
+            key.matches(descriptorKey) &&
+            (descriptorKeyIsSigned(descriptorKey, evidence) ||
+                signer.signer == SignerEntity.local),
+      ),
+    );
+    final canFinalizeLocally =
+        selectionComplete &&
+        inputEvidence.every(
+          (evidence) => policy.canBeSatisfiedBy(
+            selection: selection,
+            keychains: {evidence.keychain},
+            hasSignature: (key) => keyIsLocalOrSigned(key, evidence),
+            hasPreimage: (hashlock) => satisfiedPreimageKeys.contains(
+              '${hashlock.type.name}:${hashlock.hash.toLowerCase()}',
+            ),
+          ),
+        );
+
+    return BitcoinSigningPlan._(
+      policy: policy,
+      selection: selection,
+      canFinalizeLocally: canFinalizeLocally,
+      signedDescriptorKeyIdsByKeychain: Map.unmodifiable(signedByKeychain),
+      signedDescriptorKeyIdsByOutpoint: Map.unmodifiable(signedByOutpoint),
+      inputKeychainsByOutpoint: Map.unmodifiable(inputKeychainsByOutpoint),
+      inputKeychains: usedKeychains,
+      satisfiedPreimageKeys: Set.unmodifiable(satisfiedPreimageKeys),
+      eligibleSigners: List.unmodifiable(eligibleSigners),
+    );
+  }
+
+  bool get isSatisfied =>
+      policy.pathRequirements(selection).isEmpty &&
+      _inputEvidence.every(
+        (evidence) => policy.canBeSatisfiedBy(
+          selection: selection,
+          keychains: {evidence.keychain},
+          hasSignature: (key) => eligibleSigners.any(
+            (signer) => signer.descriptorKeys.any(
+              (descriptorKey) =>
+                  key.matches(descriptorKey) &&
+                  evidence.signedDescriptorKeyIds.contains(descriptorKey.id),
+            ),
+          ),
+          hasPreimage: (hashlock) => satisfiedPreimageKeys.contains(
+            '${hashlock.type.name}:${hashlock.hash.toLowerCase()}',
+          ),
+        ),
+      );
+
+  bool get requiresExternalSigning {
+    if (isSatisfied) return false;
+    final localSignerIds = {
+      for (final signer in eligibleSigners)
+        if (signer.signer == SignerEntity.local) signer.id,
+    };
+    final solutions = _policySignerSets(
+      policy: policy,
+      selection: selection,
+      signers: eligibleSigners,
+      inputEvidence: _inputEvidence,
+    );
+    return solutions.isNotEmpty && !solutions.any(localSignerIds.containsAll);
+  }
+
+  List<BitcoinHashlockPolicyNode> get missingPreimages {
+    if (isSatisfied) return const [];
+    return List.unmodifiable(
+      policy
+          .requiredHashlocks(selection)
+          .where(
+            (hashlock) => !satisfiedPreimageKeys.contains(
+              '${hashlock.type.name}:${hashlock.hash.toLowerCase()}',
+            ),
+          ),
+    );
+  }
+
+  int get signersNeeded {
+    if (isSatisfied) return 0;
+    final solutions = _policySignerSets(
+      policy: policy,
+      selection: selection,
+      signers: eligibleSigners,
+      inputEvidence: _inputEvidence,
+    );
+    if (solutions.isEmpty) return eligibleSigners.length;
+    return solutions
+        .map((solution) => solution.length)
+        .reduce((smallest, count) => count < smallest ? count : smallest);
+  }
+
+  bool requires(WalletSigner signer) =>
+      eligibleSigners.any((eligible) => eligible.id == signer.id);
+
+  bool isSigned(WalletSigner signer) {
+    var hasRelevantKey = false;
+    for (final evidence in _inputEvidence) {
+      final relevant = _relevantDescriptorKeys(
+        policy: policy,
+        selection: selection,
+        signer: signer,
+        keychain: evidence.keychain,
+      );
+      if (relevant.isEmpty) continue;
+      hasRelevantKey = true;
+      if (!relevant.every(
+        (key) => evidence.signedDescriptorKeyIds.contains(key.id),
+      )) {
+        return false;
+      }
+    }
+    return hasRelevantKey;
+  }
+
+  List<_InputSigningEvidence> get _inputEvidence =>
+      inputKeychainsByOutpoint.isEmpty
+      ? [
+          for (final keychain in inputKeychains)
+            (
+              keychain: keychain,
+              signedDescriptorKeyIds:
+                  signedDescriptorKeyIdsByKeychain[keychain] ?? const {},
+            ),
+        ]
+      : [
+          for (final entry in inputKeychainsByOutpoint.entries)
+            (
+              keychain: entry.value,
+              signedDescriptorKeyIds:
+                  signedDescriptorKeyIdsByOutpoint[entry.key] ?? const {},
+            ),
+        ];
+}
+
+List<WalletDescriptorKey> _relevantDescriptorKeys({
+  required BitcoinWalletPolicy policy,
+  required BitcoinPolicySelection selection,
+  required WalletSigner signer,
+  required BitcoinPolicyKeychain keychain,
+}) => [
+  for (final descriptorKey in signer.descriptorKeys)
+    if (policy
+        .signatureKeys(selection, keychains: {keychain})
+        .any((key) => key.matches(descriptorKey)))
+      descriptorKey,
+];
+
+typedef _InputSigningEvidence = ({
+  BitcoinPolicyKeychain keychain,
+  Set<String> signedDescriptorKeyIds,
+});
+
+List<Set<String>> _policySignerSets({
+  required BitcoinWalletPolicy policy,
+  required BitcoinPolicySelection selection,
+  required List<WalletSigner> signers,
+  required List<_InputSigningEvidence> inputEvidence,
+}) {
+  var solutions = <Set<String>>[<String>{}];
+  for (final evidence in inputEvidence) {
+    solutions = _mergeSignerSets(
+      solutions,
+      _nodeSignerSets(
+        node: switch (evidence.keychain) {
+          BitcoinPolicyKeychain.external => policy.external.root,
+          BitcoinPolicyKeychain.internal => policy.internal.root,
+        },
+        keychain: evidence.keychain,
+        nodePath: 'root',
+        selection: selection,
+        signers: signers,
+        signedDescriptorKeyIds: evidence.signedDescriptorKeyIds,
+      ),
+    );
+  }
+  return solutions;
+}
+
+List<Set<String>> _nodeSignerSets({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required List<WalletSigner> signers,
+  required Set<String> signedDescriptorKeyIds,
+}) {
+  if (node is BitcoinSignaturePolicyNode) {
+    final matching = [
+      for (final signer in signers)
+        for (final descriptorKey in signer.descriptorKeys)
+          if (node.key.matches(descriptorKey)) (signer, descriptorKey),
+    ];
+    if (matching.any((match) => signedDescriptorKeyIds.contains(match.$2.id))) {
+      return [<String>{}];
+    }
+    return _minimalSignerSets([
+      for (final match in matching) {match.$1.id},
+    ]);
+  }
+  if (node is! BitcoinThresholdPolicyNode) return [<String>{}];
+
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected ?? Iterable.generate(node.children.length);
+  final combinations = List.generate(node.threshold + 1, (_) => <Set<String>>[])
+    ..[0].add(<String>{});
+  for (final index in childIndices) {
+    final childSets = _nodeSignerSets(
+      node: node.children[index],
+      keychain: keychain,
+      nodePath: '$nodePath/$index',
+      selection: selection,
+      signers: signers,
+      signedDescriptorKeyIds: signedDescriptorKeyIds,
+    );
+    for (var count = node.threshold - 1; count >= 0; count--) {
+      if (combinations[count].isEmpty || childSets.isEmpty) continue;
+      combinations[count + 1] = _minimalSignerSets([
+        ...combinations[count + 1],
+        for (final existing in combinations[count])
+          for (final child in childSets) {...existing, ...child},
+      ]);
+    }
+  }
+  return combinations[node.threshold];
+}
+
+List<Set<String>> _mergeSignerSets(
+  List<Set<String>> first,
+  List<Set<String>> second,
+) {
+  if (first.isEmpty || second.isEmpty) return const [];
+  return _minimalSignerSets([
+    for (final left in first)
+      for (final right in second) {...left, ...right},
+  ]);
+}
+
+List<Set<String>> _minimalSignerSets(Iterable<Set<String>> candidates) {
+  final ordered = candidates.toList()
+    ..sort((first, second) => first.length.compareTo(second.length));
+  final minimal = <Set<String>>[];
+  for (final candidate in ordered) {
+    if (minimal.any(candidate.containsAll)) continue;
+    minimal.add(Set.unmodifiable(candidate));
+  }
+  return List.unmodifiable(minimal);
+}

--- a/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
@@ -1,0 +1,1041 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_maturity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_node.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_path.dart';
+
+final class BitcoinSpendingPolicy {
+  final BitcoinPolicyNode root;
+  final bool requiresPath;
+
+  const BitcoinSpendingPolicy({required this.root, required this.requiresPath});
+}
+
+final class BitcoinWalletPolicy {
+  final BitcoinSpendingPolicy external;
+  final BitcoinSpendingPolicy internal;
+
+  const BitcoinWalletPolicy({required this.external, required this.internal});
+
+  bool get requiresPath => external.requiresPath || internal.requiresPath;
+
+  bool get hasTimelock =>
+      _containsTimelock(external.root) || _containsTimelock(internal.root);
+
+  bool get hasHashlock =>
+      _containsHashlock(external.root) || _containsHashlock(internal.root);
+
+  bool get hasTimeBasedTimelock =>
+      _containsTimeBasedTimelock(external.root) ||
+      _containsTimeBasedTimelock(internal.root);
+
+  List<BitcoinPolicyPathRequirement> pathRequirements(
+    BitcoinPolicySelection selection,
+  ) => _rawPathSelectors(selection)
+      .where((requirement) {
+        final choice = selection.choiceFor(
+          keychain: requirement.keychain,
+          nodePath: requirement.nodePath,
+        );
+        return choice == null ||
+            choice.length != requirement.threshold ||
+            choice.any((index) => index >= requirement.options.length);
+      })
+      .toList(growable: false);
+
+  List<BitcoinPolicyPathRequirement> pathSelectors(
+    BitcoinPolicySelection selection,
+  ) {
+    final selectors = _rawPathSelectors(selection);
+    final externalByPath = {
+      for (final selector in selectors.where(
+        (selector) => selector.keychain == BitcoinPolicyKeychain.external,
+      ))
+        selector.nodePath: selector,
+    };
+    return List.unmodifiable(
+      selectors.where((selector) {
+        if (selector.keychain == BitcoinPolicyKeychain.external) return true;
+        final externalSelector = externalByPath[selector.nodePath];
+        return externalSelector == null ||
+            !_sameRequirementShape(externalSelector, selector);
+      }),
+    );
+  }
+
+  BitcoinPolicyOptionStatus optionStatus({
+    required BitcoinPolicyPathRequirement requirement,
+    required int optionIndex,
+    required BitcoinPolicySelection selection,
+    required BitcoinPolicyMaturity maturity,
+    Set<String> selectedOutpoints = const {},
+  }) {
+    if (optionIndex < 0 || optionIndex >= requirement.options.length) {
+      throw ArgumentError.value(optionIndex, 'optionIndex');
+    }
+    if (!maturity.isKnown) {
+      return BitcoinPolicyOptionStatus(
+        available: true,
+        availableAmountSat: BigInt.zero,
+        activatingAmountSat: BigInt.zero,
+      );
+    }
+
+    final optionNodes = <BitcoinPolicyKeychain, BitcoinPolicyNode>{
+      requirement.keychain: requirement.options[optionIndex],
+    };
+    final otherKeychain = switch (requirement.keychain) {
+      BitcoinPolicyKeychain.external => BitcoinPolicyKeychain.internal,
+      BitcoinPolicyKeychain.internal => BitcoinPolicyKeychain.external,
+    };
+    final otherNode = _nodeAtPath(switch (otherKeychain) {
+      BitcoinPolicyKeychain.external => external.root,
+      BitcoinPolicyKeychain.internal => internal.root,
+    }, requirement.nodePath);
+    if (otherNode is BitcoinThresholdPolicyNode &&
+        otherNode.requiresSelection &&
+        requirement.threshold == otherNode.threshold &&
+        _samePolicyOptions(requirement.options, otherNode.children)) {
+      optionNodes[otherKeychain] = otherNode.children[optionIndex];
+    }
+
+    final statuses =
+        <({BitcoinPolicyUtxoMaturity utxo, _NodeMaturity status})>[];
+    for (final utxo in maturity.utxos) {
+      if (selectedOutpoints.isNotEmpty &&
+          !selectedOutpoints.contains(utxo.outpoint)) {
+        continue;
+      }
+      final option = optionNodes[utxo.keychain];
+      if (option == null) continue;
+      statuses.add((
+        utxo: utxo,
+        status: _nodeMaturity(
+          node: option,
+          keychain: utxo.keychain,
+          nodePath: '${requirement.nodePath}/$optionIndex',
+          selection: selection,
+          maturity: maturity,
+          utxo: utxo,
+        ),
+      ));
+    }
+
+    if (statuses.isEmpty) {
+      return BitcoinPolicyOptionStatus(
+        available: false,
+        availableAmountSat: BigInt.zero,
+        activatingAmountSat: BigInt.zero,
+      );
+    }
+
+    final requireEveryUtxo = selectedOutpoints.isNotEmpty;
+    final hasEverySelectedUtxo =
+        !requireEveryUtxo ||
+        statuses
+            .map((entry) => entry.utxo.outpoint)
+            .toSet()
+            .containsAll(selectedOutpoints);
+    final available = requireEveryUtxo
+        ? hasEverySelectedUtxo &&
+              statuses.every((entry) => entry.status.available)
+        : statuses.any((entry) => entry.status.available);
+    final availableAmountSat = statuses
+        .where((entry) => entry.status.available)
+        .fold(BigInt.zero, (sum, entry) => sum + entry.utxo.amountSat);
+    final activations = statuses
+        .map((entry) => entry.status.activation)
+        .whereType<BitcoinPolicyActivation>()
+        .toList();
+    final hasUnknownRequiredActivation =
+        requireEveryUtxo &&
+        (!hasEverySelectedUtxo ||
+            statuses.any(
+              (entry) =>
+                  !entry.status.available && entry.status.activation == null,
+            ));
+    final activation = hasUnknownRequiredActivation || activations.isEmpty
+        ? null
+        : requireEveryUtxo
+        ? _latestActivation(activations)
+        : _earliestActivation(activations);
+    final activatingAmountSat = activation == null
+        ? BigInt.zero
+        : requireEveryUtxo
+        ? statuses.fold(BigInt.zero, (sum, entry) => sum + entry.utxo.amountSat)
+        : statuses
+              .where(
+                (entry) => _sameActivation(entry.status.activation, activation),
+              )
+              .fold(BigInt.zero, (sum, entry) => sum + entry.utxo.amountSat);
+    return BitcoinPolicyOptionStatus(
+      available: available,
+      availableAmountSat: availableAmountSat,
+      activatingAmountSat: activatingAmountSat,
+      activation: activation,
+    );
+  }
+
+  bool selectionIsAvailable({
+    required BitcoinPolicySelection selection,
+    required BitcoinPolicyMaturity maturity,
+    Set<String> selectedOutpoints = const {},
+  }) {
+    if (pathRequirements(selection).isNotEmpty) return false;
+    if (!maturity.isKnown) return true;
+    final candidates = maturity.utxos
+        .where(
+          (utxo) =>
+              selectedOutpoints.isEmpty ||
+              selectedOutpoints.contains(utxo.outpoint),
+        )
+        .toList();
+    if (candidates.isEmpty) return false;
+    if (selectedOutpoints.isNotEmpty &&
+        !candidates
+            .map((utxo) => utxo.outpoint)
+            .toSet()
+            .containsAll(selectedOutpoints)) {
+      return false;
+    }
+
+    bool isAvailable(BitcoinPolicyUtxoMaturity utxo) => _nodeMaturity(
+      node: switch (utxo.keychain) {
+        BitcoinPolicyKeychain.external => external.root,
+        BitcoinPolicyKeychain.internal => internal.root,
+      },
+      keychain: utxo.keychain,
+      nodePath: 'root',
+      selection: selection,
+      maturity: maturity,
+      utxo: utxo,
+    ).available;
+
+    return selectedOutpoints.isEmpty
+        ? candidates.any(isAvailable)
+        : candidates.every(isAvailable);
+  }
+
+  BitcoinPolicyActivation? nextActivation({
+    required BitcoinPolicySelection selection,
+    required BitcoinPolicyMaturity maturity,
+    Set<String> selectedOutpoints = const {},
+  }) {
+    final candidates = maturity.utxos
+        .where(
+          (utxo) =>
+              selectedOutpoints.isEmpty ||
+              selectedOutpoints.contains(utxo.outpoint),
+        )
+        .toList();
+    if (selectedOutpoints.isNotEmpty &&
+        candidates.length != selectedOutpoints.length) {
+      return null;
+    }
+    final statuses = [
+      for (final utxo in candidates)
+        _nodeMaturity(
+          node: switch (utxo.keychain) {
+            BitcoinPolicyKeychain.external => external.root,
+            BitcoinPolicyKeychain.internal => internal.root,
+          },
+          keychain: utxo.keychain,
+          nodePath: 'root',
+          selection: selection,
+          maturity: maturity,
+          utxo: utxo,
+        ),
+    ];
+    if (selectedOutpoints.isNotEmpty &&
+        statuses.any(
+          (status) => !status.available && status.activation == null,
+        )) {
+      return null;
+    }
+    final activations = [
+      for (final status in statuses)
+        if (!status.available && status.activation != null) status.activation!,
+    ];
+    if (activations.isEmpty) return null;
+    return selectedOutpoints.isNotEmpty
+        ? _latestActivation(activations)
+        : _earliestActivation(activations);
+  }
+
+  List<BitcoinPolicyPathRequirement> _rawPathSelectors(
+    BitcoinPolicySelection selection,
+  ) {
+    _validateSelection(selection);
+    final selectors = <BitcoinPolicyPathRequirement>[];
+    if (external.requiresPath) {
+      _collectPathSelectors(
+        node: external.root,
+        keychain: BitcoinPolicyKeychain.external,
+        nodePath: 'root',
+        selection: selection,
+        selectors: selectors,
+      );
+    }
+    if (internal.requiresPath) {
+      _collectPathSelectors(
+        node: internal.root,
+        keychain: BitcoinPolicyKeychain.internal,
+        nodePath: 'root',
+        selection: selection,
+        selectors: selectors,
+      );
+    }
+    return List.unmodifiable(selectors);
+  }
+
+  void _validateSelection(BitcoinPolicySelection selection) {
+    for (final entry in selection.choices.entries) {
+      final separator = entry.key.indexOf(':');
+      final keychain = BitcoinPolicyKeychain.values.byName(
+        entry.key.substring(0, separator),
+      );
+      final nodePath = entry.key.substring(separator + 1);
+      final node = _nodeAtPath(switch (keychain) {
+        BitcoinPolicyKeychain.external => external.root,
+        BitcoinPolicyKeychain.internal => internal.root,
+      }, nodePath);
+      if (node is! BitcoinThresholdPolicyNode ||
+          !node.requiresSelection ||
+          entry.value.length > node.threshold ||
+          entry.value.any((index) => index >= node.children.length)) {
+        throw ArgumentError.value(entry.value, entry.key);
+      }
+    }
+  }
+
+  BitcoinPolicySelection select({
+    required BitcoinPolicySelection current,
+    required BitcoinPolicyPathRequirement requirement,
+    required Iterable<int> selectedIndices,
+  }) {
+    final selected = selectedIndices.toSet().toList()..sort();
+    if (selected.length > requirement.threshold ||
+        selected.any((index) => index >= requirement.options.length)) {
+      throw ArgumentError.value(selectedIndices, 'selectedIndices');
+    }
+
+    var updated = current.withChoice(
+      keychain: requirement.keychain,
+      nodePath: requirement.nodePath,
+      selectedIndices: selected,
+    );
+    final otherKeychain = switch (requirement.keychain) {
+      BitcoinPolicyKeychain.external => BitcoinPolicyKeychain.internal,
+      BitcoinPolicyKeychain.internal => BitcoinPolicyKeychain.external,
+    };
+    final otherNode = _nodeAtPath(switch (otherKeychain) {
+      BitcoinPolicyKeychain.external => external.root,
+      BitcoinPolicyKeychain.internal => internal.root,
+    }, requirement.nodePath);
+    if (otherNode is BitcoinThresholdPolicyNode &&
+        otherNode.requiresSelection &&
+        requirement.threshold == otherNode.threshold &&
+        _samePolicyOptions(requirement.options, otherNode.children)) {
+      updated = updated.withChoice(
+        keychain: otherKeychain,
+        nodePath: requirement.nodePath,
+        selectedIndices: selected,
+      );
+    }
+    return updated;
+  }
+
+  BitcoinPolicySelection selectOnlyAvailablePaths({
+    required BitcoinPolicySelection current,
+    required BitcoinPolicyMaturity maturity,
+    Set<String> selectedOutpoints = const {},
+  }) {
+    var updated = current;
+    while (true) {
+      var changed = false;
+      for (final requirement in pathSelectors(updated)) {
+        final availableIndices = [
+          for (final optionIndex in Iterable<int>.generate(
+            requirement.options.length,
+          ))
+            if (optionStatus(
+              requirement: requirement,
+              optionIndex: optionIndex,
+              selection: updated,
+              maturity: maturity,
+              selectedOutpoints: selectedOutpoints,
+            ).available)
+              optionIndex,
+        ];
+        if (availableIndices.length != requirement.threshold) continue;
+
+        final selected = updated.choiceFor(
+          keychain: requirement.keychain,
+          nodePath: requirement.nodePath,
+        );
+        if (_sameIndices(selected, availableIndices)) continue;
+
+        updated = select(
+          current: updated,
+          requirement: requirement,
+          selectedIndices: availableIndices,
+        );
+        changed = true;
+      }
+      if (!changed) return updated;
+    }
+  }
+
+  BitcoinPolicyPath buildPath(
+    BitcoinPolicySelection selection, {
+    BitcoinPolicyMaturity? maturity,
+  }) {
+    final remaining = pathRequirements(selection);
+    if (remaining.isNotEmpty) {
+      throw StateError('Bitcoin policy selection is incomplete');
+    }
+    _validatePairedSelections(selection);
+
+    final externalPath = <String, List<int>>{};
+    final internalPath = <String, List<int>>{};
+    _collectPath(
+      node: external.root,
+      keychain: BitcoinPolicyKeychain.external,
+      nodePath: 'root',
+      selection: selection,
+      path: externalPath,
+    );
+    _collectPath(
+      node: internal.root,
+      keychain: BitcoinPolicyKeychain.internal,
+      nodePath: 'root',
+      selection: selection,
+      path: internalPath,
+    );
+    final eligibleExternalOutpoints = maturity == null || !maturity.isKnown
+        ? null
+        : _eligibleOutpoints(
+            policy: external,
+            keychain: BitcoinPolicyKeychain.external,
+            selection: selection,
+            maturity: maturity,
+          );
+    final eligibleInternalOutpoints = maturity == null || !maturity.isKnown
+        ? null
+        : _eligibleOutpoints(
+            policy: internal,
+            keychain: BitcoinPolicyKeychain.internal,
+            selection: selection,
+            maturity: maturity,
+          );
+    return BitcoinPolicyPath(
+      external: externalPath,
+      internal: internalPath,
+      requiresRelativeTimelock:
+          _containsRelativeTimelock(
+            node: external.root,
+            keychain: BitcoinPolicyKeychain.external,
+            nodePath: 'root',
+            selection: selection,
+          ) ||
+          _containsRelativeTimelock(
+            node: internal.root,
+            keychain: BitcoinPolicyKeychain.internal,
+            nodePath: 'root',
+            selection: selection,
+          ),
+      eligibleExternalOutpoints: eligibleExternalOutpoints,
+      eligibleInternalOutpoints: eligibleInternalOutpoints,
+    );
+  }
+
+  void _validatePairedSelections(BitcoinPolicySelection selection) {
+    final selectors = _rawPathSelectors(selection);
+    final internalByPath = {
+      for (final selector in selectors.where(
+        (selector) => selector.keychain == BitcoinPolicyKeychain.internal,
+      ))
+        selector.nodePath: selector,
+    };
+    for (final external in selectors.where(
+      (selector) => selector.keychain == BitcoinPolicyKeychain.external,
+    )) {
+      final internal = internalByPath[external.nodePath];
+      if (internal == null || !_sameRequirementShape(external, internal)) {
+        continue;
+      }
+      final externalChoice = selection.choiceFor(
+        keychain: BitcoinPolicyKeychain.external,
+        nodePath: external.nodePath,
+      );
+      final internalChoice = selection.choiceFor(
+        keychain: BitcoinPolicyKeychain.internal,
+        nodePath: internal.nodePath,
+      );
+      if (externalChoice == null ||
+          internalChoice == null ||
+          !_sameIndices(externalChoice, internalChoice)) {
+        throw StateError(
+          'Matching receive and change policies require the same selection',
+        );
+      }
+    }
+  }
+
+  bool canBeSatisfiedBy({
+    required BitcoinPolicySelection selection,
+    required bool Function(BitcoinPolicyKey key) hasSignature,
+    bool Function(BitcoinHashlockPolicyNode hashlock) hasPreimage =
+        _hasNoPreimage,
+    Set<BitcoinPolicyKeychain> keychains = const {
+      BitcoinPolicyKeychain.external,
+      BitcoinPolicyKeychain.internal,
+    },
+  }) =>
+      pathRequirements(selection).isEmpty &&
+      (!keychains.contains(BitcoinPolicyKeychain.external) ||
+          _canBeSatisfiedBy(
+            node: external.root,
+            keychain: BitcoinPolicyKeychain.external,
+            nodePath: 'root',
+            selection: selection,
+            hasSignature: hasSignature,
+            hasPreimage: hasPreimage,
+          )) &&
+      (!keychains.contains(BitcoinPolicyKeychain.internal) ||
+          _canBeSatisfiedBy(
+            node: internal.root,
+            keychain: BitcoinPolicyKeychain.internal,
+            nodePath: 'root',
+            selection: selection,
+            hasSignature: hasSignature,
+            hasPreimage: hasPreimage,
+          ));
+
+  List<BitcoinPolicyKey> signatureKeys(
+    BitcoinPolicySelection selection, {
+    Set<BitcoinPolicyKeychain> keychains = const {
+      BitcoinPolicyKeychain.external,
+      BitcoinPolicyKeychain.internal,
+    },
+  }) => List.unmodifiable({
+    if (keychains.contains(BitcoinPolicyKeychain.external))
+      ..._signatureKeys(
+        node: external.root,
+        keychain: BitcoinPolicyKeychain.external,
+        nodePath: 'root',
+        selection: selection,
+      ),
+    if (keychains.contains(BitcoinPolicyKeychain.internal))
+      ..._signatureKeys(
+        node: internal.root,
+        keychain: BitcoinPolicyKeychain.internal,
+        nodePath: 'root',
+        selection: selection,
+      ),
+  });
+
+  List<BitcoinHashlockPolicyNode> requiredHashlocks(
+    BitcoinPolicySelection selection,
+  ) => List.unmodifiable(
+    {
+      for (final hashlock in [
+        ..._hashlocks(
+          node: external.root,
+          keychain: BitcoinPolicyKeychain.external,
+          nodePath: 'root',
+          selection: selection,
+        ),
+        ..._hashlocks(
+          node: internal.root,
+          keychain: BitcoinPolicyKeychain.internal,
+          nodePath: 'root',
+          selection: selection,
+        ),
+      ])
+        '${hashlock.type.name}:${hashlock.hash}': hashlock,
+    }.values,
+  );
+}
+
+final class _NodeMaturity {
+  final bool available;
+  final BitcoinPolicyActivation? activation;
+
+  const _NodeMaturity({required this.available, this.activation});
+}
+
+_NodeMaturity _nodeMaturity({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required BitcoinPolicyMaturity maturity,
+  required BitcoinPolicyUtxoMaturity utxo,
+}) => switch (node) {
+  BitcoinSignaturePolicyNode() => const _NodeMaturity(available: true),
+  BitcoinHashlockPolicyNode() => const _NodeMaturity(available: true),
+  BitcoinAbsoluteTimelockPolicyNode(
+    type: BitcoinAbsoluteTimelockType.blockHeight,
+    :final value,
+  ) =>
+    maturity.tipHeight >= value
+        ? const _NodeMaturity(available: true)
+        : _NodeMaturity(
+            available: false,
+            activation: BitcoinPolicyActivation(
+              type: BitcoinPolicyActivationType.absoluteBlock,
+              value: value,
+              estimatedSecondsFromNow: (value - maturity.tipHeight) * 600,
+            ),
+          ),
+  BitcoinAbsoluteTimelockPolicyNode(:final value) =>
+    maturity.medianTimePast != null && maturity.medianTimePast! > value
+        ? const _NodeMaturity(available: true)
+        : maturity.medianTimePast == null
+        ? const _NodeMaturity(available: false)
+        : _NodeMaturity(
+            available: false,
+            activation: BitcoinPolicyActivation(
+              type: BitcoinPolicyActivationType.absoluteTime,
+              value: value,
+              estimatedSecondsFromNow: (value - maturity.medianTimePast! + 1)
+                  .clamp(0, value + 1),
+            ),
+          ),
+  BitcoinRelativeTimelockPolicyNode(
+    type: BitcoinRelativeTimelockType.blocks,
+    :final value,
+  ) =>
+    utxo.confirmations >= value
+        ? const _NodeMaturity(available: true)
+        : _NodeMaturity(
+            available: false,
+            activation: BitcoinPolicyActivation(
+              type: BitcoinPolicyActivationType.relativeBlocks,
+              value: value - utxo.confirmations,
+              estimatedSecondsFromNow: (value - utxo.confirmations) * 600,
+            ),
+          ),
+  BitcoinRelativeTimelockPolicyNode(:final value) => _relativeTimeMaturity(
+    value: value,
+    maturity: maturity,
+    utxo: utxo,
+  ),
+  BitcoinThresholdPolicyNode() => _thresholdMaturity(
+    node: node,
+    keychain: keychain,
+    nodePath: nodePath,
+    selection: selection,
+    maturity: maturity,
+    utxo: utxo,
+  ),
+};
+
+_NodeMaturity _relativeTimeMaturity({
+  required int value,
+  required BitcoinPolicyMaturity maturity,
+  required BitcoinPolicyUtxoMaturity utxo,
+}) {
+  final confirmationMedianTimePast = utxo.confirmationMedianTimePast;
+  final medianTimePast = maturity.medianTimePast;
+  if (confirmationMedianTimePast == null || medianTimePast == null) {
+    return const _NodeMaturity(available: false);
+  }
+  final target = confirmationMedianTimePast + value;
+  if (medianTimePast >= target) {
+    return const _NodeMaturity(available: true);
+  }
+  return _NodeMaturity(
+    available: false,
+    activation: BitcoinPolicyActivation(
+      type: BitcoinPolicyActivationType.relativeTime,
+      value: target,
+      estimatedSecondsFromNow: target - medianTimePast,
+    ),
+  );
+}
+
+_NodeMaturity _thresholdMaturity({
+  required BitcoinThresholdPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required BitcoinPolicyMaturity maturity,
+  required BitcoinPolicyUtxoMaturity utxo,
+}) {
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected != null && selected.length == node.threshold
+      ? selected
+      : Iterable<int>.generate(node.children.length);
+  final childStatuses = [
+    for (final index in childIndices)
+      _nodeMaturity(
+        node: node.children[index],
+        keychain: keychain,
+        nodePath: '$nodePath/$index',
+        selection: selection,
+        maturity: maturity,
+        utxo: utxo,
+      ),
+  ];
+  final availableCount = childStatuses
+      .where((status) => status.available)
+      .length;
+  if (availableCount >= node.threshold) {
+    return const _NodeMaturity(available: true);
+  }
+  final activations =
+      childStatuses
+          .map((status) => status.activation)
+          .whereType<BitcoinPolicyActivation>()
+          .toList()
+        ..sort(_compareActivations);
+  final needed = node.threshold - availableCount;
+  if (activations.length < needed) {
+    return const _NodeMaturity(available: false);
+  }
+  return _NodeMaturity(available: false, activation: activations[needed - 1]);
+}
+
+Set<String> _eligibleOutpoints({
+  required BitcoinSpendingPolicy policy,
+  required BitcoinPolicyKeychain keychain,
+  required BitcoinPolicySelection selection,
+  required BitcoinPolicyMaturity maturity,
+}) => {
+  for (final utxo in maturity.utxos.where((utxo) => utxo.keychain == keychain))
+    if (_nodeMaturity(
+      node: policy.root,
+      keychain: keychain,
+      nodePath: 'root',
+      selection: selection,
+      maturity: maturity,
+      utxo: utxo,
+    ).available)
+      utxo.outpoint,
+};
+
+int _compareActivations(
+  BitcoinPolicyActivation first,
+  BitcoinPolicyActivation second,
+) => first.estimatedSecondsFromNow.compareTo(second.estimatedSecondsFromNow);
+
+BitcoinPolicyActivation _earliestActivation(
+  List<BitcoinPolicyActivation> activations,
+) => activations.reduce(
+  (first, second) => _compareActivations(first, second) <= 0 ? first : second,
+);
+
+BitcoinPolicyActivation _latestActivation(
+  List<BitcoinPolicyActivation> activations,
+) => activations.reduce(
+  (first, second) => _compareActivations(first, second) >= 0 ? first : second,
+);
+
+bool _sameActivation(
+  BitcoinPolicyActivation? first,
+  BitcoinPolicyActivation second,
+) => first != null && first.type == second.type && first.value == second.value;
+
+bool _containsTimelock(BitcoinPolicyNode node) => switch (node) {
+  BitcoinAbsoluteTimelockPolicyNode() ||
+  BitcoinRelativeTimelockPolicyNode() => true,
+  BitcoinThresholdPolicyNode(:final children) => children.any(
+    _containsTimelock,
+  ),
+  _ => false,
+};
+
+bool _containsHashlock(BitcoinPolicyNode node) => switch (node) {
+  BitcoinHashlockPolicyNode() => true,
+  BitcoinThresholdPolicyNode(:final children) => children.any(
+    _containsHashlock,
+  ),
+  _ => false,
+};
+
+bool _containsTimeBasedTimelock(BitcoinPolicyNode node) => switch (node) {
+  BitcoinAbsoluteTimelockPolicyNode(
+    type: BitcoinAbsoluteTimelockType.timestamp,
+  ) =>
+    true,
+  BitcoinRelativeTimelockPolicyNode(
+    type: BitcoinRelativeTimelockType.seconds,
+  ) =>
+    true,
+  BitcoinThresholdPolicyNode(:final children) => children.any(
+    _containsTimeBasedTimelock,
+  ),
+  _ => false,
+};
+
+void _collectPathSelectors({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required List<BitcoinPolicyPathRequirement> selectors,
+}) {
+  if (node is! BitcoinThresholdPolicyNode || !node.requiresPath) return;
+
+  Iterable<int> childIndices;
+  if (node.requiresSelection) {
+    selectors.add(
+      BitcoinPolicyPathRequirement(
+        keychain: keychain,
+        nodePath: nodePath,
+        threshold: node.threshold,
+        options: node.children,
+      ),
+    );
+    final selected = selection.choiceFor(
+      keychain: keychain,
+      nodePath: nodePath,
+    );
+    if (selected == null ||
+        selected.length != node.threshold ||
+        selected.any((index) => index >= node.children.length)) {
+      return;
+    }
+    childIndices = selected;
+  } else {
+    childIndices = Iterable.generate(node.children.length);
+  }
+
+  for (final index in childIndices) {
+    _collectPathSelectors(
+      node: node.children[index],
+      keychain: keychain,
+      nodePath: '$nodePath/$index',
+      selection: selection,
+      selectors: selectors,
+    );
+  }
+}
+
+void _collectPath({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required Map<String, List<int>> path,
+}) {
+  if (node is! BitcoinThresholdPolicyNode || !node.requiresPath) return;
+
+  final List<int> childIndices = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)!
+      : List<int>.generate(node.children.length, (index) => index);
+  if (node.requiresSelection) path[node.id] = childIndices;
+  for (final index in childIndices) {
+    _collectPath(
+      node: node.children[index],
+      keychain: keychain,
+      nodePath: '$nodePath/$index',
+      selection: selection,
+      path: path,
+    );
+  }
+}
+
+bool _canBeSatisfiedBy({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+  required bool Function(BitcoinPolicyKey key) hasSignature,
+  required bool Function(BitcoinHashlockPolicyNode hashlock) hasPreimage,
+}) {
+  if (node case final BitcoinSignaturePolicyNode signature) {
+    return hasSignature(signature.key);
+  }
+  if (node case final BitcoinHashlockPolicyNode hashlock) {
+    return hasPreimage(hashlock);
+  }
+  if (node is! BitcoinThresholdPolicyNode) return true;
+
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected ?? Iterable.generate(node.children.length);
+  var satisfied = 0;
+  for (final index in childIndices) {
+    if (_canBeSatisfiedBy(
+      node: node.children[index],
+      keychain: keychain,
+      nodePath: '$nodePath/$index',
+      selection: selection,
+      hasSignature: hasSignature,
+      hasPreimage: hasPreimage,
+    )) {
+      satisfied++;
+    }
+  }
+  return satisfied >= node.threshold;
+}
+
+bool _hasNoPreimage(BitcoinHashlockPolicyNode _) => false;
+
+Set<BitcoinPolicyKey> _signatureKeys({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+}) {
+  if (node is BitcoinSignaturePolicyNode) return {node.key};
+  if (node is! BitcoinThresholdPolicyNode) return const {};
+
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected ?? Iterable.generate(node.children.length);
+  return {
+    for (final index in childIndices)
+      ..._signatureKeys(
+        node: node.children[index],
+        keychain: keychain,
+        nodePath: '$nodePath/$index',
+        selection: selection,
+      ),
+  };
+}
+
+Set<BitcoinHashlockPolicyNode> _hashlocks({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+}) {
+  if (node is BitcoinHashlockPolicyNode) return {node};
+  if (node is! BitcoinThresholdPolicyNode) return const {};
+
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected ?? Iterable.generate(node.children.length);
+  return {
+    for (final index in childIndices)
+      ..._hashlocks(
+        node: node.children[index],
+        keychain: keychain,
+        nodePath: '$nodePath/$index',
+        selection: selection,
+      ),
+  };
+}
+
+bool _containsRelativeTimelock({
+  required BitcoinPolicyNode node,
+  required BitcoinPolicyKeychain keychain,
+  required String nodePath,
+  required BitcoinPolicySelection selection,
+}) {
+  if (node is BitcoinRelativeTimelockPolicyNode) return true;
+  if (node is! BitcoinThresholdPolicyNode) return false;
+
+  final selected = node.requiresSelection
+      ? selection.choiceFor(keychain: keychain, nodePath: nodePath)
+      : null;
+  final childIndices = selected ?? Iterable.generate(node.children.length);
+  return childIndices.any(
+    (index) => _containsRelativeTimelock(
+      node: node.children[index],
+      keychain: keychain,
+      nodePath: '$nodePath/$index',
+      selection: selection,
+    ),
+  );
+}
+
+BitcoinPolicyNode? _nodeAtPath(BitcoinPolicyNode root, String nodePath) {
+  if (nodePath == 'root') return root;
+  var node = root;
+  for (final segment in nodePath.split('/').skip(1)) {
+    if (node is! BitcoinThresholdPolicyNode) return null;
+    final index = int.tryParse(segment);
+    if (index == null || index >= node.children.length) return null;
+    node = node.children[index];
+  }
+  return node;
+}
+
+bool _sameSelectionShape(
+  BitcoinThresholdPolicyNode first,
+  BitcoinThresholdPolicyNode second,
+) {
+  if (first.threshold != second.threshold ||
+      first.children.length != second.children.length) {
+    return false;
+  }
+  for (var index = 0; index < first.children.length; index++) {
+    if (!_samePolicyShape(first.children[index], second.children[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _sameRequirementShape(
+  BitcoinPolicyPathRequirement first,
+  BitcoinPolicyPathRequirement second,
+) =>
+    first.threshold == second.threshold &&
+    _samePolicyOptions(first.options, second.options);
+
+bool _samePolicyOptions(
+  List<BitcoinPolicyNode> first,
+  List<BitcoinPolicyNode> second,
+) {
+  if (first.length != second.length) return false;
+  for (var index = 0; index < first.length; index++) {
+    if (!_samePolicyShape(first[index], second[index])) return false;
+  }
+  return true;
+}
+
+bool _sameIndices(List<int>? first, List<int> second) {
+  if (first == null || first.length != second.length) return false;
+  for (var index = 0; index < first.length; index++) {
+    if (first[index] != second[index]) return false;
+  }
+  return true;
+}
+
+bool _samePolicyShape(BitcoinPolicyNode first, BitcoinPolicyNode second) {
+  if (first.runtimeType != second.runtimeType) return false;
+  return switch ((first, second)) {
+    (
+      BitcoinThresholdPolicyNode firstThreshold,
+      BitcoinThresholdPolicyNode secondThreshold,
+    ) =>
+      _sameSelectionShape(firstThreshold, secondThreshold),
+    (
+      BitcoinHashlockPolicyNode(type: final firstType),
+      BitcoinHashlockPolicyNode(type: final secondType),
+    ) =>
+      firstType == secondType,
+    (
+      BitcoinAbsoluteTimelockPolicyNode(
+        type: final firstType,
+        value: final firstValue,
+      ),
+      BitcoinAbsoluteTimelockPolicyNode(
+        type: final secondType,
+        value: final secondValue,
+      ),
+    ) =>
+      firstType == secondType && firstValue == secondValue,
+    (
+      BitcoinRelativeTimelockPolicyNode(
+        type: final firstType,
+        value: final firstValue,
+      ),
+      BitcoinRelativeTimelockPolicyNode(
+        type: final secondType,
+        value: final secondValue,
+      ),
+    ) =>
+      firstType == secondType && firstValue == secondValue,
+    _ => true,
+  };
+}

--- a/lib/core/wallet/domain/entities/wallet.dart
+++ b/lib/core/wallet/domain/entities/wallet.dart
@@ -266,11 +266,8 @@ abstract class Wallet with _$Wallet {
 
   bool get isStandardLocalSingleSignatureWallet {
     final signer = singleSigner;
-    final key = singleDescriptorKey;
-    final type = scriptType;
     return signer?.signer == SignerEntity.local &&
-        isStandardSingleSignatureWallet &&
-        type?.standardAccount(key?.derivationPath, network) == 0;
+        isStandardSingleSignatureWallet;
   }
 
   bool get supportsLegacySend => isLiquid
@@ -278,7 +275,7 @@ abstract class Wallet with _$Wallet {
       : isStandardLocalSingleSignatureWallet ||
             (signsRemotely && isStandardSingleSignatureWallet);
 
-  bool get signsRemotely => isWatchSigner;
+  bool get signsRemotely => hasRemoteSigner;
   bool get isHardwareWallet => signerDevice != null;
   bool get isBitcoinHardwareWallet => isBitcoin && isHardwareWallet;
   bool get hasLocalSigner =>

--- a/lib/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart
+++ b/lib/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart
@@ -1,0 +1,3 @@
+final class UnsupportedBitcoinPolicyPathException implements Exception {
+  const UnsupportedBitcoinPolicyPathException();
+}

--- a/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -2,6 +2,8 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_send_port.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
@@ -28,6 +30,7 @@ class PrepareBitcoinSendUsecase {
     bool drain = false,
     List<WalletUtxo>? selectedInputs,
     bool replaceByFee = true,
+    BitcoinPolicyPath? policyPath,
   }) async {
     try {
       if (amountSat == null && drain == false) {
@@ -45,15 +48,13 @@ class PrepareBitcoinSendUsecase {
         'Bitcoin wallet id $walletId building psbt. Unspendable utxos: $unspendableUtxos',
       );
 
-      // Belt-and-suspenders: defensively strip any selected input that falls in
-      // the unspendable set before building (guards a future send-from-selected
-      // path from ever pinning a frozen coin).
-      final filteredSelectedInputs = selectedInputs
-          ?.where(
+      if (selectedInputs?.any(
             (utxo) =>
-                !unspendableUtxos.contains((txId: utxo.txId, vout: utxo.vout)),
-          )
-          .toList();
+                unspendableUtxos.contains((txId: utxo.txId, vout: utxo.vout)),
+          ) ==
+          true) {
+        throw SelectedBitcoinCoinsUnavailableException();
+      }
 
       final psbt = await _bitcoinWalletRepository.buildPsbt(
         walletId: walletId,
@@ -62,10 +63,14 @@ class PrepareBitcoinSendUsecase {
         networkFee: networkFee,
         drain: drain,
         unspendable: unspendableUtxos,
-        selected: filteredSelectedInputs,
+        selected: selectedInputs,
         replaceByFee: replaceByFee,
+        policyPath: policyPath,
       );
-      final size = await _bitcoinWalletRepository.getTxSize(psbt: psbt);
+      final size = await _bitcoinWalletRepository.getTxSize(
+        psbt: psbt,
+        walletId: walletId,
+      );
       final isToSelf = await _bitcoinWalletRepository.isAddressOfWallet(
         address,
         walletId: walletId,
@@ -74,6 +79,8 @@ class PrepareBitcoinSendUsecase {
     } on NoSpendableUtxoException {
       rethrow;
     } on InsufficientFundsException {
+      rethrow;
+    } on BitcoinCoinSelectionException {
       rethrow;
     } catch (e) {
       throw PrepareBitcoinSendException(e.toString());

--- a/lib/core/wallet/domain/wallet_failure.dart
+++ b/lib/core/wallet/domain/wallet_failure.dart
@@ -7,3 +7,21 @@ sealed class WalletFailure extends Failure {
 final class WalletTransactionLookupFailure extends WalletFailure {
   const WalletTransactionLookupFailure([super.logMessage]);
 }
+
+enum BitcoinSigningFailureKind {
+  invalidPsbt,
+  walletMismatch,
+  missingLocalOrigin,
+  missingUtxo,
+  frozenUtxo,
+  unsupportedSighash,
+  unsupportedPolicyPath,
+  incomplete,
+  unexpected,
+}
+
+final class BitcoinSigningFailure extends WalletFailure {
+  final BitcoinSigningFailureKind kind;
+
+  const BitcoinSigningFailure(this.kind, [super.logMessage]);
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -19,6 +19,7 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_utxo_repository_i
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_backup_needed_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_status_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_usecase.dart';
@@ -66,7 +67,11 @@ class WalletLocator {
         bdkWalletDatasource: locator<BdkWalletDatasource>(),
         seedDatasource: locator<SeedDatasource>(),
         frozenWalletUtxoDatasource: locator<FrozenWalletUtxoDatasource>(),
+        electrumServers: locator<ElectrumServersPort>(),
       ),
+    );
+    locator.registerLazySingleton<BitcoinSigningPort>(
+      () => locator<BitcoinWalletRepository>(),
     );
 
     locator.registerLazySingleton<LiquidWalletRepository>(

--- a/lib/features/pay/presentation/pay_bloc.dart
+++ b/lib/features/pay/presentation/pay_bloc.dart
@@ -13,7 +13,8 @@ import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
-import 'package:bull_logger/bull_logger.dart' show log;
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart' hide Network;
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
@@ -22,6 +23,7 @@ import 'package:bb_mobile/features/pay/domain/create_pay_order_usecase.dart';
 import 'package:bb_mobile/features/pay/domain/get_payjoin_usecase.dart';
 import 'package:bb_mobile/features/pay/domain/refresh_pay_order_usecase.dart';
 import 'package:bb_mobile/features/pay/domain/send_with_payjoin_usecase.dart';
+import 'package:bull_logger/bull_logger.dart' show log;
 import 'package:bb_mobile/features/pay/domain/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/features/recipients/interface_adapters/presenters/models/recipient_view_model.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
@@ -653,10 +655,21 @@ class PayBloc extends Bloc<PayEvent, PayState>
           );
           waitingForPayjoin = true;
         } else {
-          final signedTx = await _signBitcoinTxUsecase.execute(
+          final signingResult = await _signBitcoinTxUsecase.execute(
             psbt: preparedSend.unsignedPsbt,
             walletId: wallet.id,
           );
+          final SignedBitcoinTransaction signedTx;
+          switch (signingResult) {
+            case Ok(:final value):
+              signedTx = value;
+            case Err():
+              _emitSendPaymentError(
+                emit,
+                const PayError.transactionSigningFailed(),
+              );
+              return;
+          }
           final txid = await _broadcastBitcoinTransactionUsecase.execute(
             signedTx.signedPsbt,
             isPsbt: true,
@@ -667,11 +680,11 @@ class PayBloc extends Bloc<PayEvent, PayState>
       if (!waitingForPayjoin) await _completeAfterBroadcast(emit);
     } on PrepareLiquidSendException catch (e) {
       _emitSendPaymentError(emit, PayError.unexpected(message: e.message));
+    } on BitcoinCoinSelectionException catch (e) {
+      _emitSendPaymentError(emit, _payCoinSelectionError(e));
     } on PrepareBitcoinSendException catch (e) {
       _emitSendPaymentError(emit, PayError.unexpected(message: e.toString()));
     } on SignLiquidTxException catch (e) {
-      _emitSendPaymentError(emit, PayError.unexpected(message: e.toString()));
-    } on SignBitcoinTxException catch (e) {
       _emitSendPaymentError(emit, PayError.unexpected(message: e.toString()));
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);
@@ -1030,6 +1043,15 @@ class PayBloc extends Bloc<PayEvent, PayState>
           ),
         );
       }
+    } on BitcoinCoinSelectionException catch (e) {
+      final liveAfterFailure = _currentPaymentState;
+      if (liveAfterFailure == null) return;
+      emit(
+        liveAfterFailure.copyWith(
+          absoluteFees: previousAbsoluteFees,
+          error: _payCoinSelectionError(e),
+        ),
+      );
     } catch (e) {
       final liveAfterFailure = _currentPaymentState;
       if (liveAfterFailure == null) return;
@@ -1041,6 +1063,14 @@ class PayBloc extends Bloc<PayEvent, PayState>
       );
     }
   }
+
+  PayError _payCoinSelectionError(BitcoinCoinSelectionException exception) =>
+      switch (exception) {
+        SelectedBitcoinCoinsUnavailableException() =>
+          const PayError.selectedCoinsUnavailable(),
+        SelectedBitcoinCoinsInsufficientException() =>
+          const PayError.selectedCoinsInsufficient(),
+      };
 
   PayPaymentState? get _currentPaymentState {
     final currentState = state;

--- a/lib/features/sell/presentation/bloc/sell_bloc.dart
+++ b/lib/features/sell/presentation/bloc/sell_bloc.dart
@@ -17,7 +17,8 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/amount_conversions.dart';
 import 'package:bb_mobile/core/utils/bitcoin_tx.dart';
 import 'package:bb_mobile/core/utils/liquid_tx.dart';
-import 'package:bull_logger/bull_logger.dart' show log;
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart' hide Network;
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
@@ -26,6 +27,7 @@ import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/features/sell/domain/label_completed_sell_order_usecase.dart';
 import 'package:bb_mobile/features/sell/domain/create_sell_order_usecase.dart';
 import 'package:bb_mobile/features/sell/domain/refresh_sell_order_usecase.dart';
+import 'package:bull_logger/bull_logger.dart' show log;
 import 'package:bb_mobile/features/sell/domain/get_payjoin_usecase.dart';
 import 'package:bb_mobile/features/sell/domain/send_with_payjoin_usecase.dart';
 import 'package:bb_mobile/features/sell/domain/watch_payjoin_usecase.dart';
@@ -695,13 +697,24 @@ class SellBloc extends Bloc<SellEvent, SellState>
             'bip21Present=${payjoinBip21 != null}, '
             'windowAvailable=${payjoinWindow != null}',
           );
-          final signedTx = await _signBitcoinTxUsecase.execute(
+          final signingResult = await _signBitcoinTxUsecase.execute(
             psbt: preparedSend.unsignedPsbt,
             walletId: wallet.id,
           );
+          final SignedBitcoinTransaction signedTx;
+          switch (signingResult) {
+            case Ok(:final value):
+              signedTx = value;
+            case Err():
+              _emitSendPaymentError(
+                emit,
+                const SellError.transactionSigningFailed(),
+              );
+              return;
+          }
           // Derived before broadcasting so the latch can be set on the very next
           // line: nothing may run between the broadcast and the latch.
-          final tx = await BitcoinTx.fromPsbt(preparedSend.unsignedPsbt);
+          final tx = await BitcoinTx.fromPsbt(signedTx.signedPsbt);
           final txid = tx.txid;
           await _broadcastBitcoinTransactionUsecase.execute(
             signedTx.signedPsbt,
@@ -720,12 +733,11 @@ class SellBloc extends Bloc<SellEvent, SellState>
       if (!waitingForPayjoin) await _completeAfterBroadcast(emit);
     } on PrepareLiquidSendException catch (e) {
       _emitSendPaymentError(emit, SellError.unexpected(message: e.message));
+    } on BitcoinCoinSelectionException catch (e) {
+      _emitSendPaymentError(emit, _sellCoinSelectionError(e));
     } on PrepareBitcoinSendException catch (e) {
       _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } on SignLiquidTxException catch (e) {
-      _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
-    } on SignBitcoinTxException catch (e) {
-      // Handle SellError and emit error state
       _emitSendPaymentError(emit, SellError.unexpected(message: e.toString()));
     } catch (e) {
       // Log unexpected errors
@@ -1158,6 +1170,15 @@ class SellBloc extends Bloc<SellEvent, SellState>
           ),
         );
       }
+    } on BitcoinCoinSelectionException catch (e) {
+      final liveAfterFailure = _currentPaymentState;
+      if (liveAfterFailure == null) return;
+      emit(
+        liveAfterFailure.copyWith(
+          absoluteFees: previousAbsoluteFees,
+          error: _sellCoinSelectionError(e),
+        ),
+      );
     } catch (e) {
       final liveAfterFailure = _currentPaymentState;
       if (liveAfterFailure == null) return;
@@ -1171,6 +1192,14 @@ class SellBloc extends Bloc<SellEvent, SellState>
       );
     }
   }
+
+  SellError _sellCoinSelectionError(BitcoinCoinSelectionException exception) =>
+      switch (exception) {
+        SelectedBitcoinCoinsUnavailableException() =>
+          const SellError.selectedCoinsUnavailable(),
+        SelectedBitcoinCoinsInsufficientException() =>
+          const SellError.selectedCoinsInsufficient(),
+      };
 
   /// Address the payin is (or will be) built for. The order's own address keeps
   /// the estimate honest — a build against one of our own addresses can differ

--- a/lib/features/send/domain/send_failure.dart
+++ b/lib/features/send/domain/send_failure.dart
@@ -35,6 +35,14 @@ final class SendInsufficientFundsForFeesFailure extends SendFailure {
   const SendInsufficientFundsForFeesFailure([super.logMessage]);
 }
 
+final class SendSelectedCoinsUnavailableFailure extends SendFailure {
+  const SendSelectedCoinsUnavailableFailure([super.logMessage]);
+}
+
+final class SendSelectedCoinsInsufficientFailure extends SendFailure {
+  const SendSelectedCoinsInsufficientFailure([super.logMessage]);
+}
+
 final class SendAmountOutOfBoundsFailure extends SendFailure {
   final BigInt? minimumSat;
   final BigInt? maximumSat;
@@ -72,6 +80,10 @@ final class SendRateLimitedFailure extends SendFailure {
 
 final class SendTransactionBuildFailure extends SendFailure {
   const SendTransactionBuildFailure([super.logMessage]);
+}
+
+final class SendTransactionSigningFailure extends SendFailure {
+  const SendTransactionSigningFailure([super.logMessage]);
 }
 
 final class SendTransactionConfirmationFailure extends SendFailure {

--- a/lib/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart
+++ b/lib/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart
@@ -1,27 +1,71 @@
-import 'package:bb_mobile/core/errors/bull_exception.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+
+typedef SignedBitcoinTransaction = ({
+  String signedPsbt,
+  int txSize,
+  bool isFinalized,
+});
 
 class SignBitcoinTxUsecase {
-  final BitcoinWalletRepository _bitcoinWalletRepository;
+  final BitcoinSigningPort _bitcoinSigningPort;
 
-  SignBitcoinTxUsecase({required this._bitcoinWalletRepository});
-  Future<({String signedPsbt, int txSize})> execute({
+  SignBitcoinTxUsecase(this._bitcoinSigningPort);
+
+  Future<Result<SignedBitcoinTransaction, BitcoinSigningFailure>> execute({
     required String psbt,
     required String walletId,
+    String? externalPsbt,
+    bool requireFinalized = true,
+    bool tryFinalize = true,
+    String? signerId,
   }) async {
+    final signingResult = externalPsbt == null
+        ? await _bitcoinSigningPort.signPsbt(
+            psbt,
+            walletId: walletId,
+            tryFinalize: tryFinalize,
+            signerId: signerId,
+          )
+        : await _bitcoinSigningPort.combinePsbts(
+            currentPsbt: psbt,
+            signedPsbt: externalPsbt,
+            walletId: walletId,
+            tryFinalize: tryFinalize,
+          );
+    final ({String psbt, bool isFinalized}) signed;
+    switch (signingResult) {
+      case Ok(:final value):
+        signed = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    if (requireFinalized && !signed.isFinalized) {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.incomplete),
+      );
+    }
     try {
-      final signedPsbt = await _bitcoinWalletRepository.signPsbt(
-        psbt,
+      final size = await _bitcoinSigningPort.getTxSize(
+        psbt: signed.psbt,
         walletId: walletId,
       );
-      final size = await _bitcoinWalletRepository.getTxSize(psbt: signedPsbt);
-      return (signedPsbt: signedPsbt, txSize: size);
-    } catch (e) {
-      throw SignBitcoinTxException(e.toString());
+      return Ok((
+        signedPsbt: signed.psbt,
+        txSize: size,
+        isFinalized: signed.isFinalized,
+      ));
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to calculate signed Bitcoin transaction size',
+        error: error,
+        trace: stackTrace,
+      );
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unexpected),
+      );
     }
   }
-}
-
-class SignBitcoinTxException extends BullException {
-  SignBitcoinTxException(super.message);
 }

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
@@ -1606,10 +1607,23 @@ class SendCubit extends Cubit<SendState>
             ),
           );
         } else {
-          final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
+          final signingResult = await _signBitcoinTxUsecase.execute(
             psbt: txPreparation.unsignedPsbt,
             walletId: state.selectedWallet!.id,
           );
+          final SignedBitcoinTransaction signedPsbtAndTxSize;
+          switch (signingResult) {
+            case Ok(:final value):
+              signedPsbtAndTxSize = value;
+            case Err(:final failure):
+              emit(
+                state.copyWith(
+                  failure: SendTransactionSigningFailure(failure.logMessage),
+                  buildingTransaction: false,
+                ),
+              );
+              return;
+          }
           final bitcoinAbsoluteFeesSat =
               await _calculateBitcoinAbsoluteFeesUsecase.execute(
                 psbt: signedPsbtAndTxSize.signedPsbt,
@@ -1678,6 +1692,20 @@ class SendCubit extends Cubit<SendState>
             failure: blamesFees
                 ? SendInsufficientFundsForFeesFailure(e.message)
                 : SendInsufficientBalanceFailure(e.message),
+            buildingTransaction: false,
+          ),
+        );
+        return;
+      }
+      if (e is BitcoinCoinSelectionException) {
+        emit(
+          state.copyWith(
+            failure: switch (e) {
+              SelectedBitcoinCoinsUnavailableException() =>
+                SendSelectedCoinsUnavailableFailure(e.message),
+              SelectedBitcoinCoinsInsufficientException() =>
+                SendSelectedCoinsInsufficientFailure(e.message),
+            },
             buildingTransaction: false,
           ),
         );
@@ -1789,10 +1817,23 @@ class SendCubit extends Cubit<SendState>
           );
           _watchPayjoin(payjoinSender.id);
         } else {
-          final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
+          final signingResult = await _signBitcoinTxUsecase.execute(
             psbt: state.unsignedPsbt!,
             walletId: state.selectedWallet!.id,
           );
+          final SignedBitcoinTransaction signedPsbtAndTxSize;
+          switch (signingResult) {
+            case Ok(:final value):
+              signedPsbtAndTxSize = value;
+            case Err(:final failure):
+              emit(
+                state.copyWith(
+                  failure: SendTransactionSigningFailure(failure.logMessage),
+                  signingTransaction: false,
+                ),
+              );
+              return;
+          }
           final bitcoinAbsoluteFeesSat =
               await _calculateBitcoinAbsoluteFeesUsecase.execute(
                 psbt: signedPsbtAndTxSize.signedPsbt,

--- a/lib/features/send/presentation/send_failure_l10n.dart
+++ b/lib/features/send/presentation/send_failure_l10n.dart
@@ -18,6 +18,10 @@ extension SendFailureL10n on SendFailure {
       context.loc.sendErrorInsufficientBalanceForPayment,
     SendInsufficientFundsForFeesFailure() =>
       context.loc.sendErrorInsufficientFundsForFees,
+    SendSelectedCoinsUnavailableFailure() =>
+      context.loc.sendErrorSelectedCoinsUnavailable,
+    SendSelectedCoinsInsufficientFailure() =>
+      context.loc.sendErrorSelectedCoinsInsufficient,
     SendAmountOutOfBoundsFailure(:final minimumSat?) =>
       context.loc.sendErrorAmountBelowMinimum(minimumSat.toString()),
     SendAmountOutOfBoundsFailure(:final maximumSat?) =>
@@ -35,6 +39,7 @@ extension SendFailureL10n on SendFailure {
     SendRateLimitedFailure(:final retryAfter) =>
       context.loc.swapErrorRateLimited(retryAfter?.inSeconds ?? 30),
     SendTransactionBuildFailure() => context.loc.sendErrorBuildFailed,
+    SendTransactionSigningFailure() => context.loc.sendErrorConfirmationFailed,
     SendTransactionConfirmationFailure(:final isBroadcastFailure) =>
       isBroadcastFailure
           ? context.loc.sendErrorBroadcastFailed

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
@@ -83,9 +84,7 @@ class SendLocator {
       ),
     );
     locator.registerFactory<SignBitcoinTxUsecase>(
-      () => SignBitcoinTxUsecase(
-        bitcoinWalletRepository: locator<BitcoinWalletRepository>(),
-      ),
+      () => SignBitcoinTxUsecase(locator<BitcoinSigningPort>()),
     );
     locator.registerFactory<CreateSendSwapUsecase>(
       () => CreateSendSwapUsecase(

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_tran
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
@@ -556,7 +557,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         replaceByFee: state.replaceByFee,
       );
 
-      final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
+      final signedPsbtAndTxSize = await _signBitcoinTransaction(
         walletId: bitcoinWalletId,
         psbt: unsignedPsbtAndTxSize.unsignedPsbt,
       );
@@ -745,7 +746,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         swap: displaySwap,
         walletId: fromWallet.id,
       );
-      final signed = await _signBitcoinTxUsecase.execute(
+      final signed = await _signBitcoinTransaction(
         walletId: fromWallet.id,
         psbt: unsigned.unsignedPsbt,
       );
@@ -1324,7 +1325,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
                 replaceByFee: stateToUse.replaceByFee,
               );
 
-        final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
+        final signedPsbtAndTxSize = await _signBitcoinTransaction(
           walletId: fromWallet.id,
           psbt: unsignedPsbtAndTxSize.unsignedPsbt,
         );
@@ -1396,7 +1397,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           walletId: fromWallet.id,
         );
 
-        final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
+        final signedPsbtAndTxSize = await _signBitcoinTransaction(
           walletId: fromWallet.id,
           psbt: unsignedPsbtAndTxSize.unsignedPsbt,
         );
@@ -1571,6 +1572,19 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     }
   }
 
+  Future<SignedBitcoinTransaction> _signBitcoinTransaction({
+    required String walletId,
+    required String psbt,
+  }) async {
+    return switch (await _signBitcoinTxUsecase.execute(
+      walletId: walletId,
+      psbt: psbt,
+    )) {
+      Ok(:final value) => value,
+      Err() => throw BuildTransactionException('bitcoin_signing_failed'),
+    };
+  }
+
   Future<void> _syncWalletsAfterBroadcast(List<String> walletIds) async {
     for (final walletId in walletIds) {
       await _syncWalletAfterBroadcast(walletId);
@@ -1644,7 +1658,8 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
 
   bool _isInsufficientFundsException(Object e) {
     return e is InsufficientFundsSwapException ||
-        e is InsufficientFundsException;
+        e is InsufficientFundsException ||
+        e is BitcoinCoinSelectionException;
   }
 
   Future<void> _onOrderSwapUpdated(

--- a/lib/features/swap/swap_locator.dart
+++ b/lib/features/swap/swap_locator.dart
@@ -10,6 +10,7 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
@@ -216,9 +217,7 @@ class SwapLocator {
       ),
     );
     locator.registerFactory<SignBitcoinTxUsecase>(
-      () => SignBitcoinTxUsecase(
-        bitcoinWalletRepository: locator<BitcoinWalletRepository>(),
-      ),
+      () => SignBitcoinTxUsecase(locator<BitcoinSigningPort>()),
     );
 
     locator.registerFactory<CalculateBitcoinAbsoluteFeesUsecase>(

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14793,5 +14793,13 @@
   "importWatchOnlyErrorSignerOriginRequired": "This hardware signer export is missing its fingerprint and account path. Export a descriptor or an account xpub with key origin information.",
   "@importWatchOnlyErrorSignerOriginRequired": {
     "description": "Shown when a hardware-wallet xpub is missing the key origin needed for signing."
+  },
+  "sendErrorSelectedCoinsUnavailable": "One or more selected coins are no longer available.",
+  "@sendErrorSelectedCoinsUnavailable": {
+    "description": "Shown when a manually selected Bitcoin input is no longer spendable"
+  },
+  "sendErrorSelectedCoinsInsufficient": "Selected coins do not cover the amount and network fees.",
+  "@sendErrorSelectedCoinsInsufficient": {
+    "description": "Shown when manually selected Bitcoin inputs cannot cover the payment and fees"
   }
 }

--- a/test/core_test/utils/bitcoin_signer_result_test.dart
+++ b/test/core_test/utils/bitcoin_signer_result_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PSBT resource boundaries', () {
+    test('accepts exactly the decoded size cap', () {
+      final bytes = <int>[0x70, 0x73, 0x62, 0x74, 0xff];
+      bytes.addAll(
+        List<int>.filled(maxBitcoinPsbtDecodedBytes - bytes.length, 0),
+      );
+
+      expect(base64.decode(normalizeBitcoinPsbt(base64.encode(bytes))), bytes);
+    });
+
+    test('rejects one byte over the decoded size cap', () {
+      final bytes = <int>[0x70, 0x73, 0x62, 0x74, 0xff];
+      bytes.addAll(
+        List<int>.filled(maxBitcoinPsbtDecodedBytes + 1 - bytes.length, 0),
+      );
+
+      expect(
+        () => normalizeBitcoinPsbt(base64.encode(bytes)),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects input over the transport cap before decoding', () {
+      expect(
+        () => normalizeBitcoinPsbt(
+          'A'.padRight(maxBitcoinPsbtTransportBytes + 1, 'A'),
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -1,32 +1,3 @@
-// Regression test for a bug where `BdkWalletDatasource.buildPsbt` silently
-// dropped manual UTXO selection and the RBF-off sequence flag.
-//
-// bdk_dart's `TxBuilder` is an IMMUTABLE builder: every method (`addUtxos`,
-// `setExactSequence`, `feeAbsolute`, `unspendable`, ...) returns a brand new
-// `TxBuilder` instance rather than mutating the receiver in place. Two call
-// sites in `buildPsbt` called `txBuilder.addUtxos(...)` and
-// `txBuilder.setExactSequence(...)` without reassigning the result, so both
-// calls were silent no-ops: BDK picked inputs on its own regardless of the
-// user's manual coin selection, and the RBF-off toggle never took effect.
-//
-// This test exercises the real production method end-to-end against a real
-// (offline, in-process) BDK wallet — no network, no mocked repository — so
-// it proves the actual `TxBuilder` wiring, not just that a mock was called
-// with the right arguments.
-//
-// Setup, fully deterministic and offline:
-//   1. A fixed BIP84 testnet wallet (the canonical
-//      "abandon ... abandon about" test mnemonic) is used to derive a
-//      public (watch-only) descriptor pair — exactly what
-//      `BitcoinWalletRepository.buildPsbt` passes down in production.
-//   2. The wallet is "funded" by hand-crafting a raw funding transaction
-//      with two outputs (to two of the wallet's own addresses) and applying
-//      it as an unconfirmed transaction via `Wallet.applyUnconfirmedTxs`.
-//      This is the standard offline way to seed known, deterministic UTXOs
-//      into a BDK wallet without hitting a real Electrum server.
-//   3. `path_provider`'s method channel is mocked to a temp directory so
-//      `BdkFacade`'s sqlite-file persister (production code, untouched)
-//      works under `flutter test`.
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -35,10 +6,13 @@ import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'bdk_wallet_test_fixture.dart';
 
 // The canonical BIP39 test mnemonic ("abandon" x11 + "about"). Public
 // knowledge, no funds, safe to hardcode.
@@ -130,14 +104,19 @@ void main() {
       keychainKind: bdk.KeychainKind.external_,
       networkKind: bdk.NetworkKind.test,
     );
+    final internal = bdk.Descriptor.newBip84(
+      secretKey: secretKey,
+      keychainKind: bdk.KeychainKind.internal,
+      networkKind: bdk.NetworkKind.test,
+    );
+
     walletModel =
         WalletModel.publicBdk(
               id: 'bdk-wallet-datasource-test',
-              descriptor: external
-                  .toString()
-                  .split('#')
-                  .first
-                  .replaceAll('/0/*', '/<0;1>/*'),
+              descriptor: twoPathDescriptor(
+                external.toString(),
+                internal.toString(),
+              ),
               isTestnet: true,
             )
             as PublicBdkWalletModel;
@@ -191,78 +170,6 @@ void main() {
       await tempDir.delete(recursive: true);
     }
   });
-
-  test(
-    'buildPsbt honors manual UTXO selection: a manually selected UTXO must '
-    'be spendable even when every other UTXO is frozen/unspendable',
-    () async {
-      final datasource = BdkWalletDatasource();
-
-      // The LARGE utxo (200k) is marked unspendable — i.e. excluded from
-      // BDK's own automatic coin-selection pool. It is ALSO the one
-      // manually `selected` here, which per BDK's documented semantics
-      // forces it into the transaction as a mandatory input REGARDLESS of
-      // the unspendable flag.
-      //
-      // NOTE: this selected-overrides-unspendable behavior is raw BDK
-      // semantics that this datasource deliberately preserves as a thin
-      // wrapper — it is the INVERSE of the app-level D7 invariant ("a
-      // frozen coin must never be spendable"). D7 is enforced one layer
-      // up: BitcoinWalletRepository.buildPsbt strips selected ∩
-      // unspendable before calling down (see
-      // bitcoin_wallet_repository_test.dart), and
-      // PrepareBitcoinSendUsecase additionally strips frozen coins from
-      // the selection. The combination is exploited here ONLY because it
-      // is a deterministic discriminator for the addUtxos-reassignment
-      // regression, with no dependency on BDK's coin-selection
-      // heuristics.
-      //
-      // The only utxo left in the automatic pool is the SMALL one (30k),
-      // which alone cannot cover the 150k send. This makes the two code
-      // paths unambiguous, with no dependency on BDK's coin-selection
-      // tie-breaking heuristics:
-      //   * Fixed code: `addUtxos` really runs, forcing the large utxo in
-      //     -> the build succeeds and spends it.
-      //   * Buggy code (return value of `addUtxos` discarded): no utxo is
-      //     forced in; BDK's automatic selection is left with only the
-      //     30k utxo, which can't cover 150k -> the build throws.
-      const sendAmountSat = 150000; // only the large (200k) utxo covers this
-      final psbt = await datasource.buildPsbt(
-        wallet: walletModel,
-        address: _externalTestnetAddress,
-        amountSat: sendAmountSat,
-        networkFee: const NetworkFee.relativeSatPerKwu(1000), // 4 sat/vB
-        unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
-        selected: [
-          WalletUtxoModel.bitcoin(
-            txId: utxoLargeTxId,
-            vout: utxoLargeVout,
-            amountSat: BigInt.from(utxoLargeAmountSat),
-            scriptPubkey: Uint8List(0),
-            address: '',
-            isExternalKeyChain: true,
-          ),
-        ],
-        replaceByFee: true,
-      );
-
-      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
-      final spendsLargeUtxo = tx.input().any(
-        (input) =>
-            input.previousOutput.txid.toString() == utxoLargeTxId &&
-            input.previousOutput.vout == utxoLargeVout,
-      );
-
-      expect(
-        spendsLargeUtxo,
-        isTrue,
-        reason:
-            'the manually selected UTXO must be forced into the built '
-            'transaction even though it is also marked unspendable for '
-            "BDK's own automatic selection",
-      );
-    },
-  );
 
   test(
     'buildPsbt sets a non-RBF sequence when replaceByFee is false',
@@ -332,9 +239,8 @@ void main() {
     },
   );
 
-  // BDK has two exception types for a shortfall and doesn't say which it uses
-  // when, so these pin it against the real builder: either must arrive as
-  // InsufficientFundsException.
+  // BDK has two exception types for a shortfall. Both must use Bull's stable
+  // failure type for the applicable coin-selection mode.
   test(
     'buildPsbt reports more than the whole balance as insufficient funds',
     () async {
@@ -355,31 +261,28 @@ void main() {
   // The amount fits the picked coin but not the fee. The large coin must be
   // unspendable too: `addUtxos` only makes a coin required, so BDK would
   // otherwise top the transaction up from it and never fall short.
-  test(
-    'buildPsbt reports a fee-only shortfall as insufficient funds',
-    () async {
-      final datasource = BdkWalletDatasource();
+  test('buildPsbt reports a selected-coin fee shortfall', () async {
+    final datasource = BdkWalletDatasource();
 
-      await expectLater(
-        datasource.buildPsbt(
-          wallet: walletModel,
-          address: _externalTestnetAddress,
-          amountSat: utxoSmallAmountSat,
-          networkFee: const NetworkFee.relativeSatPerKwu(1000),
-          selected: [
-            WalletUtxoModel.bitcoin(
-              txId: utxoLargeTxId,
-              vout: utxoSmallVout,
-              amountSat: BigInt.from(utxoSmallAmountSat),
-              scriptPubkey: Uint8List(0),
-              address: '',
-              isExternalKeyChain: true,
-            ),
-          ],
-          unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
-        ),
-        throwsA(isA<InsufficientFundsException>()),
-      );
-    },
-  );
+    await expectLater(
+      datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: utxoSmallAmountSat,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoSmallVout,
+            amountSat: BigInt.from(utxoSmallAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
+      ),
+      throwsA(isA<SelectedBitcoinCoinsInsufficientException>()),
+    );
+  });
 }

--- a/test/core_test/wallet/bdk_wallet_test_fixture.dart
+++ b/test/core_test/wallet/bdk_wallet_test_fixture.dart
@@ -1,3 +1,10 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 
 typedef SignerDescriptorKeys = ({
@@ -61,5 +68,240 @@ singleSignatureDescriptors(String words) {
       networkKind: bdk.NetworkKind.test,
     ).toString(),
     xpub: account.asPublic().toString(),
+  );
+}
+
+({String external, String fingerprint, String internal, String xpub})
+nestedSegwitSingleSignatureDescriptors(String words) {
+  final root = bdk.DescriptorSecretKey(
+    networkKind: bdk.NetworkKind.test,
+    mnemonic: bdk.Mnemonic.fromString(mnemonic: words),
+    password: null,
+  );
+  final account = root.derive(path: bdk.DerivationPath(path: "m/49'/1'/0'"));
+  return (
+    external: bdk.Descriptor.newBip49(
+      secretKey: root,
+      keychainKind: bdk.KeychainKind.external_,
+      networkKind: bdk.NetworkKind.test,
+    ).toString(),
+    fingerprint: account.asPublic().masterFingerprint(),
+    internal: bdk.Descriptor.newBip49(
+      secretKey: root,
+      keychainKind: bdk.KeychainKind.internal,
+      networkKind: bdk.NetworkKind.test,
+    ).toString(),
+    xpub: account.asPublic().toString(),
+  );
+}
+
+({String external, String fingerprint, String internal, String xpub})
+singleSignatureDescriptorsAtAccount(String words, {required int account}) {
+  final root = bdk.DescriptorSecretKey(
+    networkKind: bdk.NetworkKind.test,
+    mnemonic: bdk.Mnemonic.fromString(mnemonic: words),
+    password: null,
+  );
+  final accountKey = root.derive(
+    path: bdk.DerivationPath(path: "m/84'/1'/$account'"),
+  );
+  final publicKey = accountKey.asPublic();
+  return (
+    external: bdk.Descriptor(
+      descriptor: 'wpkh($publicKey/0/*)',
+      networkKind: bdk.NetworkKind.test,
+    ).toString(),
+    fingerprint: publicKey.masterFingerprint(),
+    internal: bdk.Descriptor(
+      descriptor: 'wpkh($publicKey/1/*)',
+      networkKind: bdk.NetworkKind.test,
+    ).toString(),
+    xpub: publicKey.toString(),
+  );
+}
+
+WalletSigner walletSigner({
+  required String fingerprint,
+  required String xpub,
+  required SignerEntity signer,
+}) => WalletSigner.single(
+  id: 'signer-$fingerprint',
+  descriptorKeyId: 'key-$fingerprint',
+  masterFingerprint: fingerprint,
+  xpubFingerprint: fingerprint,
+  xpub: xpub,
+  derivationPath: "m/48'/1'/0'/2'",
+  signer: signer,
+  signerDevice: null,
+);
+
+bool containsPolicyNode<T extends BitcoinPolicyNode>(BitcoinPolicyNode node) {
+  if (node is T) return true;
+  return node is BitcoinThresholdPolicyNode &&
+      node.children.any(containsPolicyNode<T>);
+}
+
+T? findPolicyNode<T extends BitcoinPolicyNode>(BitcoinPolicyNode node) {
+  if (node is T) return node;
+  if (node is! BitcoinThresholdPolicyNode) return null;
+  for (final child in node.children) {
+    final match = findPolicyNode<T>(child);
+    if (match != null) return match;
+  }
+  return null;
+}
+
+({String psbt, bool isFinalized}) signPsbt(
+  BdkWalletDatasource datasource,
+  String psbt, {
+  required List<SignerDescriptorKeys> signers,
+  required int signerIndex,
+}) {
+  final externalKeys = [
+    for (var i = 0; i < signers.length; i++)
+      i == signerIndex ? signers[i].externalPrivate : signers[i].externalPublic,
+  ];
+  final internalKeys = [
+    for (var i = 0; i < signers.length; i++)
+      i == signerIndex ? signers[i].internalPrivate : signers[i].internalPublic,
+  ];
+
+  return datasource.signPsbtWithDescriptor(
+    psbt,
+    descriptor: twoPathDescriptor(
+      sortedMultisigDescriptor(externalKeys),
+      sortedMultisigDescriptor(internalKeys),
+    ),
+    isTestnet: true,
+  );
+}
+
+Set<String> signedFingerprints(String psbtBase64) {
+  final psbt = bdk.Psbt(psbtBase64: psbtBase64);
+  try {
+    Set<String>? fingerprints;
+    for (final input in psbt.input()) {
+      final inputFingerprints = input.partialSigs.keys
+          .map((publicKey) => input.bip32Derivation[publicKey]?.fingerprint)
+          .whereType<String>()
+          .map((fingerprint) => fingerprint.toLowerCase())
+          .toSet();
+      fingerprints = fingerprints == null
+          ? inputFingerprints
+          : fingerprints.intersection(inputFingerprints);
+    }
+    return Set.unmodifiable(fingerprints ?? const {});
+  } finally {
+    psbt.dispose();
+  }
+}
+
+String sortedMultisigDescriptor(List<String> descriptorKeys) =>
+    'wsh(sortedmulti(2,${descriptorKeys.join(',')}))';
+
+String twoPathDescriptor(String externalDescriptor, String internalDescriptor) {
+  final external = externalDescriptor.split('#').first;
+  final internal = internalDescriptor.split('#').first;
+  final expectedInternal = external.replaceAll('/0/*', '/1/*');
+  if (expectedInternal == external || expectedInternal != internal) {
+    throw ArgumentError('Descriptors do not form /0/* and /1/* paths');
+  }
+  return external.replaceAll('/0/*', '/<0;1>/*');
+}
+
+String buildUnsignedPsbt({
+  required String descriptor,
+  int amountSat = 50000,
+  int inputCount = 1,
+  int inputIndex = 0,
+  bdk.Script? recipientScript,
+  BitcoinPolicyPath? policyPath,
+}) {
+  final wallet = BdkFacade.createEphemeralDescriptorWallet(
+    descriptor: descriptor,
+    isTestnet: true,
+  );
+  for (var index = 0; index <= inputIndex; index++) {
+    wallet.revealNextAddress(keychain: bdk.KeychainKind.external_);
+  }
+  final ownedAddress = wallet.peekAddress(
+    keychain: bdk.KeychainKind.external_,
+    index: inputIndex,
+  );
+  wallet.applyUnconfirmedTxs(
+    unconfirmedTxs: [
+      for (var index = 0; index < inputCount; index++)
+        bdk.UnconfirmedTx(
+          tx: fundingTransaction(
+            ownedAddress.address.scriptPubkey(),
+            previousTxByte: 0x22 + index,
+          ),
+          lastSeen: index + 1,
+        ),
+    ],
+  );
+  final recipient = wallet.peekAddress(
+    keychain: bdk.KeychainKind.external_,
+    index: 1,
+  );
+
+  var builder = bdk.TxBuilder()
+      .addRecipient(
+        script: recipientScript ?? recipient.address.scriptPubkey(),
+        amount: bdk.Amount.fromSat(satoshi: amountSat),
+      )
+      .feeAbsolute(feeAmount: bdk.Amount.fromSat(satoshi: 1000));
+  if (policyPath != null) {
+    builder = builder
+        .policyPath(
+          policyPath: policyPath.external,
+          keychain: bdk.KeychainKind.external_,
+        )
+        .policyPath(
+          policyPath: policyPath.internal,
+          keychain: bdk.KeychainKind.internal,
+        );
+  }
+  return builder.finish(wallet: wallet).serialize();
+}
+
+bdk.Transaction fundingTransaction(
+  bdk.Script scriptPubkey, {
+  int previousTxByte = 0x22,
+}) {
+  final script = scriptPubkey.toBytes();
+  return bdk.Transaction(
+    transactionBytes: Uint8List.fromList([
+      2,
+      0,
+      0,
+      0,
+      1,
+      ...List<int>.filled(32, previousTxByte),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0xff,
+      0xff,
+      0xff,
+      0xff,
+      1,
+      0xa0,
+      0x86,
+      0x01,
+      0,
+      0,
+      0,
+      0,
+      0,
+      script.length,
+      ...script,
+      0,
+      0,
+      0,
+      0,
+    ]),
   );
 }

--- a/test/core_test/wallet/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/bitcoin_wallet_repository_test.dart
@@ -1,27 +1,3 @@
-// Unit tests for the repository-boundary guarantees of
-// `BitcoinWalletRepository.buildPsbt`:
-//
-//  1. D7 defense in depth — "a frozen coin must never be spendable".
-//     BDK's documented semantics are the opposite: a manually added utxo
-//     (`TxBuilder.addUtxos`) overrides the `unspendable` filter, and
-//     `BdkWalletDatasource` deliberately preserves those raw semantics
-//     (see bdk_wallet_datasource_test.dart, which asserts them). The
-//     repository therefore reads the frozen store LIVE at build time and
-//     enforces the invariant itself — merging the frozen set into the
-//     `unspendable` list (automatic selection can't pick a frozen coin)
-//     and stripping it from `selected` (a frozen coin can't be forced in
-//     as a mandatory input) — so it holds for ANY caller, with any
-//     staleness of the caller's earlier utxo fetch, not only for callers
-//     going through PrepareBitcoinSendUsecase's own frozen-set handling.
-//     (Payjoin-derived exclusions remain at the usecase: they come from
-//     another repository, which this repository must not depend on.)
-//
-//  2. RBF defaults to ENABLED when the caller omits the flag. The
-//     previous `replaceByFee ?? false` was harmless while the datasource's
-//     `setExactSequence` call discarded its result (a silent no-op), but
-//     became wrong once that call was fixed: a null flag would have
-//     started disabling RBF by default, diverging from both the
-//     datasource's own default and BDK's default sequence (0xFFFFFFFD).
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
@@ -132,24 +108,34 @@ void main() {
         unspendable: any(named: 'unspendable'),
         selected: any(named: 'selected'),
         replaceByFee: any(named: 'replaceByFee'),
+        policyPath: any(named: 'policyPath'),
       ),
     ).thenAnswer((_) async => 'psbt');
   });
 
-  List<WalletUtxoModel>? capturedSelected() =>
-      verify(
-            () => bdkDatasource.buildPsbt(
-              wallet: any(named: 'wallet'),
-              address: any(named: 'address'),
-              amountSat: any(named: 'amountSat'),
-              networkFee: any(named: 'networkFee'),
-              drain: any(named: 'drain'),
-              unspendable: any(named: 'unspendable'),
-              selected: captureAny(named: 'selected'),
-              replaceByFee: any(named: 'replaceByFee'),
-            ),
-          ).captured.single
-          as List<WalletUtxoModel>?;
+  ({
+    List<WalletUtxoModel>? selected,
+    List<({String txId, int vout})>? unspendable,
+  })
+  capturedSelection() {
+    final captured = verify(
+      () => bdkDatasource.buildPsbt(
+        wallet: any(named: 'wallet'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: captureAny(named: 'unspendable'),
+        selected: captureAny(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+        policyPath: any(named: 'policyPath'),
+      ),
+    ).captured;
+    return (
+      unspendable: captured[0] as List<({String txId, int vout})>?,
+      selected: captured[1] as List<WalletUtxoModel>?,
+    );
+  }
 
   List<({String txId, int vout})>? capturedUnspendable() =>
       verify(
@@ -162,6 +148,7 @@ void main() {
               unspendable: captureAny(named: 'unspendable'),
               selected: any(named: 'selected'),
               replaceByFee: any(named: 'replaceByFee'),
+              policyPath: any(named: 'policyPath'),
             ),
           ).captured.single
           as List<({String txId, int vout})>?;
@@ -177,6 +164,7 @@ void main() {
               unspendable: any(named: 'unspendable'),
               selected: any(named: 'selected'),
               replaceByFee: captureAny(named: 'replaceByFee'),
+              policyPath: any(named: 'policyPath'),
             ),
           ).captured.single
           as bool;
@@ -195,24 +183,26 @@ void main() {
     replaceByFee: replaceByFee,
   );
 
-  group('D7 — frozen store is read live at build time', () {
-    test('a coin frozen in the store is stripped from the selection even when '
-        'the caller passes NO unspendable list', () async {
-      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
-        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
-      );
+  group('frozen coins', () {
+    test(
+      'keeps manual selection strict and forwards frozen exclusions',
+      () async {
+        when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+          (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+        );
 
-      await buildPsbt(
-        selected: [
-          _utxo(txId: 'tx-frozen', vout: 0), // frozen in DB -> stripped
-          _utxo(txId: 'tx-free', vout: 1), // passes through
-        ],
-      );
+        await buildPsbt(
+          selected: [
+            _utxo(txId: 'tx-frozen', vout: 0),
+            _utxo(txId: 'tx-free', vout: 1),
+          ],
+        );
 
-      final selected = capturedSelected();
-      expect(selected, hasLength(1));
-      expect(selected!.single.txId, 'tx-free');
-    });
+        final captured = capturedSelection();
+        expect(captured.selected, hasLength(2));
+        expect(captured.unspendable, contains((txId: 'tx-frozen', vout: 0)));
+      },
+    );
 
     test('frozen outpoints are merged into the unspendable list passed down, '
         'so automatic selection cannot pick them either', () async {
@@ -247,51 +237,6 @@ void main() {
     );
   });
 
-  group('D7 — selected ∩ unspendable (caller-supplied) is stripped', () {
-    test(
-      'a selected coin that is also unspendable never reaches the datasource',
-      () async {
-        await buildPsbt(
-          unspendable: const [(txId: 'tx-frozen', vout: 0)],
-          selected: [
-            _utxo(txId: 'tx-frozen', vout: 0), // must be stripped
-            _utxo(txId: 'tx-free', vout: 1), // must pass through
-          ],
-        );
-
-        final selected = capturedSelected();
-        expect(selected, hasLength(1));
-        expect(selected!.single.txId, 'tx-free');
-        expect(selected.single.vout, 1);
-      },
-    );
-
-    test('same txId but different vout is NOT stripped', () async {
-      await buildPsbt(
-        unspendable: const [(txId: 'tx-shared', vout: 0)],
-        selected: [_utxo(txId: 'tx-shared', vout: 1)],
-      );
-
-      final selected = capturedSelected();
-      expect(selected, hasLength(1));
-      expect(selected!.single.vout, 1);
-    });
-
-    test(
-      'empty frozen store and no unspendable leaves the selection untouched',
-      () async {
-        await buildPsbt(
-          selected: [
-            _utxo(txId: 'tx-a', vout: 0),
-            _utxo(txId: 'tx-b', vout: 1),
-          ],
-        );
-
-        expect(capturedSelected(), hasLength(2));
-      },
-    );
-  });
-
   group('replaceByFee default', () {
     test('omitted flag defaults to RBF ENABLED (true)', () async {
       await buildPsbt();
@@ -304,31 +249,5 @@ void main() {
 
       expect(capturedReplaceByFee(), isFalse);
     });
-  });
-
-  test('private wallet reconstruction rejects a higher account', () async {
-    when(() => metadataDatasource.fetch(_walletId)).thenAnswer(
-      (_) async => metadata.copyWith(
-        signers: [
-          walletSignerModel(
-            id: 'signer-0',
-            descriptorKeyId: 'key-0',
-            masterFingerprint: '73c5da0a',
-            xpubFingerprint: 'deadbeef',
-            xpub: 'tpub-test',
-            derivationPath: "m/84'/1'/1'",
-            descriptorPath: '/<0;1>/*',
-            signer: Signer.local,
-            signerDevice: null,
-          ),
-        ],
-      ),
-    );
-
-    await expectLater(
-      repository.getPrivateWallet(walletId: _walletId),
-      throwsA(isA<StateError>()),
-    );
-    verifyNever(() => seedDatasource.get(any()));
   });
 }

--- a/test/core_test/wallet/data/datasources/bdk_wallet_coin_selection_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_coin_selection_test.dart
@@ -1,0 +1,376 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_signer_table.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bitcoin_base/bitcoin_base.dart' as bitcoin_base;
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../../bdk_wallet_test_fixture.dart';
+import '../../wallet_signer_test_fixture.dart';
+
+final class _TestPathProvider extends PathProviderPlatform {
+  final String path;
+
+  _TestPathProvider(this.path);
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+final class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+final class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+final class _MockFrozenWalletUtxoDatasource extends Mock
+    implements FrozenWalletUtxoDatasource {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDirectory;
+  late PathProviderPlatform originalPathProvider;
+
+  setUp(() {
+    tempDirectory = Directory.systemTemp.createTempSync(
+      'bdk_coin_selection_test',
+    );
+    originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _TestPathProvider(tempDirectory.path);
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+    tempDirectory.deleteSync(recursive: true);
+  });
+
+  test(
+    'does not add another wallet coin to an insufficient selection',
+    () async {
+      final descriptors = singleSignatureDescriptors(testMnemonics.first);
+      final walletModel =
+          WalletModel.publicBdk(
+                id: 'manual-selection',
+                descriptor: twoPathDescriptor(
+                  descriptors.external,
+                  descriptors.internal,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final wallet = await BdkFacade.createWallet(walletModel);
+      final receivingAddress = wallet.peekAddress(
+        keychain: bdk.KeychainKind.external_,
+        index: 0,
+      );
+      wallet.applyUnconfirmedTxs(
+        unconfirmedTxs: [
+          bdk.UnconfirmedTx(
+            tx: fundingTransaction(
+              receivingAddress.address.scriptPubkey(),
+              previousTxByte: 0x31,
+            ),
+            lastSeen: 1,
+          ),
+          bdk.UnconfirmedTx(
+            tx: fundingTransaction(
+              receivingAddress.address.scriptPubkey(),
+              previousTxByte: 0x32,
+            ),
+            lastSeen: 2,
+          ),
+        ],
+      );
+      await BdkFacade.saveWallet(wallet, walletModel.hexId);
+      final selected = wallet.listUnspent().first;
+      final recipient = wallet.peekAddress(
+        keychain: bdk.KeychainKind.external_,
+        index: 1,
+      );
+      final recipientAddress = recipient.address.toString();
+      final receivingAddressString = receivingAddress.address.toString();
+      wallet.dispose();
+
+      final datasource = BdkWalletDatasource();
+      await expectLater(
+        datasource.buildPsbt(
+          address: recipientAddress,
+          amountSat: 150000,
+          networkFee: const NetworkFee.absolute(1000),
+          selected: [
+            WalletUtxoModel.bitcoin(
+              txId: selected.outpoint.txid.toString(),
+              vout: selected.outpoint.vout,
+              amountSat: BigInt.from(100000),
+              scriptPubkey: Uint8List(0),
+              address: receivingAddressString,
+              isExternalKeyChain: true,
+            ),
+          ],
+          wallet: walletModel,
+        ),
+        throwsA(isA<SelectedBitcoinCoinsInsufficientException>()),
+      );
+    },
+  );
+
+  test('rejects a witness UTXO that differs from the wallet output', () async {
+    final descriptors = singleSignatureDescriptors(testMnemonics.first);
+    final walletModel =
+        WalletModel.publicBdk(
+              id: 'witness-utxo-validation',
+              descriptor: twoPathDescriptor(
+                descriptors.external,
+                descriptors.internal,
+              ),
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final wallet = await BdkFacade.createWallet(walletModel);
+    final receivingAddress = wallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 0,
+    );
+    final recipient = wallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 1,
+    );
+    wallet.applyUnconfirmedTxs(
+      unconfirmedTxs: [
+        bdk.UnconfirmedTx(
+          tx: fundingTransaction(receivingAddress.address.scriptPubkey()),
+          lastSeen: 1,
+        ),
+      ],
+    );
+    await BdkFacade.saveWallet(wallet, walletModel.hexId);
+    wallet.dispose();
+
+    final datasource = BdkWalletDatasource();
+    final psbtBase64 = await datasource.buildPsbt(
+      wallet: walletModel,
+      address: recipient.address.toString(),
+      amountSat: 50000,
+      networkFee: const NetworkFee.absolute(1000),
+    );
+    final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+    final witnessUtxo = psbt.input.getInput<bitcoin_base.PsbtInputWitnessUtxo>(
+      0,
+      bitcoin_base.PsbtInputTypes.witnessUTXO,
+    )!;
+    psbt.input.updateInputs(0, [
+      bitcoin_base.PsbtInputWitnessUtxo(
+        amount: witnessUtxo.amount + BigInt.one,
+        scriptPubKey: witnessUtxo.scriptPubKey,
+      ),
+    ]);
+
+    await expectLater(
+      datasource.validateWalletPsbtInputs(psbt.toBase64(), wallet: walletModel),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+  });
+
+  test('rejects a PSBT that repeats a wallet input', () async {
+    final descriptors = singleSignatureDescriptors(testMnemonics.first);
+    final walletModel =
+        WalletModel.publicBdk(
+              id: 'duplicate-input-validation',
+              descriptor: twoPathDescriptor(
+                descriptors.external,
+                descriptors.internal,
+              ),
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final wallet = await BdkFacade.createWallet(walletModel);
+    final receivingAddress = wallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 0,
+    );
+    final recipient = wallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 1,
+    );
+    wallet.applyUnconfirmedTxs(
+      unconfirmedTxs: [
+        bdk.UnconfirmedTx(
+          tx: fundingTransaction(receivingAddress.address.scriptPubkey()),
+          lastSeen: 1,
+        ),
+      ],
+    );
+    await BdkFacade.saveWallet(wallet, walletModel.hexId);
+    wallet.dispose();
+    final datasource = BdkWalletDatasource();
+    final psbtBase64 = await datasource.buildPsbt(
+      wallet: walletModel,
+      address: recipient.address.toString(),
+      amountSat: 50000,
+      networkFee: const NetworkFee.absolute(1000),
+    );
+    final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+    final unsignedTransaction = psbt.global
+        .getGlobal<bitcoin_base.PsbtGlobalUnsignedTransaction>(
+          bitcoin_base.PsbtGlobalTypes.unsignedTx,
+        )!;
+    final duplicateTransaction = unsignedTransaction.transaction.copyWith(
+      inputs: [
+        ...unsignedTransaction.transaction.inputs,
+        unsignedTransaction.transaction.inputs.single.copyWith(),
+      ],
+    );
+    final duplicateInputPsbt = bitcoin_base.Psbt(
+      global: bitcoin_base.PsbtGlobal(
+        entries: [
+          for (final entry in psbt.global.entries)
+            if (entry.type != bitcoin_base.PsbtGlobalTypes.unsignedTx) entry,
+          bitcoin_base.PsbtGlobalUnsignedTransaction(duplicateTransaction),
+        ],
+        version: psbt.version,
+      ),
+      input: bitcoin_base.PsbtInput(
+        entries: [...psbt.input.entries, psbt.input.entries.single],
+        version: psbt.version,
+      ),
+      output: bitcoin_base.PsbtOutput(
+        entries: psbt.output.entries,
+        version: psbt.version,
+      ),
+    );
+
+    await expectLater(
+      datasource.validateWalletPsbtInputs(
+        duplicateInputPsbt.toBase64(),
+        wallet: walletModel,
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+  });
+
+  test(
+    'validates the spent inputs of the transaction being replaced',
+    () async {
+      final descriptors = singleSignatureDescriptors(testMnemonics.first);
+      final walletModel =
+          WalletModel.publicBdk(
+                id: 'replacement-input-validation',
+                descriptor: twoPathDescriptor(
+                  descriptors.external,
+                  descriptors.internal,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final wallet = await BdkFacade.createWallet(walletModel);
+      final receivingAddress = wallet.peekAddress(
+        keychain: bdk.KeychainKind.external_,
+        index: 0,
+      );
+      final recipient = wallet.peekAddress(
+        keychain: bdk.KeychainKind.external_,
+        index: 1,
+      );
+      wallet.applyUnconfirmedTxs(
+        unconfirmedTxs: [
+          bdk.UnconfirmedTx(
+            tx: fundingTransaction(receivingAddress.address.scriptPubkey()),
+            lastSeen: 1,
+          ),
+        ],
+      );
+      await BdkFacade.saveWallet(wallet, walletModel.hexId);
+
+      final datasource = BdkWalletDatasource();
+      final originalPsbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: recipient.address.toString(),
+        amountSat: 50000,
+        networkFee: const NetworkFee.absolute(1000),
+      );
+      final parsedOriginal = bdk.Psbt(psbtBase64: originalPsbt);
+      final originalTransaction = parsedOriginal.extractTx();
+      final originalTxid = originalTransaction.computeTxid().toString();
+      wallet.applyUnconfirmedTxs(
+        unconfirmedTxs: [
+          bdk.UnconfirmedTx(tx: originalTransaction, lastSeen: 2),
+        ],
+      );
+      await BdkFacade.saveWallet(wallet, walletModel.hexId);
+      parsedOriginal.dispose();
+      wallet.dispose();
+
+      final metadata = WalletMetadataModel(
+        id: walletModel.id,
+        network: Network.bitcoinTestnet,
+        signers: [
+          walletSignerModel(
+            id: 'local-signer',
+            descriptorKeyId: 'local-key',
+            masterFingerprint: descriptors.fingerprint,
+            xpubFingerprint: descriptors.fingerprint,
+            xpub: descriptors.xpub,
+            derivationPath: "m/84'/1'/0'",
+            descriptorPath: standardSingleSignatureDescriptorPath,
+            signer: Signer.local,
+            signerDevice: null,
+          ),
+        ],
+        isEncryptedVaultTested: false,
+        isPhysicalBackupTested: false,
+        publicDescriptor: walletModel.descriptor,
+        isDefault: false,
+      );
+      final metadataDatasource = _MockWalletMetadataDatasource();
+      final seedDatasource = _MockSeedDatasource();
+      final frozenDatasource = _MockFrozenWalletUtxoDatasource();
+      when(
+        () => metadataDatasource.fetch(metadata.id),
+      ).thenAnswer((_) async => metadata);
+      when(() => seedDatasource.get(descriptors.fingerprint)).thenAnswer(
+        (_) async =>
+            SeedModel.mnemonic(mnemonicWords: testMnemonics.first.split(' ')),
+      );
+      when(() => frozenDatasource.getAllFrozen()).thenAnswer((_) async => []);
+      final repository = BitcoinWalletRepository(
+        walletMetadataDatasource: metadataDatasource,
+        seedDatasource: seedDatasource,
+        bdkWalletDatasource: datasource,
+        frozenWalletUtxoDatasource: frozenDatasource,
+      );
+
+      final replacementPsbt = await repository.bumpFee(
+        walletId: metadata.id,
+        txid: originalTxid,
+        newFeeRate: const RelativeFee(2500),
+      );
+
+      final replacement = bdk.Psbt(psbtBase64: replacementPsbt);
+      expect(
+        replacement.input().every(
+          (input) =>
+              input.finalScriptSig != null || input.finalScriptWitness != null,
+        ),
+        isTrue,
+      );
+      replacement.dispose();
+    },
+  );
+}

--- a/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
@@ -1,0 +1,396 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/uint_8_list_x.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/wallet_descriptor_key_matcher.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_policy_maturity_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../bdk_wallet_test_fixture.dart';
+
+void main() {
+  late List<SignerDescriptorKeys> signers;
+  late String externalPublicDescriptor;
+  late String internalPublicDescriptor;
+  late BdkWalletDatasource datasource;
+
+  setUpAll(() {
+    signers = testMnemonics.map(deriveSignerKeys).toList();
+    externalPublicDescriptor = sortedMultisigDescriptor(
+      signers.map((signer) => signer.externalPublic).toList(),
+    );
+    internalPublicDescriptor = sortedMultisigDescriptor(
+      signers.map((signer) => signer.internalPublic).toList(),
+    );
+  });
+
+  setUp(() {
+    datasource = BdkWalletDatasource();
+  });
+
+  BitcoinWalletPolicy analyzePolicy({required PublicBdkWalletModel wallet}) =>
+      BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(wallet: wallet),
+      );
+
+  group('BdkWalletDatasource policy analysis', () {
+    test('classifies mobile and external single-signature wallets', () {
+      final descriptors = singleSignatureDescriptors(testMnemonics.first);
+      final policy = analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'single-signature',
+                  descriptor: twoPathDescriptor(
+                    descriptors.external,
+                    descriptors.internal,
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+      );
+      final localPlan = BitcoinSigningPlan.fromPolicy(
+        policy: policy,
+        signers: [
+          walletSigner(
+            fingerprint: descriptors.fingerprint,
+            xpub: descriptors.xpub,
+            signer: SignerEntity.local,
+          ),
+        ],
+      );
+      final externalPlan = BitcoinSigningPlan.fromPolicy(
+        policy: policy,
+        signers: [
+          walletSigner(
+            fingerprint: descriptors.fingerprint,
+            xpub: descriptors.xpub,
+            signer: SignerEntity.remote,
+          ),
+        ],
+      );
+
+      expect(localPlan.canFinalizeLocally, isTrue);
+      expect(localPlan.requiresExternalSigning, isFalse);
+      expect(externalPlan.requiresExternalSigning, isTrue);
+    });
+
+    test('requires another signer when local keys are below the threshold', () {
+      final policy = analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'multisig',
+                  descriptor: twoPathDescriptor(
+                    externalPublicDescriptor,
+                    internalPublicDescriptor,
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+      );
+      final oneLocalSigner = BitcoinSigningPlan.fromPolicy(
+        policy: policy,
+        signers: [
+          for (final (index, signer) in signers.indexed)
+            walletSigner(
+              fingerprint: signer.fingerprint,
+              xpub: signer.xpub,
+              signer: index == 0 ? SignerEntity.local : SignerEntity.remote,
+            ),
+        ],
+      );
+      final twoLocalSigners = BitcoinSigningPlan.fromPolicy(
+        policy: policy,
+        signers: [
+          for (final (index, signer) in signers.indexed)
+            walletSigner(
+              fingerprint: signer.fingerprint,
+              xpub: signer.xpub,
+              signer: index < 2 ? SignerEntity.local : SignerEntity.remote,
+            ),
+        ],
+      );
+
+      expect(policy.external.root, isA<BitcoinThresholdPolicyNode>());
+      expect(oneLocalSigner.canFinalizeLocally, isFalse);
+      expect(oneLocalSigner.requiresExternalSigning, isTrue);
+      expect(twoLocalSigners.canFinalizeLocally, isTrue);
+      expect(twoLocalSigners.requiresExternalSigning, isFalse);
+    });
+
+    test('maps Miniscript branches and relative timelocks', () {
+      final externalDescriptor = bdk.Descriptor.newWsh(
+        miniScript:
+            'or_d(pk(${signers[0].externalPublic}),and_v(v:older(10),pk(${signers[1].externalPublic})))',
+      ).toString();
+      final internalDescriptor = bdk.Descriptor.newWsh(
+        miniScript:
+            'or_d(pk(${signers[0].internalPublic}),and_v(v:older(10),pk(${signers[1].internalPublic})))',
+      ).toString();
+
+      final policy = analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'miniscript',
+                  descriptor: twoPathDescriptor(
+                    externalDescriptor,
+                    internalDescriptor,
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+      );
+
+      expect(policy.requiresPath, isTrue);
+      expect(
+        containsPolicyNode<BitcoinRelativeTimelockPolicyNode>(
+          policy.external.root,
+        ),
+        isTrue,
+      );
+
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      final delayedIndex = selector.options.indexWhere(
+        containsPolicyNode<BitcoinRelativeTimelockPolicyNode>,
+      );
+      final immediateIndex = selector.options.indexWhere(
+        (option) =>
+            !containsPolicyNode<BitcoinRelativeTimelockPolicyNode>(option),
+      );
+      final delayedSelection = policy.select(
+        current: const BitcoinPolicySelection.empty(),
+        requirement: selector,
+        selectedIndices: {delayedIndex},
+      );
+      final immediateSelection = policy.select(
+        current: const BitcoinPolicySelection.empty(),
+        requirement: selector,
+        selectedIndices: {immediateIndex},
+      );
+      final delayedPath = policy.buildPath(delayedSelection);
+
+      expect(policy.pathRequirements(delayedSelection), isEmpty);
+      expect(delayedPath.external, hasLength(1));
+      expect(delayedPath.internal, hasLength(1));
+      expect(delayedPath.requiresRelativeTimelock, isTrue);
+      expect(
+        policy.buildPath(immediateSelection).requiresRelativeTimelock,
+        isFalse,
+      );
+
+      final plan = BitcoinSigningPlan.fromPolicy(
+        policy: policy,
+        selection: delayedSelection,
+        signers: [
+          walletSigner(
+            fingerprint: signers[0].fingerprint,
+            xpub: signers[0].xpub,
+            signer: SignerEntity.local,
+          ),
+          walletSigner(
+            fingerprint: signers[1].fingerprint,
+            xpub: signers[1].xpub,
+            signer: SignerEntity.remote,
+          ),
+        ],
+      );
+      expect(
+        plan.requires(
+          walletSigner(
+            fingerprint: signers[0].fingerprint,
+            xpub: signers[0].xpub,
+            signer: SignerEntity.local,
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        bdk.Psbt(
+          psbtBase64: buildUnsignedPsbt(
+            descriptor: twoPathDescriptor(
+              externalDescriptor,
+              internalDescriptor,
+            ),
+            policyPath: delayedPath,
+          ),
+        ).extractTx().input().single.sequence,
+        10,
+      );
+    });
+
+    test('maps one signer account keys to distinct descriptor keys', () {
+      final signer = deriveSignerKeysAtAccount(testMnemonics.first, account: 0);
+      final accountKey = signer.externalPublic.replaceFirst('/0/*', '');
+      final descriptor =
+          'wsh(sortedmulti(2,$accountKey/0/<0;1>/*,$accountKey/1/<0;1>/*))';
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = [
+        for (final (index, key) in parsed.keys.indexed)
+          WalletDescriptorKeyModel(
+            id: 'key-$index',
+            signerId: 'signer-0',
+            masterFingerprint: key.masterFingerprint,
+            xpubFingerprint: key.xpubFingerprint,
+            xpub: key.xpub,
+            derivationPath: key.derivationPath,
+            descriptorPath: key.descriptorPath,
+          ),
+      ];
+
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet:
+              WalletModel.publicBdk(
+                    id: 'repeated-key',
+                    descriptor: descriptor,
+                    isTestnet: true,
+                  )
+                  as PublicBdkWalletModel,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+
+      expect(parsed.keys, hasLength(2));
+      expect(parsed.keys.map((key) => key.xpub).toSet(), hasLength(1));
+      expect(parsed.keys.map((key) => key.descriptorPath).toSet(), {
+        '/0/<0;1>/*',
+        '/1/<0;1>/*',
+      });
+      expect(_signatureKeyValues(policy.external.root), ['key-0', 'key-1']);
+
+      final firstKey = descriptorKeys.singleWhere(
+        (key) => key.descriptorPath.startsWith('/0/'),
+      );
+      final secondKey = descriptorKeys.singleWhere(
+        (key) => key.descriptorPath.startsWith('/1/'),
+      );
+      final firstPublicKey = Bip32Derivation.getBip32Xpub(
+        firstKey.xpub,
+      ).derivePath('0/0/0').public.toHexString();
+      expect(
+        walletDescriptorKeyMatches(
+          key: firstKey,
+          publicKey: firstPublicKey,
+          fingerprint: firstKey.masterFingerprint,
+          derivationPath: '${firstKey.derivationPath}/0/0/0',
+          keychain: BitcoinPolicyKeychainModel.external,
+        ),
+        isTrue,
+      );
+      expect(
+        walletDescriptorKeyMatches(
+          key: secondKey,
+          publicKey: firstPublicKey,
+          fingerprint: secondKey.masterFingerprint,
+          derivationPath: '${secondKey.derivationPath}/0/0/0',
+          keychain: BitcoinPolicyKeychainModel.external,
+        ),
+        isFalse,
+      );
+    });
+
+    test('matches multipath alternatives in keychain order', () {
+      final signer = deriveSignerKeysAtAccount(testMnemonics.first, account: 0);
+      final parsedKey = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: 'wsh(pk(${signer.xpub}/<0;1>/*))',
+        isTestnet: true,
+      ).keys.single;
+      final externalFirst = WalletDescriptorKeyModel(
+        id: 'external-first',
+        signerId: 'signer',
+        masterFingerprint: parsedKey.masterFingerprint,
+        xpubFingerprint: parsedKey.xpubFingerprint,
+        xpub: parsedKey.xpub,
+        derivationPath: parsedKey.derivationPath,
+        descriptorPath: '/<0;1>/*',
+      );
+      final internalFirst = externalFirst.copyWith(
+        id: 'internal-first',
+        descriptorPath: '/<1;0>/*',
+      );
+      final publicKey = Bip32Derivation.getBip32Xpub(
+        parsedKey.xpub,
+      ).derivePath('0/0').public.toHexString();
+      final derivationPath = '${parsedKey.derivationPath}/0/0';
+
+      expect(
+        walletDescriptorKeyMatches(
+          key: externalFirst,
+          publicKey: publicKey,
+          fingerprint: signer.fingerprint,
+          derivationPath: derivationPath,
+          keychain: BitcoinPolicyKeychainModel.external,
+        ),
+        isTrue,
+      );
+      expect(
+        walletDescriptorKeyMatches(
+          key: internalFirst,
+          publicKey: publicKey,
+          fingerprint: signer.fingerprint,
+          derivationPath: derivationPath,
+          keychain: BitcoinPolicyKeychainModel.external,
+        ),
+        isFalse,
+      );
+      expect(
+        walletDescriptorKeyMatches(
+          key: internalFirst,
+          publicKey: publicKey,
+          fingerprint: signer.fingerprint,
+          derivationPath: derivationPath,
+          keychain: BitcoinPolicyKeychainModel.internal,
+        ),
+        isTrue,
+      );
+    });
+
+    test('decodes time-based relative timelocks', () {
+      const oneTimeUnit = (1 << 22) + 1;
+      final policy = analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'time-based-miniscript',
+                  descriptor: twoPathDescriptor(
+                    bdk.Descriptor.newWsh(
+                      miniScript:
+                          'and_v(v:older($oneTimeUnit),pk(${signers[0].externalPublic}))',
+                    ).toString(),
+                    bdk.Descriptor.newWsh(
+                      miniScript:
+                          'and_v(v:older($oneTimeUnit),pk(${signers[0].internalPublic}))',
+                    ).toString(),
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+      );
+
+      final timelock = findPolicyNode<BitcoinRelativeTimelockPolicyNode>(
+        policy.external.root,
+      );
+
+      expect(timelock, isNotNull);
+      expect(timelock!.type, BitcoinRelativeTimelockType.seconds);
+      expect(timelock.value, 512);
+    });
+  });
+}
+
+List<String> _signatureKeyValues(BitcoinPolicyNode node) => switch (node) {
+  BitcoinSignaturePolicyNode(:final key) => [key.value],
+  BitcoinThresholdPolicyNode(:final children) => [
+    for (final child in children) ..._signatureKeyValues(child),
+  ],
+  _ => const [],
+};

--- a/test/core_test/wallet/data/datasources/bdk_wallet_signing_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_signing_test.dart
@@ -1,0 +1,1453 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bitcoin_base/bitcoin_base.dart' as bitcoin_base;
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import '../../bdk_wallet_test_fixture.dart';
+
+final class _TestPathProvider extends PathProviderPlatform {
+  final String path;
+
+  _TestPathProvider(this.path);
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}
+
+void main() {
+  late List<SignerDescriptorKeys> signers;
+  late String externalPublicDescriptor;
+  late String internalPublicDescriptor;
+  late BdkWalletDatasource datasource;
+  late Directory tempDirectory;
+  late PathProviderPlatform originalPathProvider;
+
+  setUpAll(() {
+    signers = testMnemonics.map(deriveSignerKeys).toList();
+    externalPublicDescriptor = sortedMultisigDescriptor(
+      signers.map((signer) => signer.externalPublic).toList(),
+    );
+    internalPublicDescriptor = sortedMultisigDescriptor(
+      signers.map((signer) => signer.internalPublic).toList(),
+    );
+  });
+
+  setUp(() {
+    tempDirectory = Directory.systemTemp.createTempSync(
+      'bdk_wallet_signing_test',
+    );
+    originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _TestPathProvider(tempDirectory.path);
+    datasource = BdkWalletDatasource();
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+    tempDirectory.deleteSync(recursive: true);
+  });
+
+  test('signs a single-signature wallet at a nonzero account', () async {
+    const account = 1;
+    final descriptors = singleSignatureDescriptorsAtAccount(
+      testMnemonics.first,
+      account: account,
+    );
+    final descriptor = twoPathDescriptor(
+      descriptors.external,
+      descriptors.internal,
+    );
+    final unsignedPsbt = buildUnsignedPsbt(descriptor: descriptor);
+    final wallet =
+        WalletModel.privateBdk(
+              id: 'account-$account',
+              scriptType: ScriptType.bip84,
+              mnemonic: testMnemonics.first,
+              account: account,
+              isTestnet: true,
+            )
+            as PrivateBdkWalletModel;
+
+    final signed = await datasource.signPsbt(unsignedPsbt, wallet: wallet);
+
+    expect(signed.isFinalized, isTrue);
+  });
+
+  for (final scenario in [
+    (
+      name: 'native SegWit',
+      scriptType: ScriptType.bip84,
+      descriptors: singleSignatureDescriptors(testMnemonics.first),
+    ),
+    (
+      name: 'nested SegWit',
+      scriptType: ScriptType.bip49,
+      descriptors: nestedSegwitSingleSignatureDescriptors(testMnemonics.first),
+    ),
+  ]) {
+    test('allows only foreign finalized ${scenario.name} inputs', () async {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          scenario.descriptors.external,
+          scenario.descriptors.internal,
+        ),
+      );
+      final owner =
+          WalletModel.privateBdk(
+                id: 'payjoin-${scenario.scriptType.name}-owner',
+                scriptType: scenario.scriptType,
+                mnemonic: testMnemonics.first,
+                account: 0,
+                isTestnet: true,
+              )
+              as PrivateBdkWalletModel;
+      final foreign =
+          WalletModel.privateBdk(
+                id: 'payjoin-foreign',
+                scriptType: ScriptType.bip84,
+                mnemonic: testMnemonics.last,
+                account: 0,
+                isTestnet: true,
+              )
+              as PrivateBdkWalletModel;
+      final finalized = await datasource.signPsbt(unsignedPsbt, wallet: owner);
+      final witnessOnly = bitcoin_base.Psbt.fromBase64(
+        finalized.psbt,
+      )..input.removeInputKeys(0, [bitcoin_base.PsbtInputTypes.nonWitnessUTXO]);
+
+      final accepted = await datasource.signPsbt(
+        witnessOnly.toBase64(),
+        wallet: foreign,
+        allowFinalizedForeignInputs: true,
+      );
+
+      expect(accepted.isFinalized, isTrue);
+      await expectLater(
+        datasource.signPsbt(
+          witnessOnly.toBase64(),
+          wallet: owner,
+          allowFinalizedForeignInputs: true,
+        ),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    });
+  }
+
+  test('allows a foreign finalized Taproot input for Payjoin', () async {
+    final root = bdk.DescriptorSecretKey(
+      networkKind: bdk.NetworkKind.test,
+      mnemonic: bdk.Mnemonic.fromString(mnemonic: testMnemonics.first),
+      password: null,
+    );
+    final external = bdk.Descriptor.newBip86(
+      secretKey: root,
+      keychainKind: bdk.KeychainKind.external_,
+      networkKind: bdk.NetworkKind.test,
+    ).toStringWithSecret();
+    final internal = bdk.Descriptor.newBip86(
+      secretKey: root,
+      keychainKind: bdk.KeychainKind.internal,
+      networkKind: bdk.NetworkKind.test,
+    ).toStringWithSecret();
+    final descriptor = twoPathDescriptor(external, internal);
+    final unsignedPsbt = buildUnsignedPsbt(descriptor: descriptor);
+    final finalizedPsbt = bdk.Psbt(psbtBase64: unsignedPsbt);
+    final owner = BdkFacade.createEphemeralDescriptorWallet(
+      descriptor: descriptor,
+      isTestnet: true,
+    );
+    final finalized = owner.sign(
+      psbt: finalizedPsbt,
+      signOptions: bdk.SignOptions(
+        trustWitnessUtxo: true,
+        assumeHeight: null,
+        allowAllSighashes: false,
+        tryFinalize: true,
+        signWithTapInternalKey: true,
+        allowGrinding: true,
+      ),
+    );
+    expect(finalized, isTrue);
+    final foreign =
+        WalletModel.privateBdk(
+              id: 'payjoin-foreign-taproot',
+              scriptType: ScriptType.bip84,
+              mnemonic: testMnemonics.last,
+              account: 0,
+              isTestnet: true,
+            )
+            as PrivateBdkWalletModel;
+    final witnessOnly = bitcoin_base.Psbt.fromBase64(finalizedPsbt.serialize())
+      ..input.removeInputKeys(0, [bitcoin_base.PsbtInputTypes.nonWitnessUTXO]);
+
+    final accepted = await datasource.signPsbt(
+      witnessOnly.toBase64(),
+      wallet: foreign,
+      allowFinalizedForeignInputs: true,
+    );
+
+    expect(accepted.isFinalized, isTrue);
+  });
+
+  test('does not mistake a key-path signature for a Taproot annex', () async {
+    const finalizedPsbt =
+        'cHNidP8BAIkCAAAAAaWqMHcygsAiO4oBjpGSIPmYdwL2TRrCaGIazFlx9nzHAAAAAAD9'
+        '////AlAxAQAAAAAAIlEg1zrPZme3hQ5uAOIbtFJaLF4tiJVqPSw1sLwG9LDfAbxoUQAA'
+        'AAAAACJRICvvoUQx1MtxiJ6h33p+qi8di5EH5gsBVk4V2r5cDf0yAAAAAAABASughgEA'
+        'AAAAACJRIDuCsrKpGFMV2m+A2l8G0EQNil4UV/qTOHwtkZyG7IeGAQhCAUBQGEy2i7Gu'
+        'AA3sZudHK1rR6K52NHRoVkiCiqYusKp0PZIQ03fiwKiRWXEiXBCmdt3gLoDwBTylRj1B'
+        'PEDYXE27AAEFILEKyX9nbPHzzNrLC3gXEoK76UqU3xQyAXANxZvMFfNoAAEFIDBYZ59tY'
+        'Lh++SHZiiqaHx4Hedrie+29HNsvFHoHg1rJAA==';
+    final parsed = bdk.Psbt(psbtBase64: finalizedPsbt);
+    final transaction = parsed.extractTx();
+    final witness = transaction.input().single.witness;
+    expect(witness, hasLength(1));
+    expect(witness.single, hasLength(64));
+    expect(witness.single.first, 0x50);
+    transaction.dispose();
+    parsed.dispose();
+    final foreign =
+        WalletModel.privateBdk(
+              id: 'payjoin-foreign-taproot-annex',
+              scriptType: ScriptType.bip84,
+              mnemonic: testMnemonics.last,
+              account: 0,
+              isTestnet: true,
+            )
+            as PrivateBdkWalletModel;
+
+    final accepted = await datasource.signPsbt(
+      finalizedPsbt,
+      wallet: foreign,
+      allowFinalizedForeignInputs: true,
+    );
+
+    expect(accepted.isFinalized, isTrue);
+  });
+
+  test('allows a foreign finalized Taproot script-path input', () async {
+    final external = bdk.Descriptor(
+      descriptor:
+          'tr(${signers[0].externalPublic},{pk(${signers[1].externalPrivate}),pk(${signers[2].externalPublic})})',
+      networkKind: bdk.NetworkKind.test,
+    ).toStringWithSecret();
+    final internal = bdk.Descriptor(
+      descriptor:
+          'tr(${signers[0].internalPublic},{pk(${signers[1].internalPrivate}),pk(${signers[2].internalPublic})})',
+      networkKind: bdk.NetworkKind.test,
+    ).toStringWithSecret();
+    final descriptor = twoPathDescriptor(external, internal);
+    final finalizedPsbt = bdk.Psbt(
+      psbtBase64: buildUnsignedPsbt(descriptor: descriptor),
+    );
+    final owner = BdkFacade.createEphemeralDescriptorWallet(
+      descriptor: descriptor,
+      isTestnet: true,
+    );
+    final finalized = owner.sign(
+      psbt: finalizedPsbt,
+      signOptions: bdk.SignOptions(
+        trustWitnessUtxo: true,
+        assumeHeight: null,
+        allowAllSighashes: false,
+        tryFinalize: true,
+        signWithTapInternalKey: false,
+        allowGrinding: true,
+      ),
+    );
+    expect(finalized, isTrue);
+    final foreign =
+        WalletModel.privateBdk(
+              id: 'payjoin-foreign-taproot-script-path',
+              scriptType: ScriptType.bip84,
+              mnemonic: testMnemonics.last,
+              account: 0,
+              isTestnet: true,
+            )
+            as PrivateBdkWalletModel;
+    final witnessOnly = bitcoin_base.Psbt.fromBase64(finalizedPsbt.serialize())
+      ..input.removeInputKeys(0, [bitcoin_base.PsbtInputTypes.nonWitnessUTXO]);
+
+    final accepted = await datasource.signPsbt(
+      witnessOnly.toBase64(),
+      wallet: foreign,
+      allowFinalizedForeignInputs: true,
+    );
+
+    expect(accepted.isFinalized, isTrue);
+  });
+
+  group('BdkWalletDatasource multisig PSBT operations', () {
+    test(
+      'verifies inputs, recipients, and change against descriptors',
+      () async {
+        final recipientDescriptors = singleSignatureDescriptors(
+          testMnemonics.last,
+        );
+        final recipientWallet = BdkFacade.createEphemeralDescriptorWallet(
+          descriptor: twoPathDescriptor(
+            recipientDescriptors.external,
+            recipientDescriptors.internal,
+          ),
+          isTestnet: true,
+        );
+        final unsignedPsbt = buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+          recipientScript: recipientWallet
+              .peekAddress(keychain: bdk.KeychainKind.external_, index: 5)
+              .address
+              .scriptPubkey(),
+        );
+        final wallet =
+            WalletModel.publicBdk(
+                  id: 'review',
+                  descriptor: twoPathDescriptor(
+                    externalPublicDescriptor,
+                    internalPublicDescriptor,
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel;
+
+        final review = await datasource.inspectPsbt(
+          unsignedPsbt,
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        );
+
+        expect(review.inputs, hasLength(1));
+        expect(review.feeSat, BigInt.from(1000));
+        expect(
+          review.outputs.where((output) => output.isWalletOwned),
+          hasLength(1),
+        );
+        expect(
+          review.outputs.where((output) => !output.isWalletOwned),
+          hasLength(1),
+        );
+        expect(
+          review.estimatedTransactionVsize,
+          greaterThan(bdk.Psbt(psbtBase64: unsignedPsbt).extractTx().vsize()),
+        );
+      },
+    );
+
+    test('estimates completed size and uses exact size after finalization', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'size',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final estimated = datasource.decodeTxSize(unsignedPsbt, wallet: wallet);
+      final first = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      expect(datasource.decodeTxSize(first.psbt, wallet: wallet), estimated);
+      final second = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final finalized = datasource.finalizePsbt(
+        datasource.combinePsbts(first: first.psbt, second: second.psbt),
+      );
+      final exact = bdk.Psbt(psbtBase64: finalized.psbt).extractTx().vsize();
+
+      expect(finalized.isFinalized, isTrue);
+      expect(datasource.decodeTxSize(finalized.psbt, wallet: wallet), exact);
+      expect(estimated, greaterThanOrEqualTo(exact));
+    });
+
+    test(
+      'reviews a finalized PSBT after signing metadata is cleared',
+      () async {
+        final recipientDescriptors = singleSignatureDescriptors(
+          testMnemonics.last,
+        );
+        final recipientWallet = BdkFacade.createEphemeralDescriptorWallet(
+          descriptor: twoPathDescriptor(
+            recipientDescriptors.external,
+            recipientDescriptors.internal,
+          ),
+          isTestnet: true,
+        );
+        final unsignedPsbt = buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+          inputIndex: 30,
+          recipientScript: recipientWallet
+              .peekAddress(keychain: bdk.KeychainKind.external_, index: 5)
+              .address
+              .scriptPubkey(),
+        );
+        final wallet =
+            WalletModel.publicBdk(
+                  id: 'finalized-review',
+                  descriptor: twoPathDescriptor(
+                    externalPublicDescriptor,
+                    internalPublicDescriptor,
+                  ),
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel;
+        final trackedWallet = await BdkFacade.createWallet(wallet);
+        for (var index = 0; index <= 30; index++) {
+          trackedWallet.revealNextAddress(keychain: bdk.KeychainKind.external_);
+        }
+        await BdkFacade.saveWallet(trackedWallet, wallet.hexId);
+        trackedWallet.dispose();
+        final first = signPsbt(
+          datasource,
+          unsignedPsbt,
+          signers: signers,
+          signerIndex: 0,
+        );
+        final second = signPsbt(
+          datasource,
+          unsignedPsbt,
+          signers: signers,
+          signerIndex: 1,
+        );
+        final finalized = datasource.finalizePsbt(
+          datasource.combinePsbts(first: first.psbt, second: second.psbt),
+        );
+        final finalizedPsbt = bdk.Psbt(psbtBase64: finalized.psbt);
+        expect(finalizedPsbt.input().single.bip32Derivation, isEmpty);
+        finalizedPsbt.dispose();
+
+        final review = await datasource.inspectPsbt(
+          finalized.psbt,
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        );
+
+        expect(finalized.isFinalized, isTrue);
+        expect(review.inputs, hasLength(1));
+        expect(review.inputs.single.signedKeySources, isEmpty);
+        expect(
+          review.outputs.where((output) => output.isWalletOwned),
+          hasLength(1),
+        );
+        expect(
+          review.outputs.where((output) => !output.isWalletOwned),
+          hasLength(1),
+        );
+      },
+    );
+
+    test('estimates a regular single-signature Bitcoin send', () {
+      final descriptors = singleSignatureDescriptors(testMnemonics.first);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'regular-send-size',
+                descriptor: twoPathDescriptor(
+                  descriptors.external,
+                  descriptors.internal,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          descriptors.external,
+          descriptors.internal,
+        ),
+      );
+      final estimated = datasource.decodeTxSize(unsignedPsbt, wallet: wallet);
+      final root = bdk.DescriptorSecretKey(
+        networkKind: bdk.NetworkKind.test,
+        mnemonic: bdk.Mnemonic.fromString(mnemonic: testMnemonics.first),
+        password: null,
+      );
+      final signed = datasource.signPsbtWithDescriptor(
+        unsignedPsbt,
+        descriptor: twoPathDescriptor(
+          bdk.Descriptor.newBip84(
+            secretKey: root,
+            keychainKind: bdk.KeychainKind.external_,
+            networkKind: bdk.NetworkKind.test,
+          ).toStringWithSecret(),
+          bdk.Descriptor.newBip84(
+            secretKey: root,
+            keychainKind: bdk.KeychainKind.internal,
+            networkKind: bdk.NetworkKind.test,
+          ).toStringWithSecret(),
+        ),
+        isTestnet: true,
+      );
+      final exact = bdk.Psbt(psbtBase64: signed.psbt).extractTx().vsize();
+
+      expect(signed.isFinalized, isTrue);
+      expect(datasource.decodeTxSize(signed.psbt, wallet: wallet), exact);
+      expect(estimated, greaterThanOrEqualTo(exact));
+    });
+
+    test('estimates completed size for multiple native SegWit inputs', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+        amountSat: 150000,
+        inputCount: 2,
+      );
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'multi-input-size',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      expect(bdk.Psbt(psbtBase64: unsignedPsbt).input(), hasLength(2));
+      final estimated = datasource.decodeTxSize(unsignedPsbt, wallet: wallet);
+      final first = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final second = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final finalized = datasource.finalizePsbt(
+        datasource.combinePsbts(first: first.psbt, second: second.psbt),
+      );
+      final exact = bdk.Psbt(psbtBase64: finalized.psbt).extractTx().vsize();
+
+      expect(finalized.isFinalized, isTrue);
+      expect(datasource.decodeTxSize(finalized.psbt, wallet: wallet), exact);
+      expect(estimated, greaterThanOrEqualTo(exact));
+    });
+
+    test('rejects a PSBT belonging to a different descriptor wallet', () async {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final other = singleSignatureDescriptors(testMnemonics.last);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'other',
+                descriptor: twoPathDescriptor(other.external, other.internal),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+
+      await expectLater(
+        datasource.inspectPsbt(
+          unsignedPsbt,
+          wallet: wallet,
+          walletFingerprints: {other.fingerprint},
+        ),
+        throwsA(isA<BitcoinPsbtWalletMismatchException>()),
+      );
+    });
+
+    test('rejects a PSBT without previous output data', () async {
+      final psbt = bitcoin_base.Psbt.fromBase64(
+        buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+        ),
+      );
+      psbt.input.removeInputKeys(0, [
+        bitcoin_base.PsbtInputTypes.nonWitnessUTXO,
+        bitcoin_base.PsbtInputTypes.witnessUTXO,
+      ]);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'missing-utxo',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+
+      await expectLater(
+        datasource.inspectPsbt(
+          psbt.toBase64(),
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        ),
+        throwsA(isA<BitcoinPsbtMissingUtxoException>()),
+      );
+    });
+
+    test('rejects a PSBT that does not commit to every output', () async {
+      final psbt = bitcoin_base.Psbt.fromBase64(
+        buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+        ),
+      );
+      psbt.input.updateInputs(0, [
+        bitcoin_base.PsbtInputSigHash(
+          bitcoin_base.BitcoinOpCodeConst.sighashNone,
+        ),
+      ]);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'unsafe-sighash',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+
+      await expectLater(
+        datasource.inspectPsbt(
+          psbt.toBase64(),
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        ),
+        throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+      );
+    });
+
+    test('rejects a PSBT containing a forged partial signature', () async {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final signed = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final forged = _replaceSignature(signed.psbt, (signature) {
+        signature[signature.length - 2] ^= 0x01;
+      });
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'forged-signature',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+
+      await expectLater(
+        datasource.inspectPsbt(
+          forged,
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        ),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    });
+
+    test('rejects a PSBT containing an undisclosed unsafe signature', () async {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final signed = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final unsafe = _replaceSignature(
+        signed.psbt,
+        (signature) => signature[signature.length - 1] =
+            bitcoin_base.BitcoinOpCodeConst.sighashSingle,
+      );
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'unsafe-signature',
+                descriptor: twoPathDescriptor(
+                  externalPublicDescriptor,
+                  internalPublicDescriptor,
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+
+      await expectLater(
+        datasource.inspectPsbt(
+          unsafe,
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        ),
+        throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+      );
+    });
+
+    test('finalizes only after combining enough partial signatures', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final firstSignature = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final secondSignature = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+
+      expect(firstSignature.isFinalized, isFalse);
+      final partial = datasource.finalizePsbt(firstSignature.psbt);
+      expect(partial.isFinalized, isFalse);
+      expect(signedFingerprints(partial.psbt), {
+        signers.first.fingerprint.toLowerCase(),
+      });
+
+      final combined = datasource.combinePsbts(
+        first: firstSignature.psbt,
+        second: secondSignature.psbt,
+      );
+
+      expect(datasource.finalizePsbt(combined).isFinalized, isTrue);
+    });
+
+    test('does not partially finalize a multi-input PSBT', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+        amountSat: 150000,
+        inputCount: 2,
+      );
+      final first = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final second = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final unevenSecond = bitcoin_base.Psbt.fromBase64(second.psbt)
+        ..input.removeInputKeys(1, [
+          bitcoin_base.PsbtInputTypes.partialSignature,
+        ]);
+      final combined = datasource.combinePsbts(
+        first: first.psbt,
+        second: unevenSecond.toBase64(),
+      );
+
+      final partial = datasource.finalizePsbt(combined);
+      final parsed = bdk.Psbt(psbtBase64: partial.psbt);
+      final int finalizedInputCount;
+      try {
+        finalizedInputCount = parsed
+            .input()
+            .where(
+              (input) =>
+                  input.finalScriptSig != null ||
+                  input.finalScriptWitness != null,
+            )
+            .length;
+      } finally {
+        parsed.dispose();
+      }
+
+      expect(partial.isFinalized, isFalse);
+      expect(finalizedInputCount, 0);
+      final completed = signPsbt(
+        datasource,
+        partial.psbt,
+        signers: signers,
+        signerIndex: 2,
+      );
+      expect(completed.isFinalized, isTrue);
+    });
+
+    for (final scriptType in [
+      (name: 'nested SegWit', wrap: (String multisig) => 'sh(wsh($multisig))'),
+      (name: 'legacy', wrap: (String multisig) => 'sh($multisig)'),
+    ]) {
+      test('round-trips ${scriptType.name} multisig signing', () {
+        String descriptor({required bool internal, int? privateSignerIndex}) {
+          final keys = [
+            for (final (index, signer) in signers.indexed)
+              if (internal)
+                index == privateSignerIndex
+                    ? signer.internalPrivate
+                    : signer.internalPublic
+              else
+                index == privateSignerIndex
+                    ? signer.externalPrivate
+                    : signer.externalPublic,
+          ];
+          return scriptType.wrap('sortedmulti(2,${keys.join(',')})');
+        }
+
+        final publicDescriptor = twoPathDescriptor(
+          descriptor(internal: false),
+          descriptor(internal: true),
+        );
+        final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+          descriptor: publicDescriptor,
+          isTestnet: true,
+        );
+        final wallet =
+            WalletModel.publicBdk(
+                  id: '${scriptType.name}-multisig',
+                  descriptor: publicDescriptor,
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel;
+        final policy = BitcoinWalletPolicyMapper.toEntity(
+          datasource.analyzePolicy(wallet: wallet),
+        );
+        final unsignedPsbt = buildUnsignedPsbt(descriptor: publicDescriptor);
+        final firstSignature = datasource.signPsbtWithDescriptor(
+          unsignedPsbt,
+          descriptor: twoPathDescriptor(
+            descriptor(internal: false, privateSignerIndex: 0),
+            descriptor(internal: true, privateSignerIndex: 0),
+          ),
+          isTestnet: true,
+        );
+        final secondSignature = datasource.signPsbtWithDescriptor(
+          unsignedPsbt,
+          descriptor: twoPathDescriptor(
+            descriptor(internal: false, privateSignerIndex: 1),
+            descriptor(internal: true, privateSignerIndex: 1),
+          ),
+          isTestnet: true,
+        );
+        final combined = datasource.combinePsbts(
+          first: firstSignature.psbt,
+          second: secondSignature.psbt,
+        );
+
+        expect(parsed.keys, hasLength(signers.length));
+        expect(policy.external.root, isA<BitcoinThresholdPolicyNode>());
+        expect(firstSignature.isFinalized, isFalse);
+        expect(datasource.finalizePsbt(combined).isFinalized, isTrue);
+      });
+    }
+
+    test('signs a selected branch through nested policy thresholds', () {
+      final externalPublic = _nestedPolicyDescriptor([
+        signers[0].externalPublic,
+        signers[1].externalPublic,
+        signers[2].externalPublic,
+      ]);
+      final internalPublic = _nestedPolicyDescriptor([
+        signers[0].internalPublic,
+        signers[1].internalPublic,
+        signers[2].internalPublic,
+      ]);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'nested-policy',
+                descriptor: twoPathDescriptor(externalPublic, internalPublic),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(wallet: wallet),
+      );
+      var selection = const BitcoinPolicySelection.empty();
+      for (var depth = 0; depth < 2; depth++) {
+        final requirement = policy.pathRequirements(selection).first;
+        selection = policy.select(
+          current: selection,
+          requirement: requirement,
+          selectedIndices: {requirement.nodePath == 'root' ? 1 : 0},
+        );
+      }
+
+      expect(policy.pathRequirements(selection), isEmpty);
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(externalPublic, internalPublic),
+        policyPath: policy.buildPath(selection),
+      );
+      final signed = datasource.signPsbtWithDescriptor(
+        unsignedPsbt,
+        descriptor: twoPathDescriptor(
+          _nestedPolicyDescriptor([
+            signers[0].externalPublic,
+            signers[1].externalPrivate,
+            signers[2].externalPrivate,
+          ]),
+          _nestedPolicyDescriptor([
+            signers[0].internalPublic,
+            signers[1].internalPrivate,
+            signers[2].internalPrivate,
+          ]),
+        ),
+        isTestnet: true,
+      );
+
+      expect(signed.isFinalized, isTrue);
+    });
+
+    test('accepts a cryptographically valid added partial signature', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final signed = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+
+      expect(
+        () => datasource.validateExternalPartialPsbt(
+          currentPsbtBase64: unsignedPsbt,
+          signedPsbtBase64: signed.psbt,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('rejects a forged partial signature', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final signed = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final forged = _replaceSignature(signed.psbt, (signature) {
+        signature[signature.length - 2] ^= 0x01;
+      });
+
+      expect(
+        () => datasource.validateExternalPartialPsbt(
+          currentPsbtBase64: unsignedPsbt,
+          signedPsbtBase64: forged,
+        ),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    });
+
+    for (final (label, sighash, addContradictoryAllField) in [
+      ('SIGHASH_NONE', bitcoin_base.BitcoinOpCodeConst.sighashNone, false),
+      ('SIGHASH_SINGLE', bitcoin_base.BitcoinOpCodeConst.sighashSingle, true),
+      (
+        'SIGHASH_ALL|ANYONECANPAY',
+        bitcoin_base.BitcoinOpCodeConst.sighashAll |
+            bitcoin_base.BitcoinOpCodeConst.sighashAnyoneCanPay,
+        false,
+      ),
+    ]) {
+      test('rejects actual $label when the metadata does not disclose it', () {
+        final unsignedPsbt = buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+        );
+        final signed = signPsbt(
+          datasource,
+          unsignedPsbt,
+          signers: signers,
+          signerIndex: 0,
+        );
+        final unsafe = _replaceSignature(
+          signed.psbt,
+          (signature) => signature[signature.length - 1] = sighash,
+          addSighashAllField: addContradictoryAllField,
+        );
+
+        expect(
+          () => datasource.validateExternalPartialPsbt(
+            currentPsbtBase64: unsignedPsbt,
+            signedPsbtBase64: unsafe,
+          ),
+          throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+        );
+        expect(
+          () => datasource.finalizePsbt(unsafe),
+          throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+        );
+      });
+    }
+
+    test('rejects an externally finalized PSBT input', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final first = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final second = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final finalized = datasource.finalizePsbt(
+        datasource.combinePsbts(first: first.psbt, second: second.psbt),
+      );
+      expect(finalized.isFinalized, isTrue);
+
+      expect(
+        () => datasource.validateExternalPartialPsbt(
+          currentPsbtBase64: unsignedPsbt,
+          signedPsbtBase64: finalized.psbt,
+        ),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    });
+
+    test('rejects an unsupported sighash in a finalized PSBT input', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final first = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final second = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final finalized = datasource.finalizePsbt(
+        datasource.combinePsbts(first: first.psbt, second: second.psbt),
+      );
+      final unsafe = _replaceFinalizedWitnessSighash(
+        finalized.psbt,
+        bitcoin_base.BitcoinOpCodeConst.sighashNone,
+      );
+
+      expect(
+        () => datasource.finalizePsbt(unsafe),
+        throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+      );
+    });
+
+    test('rejects a finalized PSBT input without a signature', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final psbt = bitcoin_base.Psbt.fromBase64(unsignedPsbt);
+      psbt.input.updateInputs(0, [
+        bitcoin_base.PsbtInputFinalizedScriptWitness(
+          bitcoin_base.TxWitnessInput(stack: const ['00']),
+        ),
+      ]);
+      final invalidPsbt = psbt.toBase64();
+
+      expect(
+        () => datasource.finalizePsbt(invalidPsbt),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+      expect(
+        () =>
+            signPsbt(datasource, invalidPsbt, signers: signers, signerIndex: 0),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    });
+
+    test('rejects PSBTs containing different unsigned transactions', () {
+      final first = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+        amountSat: 50000,
+      );
+      final second = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+        amountSat: 51000,
+      );
+
+      expect(
+        () => datasource.combinePsbts(first: first, second: second),
+        throwsA(isA<bdk.PsbtException>()),
+      );
+    });
+
+    test('accepts a final transaction only for the prepared PSBT', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final firstSignature = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 0,
+      );
+      final secondSignature = signPsbt(
+        datasource,
+        unsignedPsbt,
+        signers: signers,
+        signerIndex: 1,
+      );
+      final combined = datasource.combinePsbts(
+        first: firstSignature.psbt,
+        second: secondSignature.psbt,
+      );
+      final finalized = datasource.finalizePsbt(combined);
+      final transaction = hex.encode(
+        bdk.Psbt(psbtBase64: finalized.psbt).extractTx().serialize(),
+      );
+
+      final verified = datasource.verifyFinalTransaction(
+        psbtBase64: unsignedPsbt,
+        transactionHex: transaction,
+      );
+      expect(verified.transaction, transaction);
+      expect(verified.txSize, greaterThan(0));
+
+      final differentPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+        amountSat: 51000,
+      );
+      expect(
+        () => datasource.verifyFinalTransaction(
+          psbtBase64: differentPsbt,
+          transactionHex: transaction,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    for (final (label, sighash) in [
+      ('SIGHASH_NONE', bitcoin_base.BitcoinOpCodeConst.sighashNone),
+      ('SIGHASH_SINGLE', bitcoin_base.BitcoinOpCodeConst.sighashSingle),
+      (
+        'SIGHASH_ALL|ANYONECANPAY',
+        bitcoin_base.BitcoinOpCodeConst.sighashAllAnyOneCanPay,
+      ),
+    ]) {
+      test('rejects a final raw transaction containing $label', () {
+        final unsignedPsbt = buildUnsignedPsbt(
+          descriptor: twoPathDescriptor(
+            externalPublicDescriptor,
+            internalPublicDescriptor,
+          ),
+        );
+        final first = signPsbt(
+          datasource,
+          unsignedPsbt,
+          signers: signers,
+          signerIndex: 0,
+        );
+        final second = signPsbt(
+          datasource,
+          unsignedPsbt,
+          signers: signers,
+          signerIndex: 1,
+        );
+        final finalized = datasource.finalizePsbt(
+          datasource.combinePsbts(first: first.psbt, second: second.psbt),
+        );
+        final transaction = bdk.Psbt(psbtBase64: finalized.psbt).extractTx();
+        final signature = transaction.input().single.witness.firstWhere(
+          (item) => item.length >= 9 && item.first == 0x30,
+        );
+        final bytes = transaction.serialize().toList();
+        final signatureOffset = _sublistIndex(bytes, signature);
+        expect(signatureOffset, greaterThanOrEqualTo(0));
+        bytes[signatureOffset + signature.length - 1] = sighash;
+
+        expect(
+          () => datasource.verifyFinalTransaction(
+            psbtBase64: unsignedPsbt,
+            transactionHex: hex.encode(bytes),
+          ),
+          throwsFormatException,
+        );
+      });
+    }
+
+    test('rejects an unsigned raw transaction', () {
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(
+          externalPublicDescriptor,
+          internalPublicDescriptor,
+        ),
+      );
+      final transaction = hex.encode(
+        bdk.Psbt(psbtBase64: unsignedPsbt).extractTx().serialize(),
+      );
+
+      expect(
+        () => datasource.verifyFinalTransaction(
+          psbtBase64: unsignedPsbt,
+          transactionHex: transaction,
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('BdkWalletDatasource hashlock satisfaction', () {
+    test('validates, inserts and signs a SHA256 preimage', () async {
+      // This valid 32-byte preimage is deliberately DER-shaped. Final
+      // transaction validation must not mistake it for a signature.
+      final preimageHex = hex.encode([
+        0x30,
+        0x1d,
+        0x02,
+        0x01,
+        0x01,
+        0x02,
+        0x18,
+        ...List<int>.filled(24, 0x01),
+        0x02,
+      ]);
+      final hash = sha256.convert(hex.decode(preimageHex)).toString();
+      final externalPublic =
+          'wsh(and_v(v:pk(${signers[0].externalPublic}),sha256($hash)))';
+      final internalPublic =
+          'wsh(and_v(v:pk(${signers[0].internalPublic}),sha256($hash)))';
+      final externalPrivate =
+          'wsh(and_v(v:pk(${signers[0].externalPrivate}),sha256($hash)))';
+      final internalPrivate =
+          'wsh(and_v(v:pk(${signers[0].internalPrivate}),sha256($hash)))';
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'hashlock',
+                descriptor: twoPathDescriptor(externalPublic, internalPublic),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(wallet: wallet),
+      );
+      final hashlock = policy
+          .requiredHashlocks(const BitcoinPolicySelection.empty())
+          .single;
+      final preimage = BitcoinPolicyPreimage(
+        type: hashlock.type,
+        hash: hashlock.hash,
+        preimageHex: preimageHex,
+      );
+
+      expect(policy.hasHashlock, isTrue);
+      expect(datasource.validatePolicyPreimage(preimage), isTrue);
+      expect(
+        datasource.validatePolicyPreimage(
+          BitcoinPolicyPreimage(
+            type: hashlock.type,
+            hash: hashlock.hash,
+            preimageHex: List.filled(32, 'ff').join(),
+          ),
+        ),
+        isFalse,
+      );
+
+      final unsignedPsbt = buildUnsignedPsbt(
+        descriptor: twoPathDescriptor(externalPublic, internalPublic),
+      );
+      final withPreimage = datasource.applyPolicyPreimages(unsignedPsbt, [
+        preimage,
+      ]);
+      expect(
+        bdk.Psbt(
+          psbtBase64: withPreimage,
+        ).input().single.sha256Preimages.keys.single,
+        hash,
+      );
+      expect(
+        bdk.Psbt(
+          psbtBase64: withPreimage,
+        ).input().single.sha256Preimages.values.single,
+        hex.decode(preimageHex),
+      );
+      final signed = datasource.signPsbtWithDescriptor(
+        withPreimage,
+        descriptor: twoPathDescriptor(externalPrivate, internalPrivate),
+        isTestnet: true,
+      );
+
+      expect(signed.isFinalized, isTrue);
+      await datasource.inspectPsbt(
+        signed.psbt,
+        wallet: wallet,
+        walletFingerprints: {signers[0].fingerprint},
+      );
+      final finalizedPsbt = bdk.Psbt(psbtBase64: signed.psbt);
+      try {
+        final transaction = finalizedPsbt.extractTx();
+        try {
+          expect(
+            () => datasource.verifyFinalTransaction(
+              psbtBase64: withPreimage,
+              transactionHex: hex.encode(transaction.serialize()),
+            ),
+            returnsNormally,
+          );
+        } finally {
+          transaction.dispose();
+        }
+      } finally {
+        finalizedPsbt.dispose();
+      }
+    });
+  });
+}
+
+String _nestedPolicyDescriptor(List<String> keys) =>
+    'wsh(or_d(pk(${keys[0]}),and_v(v:pk(${keys[1]}),'
+    'or_i(pk(${keys[2]}),and_v(v:older(10),'
+    'sha256(${List.filled(32, '11').join()}))))))';
+
+String _replaceSignature(
+  String psbtBase64,
+  void Function(List<int> signature) mutate, {
+  bool addSighashAllField = false,
+}) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  final partial = psbt.input
+      .getInputs<bitcoin_base.PsbtInputPartialSig>(
+        0,
+        bitcoin_base.PsbtInputTypes.partialSignature,
+      )!
+      .single;
+  final signature = partial.signature.toList();
+  mutate(signature);
+  psbt.input.updateInputs(0, [
+    bitcoin_base.PsbtInputPartialSig(
+      signature: signature,
+      publicKey: partial.publicKeyBytes,
+    ),
+    if (addSighashAllField)
+      bitcoin_base.PsbtInputSigHash(bitcoin_base.BitcoinOpCodeConst.sighashAll),
+  ]);
+  return psbt.toBase64();
+}
+
+String _replaceFinalizedWitnessSighash(String psbtBase64, int sighash) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  final finalized = psbt.input
+      .getInputs<bitcoin_base.PsbtInputFinalizedScriptWitness>(
+        0,
+        bitcoin_base.PsbtInputTypes.finalizedWitness,
+      )!
+      .single;
+  final stack = finalized.finalizedScriptWitness.stack.toList();
+  final signatureIndex = stack.indexWhere((item) {
+    final bytes = hex.decode(item);
+    return bytes.length >= 9 && bytes.first == 0x30;
+  });
+  final signature = hex.decode(stack[signatureIndex]);
+  signature[signature.length - 1] = sighash;
+  stack[signatureIndex] = hex.encode(signature);
+  psbt.input.updateInputs(0, [
+    bitcoin_base.PsbtInputFinalizedScriptWitness(
+      bitcoin_base.TxWitnessInput(stack: stack),
+    ),
+  ]);
+  return psbt.toBase64();
+}
+
+int _sublistIndex(List<int> bytes, List<int> needle) {
+  for (var offset = 0; offset <= bytes.length - needle.length; offset++) {
+    if (Iterable<int>.generate(
+      needle.length,
+    ).every((index) => bytes[offset + index] == needle[index])) {
+      return offset;
+    }
+  }
+  return -1;
+}

--- a/test/core_test/wallet/data/payjoin_wallet_adapter_test.dart
+++ b/test/core_test/wallet/data/payjoin_wallet_adapter_test.dart
@@ -1,13 +1,15 @@
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/storage/tables/wallet_signer_table.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/payjoin_wallet_adapter.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:primitives/primitives.dart';
+import 'package:primitives/primitives.dart' hide ScriptType;
 
 import '../wallet_signer_test_fixture.dart';
 
@@ -19,43 +21,61 @@ class _MockWalletMetadataDatasource extends Mock
     implements WalletMetadataDatasource {}
 
 void main() {
-  test('rejects Payjoin signing for a higher-account wallet', () async {
-    final seed = _MockSeedDatasource();
-    final wallet = _MockBdkWalletDatasource();
-    final metadata = _MockWalletMetadataDatasource();
-    when(() => metadata.fetch('wallet')).thenAnswer(
-      (_) async => WalletMetadataModel(
+  test(
+    'signs Payjoin at the stored account with foreign final inputs',
+    () async {
+      final seed = _MockSeedDatasource();
+      final wallet = _MockBdkWalletDatasource();
+      final metadata = _MockWalletMetadataDatasource();
+      when(() => metadata.fetch('wallet')).thenAnswer(
+        (_) async => WalletMetadataModel(
+          id: 'wallet',
+          network: Network.bitcoinMainnet,
+          signers: [
+            walletSignerModel(
+              id: 'signer-0',
+              descriptorKeyId: 'key-0',
+              masterFingerprint: '73c5da0a',
+              xpubFingerprint: 'deadbeef',
+              xpub: 'xpub-test',
+              derivationPath: "m/84'/0'/1'",
+              descriptorPath: '/<0;1>/*',
+              signer: Signer.local,
+              signerDevice: null,
+            ),
+          ],
+          isEncryptedVaultTested: false,
+          isPhysicalBackupTested: false,
+          publicDescriptor: 'wpkh(xpub-test/<0;1>/*)',
+          isDefault: false,
+        ),
+      );
+      const privateWallet = WalletModel.privateBdk(
         id: 'wallet',
-        network: Network.bitcoinMainnet,
-        signers: [
-          walletSignerModel(
-            id: 'signer-0',
-            descriptorKeyId: 'key-0',
-            masterFingerprint: '73c5da0a',
-            xpubFingerprint: 'deadbeef',
-            xpub: 'xpub-test',
-            derivationPath: "m/84'/0'/1'",
-            descriptorPath: '/<0;1>/*',
-            signer: Signer.local,
-            signerDevice: null,
-          ),
-        ],
-        isEncryptedVaultTested: false,
-        isPhysicalBackupTested: false,
-        publicDescriptor: 'wpkh(xpub-test/<0;1>/*)',
-        isDefault: false,
-      ),
-    );
-    final adapter = PayjoinWalletAdapter(seed, wallet, metadata);
+        scriptType: ScriptType.bip84,
+        mnemonic: 'test',
+        account: 1,
+        isTestnet: false,
+      );
+      when(() => seed.get('73c5da0a')).thenAnswer(
+        (_) async => const SeedModel.mnemonic(mnemonicWords: ['test']),
+      );
+      when(
+        () => wallet.signPsbt(
+          'psbt',
+          wallet: privateWallet as PrivateBdkWalletModel,
+          allowFinalizedForeignInputs: true,
+        ),
+      ).thenAnswer((_) async => (psbt: 'signed', isFinalized: true));
+      final adapter = PayjoinWalletAdapter(seed, wallet, metadata);
 
-    await expectLater(
-      adapter.signPsbt(
+      final result = await adapter.signPsbt(
         walletId: 'wallet',
         network: BitcoinNetwork.mainnet,
         psbt: 'psbt',
-      ),
-      throwsA(isA<StateError>()),
-    );
-    verifyNever(() => seed.get(any()));
-  });
+      );
+
+      expect(result, 'signed');
+    },
+  );
 }

--- a/test/core_test/wallet/data/repositories/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/data/repositories/bitcoin_wallet_repository_test.dart
@@ -1,0 +1,756 @@
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_signer_table.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_signer_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../bdk_wallet_test_fixture.dart';
+import '../../wallet_signer_test_fixture.dart';
+
+class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+class _MockFrozenWalletUtxoDatasource extends Mock
+    implements FrozenWalletUtxoDatasource {}
+
+class _MockBdkWalletDatasource extends Mock implements BdkWalletDatasource {}
+
+class _SigningTestBdkWalletDatasource extends BdkWalletDatasource {
+  @override
+  Future<void> validateWalletPsbtInputs(
+    String psbtBase64, {
+    required PublicBdkWalletModel wallet,
+    Set<String> frozenOutpoints = const {},
+    String? replacingTxid,
+  }) async {}
+}
+
+typedef _SignerFixture = ({
+  String externalPublic,
+  String fingerprint,
+  String internalPublic,
+  SeedModel seed,
+  String xpub,
+});
+
+void main() {
+  late WalletMetadataDatasource metadataDatasource;
+  late SeedDatasource seedDatasource;
+  late BdkWalletDatasource bdkDatasource;
+  late FrozenWalletUtxoDatasource frozenWalletUtxoDatasource;
+  late BitcoinWalletRepository repository;
+
+  setUp(() {
+    metadataDatasource = _MockWalletMetadataDatasource();
+    seedDatasource = _MockSeedDatasource();
+    bdkDatasource = _SigningTestBdkWalletDatasource();
+    frozenWalletUtxoDatasource = _MockFrozenWalletUtxoDatasource();
+    when(
+      () => frozenWalletUtxoDatasource.getAllFrozen(),
+    ).thenAnswer((_) async => const []);
+    repository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: seedDatasource,
+      bdkWalletDatasource: bdkDatasource,
+      frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+    );
+  });
+
+  void stubWallet(
+    WalletMetadataModel metadata,
+    List<_SignerFixture> localSigners,
+  ) {
+    when(
+      () => metadataDatasource.fetch(metadata.id),
+    ).thenAnswer((_) async => metadata);
+    for (final signer in localSigners) {
+      when(
+        () => seedDatasource.get(signer.fingerprint),
+      ).thenAnswer((_) async => signer.seed);
+    }
+  }
+
+  test('single local signer finalizes a mobile wallet PSBT', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final metadata = _metadata(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+      signers: [signer],
+      localSignerCount: 1,
+    );
+    stubWallet(metadata, [signer]);
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(unsignedPsbt, walletId: metadata.id),
+    );
+
+    expect(signed.isFinalized, isTrue);
+  });
+
+  test('private wallet reconstruction rejects nonstandard keychains', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final metadata = _metadata(
+      descriptor: signer.externalPublic.replaceAll('/0/*', '/2/*'),
+      signers: [signer],
+      localSignerCount: 1,
+      descriptorPath: '/2/*',
+    );
+    stubWallet(metadata, const []);
+
+    expect(
+      () => repository.getPrivateWallet(walletId: metadata.id),
+      throwsStateError,
+    );
+  });
+
+  test('private wallet reconstruction preserves the account index', () async {
+    const account = 1;
+    final signer = _singleSignatureFixture(
+      testMnemonics.first,
+      account: account,
+    );
+    final metadata = _metadata(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+      signers: [signer],
+      localSignerCount: 1,
+      derivationPath: "m/84'/1'/$account'",
+    );
+    stubWallet(metadata, [signer]);
+
+    final privateWallet = await repository.getPrivateWallet(
+      walletId: metadata.id,
+    );
+
+    expect(privateWallet.account, account);
+  });
+
+  test('preserves an existing PSBT when adding a local signature', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final metadata = _metadata(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+      signers: [signer],
+      localSignerCount: 1,
+    );
+    stubWallet(metadata, [signer]);
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(
+        unsignedPsbt,
+        walletId: metadata.id,
+        tryFinalize: false,
+      ),
+    );
+
+    expect(signed.isFinalized, isFalse);
+    expect(signedFingerprints(signed.psbt), {signer.fingerprint.toLowerCase()});
+  });
+
+  test('adds a partial signature for a delayed Miniscript path', () async {
+    final remote = _multisigFixture(testMnemonics.first);
+    final local = _miniscriptBip84Fixture(testMnemonics[1]);
+    final externalDescriptor = bdk.Descriptor.newWsh(
+      miniScript:
+          'or_d(pk(${remote.externalPublic}),and_v(v:pkh(${local.externalPublic}),older(1)))',
+    ).toString();
+    final internalDescriptor = bdk.Descriptor.newWsh(
+      miniScript:
+          'or_d(pk(${remote.internalPublic}),and_v(v:pkh(${local.internalPublic}),older(1)))',
+    ).toString();
+    final metadata = WalletMetadataModel(
+      id: 'wallet',
+      network: Network.bitcoinTestnet,
+      signers: [
+        walletSignerModel(
+          id: 'signer-0',
+          descriptorKeyId: 'key-0',
+          masterFingerprint: remote.fingerprint,
+          xpubFingerprint: remote.fingerprint,
+          xpub: remote.xpub,
+          derivationPath: "m/48'/1'/0'/2'",
+          signer: Signer.remote,
+          signerDevice: null,
+        ),
+        walletSignerModel(
+          id: 'signer-1',
+          descriptorKeyId: 'key-1',
+          masterFingerprint: local.fingerprint,
+          xpubFingerprint: local.fingerprint,
+          xpub: local.xpub,
+          derivationPath: "m/84'/1'/0'",
+          signer: Signer.local,
+          signerDevice: null,
+        ),
+      ],
+      isEncryptedVaultTested: false,
+      isPhysicalBackupTested: false,
+      publicDescriptor: twoPathDescriptor(
+        externalDescriptor,
+        internalDescriptor,
+      ),
+      isDefault: false,
+    );
+    stubWallet(metadata, [local]);
+    final policy = _unwrapSigning(
+      await repository.getPolicy(walletId: metadata.id),
+    );
+    final selector = policy
+        .pathSelectors(const BitcoinPolicySelection.empty())
+        .single;
+    final delayedIndex = selector.options.indexWhere(
+      containsPolicyNode<BitcoinRelativeTimelockPolicyNode>,
+    );
+    final selection = policy.select(
+      current: const BitcoinPolicySelection.empty(),
+      requirement: selector,
+      selectedIndices: {delayedIndex},
+    );
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: twoPathDescriptor(externalDescriptor, internalDescriptor),
+      policyPath: policy.buildPath(selection),
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(
+        unsignedPsbt,
+        walletId: metadata.id,
+        tryFinalize: false,
+      ),
+    );
+
+    expect(signed.isFinalized, isFalse);
+    expect(signedFingerprints(signed.psbt), {local.fingerprint.toLowerCase()});
+  });
+
+  test('one local multisig key returns a partial PSBT', () async {
+    final signers = testMnemonics.map(_multisigFixture).toList();
+    final metadata = _multisigMetadata(signers, localSignerCount: 1);
+    stubWallet(metadata, signers.take(1).toList());
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: metadata.publicDescriptor,
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(unsignedPsbt, walletId: metadata.id),
+    );
+
+    expect(signed.isFinalized, isFalse);
+    expect(bdkDatasource.finalizePsbt(signed.psbt).isFinalized, isFalse);
+  });
+
+  test('enough local multisig keys finalize the PSBT', () async {
+    final signers = testMnemonics.map(_multisigFixture).toList();
+    final metadata = _multisigMetadata(signers, localSignerCount: 2);
+    stubWallet(metadata, signers.take(2).toList());
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: metadata.publicDescriptor,
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(unsignedPsbt, walletId: metadata.id),
+    );
+
+    expect(signed.isFinalized, isTrue);
+  });
+
+  test('injects one account key shared by multiple descriptor keys', () async {
+    final signer = _multisigFixture(testMnemonics.first);
+    final descriptor =
+        'wsh(sortedmulti(2,${signer.xpub}/0/<0;1>/*,'
+        '${signer.xpub}/1/<0;1>/*))';
+    final metadata = WalletMetadataModel(
+      id: 'wallet',
+      network: Network.bitcoinTestnet,
+      signers: [
+        WalletSignerModel(
+          id: 'signer-0',
+          signer: Signer.local,
+          signerDevice: null,
+          descriptorKeys: [
+            for (final (index, descriptorPath) in [
+              '/0/<0;1>/*',
+              '/1/<0;1>/*',
+            ].indexed)
+              WalletDescriptorKeyModel(
+                id: 'key-$index',
+                signerId: 'signer-0',
+                masterFingerprint: signer.fingerprint,
+                xpubFingerprint: signer.fingerprint,
+                xpub: signer.xpub,
+                derivationPath: "m/48'/1'/0'/2'",
+                descriptorPath: descriptorPath,
+              ),
+          ],
+        ),
+      ],
+      isEncryptedVaultTested: false,
+      isPhysicalBackupTested: false,
+      publicDescriptor: descriptor,
+      isDefault: false,
+    );
+    stubWallet(metadata, [signer]);
+    final unsignedPsbt = buildUnsignedPsbt(descriptor: descriptor);
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(unsignedPsbt, walletId: metadata.id),
+    );
+
+    expect(signedFingerprints(signed.psbt), {signer.fingerprint.toLowerCase()});
+  });
+
+  test('signs with only the selected local multisig key', () async {
+    final signers = testMnemonics.map(_multisigFixture).toList();
+    final metadata = _multisigMetadata(signers, localSignerCount: 2);
+    stubWallet(metadata, signers.take(2).toList());
+    final unsignedPsbt = buildUnsignedPsbt(
+      descriptor: metadata.publicDescriptor,
+    );
+
+    final signed = _unwrapSigning(
+      await repository.signPsbt(
+        unsignedPsbt,
+        walletId: metadata.id,
+        tryFinalize: false,
+        signerId: 'signer-1',
+      ),
+    );
+
+    expect(signedFingerprints(signed.psbt), {
+      signers[1].fingerprint.toLowerCase(),
+    });
+  });
+
+  test(
+    'rejects a PSBT whose witness UTXO amount differs from the wallet',
+    () async {
+      final signer = _singleSignatureFixture(testMnemonics.first);
+      final descriptor = twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      );
+      final metadata = _metadata(
+        descriptor: descriptor,
+        signers: [signer],
+        localSignerCount: 1,
+      );
+      final wallet =
+          WalletModel.publicBdk(
+                id: metadata.id,
+                descriptor: descriptor,
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final datasource = _MockBdkWalletDatasource();
+      when(
+        () => metadataDatasource.fetch(metadata.id),
+      ).thenAnswer((_) async => metadata);
+      when(
+        () => datasource.validateWalletPsbtInputs(
+          'psbt',
+          wallet: wallet,
+          frozenOutpoints: const {},
+        ),
+      ).thenThrow(const InvalidBitcoinPsbtException());
+      final reviewRepository = BitcoinWalletRepository(
+        walletMetadataDatasource: metadataDatasource,
+        seedDatasource: seedDatasource,
+        bdkWalletDatasource: datasource,
+        frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+      );
+
+      final result = await reviewRepository.reviewPsbt(
+        'psbt',
+        walletId: metadata.id,
+        requireLocalOrigin: false,
+      );
+
+      expect(_failureKind(result), BitcoinSigningFailureKind.invalidPsbt);
+    },
+  );
+
+  test('maps malformed PSBT encoding to invalid PSBT', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final metadata = _metadata(
+      descriptor: twoPathDescriptor(
+        signer.externalPublic,
+        signer.internalPublic,
+      ),
+      signers: [signer],
+      localSignerCount: 0,
+    );
+    stubWallet(metadata, const []);
+
+    final result = await repository.reviewPsbt(
+      'not-a-psbt',
+      walletId: metadata.id,
+      requireLocalOrigin: false,
+    );
+
+    expect(_failureKind(result), BitcoinSigningFailureKind.invalidPsbt);
+  });
+
+  test('does not report wallet storage failures as invalid PSBTs', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final descriptor = twoPathDescriptor(
+      signer.externalPublic,
+      signer.internalPublic,
+    );
+    final metadata = _metadata(
+      descriptor: descriptor,
+      signers: [signer],
+      localSignerCount: 0,
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: metadata.id,
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final datasource = _MockBdkWalletDatasource();
+    when(
+      () => metadataDatasource.fetch(metadata.id),
+    ).thenAnswer((_) async => metadata);
+    when(
+      () => datasource.validateWalletPsbtInputs(
+        'psbt',
+        wallet: wallet,
+        frozenOutpoints: const {},
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => datasource.inspectPsbt(
+        'psbt',
+        wallet: wallet,
+        walletFingerprints: any(named: 'walletFingerprints'),
+      ),
+    ).thenThrow(Exception('wallet database unavailable'));
+    final reviewRepository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: seedDatasource,
+      bdkWalletDatasource: datasource,
+      frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+    );
+
+    final result = await reviewRepository.reviewPsbt(
+      'psbt',
+      walletId: metadata.id,
+      requireLocalOrigin: false,
+    );
+
+    expect(_failureKind(result), BitcoinSigningFailureKind.unexpected);
+  });
+
+  test('maps mismatching external signer results to invalid PSBT', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final descriptor = twoPathDescriptor(
+      signer.externalPublic,
+      signer.internalPublic,
+    );
+    final metadata = _metadata(
+      descriptor: descriptor,
+      signers: [signer],
+      localSignerCount: 0,
+    );
+    final datasource = _MockBdkWalletDatasource();
+    when(
+      () => metadataDatasource.fetch(metadata.id),
+    ).thenAnswer((_) async => metadata);
+    when(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: 'current',
+        signedPsbtBase64: 'unrelated',
+      ),
+    ).thenReturn(null);
+    when(
+      () => datasource.combinePsbts(first: 'current', second: 'unrelated'),
+    ).thenThrow(bdk.UnexpectedUnsignedTxPsbtException());
+    when(
+      () => datasource.verifyFinalTransaction(
+        psbtBase64: 'current',
+        transactionHex: 'unrelated',
+      ),
+    ).thenThrow(const FormatException());
+    when(
+      () => datasource.verifyFinalTransaction(
+        psbtBase64: 'current',
+        transactionHex: 'malformed',
+      ),
+    ).thenThrow(bdk.IoTransactionException());
+    final signingRepository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: seedDatasource,
+      bdkWalletDatasource: datasource,
+      frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+    );
+
+    final results = [
+      await signingRepository.combinePsbts(
+        currentPsbt: 'current',
+        signedPsbt: 'unrelated',
+        walletId: metadata.id,
+      ),
+      await signingRepository.verifyFinalTransaction(
+        psbt: 'current',
+        transaction: 'unrelated',
+      ),
+      await signingRepository.verifyFinalTransaction(
+        psbt: 'current',
+        transaction: 'malformed',
+      ),
+    ];
+
+    expect(
+      results.map(_failureKind),
+      everyElement(BitcoinSigningFailureKind.invalidPsbt),
+    );
+  });
+
+  test('rejects a frozen input before adding a local signature', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final descriptor = twoPathDescriptor(
+      signer.externalPublic,
+      signer.internalPublic,
+    );
+    final metadata = _metadata(
+      descriptor: descriptor,
+      signers: [signer],
+      localSignerCount: 1,
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: metadata.id,
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final datasource = _MockBdkWalletDatasource();
+    when(
+      () => metadataDatasource.fetch(metadata.id),
+    ).thenAnswer((_) async => metadata);
+    when(() => frozenWalletUtxoDatasource.getAllFrozen()).thenAnswer(
+      (_) async => const [(walletId: 'wallet', txId: 'funding', vout: 0)],
+    );
+    when(
+      () => datasource.validateWalletPsbtInputs(
+        'psbt',
+        wallet: wallet,
+        frozenOutpoints: const {'funding:0'},
+      ),
+    ).thenThrow(const BitcoinPsbtFrozenUtxoException());
+    final signingRepository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: seedDatasource,
+      bdkWalletDatasource: datasource,
+      frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+    );
+
+    final result = await signingRepository.signPsbt(
+      'psbt',
+      walletId: metadata.id,
+    );
+
+    expect(_failureKind(result), BitcoinSigningFailureKind.frozenUtxo);
+  });
+
+  test('rejects a frozen input when combining signer PSBTs', () async {
+    final signer = _singleSignatureFixture(testMnemonics.first);
+    final descriptor = twoPathDescriptor(
+      signer.externalPublic,
+      signer.internalPublic,
+    );
+    final metadata = _metadata(
+      descriptor: descriptor,
+      signers: [signer],
+      localSignerCount: 1,
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: metadata.id,
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final datasource = _MockBdkWalletDatasource();
+    when(
+      () => metadataDatasource.fetch(metadata.id),
+    ).thenAnswer((_) async => metadata);
+    when(() => frozenWalletUtxoDatasource.getAllFrozen()).thenAnswer(
+      (_) async => const [(walletId: 'wallet', txId: 'funding', vout: 0)],
+    );
+    when(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: 'current',
+        signedPsbtBase64: 'signed',
+      ),
+    ).thenReturn(null);
+    when(
+      () => datasource.combinePsbts(first: 'current', second: 'signed'),
+    ).thenReturn('combined');
+    when(
+      () => datasource.validateWalletPsbtInputs(
+        'combined',
+        wallet: wallet,
+        frozenOutpoints: const {'funding:0'},
+      ),
+    ).thenThrow(const BitcoinPsbtFrozenUtxoException());
+    final signingRepository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: seedDatasource,
+      bdkWalletDatasource: datasource,
+      frozenWalletUtxoDatasource: frozenWalletUtxoDatasource,
+    );
+
+    final result = await signingRepository.combinePsbts(
+      currentPsbt: 'current',
+      signedPsbt: 'signed',
+      walletId: metadata.id,
+    );
+
+    expect(_failureKind(result), BitcoinSigningFailureKind.frozenUtxo);
+  });
+}
+
+T _unwrapSigning<T>(Result<T, BitcoinSigningFailure> result) =>
+    switch (result) {
+      Ok(:final value) => value,
+      Err(:final failure) => throw StateError(
+        'Unexpected failure: ${failure.kind}',
+      ),
+    };
+
+BitcoinSigningFailureKind? _failureKind<T>(
+  Result<T, BitcoinSigningFailure> result,
+) => switch (result) {
+  Ok() => null,
+  Err(:final failure) => failure.kind,
+};
+
+WalletMetadataModel _multisigMetadata(
+  List<_SignerFixture> signers, {
+  required int localSignerCount,
+}) {
+  final externalDescriptor = sortedMultisigDescriptor(
+    signers.map((signer) => signer.externalPublic).toList(),
+  );
+  final internalDescriptor = sortedMultisigDescriptor(
+    signers.map((signer) => signer.internalPublic).toList(),
+  );
+  return _metadata(
+    descriptor: twoPathDescriptor(externalDescriptor, internalDescriptor),
+    signers: signers,
+    localSignerCount: localSignerCount,
+  );
+}
+
+WalletMetadataModel _metadata({
+  required String descriptor,
+  required List<_SignerFixture> signers,
+  required int localSignerCount,
+  String? derivationPath,
+  String? descriptorPath,
+}) => WalletMetadataModel(
+  id: 'wallet',
+  network: Network.bitcoinTestnet,
+  signers: [
+    for (final (index, signer) in signers.indexed)
+      walletSignerModel(
+        id: 'signer-$index',
+        descriptorKeyId: 'key-$index',
+        masterFingerprint: signer.fingerprint,
+        xpubFingerprint: signer.fingerprint,
+        xpub: signer.xpub,
+        derivationPath:
+            derivationPath ??
+            (signers.length == 1 ? "m/84'/1'/0'" : "m/48'/1'/0'/2'"),
+        descriptorPath:
+            descriptorPath ??
+            (signers.length == 1 ? standardSingleSignatureDescriptorPath : ''),
+        signer: index < localSignerCount ? Signer.local : Signer.remote,
+        signerDevice: null,
+      ),
+  ],
+  isEncryptedVaultTested: false,
+  isPhysicalBackupTested: false,
+  publicDescriptor: descriptor,
+  isDefault: false,
+);
+
+_SignerFixture _singleSignatureFixture(String words, {int account = 0}) {
+  final seed = SeedModel.mnemonic(mnemonicWords: words.split(' '));
+  final descriptors = account == 0
+      ? singleSignatureDescriptors(words)
+      : singleSignatureDescriptorsAtAccount(words, account: account);
+  return (
+    externalPublic: descriptors.external,
+    fingerprint: descriptors.fingerprint,
+    internalPublic: descriptors.internal,
+    seed: seed,
+    xpub: descriptors.xpub,
+  );
+}
+
+_SignerFixture _multisigFixture(String words) {
+  final seed = SeedModel.mnemonic(mnemonicWords: words.split(' '));
+  final keys = deriveSignerKeys(words);
+  return (
+    externalPublic: keys.externalPublic,
+    fingerprint: keys.fingerprint,
+    internalPublic: keys.internalPublic,
+    seed: seed,
+    xpub: keys.xpub,
+  );
+}
+
+_SignerFixture _miniscriptBip84Fixture(String words) {
+  final seed = SeedModel.mnemonic(mnemonicWords: words.split(' '));
+  final root = bdk.DescriptorSecretKey(
+    networkKind: bdk.NetworkKind.test,
+    mnemonic: bdk.Mnemonic.fromString(mnemonic: words),
+    password: null,
+  );
+  final account = root.derive(path: bdk.DerivationPath(path: "m/84'/1'/0'"));
+  final public = account.asPublic();
+  return (
+    externalPublic: '$public/0/*',
+    fingerprint: public.masterFingerprint(),
+    internalPublic: '$public/1/*',
+    seed: seed,
+    xpub: public.toString(),
+  );
+}

--- a/test/core_test/wallet/domain/entities/bitcoin_psbt_review_test.dart
+++ b/test/core_test/wallet/domain/entities/bitcoin_psbt_review_test.dart
@@ -1,0 +1,236 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('summarizes recipient and wallet-owned outputs', () {
+    final review = BitcoinPsbtReview(
+      transactionId: 'txid',
+      inputs: [_input()],
+      outputs: [
+        _output(index: 0, amountSat: 8000),
+        _output(index: 1, amountSat: 1000, isWalletOwned: true),
+      ],
+      feeSat: BigInt.from(1000),
+      estimatedTransactionVsize: 100,
+      lockTime: 0,
+      version: 2,
+    );
+
+    expect(review.recipients, hasLength(1));
+    expect(review.walletOwnedOutputs, hasLength(1));
+    expect(review.recipientAmountSat, BigInt.from(8000));
+    expect(review.estimatedFeeRateSatPerVbyte, 10);
+    expect(review.outpoints, {'00:0'});
+  });
+
+  test('rejects an empty transaction', () {
+    expect(
+      () => BitcoinPsbtReview(
+        transactionId: 'txid',
+        inputs: const [],
+        outputs: [_output(index: 0, amountSat: 1)],
+        feeSat: BigInt.zero,
+        estimatedTransactionVsize: 100,
+        lockTime: 0,
+        version: 2,
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('reports only descriptor keys signed on every input of a keychain', () {
+    final review = BitcoinPsbtReview(
+      transactionId: 'txid',
+      inputs: [
+        _input(signedDescriptorKeyIds: const {'key-a', 'key-b'}),
+        _input(outpoint: '11:1', signedDescriptorKeyIds: const {'key-a'}),
+      ],
+      outputs: [_output(index: 0, amountSat: 9000)],
+      feeSat: BigInt.from(1000),
+      estimatedTransactionVsize: 100,
+      lockTime: 0,
+      version: 2,
+    );
+
+    expect(review.signedDescriptorKeyIdsByKeychain, {
+      BitcoinPolicyKeychain.external: {'key-a'},
+    });
+    expect(review.signedDescriptorKeyIdsByOutpoint, {
+      '00:0': {'key-a', 'key-b'},
+      '11:1': {'key-a'},
+    });
+  });
+
+  test('detects an unsatisfied absolute transaction locktime', () {
+    final review = _review(lockTime: 101);
+    final maturity = _maturity(confirmations: 20, tipHeight: 100);
+
+    expect(review.hasTimingConstraint, isTrue);
+    expect(review.timingIsSatisfied(maturity), isFalse);
+    expect(
+      review.blockingTimingActivation(maturity),
+      isA<BitcoinPolicyActivation>()
+          .having(
+            (activation) => activation.type,
+            'type',
+            BitcoinPolicyActivationType.absoluteBlock,
+          )
+          .having((activation) => activation.value, 'height', 101),
+    );
+    expect(
+      review.timingIsSatisfied(_maturity(confirmations: 20, tipHeight: 101)),
+      isTrue,
+    );
+  });
+
+  test('checks relative transaction locktime against each input', () {
+    final review = _review(sequence: 10);
+
+    expect(review.hasTimingConstraint, isTrue);
+    expect(
+      review.timingIsSatisfied(_maturity(confirmations: 9, tipHeight: 100)),
+      isFalse,
+    );
+    expect(
+      review.blockingTimingActivation(
+        _maturity(confirmations: 9, tipHeight: 100),
+      ),
+      isA<BitcoinPolicyActivation>()
+          .having(
+            (activation) => activation.type,
+            'type',
+            BitcoinPolicyActivationType.relativeBlocks,
+          )
+          .having((activation) => activation.value, 'remaining blocks', 1),
+    );
+    expect(
+      review.timingIsSatisfied(_maturity(confirmations: 10, tipHeight: 100)),
+      isTrue,
+    );
+  });
+
+  test('ignores transaction timelock fields that are not active', () {
+    expect(
+      _review(lockTime: 101, sequence: 0xffffffff).hasTimingConstraint,
+      isFalse,
+    );
+    expect(_review(sequence: 0x8000000a).hasTimingConstraint, isFalse);
+    expect(_review(sequence: 10, version: 1).hasTimingConstraint, isFalse);
+  });
+
+  test('checks time-based transaction conditions against median time', () {
+    final absolute = _review(lockTime: 600000000);
+    expect(
+      absolute.timingIsSatisfied(
+        _maturity(confirmations: 20, tipHeight: 100, medianTimePast: 600000000),
+      ),
+      isFalse,
+    );
+    expect(
+      absolute.timingIsSatisfied(
+        _maturity(confirmations: 20, tipHeight: 100, medianTimePast: 600000001),
+      ),
+      isTrue,
+    );
+
+    final relative = _review(sequence: (1 << 22) | 2);
+    expect(
+      relative.timingIsSatisfied(
+        _maturity(
+          confirmations: 20,
+          tipHeight: 100,
+          medianTimePast: 600001023,
+          confirmationMedianTimePast: 600000000,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      relative.blockingTimingActivation(
+        _maturity(
+          confirmations: 20,
+          tipHeight: 100,
+          medianTimePast: 600001023,
+          confirmationMedianTimePast: 600000000,
+        ),
+      ),
+      isA<BitcoinPolicyActivation>()
+          .having(
+            (activation) => activation.type,
+            'type',
+            BitcoinPolicyActivationType.relativeTime,
+          )
+          .having((activation) => activation.value, 'timestamp', 600001024),
+    );
+    expect(
+      relative.timingIsSatisfied(
+        _maturity(
+          confirmations: 20,
+          tipHeight: 100,
+          medianTimePast: 600001024,
+          confirmationMedianTimePast: 600000000,
+        ),
+      ),
+      isTrue,
+    );
+  });
+}
+
+BitcoinPsbtReview _review({
+  int sequence = 0xfffffffd,
+  int lockTime = 0,
+  int version = 2,
+}) => BitcoinPsbtReview(
+  transactionId: 'txid',
+  inputs: [_input(sequence: sequence)],
+  outputs: [_output(index: 0, amountSat: 9000)],
+  feeSat: BigInt.from(1000),
+  estimatedTransactionVsize: 100,
+  lockTime: lockTime,
+  version: version,
+);
+
+BitcoinPolicyMaturity _maturity({
+  required int confirmations,
+  required int tipHeight,
+  int medianTimePast = 600000000,
+  int confirmationMedianTimePast = 599990000,
+}) => BitcoinPolicyMaturity(
+  tipHeight: tipHeight,
+  medianTimePast: medianTimePast,
+  utxos: [
+    BitcoinPolicyUtxoMaturity(
+      outpoint: '00:0',
+      keychain: BitcoinPolicyKeychain.external,
+      amountSat: BigInt.from(10000),
+      confirmations: confirmations,
+      confirmationMedianTimePast: confirmationMedianTimePast,
+    ),
+  ],
+);
+
+BitcoinPsbtInputReview _input({
+  String outpoint = '00:0',
+  int sequence = 0xfffffffd,
+  Set<String> signedDescriptorKeyIds = const {},
+}) => BitcoinPsbtInputReview(
+  outpoint: outpoint,
+  amountSat: BigInt.zero,
+  keychain: BitcoinPolicyKeychain.external,
+  localDescriptorKeyIds: const {'key-local'},
+  sequence: sequence,
+  signedDescriptorKeyIds: signedDescriptorKeyIds,
+);
+
+BitcoinPsbtOutputReview _output({
+  required int index,
+  required int amountSat,
+  bool isWalletOwned = false,
+}) => BitcoinPsbtOutputReview(
+  index: index,
+  amountSat: BigInt.from(amountSat),
+  address: 'tb1qoutput',
+  scriptHex: '0014aa',
+  isWalletOwned: isWalletOwned,
+);

--- a/test/core_test/wallet/domain/entities/bitcoin_signing_plan_test.dart
+++ b/test/core_test/wallet/domain/entities/bitcoin_signing_plan_test.dart
@@ -1,0 +1,329 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('stops at the minimum signer set for a threshold policy', () {
+    final signers = [
+      _signer('aaaaaaaa', SignerEntity.local),
+      _signer('bbbbbbbb', SignerEntity.remote),
+      _signer('cccccccc', SignerEntity.remote),
+    ];
+    final policy = _thresholdPolicy(
+      threshold: 2,
+      keyIds: signers.map((signer) => signer.descriptorKeys.single.id),
+    );
+
+    final unsigned = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: signers,
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+    final externalFirst = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: signers,
+      signedDescriptorKeyIdsByKeychain: const {
+        BitcoinPolicyKeychain.external: {'key-bbbbbbbb'},
+      },
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+    final satisfied = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: signers,
+      signedDescriptorKeyIdsByKeychain: const {
+        BitcoinPolicyKeychain.external: {'key-bbbbbbbb', 'key-cccccccc'},
+      },
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+
+    expect(unsigned.eligibleSigners, signers);
+    expect(unsigned.signersNeeded, 2);
+    expect(externalFirst.signersNeeded, 1);
+    expect(satisfied.isSatisfied, isTrue);
+    expect(satisfied.signersNeeded, 0);
+
+    final groupedSigner = WalletSigner(
+      id: 'signer-grouped',
+      signer: SignerEntity.local,
+      signerDevice: null,
+      descriptorKeys: signers
+          .take(2)
+          .expand((signer) => signer.descriptorKeys)
+          .map((key) => key.copyWith(signerId: 'signer-grouped'))
+          .toList(),
+    );
+    final grouped = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: [groupedSigner, signers.last],
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+
+    expect(grouped.eligibleSigners, [groupedSigner, signers.last]);
+    expect(grouped.signersNeeded, 1);
+  });
+
+  test('counts a Miniscript threshold path independently of path choice', () {
+    final signers = [
+      _signer('aaaaaaaa', SignerEntity.local),
+      _signer('bbbbbbbb', SignerEntity.remote),
+      _signer('cccccccc', SignerEntity.remote),
+    ];
+    final policy = _thresholdPolicy(
+      threshold: 2,
+      keyIds: signers.map((signer) => signer.descriptorKeys.single.id),
+      requiresPath: true,
+    );
+    final selector = policy
+        .pathSelectors(const BitcoinPolicySelection.empty())
+        .single;
+    final incomplete = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: signers,
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+    final selection = policy.select(
+      current: const BitcoinPolicySelection.empty(),
+      requirement: selector,
+      selectedIndices: const {0, 1},
+    );
+
+    final plan = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      selection: selection,
+      signers: signers,
+      signedDescriptorKeyIdsByKeychain: const {
+        BitcoinPolicyKeychain.external: {'key-bbbbbbbb'},
+      },
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+
+    expect(incomplete.eligibleSigners, signers);
+    expect(incomplete.signersNeeded, 2);
+    expect(incomplete.requiresExternalSigning, isTrue);
+    expect(plan.eligibleSigners, signers.take(2));
+    expect(plan.signersNeeded, 1);
+    expect(plan.isSatisfied, isFalse);
+  });
+
+  test('evaluates threshold satisfaction for each input', () {
+    final signers = [
+      _signer('aaaaaaaa', SignerEntity.remote),
+      _signer('bbbbbbbb', SignerEntity.remote),
+      _signer('cccccccc', SignerEntity.remote),
+    ];
+    final policy = _thresholdPolicy(
+      threshold: 2,
+      keyIds: signers.map((signer) => signer.descriptorKeys.single.id),
+    );
+
+    final plan = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: signers,
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+      inputKeychainsByOutpoint: const {
+        'funding:0': BitcoinPolicyKeychain.external,
+        'funding:1': BitcoinPolicyKeychain.external,
+      },
+      signedDescriptorKeyIdsByOutpoint: const {
+        'funding:0': {'key-aaaaaaaa', 'key-bbbbbbbb'},
+        'funding:1': {'key-bbbbbbbb', 'key-cccccccc'},
+      },
+    );
+
+    expect(plan.isSatisfied, isTrue);
+    expect(plan.signersNeeded, 0);
+    expect(plan.isSigned(signers[1]), isTrue);
+  });
+
+  test('tracks signatures for the keychain used by every input', () {
+    final local = _signer('aaaaaaaa', SignerEntity.local);
+    final remote = _signer('bbbbbbbb', SignerEntity.remote);
+    final policy = BitcoinWalletPolicy(
+      external: BitcoinSpendingPolicy(
+        requiresPath: false,
+        root: BitcoinSignaturePolicyNode(
+          id: 'external',
+          key: BitcoinPolicyKey(
+            kind: BitcoinPolicyKeyKind.descriptorKey,
+            value: local.descriptorKeys.single.id,
+          ),
+        ),
+      ),
+      internal: BitcoinSpendingPolicy(
+        requiresPath: false,
+        root: BitcoinSignaturePolicyNode(
+          id: 'internal',
+          key: BitcoinPolicyKey(
+            kind: BitcoinPolicyKeyKind.descriptorKey,
+            value: remote.descriptorKeys.single.id,
+          ),
+        ),
+      ),
+    );
+
+    final plan = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: [local, remote],
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+      signedDescriptorKeyIdsByKeychain: const {
+        BitcoinPolicyKeychain.external: {'key-aaaaaaaa'},
+      },
+      signedDescriptorKeyIdsByOutpoint: const {
+        'funding:0': {'key-aaaaaaaa'},
+        'funding:1': {'key-bbbbbbbb'},
+      },
+    );
+
+    expect(plan.eligibleSigners, [local]);
+    expect(plan.isSigned(local), isTrue);
+    expect(plan.isSatisfied, isTrue);
+    expect(plan.signedDescriptorKeyIdsByOutpoint, const {
+      'funding:0': {'key-aaaaaaaa'},
+      'funding:1': {'key-bbbbbbbb'},
+    });
+  });
+
+  test('requires a supplied preimage for a hashlock path', () {
+    final signer = _signer('aaaaaaaa', SignerEntity.local);
+    final spendingPolicy = BitcoinSpendingPolicy(
+      requiresPath: false,
+      root: BitcoinThresholdPolicyNode(
+        id: 'and',
+        threshold: 2,
+        children: [
+          BitcoinSignaturePolicyNode(
+            id: 'signature',
+            key: BitcoinPolicyKey(
+              kind: BitcoinPolicyKeyKind.descriptorKey,
+              value: signer.descriptorKeys.single.id,
+            ),
+          ),
+          BitcoinHashlockPolicyNode(
+            id: 'hashlock',
+            type: BitcoinHashlockType.sha256,
+            hash: 'aa',
+          ),
+        ],
+      ),
+    );
+    final policy = BitcoinWalletPolicy(
+      external: spendingPolicy,
+      internal: spendingPolicy,
+    );
+    BitcoinSigningPlan plan(Set<String> preimages) =>
+        BitcoinSigningPlan.fromPolicy(
+          policy: policy,
+          signers: [signer],
+          inputKeychains: const {BitcoinPolicyKeychain.external},
+          signedDescriptorKeyIdsByKeychain: const {
+            BitcoinPolicyKeychain.external: {'key-aaaaaaaa'},
+          },
+          satisfiedPreimageKeys: preimages,
+        );
+
+    final missingPreimage = plan(const {});
+    expect(missingPreimage.isSatisfied, isFalse);
+    expect(missingPreimage.requiresExternalSigning, isFalse);
+    expect(missingPreimage.missingPreimages, hasLength(1));
+
+    final satisfied = plan(const {'sha256:aa'});
+    expect(satisfied.isSatisfied, isTrue);
+    expect(satisfied.missingPreimages, isEmpty);
+  });
+
+  test('does not require a preimage when another branch is satisfied', () {
+    final immediate = _signer('aaaaaaaa', SignerEntity.remote);
+    final hashlocked = _signer('bbbbbbbb', SignerEntity.remote);
+    final hashlock = BitcoinHashlockPolicyNode(
+      id: 'hashlock',
+      type: BitcoinHashlockType.sha256,
+      hash: 'aa',
+    );
+    final spendingPolicy = BitcoinSpendingPolicy(
+      requiresPath: false,
+      root: BitcoinThresholdPolicyNode(
+        id: 'or',
+        threshold: 1,
+        children: [
+          BitcoinSignaturePolicyNode(
+            id: 'immediate',
+            key: BitcoinPolicyKey(
+              kind: BitcoinPolicyKeyKind.descriptorKey,
+              value: immediate.descriptorKeys.single.id,
+            ),
+          ),
+          BitcoinThresholdPolicyNode(
+            id: 'hashlocked-branch',
+            threshold: 2,
+            children: [
+              BitcoinSignaturePolicyNode(
+                id: 'hashlocked',
+                key: BitcoinPolicyKey(
+                  kind: BitcoinPolicyKeyKind.descriptorKey,
+                  value: hashlocked.descriptorKeys.single.id,
+                ),
+              ),
+              hashlock,
+            ],
+          ),
+        ],
+      ),
+    );
+    final policy = BitcoinWalletPolicy(
+      external: spendingPolicy,
+      internal: spendingPolicy,
+    );
+    final plan = BitcoinSigningPlan.fromPolicy(
+      policy: policy,
+      signers: [immediate, hashlocked],
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+      signedDescriptorKeyIdsByKeychain: {
+        BitcoinPolicyKeychain.external: {immediate.descriptorKeys.single.id},
+      },
+    );
+
+    expect(plan.isSatisfied, isTrue);
+    expect(plan.missingPreimages, isEmpty);
+  });
+}
+
+WalletSigner _signer(String fingerprint, SignerEntity signer) =>
+    WalletSigner.single(
+      id: 'signer-$fingerprint',
+      descriptorKeyId: 'key-$fingerprint',
+      masterFingerprint: fingerprint,
+      xpubFingerprint: fingerprint,
+      xpub: 'tpub-$fingerprint',
+      signer: signer,
+      signerDevice: null,
+    );
+
+BitcoinWalletPolicy _thresholdPolicy({
+  required int threshold,
+  required Iterable<String> keyIds,
+  bool requiresPath = false,
+}) {
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: requiresPath,
+    root: BitcoinThresholdPolicyNode(
+      id: 'threshold',
+      threshold: threshold,
+      requiresPath: requiresPath,
+      children: [
+        for (final keyId in keyIds)
+          BitcoinSignaturePolicyNode(
+            id: keyId,
+            key: BitcoinPolicyKey(
+              kind: BitcoinPolicyKeyKind.descriptorKey,
+              value: keyId,
+            ),
+          ),
+      ],
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
+}

--- a/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
+++ b/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
@@ -1,0 +1,523 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BitcoinWalletPolicy maturity', () {
+    test('rejects duplicate and out-of-range path choices', () {
+      final policy = thresholdPolicy();
+
+      expect(
+        () => BitcoinPolicySelection(
+          choices: const {
+            'external:root': [0, 0],
+          },
+        ),
+        throwsArgumentError,
+      );
+
+      final outOfRange = BitcoinPolicySelection(
+        choices: const {
+          'external:root': [0, 3],
+          'internal:root': [0, 3],
+        },
+      );
+      expect(() => policy.pathRequirements(outOfRange), throwsArgumentError);
+
+      expect(
+        BitcoinPolicySelection(
+          choices: const {
+            'external:root': [1, 0],
+          },
+        ).hasSameChoices(
+          BitcoinPolicySelection(
+            choices: const {
+              'external:root': [0, 1],
+            },
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects different receive and change path selections', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(id: 'delay', value: 10),
+      );
+      final selection = BitcoinPolicySelection(
+        choices: const {
+          'external:root': [0],
+          'internal:root': [1],
+        },
+      );
+
+      expect(() => policy.buildPath(selection), throwsStateError);
+    });
+
+    test('tracks relative path maturity per UTXO', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(id: 'delay', value: 10),
+      );
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      final delayedSelection = policy.select(
+        current: const BitcoinPolicySelection.empty(),
+        requirement: selector,
+        selectedIndices: const {1},
+      );
+      final maturity = BitcoinPolicyMaturity(
+        tipHeight: 100,
+        medianTimePast: 100000,
+        utxos: [
+          BitcoinPolicyUtxoMaturity(
+            outpoint: 'external:0',
+            keychain: BitcoinPolicyKeychain.external,
+            amountSat: BigInt.from(1000),
+            confirmations: 5,
+          ),
+          BitcoinPolicyUtxoMaturity(
+            outpoint: 'internal:1',
+            keychain: BitcoinPolicyKeychain.internal,
+            amountSat: BigInt.from(2000),
+            confirmations: 12,
+          ),
+        ],
+      );
+
+      final walletStatus = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity,
+      );
+      final immatureCoinStatus = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity,
+        selectedOutpoints: const {'external:0'},
+      );
+      final path = policy.buildPath(delayedSelection, maturity: maturity);
+
+      expect(walletStatus.available, isTrue);
+      expect(walletStatus.availableAmountSat, BigInt.from(2000));
+      expect(walletStatus.activatingAmountSat, BigInt.from(1000));
+      expect(walletStatus.activation?.value, 5);
+      expect(immatureCoinStatus.available, isFalse);
+      expect(immatureCoinStatus.availableAmountSat, BigInt.zero);
+      expect(immatureCoinStatus.activatingAmountSat, BigInt.from(1000));
+      expect(
+        immatureCoinStatus.activation?.type,
+        BitcoinPolicyActivationType.relativeBlocks,
+      );
+      expect(immatureCoinStatus.activation?.value, 5);
+      expect(
+        policy.selectionIsAvailable(
+          selection: delayedSelection,
+          maturity: maturity,
+        ),
+        isTrue,
+      );
+      expect(
+        policy.selectionIsAvailable(
+          selection: delayedSelection,
+          maturity: maturity,
+          selectedOutpoints: const {'external:0'},
+        ),
+        isFalse,
+      );
+      expect(
+        policy.selectionIsAvailable(
+          selection: delayedSelection,
+          maturity: maturity,
+          selectedOutpoints: const {'internal:1', 'missing:2'},
+        ),
+        isFalse,
+      );
+      expect(path.eligibleExternalOutpoints, isEmpty);
+      expect(path.eligibleInternalOutpoints, {'internal:1'});
+    });
+
+    test('selects the only currently available spending path', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(id: 'delay', value: 10),
+      );
+      BitcoinPolicyMaturity maturity(int confirmations) =>
+          BitcoinPolicyMaturity(
+            tipHeight: 100,
+            medianTimePast: 100000,
+            utxos: [
+              BitcoinPolicyUtxoMaturity(
+                outpoint: 'external:0',
+                keychain: BitcoinPolicyKeychain.external,
+                amountSat: BigInt.from(1000),
+                confirmations: confirmations,
+              ),
+            ],
+          );
+
+      final onlyImmediate = policy.selectOnlyAvailablePaths(
+        current: const BitcoinPolicySelection.empty(),
+        maturity: maturity(5),
+      );
+      final multipleAvailable = policy.selectOnlyAvailablePaths(
+        current: const BitcoinPolicySelection.empty(),
+        maturity: maturity(12),
+      );
+
+      expect(policy.pathRequirements(onlyImmediate), isEmpty);
+      expect(policy.pathRequirements(multipleAvailable), isNotEmpty);
+    });
+
+    test(
+      'activates absolute paths for the whole wallet at the target block',
+      () {
+        final policy = delayedPolicy(
+          BitcoinAbsoluteTimelockPolicyNode(
+            id: 'delay',
+            type: BitcoinAbsoluteTimelockType.blockHeight,
+            value: 101,
+          ),
+        );
+        final selector = policy
+            .pathSelectors(const BitcoinPolicySelection.empty())
+            .single;
+        BitcoinPolicyMaturity maturity(int height) => BitcoinPolicyMaturity(
+          tipHeight: height,
+          medianTimePast: 100000,
+          utxos: [
+            BitcoinPolicyUtxoMaturity(
+              outpoint: 'external:0',
+              keychain: BitcoinPolicyKeychain.external,
+              amountSat: BigInt.from(1000),
+              confirmations: 20,
+            ),
+          ],
+        );
+
+        final before = policy.optionStatus(
+          requirement: selector,
+          optionIndex: 1,
+          selection: const BitcoinPolicySelection.empty(),
+          maturity: maturity(100),
+        );
+        final after = policy.optionStatus(
+          requirement: selector,
+          optionIndex: 1,
+          selection: const BitcoinPolicySelection.empty(),
+          maturity: maturity(101),
+        );
+
+        expect(before.available, isFalse);
+        expect(
+          before.activation?.type,
+          BitcoinPolicyActivationType.absoluteBlock,
+        );
+        expect(before.activation?.value, 101);
+        expect(after.available, isTrue);
+      },
+    );
+
+    test('uses median time past for absolute time paths', () {
+      final policy = delayedPolicy(
+        BitcoinAbsoluteTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinAbsoluteTimelockType.timestamp,
+          value: 100000,
+        ),
+      );
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      BitcoinPolicyMaturity maturity(int medianTimePast) =>
+          BitcoinPolicyMaturity(
+            tipHeight: 100,
+            medianTimePast: medianTimePast,
+            utxos: [
+              BitcoinPolicyUtxoMaturity(
+                outpoint: 'external:0',
+                keychain: BitcoinPolicyKeychain.external,
+                amountSat: BigInt.from(1000),
+                confirmations: 20,
+              ),
+            ],
+          );
+
+      final atTarget = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity(100000),
+      );
+      final afterTarget = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity(100001),
+      );
+
+      expect(atTarget.available, isFalse);
+      expect(
+        atTarget.activation?.type,
+        BitcoinPolicyActivationType.absoluteTime,
+      );
+      expect(afterTarget.available, isTrue);
+    });
+
+    test('does not estimate absolute time activation without median time', () {
+      final policy = delayedPolicy(
+        BitcoinAbsoluteTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinAbsoluteTimelockType.timestamp,
+          value: 100000,
+        ),
+      );
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      final status = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: BitcoinPolicyMaturity(
+          tipHeight: 100,
+          medianTimePast: null,
+          utxos: const [],
+        ),
+      );
+
+      expect(status.available, isFalse);
+      expect(status.activation, isNull);
+    });
+
+    test('uses each UTXO confirmation time for relative time paths', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinRelativeTimelockType.seconds,
+          value: 512,
+        ),
+      );
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      BitcoinPolicyMaturity maturity(int medianTimePast) =>
+          BitcoinPolicyMaturity(
+            tipHeight: 100,
+            medianTimePast: medianTimePast,
+            utxos: [
+              BitcoinPolicyUtxoMaturity(
+                outpoint: 'external:0',
+                keychain: BitcoinPolicyKeychain.external,
+                amountSat: BigInt.from(1000),
+                confirmations: 20,
+                confirmationMedianTimePast: 100000,
+              ),
+            ],
+          );
+
+      final before = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity(100511),
+      );
+      final atTarget = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: maturity(100512),
+      );
+
+      expect(before.available, isFalse);
+      expect(before.activation?.type, BitcoinPolicyActivationType.relativeTime);
+      expect(before.activation?.value, 100512);
+      expect(atTarget.available, isTrue);
+    });
+
+    test('keeps selected-input activation unknown when one is unknown', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinRelativeTimelockType.seconds,
+          value: 512,
+        ),
+      );
+      final selector = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      final status = policy.optionStatus(
+        requirement: selector,
+        optionIndex: 1,
+        selection: const BitcoinPolicySelection.empty(),
+        maturity: BitcoinPolicyMaturity(
+          tipHeight: 100,
+          medianTimePast: 100000,
+          utxos: [
+            BitcoinPolicyUtxoMaturity(
+              outpoint: 'external:0',
+              keychain: BitcoinPolicyKeychain.external,
+              amountSat: BigInt.from(1000),
+              confirmations: 1,
+              confirmationMedianTimePast: 100000,
+            ),
+            BitcoinPolicyUtxoMaturity(
+              outpoint: 'external:1',
+              keychain: BitcoinPolicyKeychain.external,
+              amountSat: BigInt.from(2000),
+              confirmations: 0,
+            ),
+          ],
+        ),
+        selectedOutpoints: const {'external:0', 'external:1'},
+      );
+
+      expect(status.available, isFalse);
+      expect(status.activation, isNull);
+      expect(status.activatingAmountSat, BigInt.zero);
+    });
+
+    test('calculates activation for the complete selected policy', () {
+      final mandatoryDelay = policyWithRoot(
+        BitcoinThresholdPolicyNode(
+          id: 'and',
+          threshold: 2,
+          children: [
+            BitcoinAbsoluteTimelockPolicyNode(
+              id: 'delay',
+              type: BitcoinAbsoluteTimelockType.blockHeight,
+              value: 101,
+            ),
+            BitcoinThresholdPolicyNode(
+              id: 'alternative',
+              threshold: 1,
+              requiresPath: true,
+              children: [signaturePolicy('a'), signaturePolicy('b')],
+            ),
+          ],
+        ),
+      );
+      final selection = BitcoinPolicySelection(
+        choices: const {
+          'external:root/1': [0],
+          'internal:root/1': [0],
+        },
+      );
+
+      expect(
+        mandatoryDelay
+            .nextActivation(selection: selection, maturity: maturityAt(1))
+            ?.value,
+        101,
+      );
+
+      final thresholdDelay = policyWithRoot(
+        BitcoinThresholdPolicyNode(
+          id: 'threshold',
+          threshold: 2,
+          children: [
+            BitcoinRelativeTimelockPolicyNode(id: 'first', value: 5),
+            BitcoinRelativeTimelockPolicyNode(id: 'second', value: 10),
+            BitcoinRelativeTimelockPolicyNode(id: 'third', value: 20),
+          ],
+        ),
+      );
+
+      expect(
+        thresholdDelay
+            .nextActivation(
+              selection: const BitcoinPolicySelection.empty(),
+              maturity: maturityAt(0),
+            )
+            ?.value,
+        10,
+      );
+    });
+  });
+}
+
+BitcoinSignaturePolicyNode signaturePolicy(String id) =>
+    BitcoinSignaturePolicyNode(
+      id: id,
+      key: BitcoinPolicyKey(
+        kind: BitcoinPolicyKeyKind.fingerprint,
+        value: '11111111',
+      ),
+    );
+
+BitcoinWalletPolicy policyWithRoot(BitcoinPolicyNode root) {
+  final spending = BitcoinSpendingPolicy(root: root, requiresPath: true);
+  return BitcoinWalletPolicy(external: spending, internal: spending);
+}
+
+BitcoinPolicyMaturity maturityAt(int confirmations) => BitcoinPolicyMaturity(
+  tipHeight: 100,
+  medianTimePast: 100000,
+  utxos: [
+    BitcoinPolicyUtxoMaturity(
+      outpoint: 'external:0',
+      keychain: BitcoinPolicyKeychain.external,
+      amountSat: BigInt.from(1000),
+      confirmations: confirmations,
+    ),
+  ],
+);
+
+BitcoinWalletPolicy thresholdPolicy() {
+  BitcoinPolicyNode root(String suffix) => BitcoinThresholdPolicyNode(
+    id: 'root-$suffix',
+    threshold: 2,
+    requiresPath: true,
+    children: [
+      for (var index = 0; index < 3; index++)
+        BitcoinSignaturePolicyNode(
+          id: 'key-$index-$suffix',
+          key: BitcoinPolicyKey(
+            kind: BitcoinPolicyKeyKind.fingerprint,
+            value: '0000000$index',
+          ),
+        ),
+    ],
+  );
+
+  return BitcoinWalletPolicy(
+    external: BitcoinSpendingPolicy(root: root('external'), requiresPath: true),
+    internal: BitcoinSpendingPolicy(root: root('internal'), requiresPath: true),
+  );
+}
+
+BitcoinWalletPolicy delayedPolicy(BitcoinPolicyNode timelock) {
+  BitcoinPolicyNode root(String suffix) => BitcoinThresholdPolicyNode(
+    id: 'root-$suffix',
+    threshold: 1,
+    requiresPath: true,
+    children: [
+      BitcoinSignaturePolicyNode(
+        id: 'immediate-$suffix',
+        key: BitcoinPolicyKey(
+          kind: BitcoinPolicyKeyKind.fingerprint,
+          value: '11111111',
+        ),
+      ),
+      BitcoinThresholdPolicyNode(
+        id: 'delayed-$suffix',
+        threshold: 2,
+        children: [
+          timelock,
+          BitcoinSignaturePolicyNode(
+            id: 'recovery-$suffix',
+            key: BitcoinPolicyKey(
+              kind: BitcoinPolicyKeyKind.fingerprint,
+              value: '22222222',
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  return BitcoinWalletPolicy(
+    external: BitcoinSpendingPolicy(root: root('external'), requiresPath: true),
+    internal: BitcoinSpendingPolicy(root: root('internal'), requiresPath: true),
+  );
+}

--- a/test/core_test/wallet/domain/entities/wallet_test.dart
+++ b/test/core_test/wallet/domain/entities/wallet_test.dart
@@ -113,8 +113,8 @@ void main() {
       expect(wallet(signer: SignerEntity.remote).supportsLegacySend, isTrue);
     });
 
-    test('accepts higher accounts only for remote signers', () {
-      expect(wallet(derivationPath: "m/84'/0'/1'").supportsLegacySend, isFalse);
+    test('accepts higher accounts for local and remote signers', () {
+      expect(wallet(derivationPath: "m/84'/0'/1'").supportsLegacySend, isTrue);
       expect(
         wallet(
           derivationPath: 'm/84h/0h/1h',

--- a/test/features/pay/presentation/pay_bloc_test.dart
+++ b/test/features/pay/presentation/pay_bloc_test.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart'
 import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
@@ -34,7 +35,7 @@ import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.d
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
-import 'package:primitives/primitives.dart' show BitcoinNetwork, Sats;
+import 'package:primitives/primitives.dart' show BitcoinNetwork, Ok, Sats;
 
 class _MockGetUserSummary extends Mock
     implements GetExchangeUserSummaryUsecase {}
@@ -273,7 +274,10 @@ void main() {
         psbt: any(named: 'psbt'),
         walletId: any(named: 'walletId'),
       ),
-    ).thenAnswer((_) async => (signedPsbt: unsignedPsbt, txSize: 110));
+    ).thenAnswer(
+      (_) async =>
+          Ok((signedPsbt: unsignedPsbt, txSize: 110, isFinalized: true)),
+    );
     when(
       () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
     ).thenAnswer((_) async => expectedTxid);
@@ -1246,5 +1250,27 @@ void main() {
       // Let the confirmation settle so nothing emits after tearDown closes.
       await Future<void>.delayed(const Duration(seconds: 6));
     }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('reports an unavailable manual coin selection', () async {
+      when(
+        () => prepareBitcoinSend.execute(
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          networkFee: any(named: 'networkFee'),
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: any(named: 'replaceByFee'),
+        ),
+      ).thenThrow(SelectedBitcoinCoinsUnavailableException());
+
+      bloc.add(const PayEvent.sendPaymentConfirmed());
+      final paymentState =
+          await bloc.stream.firstWhere(
+                (state) => state is PayPaymentState && state.error != null,
+              )
+              as PayPaymentState;
+
+      expect(paymentState.error, isA<SelectedCoinsUnavailablePayError>());
+    });
   });
 }

--- a/test/features/sell/presentation/sell_bloc_test.dart
+++ b/test/features/sell/presentation/sell_bloc_test.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
@@ -309,7 +310,10 @@ void main() {
         psbt: any(named: 'psbt'),
         walletId: any(named: 'walletId'),
       ),
-    ).thenAnswer((_) async => (signedPsbt: unsignedPsbt, txSize: 110));
+    ).thenAnswer(
+      (_) async =>
+          Ok((signedPsbt: unsignedPsbt, txSize: 110, isFinalized: true)),
+    );
     when(
       () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
     ).thenAnswer((_) async => expectedTxid);
@@ -1051,6 +1055,28 @@ void main() {
       // Let the confirmation settle so nothing emits after tearDown closes.
       await Future<void>.delayed(const Duration(seconds: 6));
     }, timeout: const Timeout(Duration(seconds: 60)));
+  });
+
+  test('reports an insufficient manual coin selection', () async {
+    when(
+      () => prepareBitcoinSend.execute(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        selectedInputs: any(named: 'selectedInputs'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenThrow(SelectedBitcoinCoinsInsufficientException());
+
+    bloc.add(const SellEvent.sendPaymentConfirmed());
+    final paymentState =
+        await bloc.stream.firstWhere(
+              (state) => state is SellPaymentState && state.error != null,
+            )
+            as SellPaymentState;
+
+    expect(paymentState.error, isA<SelectedCoinsInsufficientSellError>());
   });
 
   group('SellBloc — fee selection (#2521)', () {

--- a/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
+++ b/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
@@ -1,8 +1,10 @@
 import 'dart:typed_data';
 
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
@@ -65,7 +67,10 @@ void main() {
       ),
     ).thenAnswer((_) async => 'psbt');
     when(
-      () => bitcoinWallet.getTxSize(psbt: any(named: 'psbt')),
+      () => bitcoinWallet.getTxSize(
+        psbt: any(named: 'psbt'),
+        walletId: any(named: 'walletId'),
+      ),
     ).thenAnswer((_) async => 110);
     when(
       () => bitcoinWallet.isAddressOfWallet(
@@ -90,22 +95,6 @@ void main() {
       ),
     ).captured;
     return captured.single as List<Outpoint>?;
-  }
-
-  List<WalletUtxo>? capturedSelected() {
-    final captured = verify(
-      () => bitcoinWallet.buildPsbt(
-        walletId: any(named: 'walletId'),
-        address: any(named: 'address'),
-        amountSat: any(named: 'amountSat'),
-        networkFee: any(named: 'networkFee'),
-        drain: any(named: 'drain'),
-        unspendable: any(named: 'unspendable'),
-        selected: captureAny(named: 'selected'),
-        replaceByFee: any(named: 'replaceByFee'),
-      ),
-    ).captured;
-    return captured.single as List<WalletUtxo>?;
   }
 
   test(
@@ -266,7 +255,7 @@ void main() {
     },
   );
 
-  test('a selectedInput that is frozen is stripped before buildPsbt', () async {
+  test('rejects a frozen manual selection without building a PSBT', () async {
     when(
       () => walletUtxo.getAllFrozenOutpoints(),
     ).thenAnswer((_) async => [(txId: 'tx-frozen', vout: 0)]);
@@ -275,20 +264,29 @@ void main() {
     ).thenAnswer((_) async => const Ok(<Outpoint>{}));
 
     final frozenInput = _utxo(txId: 'tx-frozen', vout: 0);
-    final spendableInput = _utxo(txId: 'tx-ok', vout: 1);
-
-    await usecase.execute(
-      walletId: walletId,
-      address: address,
-      networkFee: networkFee,
-      amountSat: 50000,
-      selectedInputs: [frozenInput, spendableInput],
+    await expectLater(
+      usecase.execute(
+        walletId: walletId,
+        address: address,
+        networkFee: networkFee,
+        amountSat: 50000,
+        selectedInputs: [frozenInput],
+      ),
+      throwsA(isA<SelectedBitcoinCoinsUnavailableException>()),
     );
 
-    final selected = capturedSelected()!;
-    expect(selected, hasLength(1));
-    expect(selected.single.txId, 'tx-ok');
-    expect(selected.any((u) => u.txId == 'tx-frozen'), isFalse);
+    verifyNever(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    );
   });
 
   test(
@@ -333,4 +331,55 @@ void main() {
       expect(captured[1] as List<WalletUtxo>?, hasLength(1));
     },
   );
+
+  test('forwards the selected descriptor policy path', () async {
+    when(() => walletUtxo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+    when(
+      () => payjoin.reservedOutpoints(),
+    ).thenAnswer((_) async => const Ok(<Outpoint>{}));
+    final policyPath = BitcoinPolicyPath(
+      external: const {
+        'external-policy': [1],
+      },
+      internal: const {
+        'internal-policy': [1],
+      },
+      requiresRelativeTimelock: true,
+    );
+    when(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+        policyPath: policyPath,
+      ),
+    ).thenAnswer((_) async => 'psbt');
+
+    await usecase.execute(
+      walletId: walletId,
+      address: address,
+      networkFee: networkFee,
+      amountSat: 50000,
+      policyPath: policyPath,
+    );
+
+    verify(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+        policyPath: policyPath,
+      ),
+    ).called(1);
+  });
 }

--- a/test/features/send/domain/usecases/sign_bitcoin_tx_usecase_test.dart
+++ b/test/features/send/domain/usecases/sign_bitcoin_tx_usecase_test.dart
@@ -1,0 +1,141 @@
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _FakeBitcoinSigningPort implements BitcoinSigningPort {
+  final ({String psbt, bool isFinalized}) signingResult;
+  int signCalls = 0;
+  int combineCalls = 0;
+
+  _FakeBitcoinSigningPort(this.signingResult);
+
+  @override
+  Future<Result<({String psbt, bool isFinalized}), BitcoinSigningFailure>>
+  combinePsbts({
+    required String currentPsbt,
+    required String signedPsbt,
+    required String walletId,
+    bool tryFinalize = true,
+  }) async {
+    combineCalls++;
+    return Ok(signingResult);
+  }
+
+  @override
+  Future<Result<BitcoinWalletPolicy, BitcoinSigningFailure>> getPolicy({
+    required String walletId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<BitcoinPolicyMaturity, BitcoinSigningFailure>>
+  getPolicyMaturity({
+    required String walletId,
+    required bool includeTimeBasedLocks,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<BitcoinPsbtReview, BitcoinSigningFailure>> reviewPsbt(
+    String psbt, {
+    required String walletId,
+    bool requireLocalOrigin = true,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<int> getTxSize({
+    required String psbt,
+    required String walletId,
+  }) async => 120;
+
+  @override
+  Future<Result<String, BitcoinSigningFailure>> applyPolicyPreimages({
+    required String psbt,
+    required List<BitcoinPolicyPreimage> preimages,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<bool, BitcoinSigningFailure>> validatePolicyPreimage(
+    BitcoinPolicyPreimage preimage,
+  ) => throw UnimplementedError();
+
+  @override
+  Future<Result<({String transaction, int txSize}), BitcoinSigningFailure>>
+  verifyFinalTransaction({required String psbt, required String transaction}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Result<({bool isFinalized, String psbt}), BitcoinSigningFailure>>
+  signPsbt(
+    String psbt, {
+    required String walletId,
+    bool tryFinalize = true,
+    String? signerId,
+  }) async {
+    signCalls++;
+    return Ok(signingResult);
+  }
+}
+
+void main() {
+  test(
+    'returns a failure when the PSBT is not fully signed by default',
+    () async {
+      final usecase = SignBitcoinTxUsecase(
+        _FakeBitcoinSigningPort((psbt: 'partial', isFinalized: false)),
+      );
+
+      final result = await usecase.execute(
+        psbt: 'unsigned',
+        walletId: 'wallet',
+      );
+
+      expect(
+        result,
+        isA<Err<SignedBitcoinTransaction, BitcoinSigningFailure>>(),
+      );
+      expect(switch (result) {
+        Ok() => null,
+        Err(:final failure) => failure.kind,
+      }, BitcoinSigningFailureKind.incomplete);
+    },
+  );
+
+  test(
+    'returns a partial PSBT when the caller is coordinating signers',
+    () async {
+      final usecase = SignBitcoinTxUsecase(
+        _FakeBitcoinSigningPort((psbt: 'partial', isFinalized: false)),
+      );
+
+      final result = await usecase.execute(
+        psbt: 'unsigned',
+        walletId: 'wallet',
+        requireFinalized: false,
+      );
+      final signed = (result as Ok).value as SignedBitcoinTransaction;
+
+      expect(signed.signedPsbt, 'partial');
+      expect(signed.isFinalized, isFalse);
+      expect(signed.txSize, 120);
+    },
+  );
+
+  test('combines a PSBT returned by an external signer', () async {
+    final port = _FakeBitcoinSigningPort((psbt: 'combined', isFinalized: true));
+    final usecase = SignBitcoinTxUsecase(port);
+
+    final result = await usecase.execute(
+      psbt: 'current',
+      externalPsbt: 'external',
+      walletId: 'wallet',
+    );
+    final signed = (result as Ok).value as SignedBitcoinTransaction;
+
+    expect(signed.signedPsbt, 'combined');
+    expect(port.combineCalls, 1);
+    expect(port.signCalls, 0);
+  });
+}

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_se
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
@@ -1042,6 +1043,57 @@ void main() {
   // A shortfall used to show "Build Failed", the same message as a dead
   // Electrum server or a bad address.
   group('SendCubit.createTransaction shortfalls', () {
+    for (final scenario in [
+      (
+        exception: SelectedBitcoinCoinsUnavailableException(),
+        failure: isA<SendSelectedCoinsUnavailableFailure>(),
+      ),
+      (
+        exception: SelectedBitcoinCoinsInsufficientException(),
+        failure: isA<SendSelectedCoinsInsufficientFailure>(),
+      ),
+    ]) {
+      test('maps ${scenario.exception.runtimeType}', () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        final selected = _utxo(amountSat: 1000);
+        when(
+          () => prepareBitcoinSendUsecase.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            networkFee: any(named: 'networkFee'),
+            amountSat: any(named: 'amountSat'),
+            drain: any(named: 'drain'),
+            selectedInputs: any(named: 'selectedInputs'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        ).thenThrow(scenario.exception);
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => [selected]);
+        cubit.setStateForTest(
+          SendState(
+            step: SendStep.amount,
+            sendType: SendType.bitcoin,
+            selectedWallet: _bitcoinWallet(balanceSat: 20000),
+            paymentRequest: const PaymentRequest.bitcoin(
+              address: 'bc1-address',
+              isTestnet: false,
+            ),
+            amount: '500',
+            inputAmountCurrencyCode: 'sats',
+            liquidFeesList: _feeOptions(),
+            bitcoinFeesList: _feeOptions(),
+            selectedUtxos: [selected],
+          ),
+        );
+
+        await cubit.onAmountConfirmed();
+
+        expect(cubit.state.failure, scenario.failure);
+      });
+    }
+
     test(
       'a shortfall at build time is an insufficient-balance failure',
       () async {

--- a/test/security_audit/issue_2654_test.dart
+++ b/test/security_audit/issue_2654_test.dart
@@ -10,7 +10,8 @@ void main() {
   group('Security audit #2654 stripped PSBT', () {
     test('BitcoinTx.fromPsbt finalizes through the stripped-metadata path', () {
       final source = File('lib/core/utils/bitcoin_tx.dart').readAsStringSync();
-      expect(source, contains('final psbt = Psbt.fromBase64(psbtBase64);'));
+      expect(source, contains('final normalized = normalizeBitcoinPsbt'));
+      expect(source, contains('final psbt = Psbt.fromBase64(normalized);'));
       expect(source, contains('finalizeAll().toBytes()'));
     });
   });


### PR DESCRIPTION
## Summary

- Analyze supported single-signature, multisig and Miniscript descriptors.
- Represent spending options, thresholds, timelocks and hashlocks for the application.
- Determine which spending options are currently available for the selected coins.
- Track signing status by descriptor key and input.
- Build, validate, merge and finalize PSBTs for descriptor wallets.
- Allow signatures to be collected from eligible signers in any order.
- Enforce strict manual coin selection without silently adding or replacing wallet coins.

## Policy examples

Multisig:

```text
wsh(sortedmulti(2,KEY_A,KEY_B,KEY_C))
```

Delayed alternative:

```text
wsh(or_d(pk(KEY_A),and_v(v:older(144),pk(KEY_B))))
```

## Safety checks

- Returned PSBTs must preserve the original transaction.
- Signatures are cryptographically verified before being accepted.
- Change outputs are verified against the wallet descriptor.
- Unsupported sighash types and incompatible spending selections are rejected.
- Timelocks and hash preimages are applied according to the selected policy.
