### PR TITLE
feat(send): persist resumable bitcoin transactions

### DIFF
--- a/lib/core/storage/migrations/schema_15_to_16.dart
+++ b/lib/core/storage/migrations/schema_15_to_16.dart
@@ -135,11 +135,17 @@ class Schema15To16 {
         );
       }
 
+      await m.createTable(schema16.sendTransactions);
+      await m.createTable(schema16.sendTransactionInputs);
+      await m.createTable(schema16.sendTransactionPolicyChoices);
+      await m.createIndex(schema16.sendTransactionsWallet);
+      await m.createIndex(schema16.sendTransactionsUpdatedAt);
+
       final foreignKeyViolations = await m.database
           .customSelect('PRAGMA foreign_key_check')
           .get();
       if (foreignKeyViolations.isNotEmpty) {
-        throw StateError('The v16 wallet migration violated a foreign key');
+        throw StateError('The v16 migration violated a foreign key');
       }
 
       // Keep the version marker in the same atomic transaction as the schema

--- a/lib/core/storage/schemas/bull_database/drift_schema_v16.json
+++ b/lib/core/storage/schemas/bull_database/drift_schema_v16.json
@@ -2658,6 +2658,329 @@
     {
       "id": 20,
       "references": [
+        1
+      ],
+      "type": "table",
+      "data": {
+        "name": "send_transactions",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "wallet_id",
+            "getter_name": "walletId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "stage",
+            "getter_name": "stage",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "label",
+            "getter_name": "label",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "recipient",
+            "getter_name": "recipient",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "amount",
+            "getter_name": "amount",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "amount_currency_code",
+            "getter_name": "amountCurrencyCode",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "send_max",
+            "getter_name": "sendMax",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"send_max\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"send_max\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "fee_selection",
+            "getter_name": "feeSelection",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "custom_fee_kind",
+            "getter_name": "customFeeKind",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "custom_fee_value",
+            "getter_name": "customFeeValue",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "replace_by_fee",
+            "getter_name": "replaceByFee",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"replace_by_fee\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"replace_by_fee\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "payjoin_opted_out",
+            "getter_name": "payjoinOptedOut",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"payjoin_opted_out\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"payjoin_opted_out\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "psbt",
+            "getter_name": "psbt",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "final_transaction",
+            "getter_name": "finalTransaction",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at",
+            "getter_name": "createdAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at",
+            "getter_name": "updatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "revision",
+            "getter_name": "revision",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [
+          "FOREIGN KEY(wallet_id) REFERENCES wallet_metadatas(id) ON DELETE CASCADE",
+          "CHECK(stage IN ('draft', 'needsSignatures', 'readyToBroadcast'))",
+          "CHECK(custom_fee_kind IS NULL OR custom_fee_kind IN ('absolute', 'relative'))",
+          "CHECK((custom_fee_kind IS NULL) = (custom_fee_value IS NULL))",
+          "CHECK(stage = 'draft' OR psbt IS NOT NULL)"
+        ],
+        "explicit_pk": [
+          "id"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "references": [
+        20
+      ],
+      "type": "table",
+      "data": {
+        "name": "send_transaction_inputs",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "transaction_id",
+            "getter_name": "transactionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tx_id",
+            "getter_name": "txId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "vout",
+            "getter_name": "vout",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [
+          "FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE"
+        ],
+        "explicit_pk": [
+          "transaction_id",
+          "tx_id",
+          "vout"
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "references": [
+        20
+      ],
+      "type": "table",
+      "data": {
+        "name": "send_transaction_policy_choices",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "transaction_id",
+            "getter_name": "transactionId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "node",
+            "getter_name": "node",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "option_index",
+            "getter_name": "optionIndex",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [
+          "FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE"
+        ],
+        "explicit_pk": [
+          "transaction_id",
+          "node",
+          "option_index"
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "references": [
         19
       ],
       "type": "index",
@@ -2675,7 +2998,7 @@
       }
     },
     {
-      "id": 21,
+      "id": 24,
       "references": [
         19
       ],
@@ -2694,7 +3017,7 @@
       }
     },
     {
-      "id": 22,
+      "id": 25,
       "references": [
         19
       ],
@@ -2713,7 +3036,7 @@
       }
     },
     {
-      "id": 23,
+      "id": 26,
       "references": [
         19
       ],
@@ -2732,7 +3055,7 @@
       }
     },
     {
-      "id": 24,
+      "id": 27,
       "references": [
         19
       ],
@@ -2751,7 +3074,7 @@
       }
     },
     {
-      "id": 25,
+      "id": 28,
       "references": [
         19
       ],
@@ -2770,7 +3093,7 @@
       }
     },
     {
-      "id": 26,
+      "id": 29,
       "references": [
         19
       ],
@@ -2783,6 +3106,44 @@
         "columns": [
           {
             "column": "local_payin_transaction_id",
+            "order_by": null
+          }
+        ]
+      }
+    },
+    {
+      "id": 30,
+      "references": [
+        20
+      ],
+      "type": "index",
+      "data": {
+        "on": 20,
+        "name": "send_transactions_wallet",
+        "sql": null,
+        "unique": false,
+        "columns": [
+          {
+            "column": "wallet_id",
+            "order_by": null
+          }
+        ]
+      }
+    },
+    {
+      "id": 31,
+      "references": [
+        20
+      ],
+      "type": "index",
+      "data": {
+        "on": 20,
+        "name": "send_transactions_updated_at",
+        "sql": null,
+        "unique": false,
+        "columns": [
+          {
+            "column": "updated_at",
             "order_by": null
           }
         ]
@@ -2971,6 +3332,33 @@
       ]
     },
     {
+      "name": "send_transactions",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"send_transactions\" (\"id\" TEXT NOT NULL, \"wallet_id\" TEXT NOT NULL, \"stage\" TEXT NOT NULL, \"label\" TEXT NULL, \"recipient\" TEXT NOT NULL, \"amount\" TEXT NOT NULL, \"amount_currency_code\" TEXT NOT NULL, \"send_max\" INTEGER NOT NULL CHECK (\"send_max\" IN (0, 1)), \"fee_selection\" TEXT NOT NULL, \"custom_fee_kind\" TEXT NULL, \"custom_fee_value\" INTEGER NULL, \"replace_by_fee\" INTEGER NOT NULL CHECK (\"replace_by_fee\" IN (0, 1)), \"payjoin_opted_out\" INTEGER NOT NULL DEFAULT 0 CHECK (\"payjoin_opted_out\" IN (0, 1)), \"psbt\" TEXT NULL, \"final_transaction\" TEXT NULL, \"created_at\" TEXT NOT NULL, \"updated_at\" TEXT NOT NULL, \"revision\" INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (\"id\"), FOREIGN KEY(wallet_id) REFERENCES wallet_metadatas(id) ON DELETE CASCADE, CHECK(stage IN ('draft', 'needsSignatures', 'readyToBroadcast')), CHECK(custom_fee_kind IS NULL OR custom_fee_kind IN ('absolute', 'relative')), CHECK((custom_fee_kind IS NULL) = (custom_fee_value IS NULL)), CHECK(stage = 'draft' OR psbt IS NOT NULL));"
+        }
+      ]
+    },
+    {
+      "name": "send_transaction_inputs",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"send_transaction_inputs\" (\"transaction_id\" TEXT NOT NULL, \"tx_id\" TEXT NOT NULL, \"vout\" INTEGER NOT NULL, PRIMARY KEY (\"transaction_id\", \"tx_id\", \"vout\"), FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE);"
+        }
+      ]
+    },
+    {
+      "name": "send_transaction_policy_choices",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"send_transaction_policy_choices\" (\"transaction_id\" TEXT NOT NULL, \"node\" TEXT NOT NULL, \"option_index\" INTEGER NOT NULL, PRIMARY KEY (\"transaction_id\", \"node\", \"option_index\"), FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE);"
+        }
+      ]
+    },
+    {
       "name": "order_swaps_request_id",
       "sql": [
         {
@@ -3030,6 +3418,24 @@
         {
           "dialect": "sqlite",
           "sql": "CREATE INDEX order_swaps_local_payin_txid ON order_swaps (local_payin_transaction_id)"
+        }
+      ]
+    },
+    {
+      "name": "send_transactions_wallet",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE INDEX send_transactions_wallet ON send_transactions (wallet_id)"
+        }
+      ]
+    },
+    {
+      "name": "send_transactions_updated_at",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE INDEX send_transactions_updated_at ON send_transactions (updated_at)"
         }
       ]
     }

--- a/lib/core/storage/sqlite_database.dart
+++ b/lib/core/storage/sqlite_database.dart
@@ -19,6 +19,7 @@ import 'package:bb_mobile/core/storage/tables/payjoin_receivers_table.dart';
 import 'package:bb_mobile/core/storage/tables/payjoin_senders_table.dart';
 import 'package:bb_mobile/core/storage/tables/prices_table.dart';
 import 'package:bb_mobile/core/storage/tables/recoverbull_table.dart';
+import 'package:bb_mobile/core/storage/tables/send_transactions_table.dart';
 import 'package:bb_mobile/core/storage/tables/settings_table.dart';
 import 'package:bb_mobile/core/storage/tables/swaps_table.dart';
 import 'package:bb_mobile/core/storage/tables/transactions_table.dart';
@@ -57,6 +58,9 @@ part 'sqlite_database.g.dart';
     FrozenUtxos,
     DismissedAnnouncements,
     OrderSwaps,
+    SendTransactions,
+    SendTransactionInputs,
+    SendTransactionPolicyChoices,
   ],
 )
 class SqliteDatabase extends _$SqliteDatabase {

--- a/lib/core/storage/sqlite_database.steps.dart
+++ b/lib/core/storage/sqlite_database.steps.dart
@@ -7713,6 +7713,9 @@ final class Schema16 extends i0.VersionedSchema {
     frozenUtxos,
     dismissedAnnouncements,
     orderSwaps,
+    sendTransactions,
+    sendTransactionInputs,
+    sendTransactionPolicyChoices,
     orderSwapsRequestId,
     orderSwapsLocalStatus,
     orderSwapsSourceWallet,
@@ -7720,6 +7723,8 @@ final class Schema16 extends i0.VersionedSchema {
     orderSwapsBitcoinTxid,
     orderSwapsLiquidTxid,
     orderSwapsLocalPayinTxid,
+    sendTransactionsWallet,
+    sendTransactionsUpdatedAt,
   ];
   late final Shape0 transactions = Shape0(
     source: i0.VersionedTable(
@@ -8166,6 +8171,71 @@ final class Schema16 extends i0.VersionedSchema {
     ),
     alias: null,
   );
+  late final Shape46 sendTransactions = Shape46(
+    source: i0.VersionedTable(
+      entityName: 'send_transactions',
+      withoutRowId: false,
+      isStrict: false,
+      tableConstraints: [
+        'PRIMARY KEY(id)',
+        'FOREIGN KEY(wallet_id)REFERENCES wallet_metadatas(id)ON DELETE CASCADE',
+        'CHECK(stage IN (\'draft\', \'needsSignatures\', \'readyToBroadcast\'))',
+        'CHECK(custom_fee_kind IS NULL OR custom_fee_kind IN (\'absolute\', \'relative\'))',
+        'CHECK((custom_fee_kind IS NULL)=(custom_fee_value IS NULL))',
+        'CHECK(stage = \'draft\' OR psbt IS NOT NULL)',
+      ],
+      columns: [
+        _column_126,
+        _column_161,
+        _column_293,
+        _column_139,
+        _column_294,
+        _column_295,
+        _column_296,
+        _column_297,
+        _column_298,
+        _column_299,
+        _column_300,
+        _column_301,
+        _column_302,
+        _column_303,
+        _column_304,
+        _column_231,
+        _column_305,
+        _column_306,
+      ],
+      attachedDatabase: database,
+    ),
+    alias: null,
+  );
+  late final Shape47 sendTransactionInputs = Shape47(
+    source: i0.VersionedTable(
+      entityName: 'send_transaction_inputs',
+      withoutRowId: false,
+      isStrict: false,
+      tableConstraints: [
+        'PRIMARY KEY(transaction_id, tx_id, vout)',
+        'FOREIGN KEY(transaction_id)REFERENCES send_transactions(id)ON DELETE CASCADE',
+      ],
+      columns: [_column_307, _column_240, _column_241],
+      attachedDatabase: database,
+    ),
+    alias: null,
+  );
+  late final Shape48 sendTransactionPolicyChoices = Shape48(
+    source: i0.VersionedTable(
+      entityName: 'send_transaction_policy_choices',
+      withoutRowId: false,
+      isStrict: false,
+      tableConstraints: [
+        'PRIMARY KEY(transaction_id, node, option_index)',
+        'FOREIGN KEY(transaction_id)REFERENCES send_transactions(id)ON DELETE CASCADE',
+      ],
+      columns: [_column_307, _column_308, _column_309],
+      attachedDatabase: database,
+    ),
+    alias: null,
+  );
   final i1.Index orderSwapsRequestId = i1.Index(
     'order_swaps_request_id',
     'CREATE UNIQUE INDEX order_swaps_request_id ON order_swaps (request_id)',
@@ -8193,6 +8263,14 @@ final class Schema16 extends i0.VersionedSchema {
   final i1.Index orderSwapsLocalPayinTxid = i1.Index(
     'order_swaps_local_payin_txid',
     'CREATE INDEX order_swaps_local_payin_txid ON order_swaps (local_payin_transaction_id)',
+  );
+  final i1.Index sendTransactionsWallet = i1.Index(
+    'send_transactions_wallet',
+    'CREATE INDEX send_transactions_wallet ON send_transactions (wallet_id)',
+  );
+  final i1.Index sendTransactionsUpdatedAt = i1.Index(
+    'send_transactions_updated_at',
+    'CREATE INDEX send_transactions_updated_at ON send_transactions (updated_at)',
   );
 }
 
@@ -8300,6 +8378,208 @@ i1.GeneratedColumn<String> _column_292(String aliasedName) =>
       type: i1.DriftSqlType.string,
       $customConstraints: 'NOT NULL DEFAULT \'\'',
       defaultValue: const i1.CustomExpression('\'\''),
+    );
+
+class Shape46 extends i0.VersionedTable {
+  Shape46({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<String> get id =>
+      columnsByName['id']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get walletId =>
+      columnsByName['wallet_id']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get stage =>
+      columnsByName['stage']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get label =>
+      columnsByName['label']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get recipient =>
+      columnsByName['recipient']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get amount =>
+      columnsByName['amount']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get amountCurrencyCode =>
+      columnsByName['amount_currency_code']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get sendMax =>
+      columnsByName['send_max']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<String> get feeSelection =>
+      columnsByName['fee_selection']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get customFeeKind =>
+      columnsByName['custom_fee_kind']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get customFeeValue =>
+      columnsByName['custom_fee_value']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get replaceByFee =>
+      columnsByName['replace_by_fee']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<int> get payjoinOptedOut =>
+      columnsByName['payjoin_opted_out']! as i1.GeneratedColumn<int>;
+  i1.GeneratedColumn<String> get psbt =>
+      columnsByName['psbt']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get finalTransaction =>
+      columnsByName['final_transaction']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get createdAt =>
+      columnsByName['created_at']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get updatedAt =>
+      columnsByName['updated_at']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get revision =>
+      columnsByName['revision']! as i1.GeneratedColumn<int>;
+}
+
+i1.GeneratedColumn<String> _column_293(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'stage',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<String> _column_294(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'recipient',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<String> _column_295(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'amount',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<String> _column_296(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'amount_currency_code',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<int> _column_297(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'send_max',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NOT NULL CHECK (send_max IN (0, 1))',
+    );
+i1.GeneratedColumn<String> _column_298(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'fee_selection',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<String> _column_299(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'custom_fee_kind',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NULL',
+    );
+i1.GeneratedColumn<int> _column_300(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'custom_fee_value',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NULL',
+    );
+i1.GeneratedColumn<int> _column_301(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'replace_by_fee',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NOT NULL CHECK (replace_by_fee IN (0, 1))',
+    );
+i1.GeneratedColumn<int> _column_302(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'payjoin_opted_out',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints:
+          'NOT NULL DEFAULT 0 CHECK (payjoin_opted_out IN (0, 1))',
+      defaultValue: const i1.CustomExpression('0'),
+    );
+i1.GeneratedColumn<String> _column_303(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'psbt',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NULL',
+    );
+i1.GeneratedColumn<String> _column_304(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'final_transaction',
+      aliasedName,
+      true,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NULL',
+    );
+i1.GeneratedColumn<String> _column_305(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'updated_at',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<int> _column_306(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'revision',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NOT NULL DEFAULT 0',
+      defaultValue: const i1.CustomExpression('0'),
+    );
+
+class Shape47 extends i0.VersionedTable {
+  Shape47({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<String> get transactionId =>
+      columnsByName['transaction_id']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get txId =>
+      columnsByName['tx_id']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get vout =>
+      columnsByName['vout']! as i1.GeneratedColumn<int>;
+}
+
+i1.GeneratedColumn<String> _column_307(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'transaction_id',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+
+class Shape48 extends i0.VersionedTable {
+  Shape48({required super.source, required super.alias}) : super.aliased();
+  i1.GeneratedColumn<String> get transactionId =>
+      columnsByName['transaction_id']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<String> get node =>
+      columnsByName['node']! as i1.GeneratedColumn<String>;
+  i1.GeneratedColumn<int> get optionIndex =>
+      columnsByName['option_index']! as i1.GeneratedColumn<int>;
+}
+
+i1.GeneratedColumn<String> _column_308(String aliasedName) =>
+    i1.GeneratedColumn<String>(
+      'node',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.string,
+      $customConstraints: 'NOT NULL',
+    );
+i1.GeneratedColumn<int> _column_309(String aliasedName) =>
+    i1.GeneratedColumn<int>(
+      'option_index',
+      aliasedName,
+      false,
+      type: i1.DriftSqlType.int,
+      $customConstraints: 'NOT NULL',
     );
 i0.MigrationStepWithVersion migrationSteps({
   required Future<void> Function(i1.Migrator m, Schema2 schema) from1To2,

--- a/lib/core/storage/tables/send_transactions_table.dart
+++ b/lib/core/storage/tables/send_transactions_table.dart
@@ -1,0 +1,72 @@
+// Drift resolves the referenced table from this import when generating the
+// raw foreign-key constraint.
+// ignore: unused_import
+import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
+import 'package:drift/drift.dart';
+
+@DataClassName('SendTransactionRow')
+@TableIndex(name: 'send_transactions_wallet', columns: {#walletId})
+@TableIndex(name: 'send_transactions_updated_at', columns: {#updatedAt})
+class SendTransactions extends Table {
+  TextColumn get id => text()();
+  TextColumn get walletId => text()();
+  TextColumn get stage => text()();
+  TextColumn get label => text().nullable()();
+  TextColumn get recipient => text()();
+  TextColumn get amount => text()();
+  TextColumn get amountCurrencyCode => text()();
+  BoolColumn get sendMax => boolean()();
+  TextColumn get feeSelection => text()();
+  TextColumn get customFeeKind => text().nullable()();
+  IntColumn get customFeeValue => integer().nullable()();
+  BoolColumn get replaceByFee => boolean()();
+  BoolColumn get payjoinOptedOut =>
+      boolean().withDefault(const Constant(false))();
+  TextColumn get psbt => text().nullable()();
+  TextColumn get finalTransaction => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+  DateTimeColumn get updatedAt => dateTime()();
+  IntColumn get revision => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column<Object>> get primaryKey => {id};
+
+  @override
+  List<String> get customConstraints => [
+    'FOREIGN KEY(wallet_id) REFERENCES wallet_metadatas(id) ON DELETE CASCADE',
+    "CHECK(stage IN ('draft', 'needsSignatures', 'readyToBroadcast'))",
+    "CHECK(custom_fee_kind IS NULL OR custom_fee_kind IN ('absolute', 'relative'))",
+    'CHECK((custom_fee_kind IS NULL) = (custom_fee_value IS NULL))',
+    "CHECK(stage = 'draft' OR psbt IS NOT NULL)",
+  ];
+}
+
+@DataClassName('SendTransactionInputRow')
+class SendTransactionInputs extends Table {
+  TextColumn get transactionId => text()();
+  TextColumn get txId => text()();
+  IntColumn get vout => integer()();
+
+  @override
+  Set<Column<Object>> get primaryKey => {transactionId, txId, vout};
+
+  @override
+  List<String> get customConstraints => [
+    'FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE',
+  ];
+}
+
+@DataClassName('SendTransactionPolicyChoiceRow')
+class SendTransactionPolicyChoices extends Table {
+  TextColumn get transactionId => text()();
+  TextColumn get node => text()();
+  IntColumn get optionIndex => integer()();
+
+  @override
+  Set<Column<Object>> get primaryKey => {transactionId, node, optionIndex};
+
+  @override
+  List<String> get customConstraints => [
+    'FOREIGN KEY(transaction_id) REFERENCES send_transactions(id) ON DELETE CASCADE',
+  ];
+}

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -759,6 +759,7 @@ class BdkWalletDatasource {
                   : BitcoinPolicyKeychainModel.internal,
               originKeySources: originKeySources,
               outpoint: '${previousOutput.txid}:${previousOutput.vout}',
+              satisfiedPreimageKeys: _satisfiedPreimageKeys(input),
               sequence: transactionInputs[index].sequence,
               signedKeySources: signedKeySources,
             ));
@@ -811,6 +812,7 @@ class BdkWalletDatasource {
                   .toList(),
               wallet: wallet,
             ),
+            isFinalized: psbtInputs.every(_isFinalizedInput),
             lockTime: transaction.lockTime(),
             version: transaction.version(),
           );
@@ -832,6 +834,7 @@ class BdkWalletDatasource {
     required PublicBdkWalletModel wallet,
     Set<String> frozenOutpoints = const {},
     String? replacingTxid,
+    bool allowSpentWalletInputs = false,
   }) async {
     final psbt = _parsePsbt(psbtBase64);
     try {
@@ -865,6 +868,7 @@ class BdkWalletDatasource {
             final localOutput = outputs[outpoint];
             if (localOutput == null ||
                 (localOutput.isSpent &&
+                    !allowSpentWalletInputs &&
                     !replacedOutpoints.contains(outpoint))) {
               throw const BitcoinPsbtMissingUtxoException();
             }
@@ -1677,6 +1681,51 @@ int _completedTransactionVsize({
 
 bool _isFinalizedInput(bdk.Input input) =>
     input.finalScriptSig != null || input.finalScriptWitness != null;
+
+Set<String> _satisfiedPreimageKeys(bdk.Input input) {
+  final keys = <String>{
+    for (final entry in input.sha256Preimages.entries)
+      if (_sameBytes(
+        hex.decode(entry.key),
+        _preimageHash(bitcoin_base.PsbtInputSha256.fromPreImage(entry.value)),
+      ))
+        'sha256:${entry.key.toLowerCase()}',
+    for (final entry in input.hash256Preimages.entries)
+      if (_sameBytes(
+        hex.decode(entry.key),
+        _preimageHash(bitcoin_base.PsbtInputHash256.fromPreImage(entry.value)),
+      ))
+        'hash256:${entry.key.toLowerCase()}',
+    for (final entry in input.ripemd160Preimages.entries)
+      if (_sameBytes(
+        hex.decode(entry.key),
+        _preimageHash(
+          bitcoin_base.PsbtInputRipemd160.fromPreImage(entry.value),
+        ),
+      ))
+        'ripemd160:${entry.key.toLowerCase()}',
+    for (final entry in input.hash160Preimages.entries)
+      if (_sameBytes(
+        hex.decode(entry.key),
+        _preimageHash(bitcoin_base.PsbtInputHash160.fromPreImage(entry.value)),
+      ))
+        'hash160:${entry.key.toLowerCase()}',
+  };
+
+  for (final item in input.finalScriptWitness ?? const []) {
+    if (item.length != 32) continue;
+    keys.addAll(_preimageCommitmentKeys(item));
+  }
+
+  return Set.unmodifiable(keys);
+}
+
+Set<String> _preimageCommitmentKeys(List<int> preimage) => {
+  'sha256:${hex.encode(_preimageHash(bitcoin_base.PsbtInputSha256.fromPreImage(preimage)))}',
+  'hash256:${hex.encode(_preimageHash(bitcoin_base.PsbtInputHash256.fromPreImage(preimage)))}',
+  'ripemd160:${hex.encode(_preimageHash(bitcoin_base.PsbtInputRipemd160.fromPreImage(preimage)))}',
+  'hash160:${hex.encode(_preimageHash(bitcoin_base.PsbtInputHash160.fromPreImage(preimage)))}',
+};
 
 void _rejectFinalizedInputs(List<bdk.Input> inputs) {
   if (inputs.any(_isFinalizedInput)) {

--- a/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
@@ -32,6 +32,7 @@ class BitcoinPsbtReviewMapper {
     ],
     feeSat: model.feeSat,
     estimatedTransactionVsize: model.estimatedTransactionVsize,
+    isFinalized: model.isFinalized,
     lockTime: model.lockTime,
     version: model.version,
   );
@@ -66,6 +67,7 @@ class BitcoinPsbtReviewMapper {
         null => null,
       },
       localDescriptorKeyIds: localKeyIds,
+      satisfiedPreimageKeys: input.satisfiedPreimageKeys,
       sequence: input.sequence,
       signedDescriptorKeyIds: signedKeyIds,
     );

--- a/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
@@ -10,6 +10,7 @@ typedef BitcoinPsbtInputReviewRecord = ({
   BigInt amountSat,
   BitcoinPolicyKeychainModel? keychain,
   List<BitcoinPsbtKeySourceRecord> originKeySources,
+  Set<String> satisfiedPreimageKeys,
   List<BitcoinPsbtKeySourceRecord> signedKeySources,
   String outpoint,
   int sequence,
@@ -29,6 +30,7 @@ final class BitcoinPsbtReviewModel {
   final List<BitcoinPsbtOutputReviewRecord> outputs;
   final BigInt feeSat;
   final int estimatedTransactionVsize;
+  final bool isFinalized;
   final int lockTime;
   final int version;
 
@@ -38,6 +40,7 @@ final class BitcoinPsbtReviewModel {
     required List<BitcoinPsbtOutputReviewRecord> outputs,
     required this.feeSat,
     required this.estimatedTransactionVsize,
+    required this.isFinalized,
     required this.lockTime,
     required this.version,
   }) : inputs = List.unmodifiable(inputs),

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -221,11 +221,13 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
     String psbt, {
     required String walletId,
     bool requireLocalOrigin = true,
+    bool allowSpentWalletInputs = false,
   }) => _guardSigning(
     () => _reviewPsbt(
       psbt,
       walletId: walletId,
       requireLocalOrigin: requireLocalOrigin,
+      allowSpentWalletInputs: allowSpentWalletInputs,
     ),
   );
 
@@ -233,6 +235,7 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
     String psbt, {
     required String walletId,
     bool requireLocalOrigin = true,
+    bool allowSpentWalletInputs = false,
   }) async {
     final context = await _publicWalletContext(walletId);
     final metadata = context.metadata;
@@ -245,7 +248,11 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
       throw const BitcoinPsbtMissingLocalOriginException();
     }
 
-    await _validateWalletPsbtInputs(psbt: psbt, wallet: wallet);
+    await _validateWalletPsbtInputs(
+      psbt: psbt,
+      wallet: wallet,
+      allowSpentWalletInputs: allowSpentWalletInputs,
+    );
     final model = await _bdkWallet.inspectPsbt(
       psbt,
       wallet: wallet,
@@ -608,6 +615,7 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
     required String psbt,
     required PublicBdkWalletModel wallet,
     String? replacingTxid,
+    bool allowSpentWalletInputs = false,
   }) async {
     final frozenRows = await _frozenUtxos.getAllFrozen();
     final frozenOutpoints = {
@@ -618,6 +626,7 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
         psbt,
         wallet: wallet,
         frozenOutpoints: frozenOutpoints,
+        allowSpentWalletInputs: allowSpentWalletInputs,
       );
     } else {
       await _bdkWallet.validateWalletPsbtInputs(
@@ -625,6 +634,7 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
         wallet: wallet,
         frozenOutpoints: frozenOutpoints,
         replacingTxid: replacingTxid,
+        allowSpentWalletInputs: allowSpentWalletInputs,
       );
     }
   }

--- a/lib/core/wallet/domain/bitcoin_signing_port.dart
+++ b/lib/core/wallet/domain/bitcoin_signing_port.dart
@@ -31,6 +31,7 @@ abstract interface class BitcoinSigningPort {
     String psbt, {
     required String walletId,
     bool requireLocalOrigin = true,
+    bool allowSpentWalletInputs = false,
   });
 
   @useResult

--- a/lib/core/wallet/domain/entities/bitcoin_policy_path.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy_path.dart
@@ -22,6 +22,9 @@ final class BitcoinPolicySelection {
   BitcoinPolicySelection({required Map<String, List<int>> choices})
     : choices = Map<String, List<int>>.unmodifiable(
         choices.map((key, value) {
+          if (!_selectionKeyPattern.hasMatch(key)) {
+            throw ArgumentError.value(key, 'choices');
+          }
           if (value.any((index) => index < 0) ||
               value.toSet().length != value.length) {
             throw ArgumentError.value(value, key);
@@ -64,6 +67,8 @@ final class BitcoinPolicySelection {
     );
   }
 }
+
+final _selectionKeyPattern = RegExp(r'^(external|internal):root(?:/[0-9]+)*$');
 
 final class BitcoinPolicyPath {
   final Map<String, List<int>> external;

--- a/lib/core/wallet/domain/entities/bitcoin_psbt_review.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_psbt_review.dart
@@ -6,6 +6,7 @@ final class BitcoinPsbtInputReview {
   final BigInt amountSat;
   final BitcoinPolicyKeychain? keychain;
   final Set<String> localDescriptorKeyIds;
+  final Set<String> satisfiedPreimageKeys;
   final int sequence;
   final Set<String> signedDescriptorKeyIds;
 
@@ -14,9 +15,11 @@ final class BitcoinPsbtInputReview {
     required this.amountSat,
     required this.keychain,
     Set<String> localDescriptorKeyIds = const {},
+    Set<String> satisfiedPreimageKeys = const {},
     required this.sequence,
     Set<String> signedDescriptorKeyIds = const {},
   }) : localDescriptorKeyIds = Set.unmodifiable(localDescriptorKeyIds),
+       satisfiedPreimageKeys = Set.unmodifiable(satisfiedPreimageKeys),
        signedDescriptorKeyIds = Set.unmodifiable(signedDescriptorKeyIds) {
     if (outpoint.isEmpty) throw ArgumentError.value(outpoint, 'outpoint');
     if (amountSat < BigInt.zero) {
@@ -58,6 +61,7 @@ final class BitcoinPsbtReview {
   final List<BitcoinPsbtOutputReview> outputs;
   final BigInt feeSat;
   final int estimatedTransactionVsize;
+  final bool isFinalized;
   final int lockTime;
   final int version;
 
@@ -67,6 +71,7 @@ final class BitcoinPsbtReview {
     required List<BitcoinPsbtOutputReview> outputs,
     required this.feeSat,
     required this.estimatedTransactionVsize,
+    this.isFinalized = false,
     required this.lockTime,
     required this.version,
   }) : inputs = List.unmodifiable(inputs),
@@ -129,6 +134,15 @@ final class BitcoinPsbtReview {
         for (final input in inputs)
           input.outpoint: Set.unmodifiable(input.signedDescriptorKeyIds),
       });
+
+  Set<String> get satisfiedPreimageKeys {
+    if (inputs.isEmpty) return const {};
+    return Set.unmodifiable(
+      inputs
+          .map((input) => input.satisfiedPreimageKeys)
+          .reduce((satisfied, next) => satisfied.intersection(next)),
+    );
+  }
 
   bool get hasTimingConstraint =>
       _hasAbsoluteTimingConstraint ||

--- a/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
@@ -473,7 +473,9 @@ final class BitcoinWalletPolicy {
       if (externalChoice == null ||
           internalChoice == null ||
           !_sameIndices(externalChoice, internalChoice)) {
-        throw StateError(
+        throw ArgumentError.value(
+          selection.choices,
+          'selection',
           'Matching receive and change policies require the same selection',
         );
       }
@@ -953,7 +955,9 @@ BitcoinPolicyNode? _nodeAtPath(BitcoinPolicyNode root, String nodePath) {
   for (final segment in nodePath.split('/').skip(1)) {
     if (node is! BitcoinThresholdPolicyNode) return null;
     final index = int.tryParse(segment);
-    if (index == null || index >= node.children.length) return null;
+    if (index == null || index < 0 || index >= node.children.length) {
+      return null;
+    }
     node = node.children[index];
   }
   return node;

--- a/lib/features/send/data/models/pending_bitcoin_transaction_model.dart
+++ b/lib/features/send/data/models/pending_bitcoin_transaction_model.dart
@@ -1,0 +1,30 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pending_bitcoin_transaction_model.freezed.dart';
+
+@freezed
+abstract class PendingBitcoinTransactionModel
+    with _$PendingBitcoinTransactionModel {
+  const factory PendingBitcoinTransactionModel({
+    required String id,
+    required String walletId,
+    required String stage,
+    String? label,
+    required String recipient,
+    required String amount,
+    required String amountCurrencyCode,
+    required bool sendMax,
+    required String feeSelection,
+    String? customFeeKind,
+    int? customFeeValue,
+    required bool replaceByFee,
+    @Default(false) bool payjoinOptedOut,
+    required Set<String> selectedOutpoints,
+    required Map<String, List<int>> policyChoices,
+    String? psbt,
+    String? finalTransaction,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    @Default(0) int revision,
+  }) = _PendingBitcoinTransactionModel;
+}

--- a/lib/features/send/data/pending_bitcoin_transaction_datasource.dart
+++ b/lib/features/send/data/pending_bitcoin_transaction_datasource.dart
@@ -1,0 +1,193 @@
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/features/send/data/models/pending_bitcoin_transaction_model.dart';
+import 'package:drift/drift.dart';
+
+class PendingBitcoinTransactionDatasource {
+  final SqliteDatabase _database;
+
+  const PendingBitcoinTransactionDatasource(this._database);
+
+  Future<PendingBitcoinTransactionModel> save(
+    PendingBitcoinTransactionModel model, {
+    int? expectedRevision,
+  }) async {
+    final persistedModel = model.copyWith(
+      createdAt: _sqliteDateTime(model.createdAt),
+      updatedAt: _sqliteDateTime(model.updatedAt),
+      revision: expectedRevision == null
+          ? model.revision
+          : expectedRevision + 1,
+    );
+
+    return _database.transaction(() async {
+      final row = SendTransactionsCompanion.insert(
+        id: persistedModel.id,
+        walletId: persistedModel.walletId,
+        stage: persistedModel.stage,
+        label: Value(persistedModel.label),
+        recipient: persistedModel.recipient,
+        amount: persistedModel.amount,
+        amountCurrencyCode: persistedModel.amountCurrencyCode,
+        sendMax: persistedModel.sendMax,
+        feeSelection: persistedModel.feeSelection,
+        customFeeKind: Value(persistedModel.customFeeKind),
+        customFeeValue: Value(persistedModel.customFeeValue),
+        replaceByFee: persistedModel.replaceByFee,
+        payjoinOptedOut: Value(persistedModel.payjoinOptedOut),
+        psbt: Value(persistedModel.psbt),
+        finalTransaction: Value(persistedModel.finalTransaction),
+        createdAt: persistedModel.createdAt,
+        updatedAt: persistedModel.updatedAt,
+        revision: Value(persistedModel.revision),
+      );
+      if (expectedRevision == null) {
+        await _database.into(_database.sendTransactions).insert(row);
+      } else {
+        final updated =
+            await (_database.update(_database.sendTransactions)..where(
+                  (stored) =>
+                      stored.id.equals(persistedModel.id) &
+                      stored.revision.equals(expectedRevision),
+                ))
+                .write(row);
+        if (updated != 1) {
+          throw const PendingBitcoinTransactionChangedException();
+        }
+      }
+      await (_database.delete(
+        _database.sendTransactionInputs,
+      )..where((row) => row.transactionId.equals(persistedModel.id))).go();
+      await (_database.delete(
+        _database.sendTransactionPolicyChoices,
+      )..where((row) => row.transactionId.equals(persistedModel.id))).go();
+      for (final outpoint in persistedModel.selectedOutpoints) {
+        final separator = outpoint.lastIndexOf(':');
+        if (separator <= 0) throw const FormatException('Invalid outpoint');
+        await _database
+            .into(_database.sendTransactionInputs)
+            .insert(
+              SendTransactionInputsCompanion.insert(
+                transactionId: persistedModel.id,
+                txId: outpoint.substring(0, separator),
+                vout: int.parse(outpoint.substring(separator + 1)),
+              ),
+            );
+      }
+      for (final entry in persistedModel.policyChoices.entries) {
+        for (final optionIndex in entry.value) {
+          await _database
+              .into(_database.sendTransactionPolicyChoices)
+              .insert(
+                SendTransactionPolicyChoicesCompanion.insert(
+                  transactionId: persistedModel.id,
+                  node: entry.key,
+                  optionIndex: optionIndex,
+                ),
+              );
+        }
+      }
+      return persistedModel;
+    });
+  }
+
+  Future<PendingBitcoinTransactionModel?> get(String id) async {
+    return _database.transaction(() async {
+      final row = await (_database.select(
+        _database.sendTransactions,
+      )..where((row) => row.id.equals(id))).getSingleOrNull();
+      return row == null ? null : _withChildren(row);
+    });
+  }
+
+  Stream<List<PendingBitcoinTransactionModel>> watchWallet(String walletId) {
+    final query =
+        _database.select(_database.sendTransactions).join([
+            innerJoin(
+              _database.walletMetadatas,
+              _database.walletMetadatas.id.equalsExp(
+                _database.sendTransactions.walletId,
+              ),
+            ),
+          ])
+          ..where(_database.sendTransactions.walletId.equals(walletId))
+          ..orderBy([
+            OrderingTerm.desc(_database.sendTransactions.updatedAt),
+            OrderingTerm.desc(_database.sendTransactions.revision),
+          ]);
+    return query.watch().asyncMap(
+      (_) => _database.transaction(() async {
+        final rows = [
+          for (final row in await query.get())
+            row.readTable(_database.sendTransactions),
+        ];
+        return Future.wait(rows.map(_withChildren));
+      }),
+    );
+  }
+
+  Future<void> delete(String id, {required int expectedRevision}) async {
+    final deleted =
+        await (_database.delete(_database.sendTransactions)..where(
+              (row) =>
+                  row.id.equals(id) & row.revision.equals(expectedRevision),
+            ))
+            .go();
+    if (deleted != 1) {
+      throw const PendingBitcoinTransactionChangedException();
+    }
+  }
+
+  Future<PendingBitcoinTransactionModel> _withChildren(
+    SendTransactionRow row,
+  ) async {
+    final inputs = await (_database.select(
+      _database.sendTransactionInputs,
+    )..where((input) => input.transactionId.equals(row.id))).get();
+    final choices = await (_database.select(
+      _database.sendTransactionPolicyChoices,
+    )..where((choice) => choice.transactionId.equals(row.id))).get();
+    final policyChoices = <String, List<int>>{};
+    for (final choice in choices) {
+      (policyChoices[choice.node] ??= []).add(choice.optionIndex);
+    }
+    for (final value in policyChoices.values) {
+      value.sort();
+    }
+    return PendingBitcoinTransactionModel(
+      id: row.id,
+      walletId: row.walletId,
+      stage: row.stage,
+      label: row.label,
+      recipient: row.recipient,
+      amount: row.amount,
+      amountCurrencyCode: row.amountCurrencyCode,
+      sendMax: row.sendMax,
+      feeSelection: row.feeSelection,
+      customFeeKind: row.customFeeKind,
+      customFeeValue: row.customFeeValue,
+      replaceByFee: row.replaceByFee,
+      payjoinOptedOut: row.payjoinOptedOut,
+      selectedOutpoints: {
+        for (final input in inputs) '${input.txId}:${input.vout}',
+      },
+      policyChoices: policyChoices,
+      psbt: row.psbt,
+      finalTransaction: row.finalTransaction,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      revision: row.revision,
+    );
+  }
+}
+
+DateTime _sqliteDateTime(DateTime value) {
+  final milliseconds = value.millisecondsSinceEpoch;
+  return DateTime.fromMillisecondsSinceEpoch(
+    milliseconds - milliseconds % Duration.millisecondsPerSecond,
+    isUtc: true,
+  );
+}
+
+final class PendingBitcoinTransactionChangedException implements Exception {
+  const PendingBitcoinTransactionChangedException();
+}

--- a/lib/features/send/data/pending_bitcoin_transaction_mapper.dart
+++ b/lib/features/send/data/pending_bitcoin_transaction_mapper.dart
@@ -1,0 +1,74 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_path.dart';
+import 'package:bb_mobile/features/send/data/models/pending_bitcoin_transaction_model.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+
+class PendingBitcoinTransactionMapper {
+  static PendingBitcoinTransaction toEntity(
+    PendingBitcoinTransactionModel model,
+  ) => PendingBitcoinTransaction(
+    id: model.id,
+    walletId: model.walletId,
+    stage: PendingBitcoinTransactionStage.values.byName(model.stage),
+    label: model.label,
+    recipient: model.recipient,
+    amount: model.amount,
+    amountCurrencyCode: model.amountCurrencyCode,
+    sendMax: model.sendMax,
+    feeSelection: FeeSelection.values.byName(model.feeSelection),
+    customFee: _customFee(model),
+    replaceByFee: model.replaceByFee,
+    payjoinOptedOut: model.payjoinOptedOut,
+    selectedOutpoints: model.selectedOutpoints,
+    policySelection: BitcoinPolicySelection(choices: model.policyChoices),
+    psbt: model.psbt,
+    finalTransaction: model.finalTransaction,
+    createdAt: model.createdAt,
+    updatedAt: model.updatedAt,
+    revision: model.revision,
+  );
+
+  static PendingBitcoinTransactionModel toModel(
+    PendingBitcoinTransaction entity,
+  ) {
+    final customFee = entity.customFee;
+    return PendingBitcoinTransactionModel(
+      id: entity.id,
+      walletId: entity.walletId,
+      stage: entity.stage.name,
+      label: entity.label,
+      recipient: entity.recipient,
+      amount: entity.amount,
+      amountCurrencyCode: entity.amountCurrencyCode,
+      sendMax: entity.sendMax,
+      feeSelection: entity.feeSelection.name,
+      customFeeKind: switch (customFee) {
+        AbsoluteFee() => 'absolute',
+        RelativeFee() => 'relative',
+        null => null,
+      },
+      customFeeValue: switch (customFee) {
+        AbsoluteFee(:final sats) => sats,
+        RelativeFee(:final satPerKwu) => satPerKwu,
+        null => null,
+      },
+      replaceByFee: entity.replaceByFee,
+      payjoinOptedOut: entity.payjoinOptedOut,
+      selectedOutpoints: entity.selectedOutpoints,
+      policyChoices: entity.policySelection.choices,
+      psbt: entity.psbt,
+      finalTransaction: entity.finalTransaction,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      revision: entity.revision,
+    );
+  }
+
+  static NetworkFee? _customFee(PendingBitcoinTransactionModel model) =>
+      switch ((model.customFeeKind, model.customFeeValue)) {
+        (null, null) => null,
+        ('absolute', final value?) => NetworkFee.absolute(value),
+        ('relative', final value?) => NetworkFee.relativeSatPerKwu(value),
+        _ => throw const FormatException('Invalid custom fee'),
+      };
+}

--- a/lib/features/send/data/pending_bitcoin_transaction_repository_impl.dart
+++ b/lib/features/send/data/pending_bitcoin_transaction_repository_impl.dart
@@ -1,0 +1,143 @@
+import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/data/models/pending_bitcoin_transaction_model.dart';
+import 'package:bb_mobile/features/send/data/pending_bitcoin_transaction_datasource.dart';
+import 'package:bb_mobile/features/send/data/pending_bitcoin_transaction_mapper.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+
+class PendingBitcoinTransactionRepositoryImpl
+    implements PendingBitcoinTransactionRepository {
+  final PendingBitcoinTransactionDatasource _datasource;
+
+  const PendingBitcoinTransactionRepositoryImpl(this._datasource);
+
+  @override
+  Future<Result<PendingBitcoinTransaction, SendFailure>> save(
+    PendingBitcoinTransaction transaction, {
+    int? expectedRevision,
+  }) async {
+    try {
+      final saved = await _datasource.save(
+        PendingBitcoinTransactionMapper.toModel(transaction),
+        expectedRevision: expectedRevision,
+      );
+      return Ok(PendingBitcoinTransactionMapper.toEntity(saved));
+    } on PendingBitcoinTransactionChangedException catch (_, stackTrace) {
+      log.warning(
+        'A stale pending Bitcoin transaction update was rejected',
+        trace: stackTrace,
+      );
+      return const Err(SendPendingTransactionChangedFailure());
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to save a pending Bitcoin transaction',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      return const Err(SendPersistenceFailure());
+    }
+  }
+
+  @override
+  Future<Result<PendingBitcoinTransaction?, SendFailure>> get(String id) async {
+    final PendingBitcoinTransactionModel? model;
+    try {
+      model = await _datasource.get(id);
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to load a pending Bitcoin transaction',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      return const Err(SendPersistenceFailure());
+    }
+    if (model == null) return const Ok(null);
+    try {
+      return Ok(PendingBitcoinTransactionMapper.toEntity(model));
+    } on ArgumentError catch (error, stackTrace) {
+      log.warning(
+        'Loaded an invalid pending Bitcoin transaction',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      return const Err(SendStoredTransactionInvalidFailure());
+    } on FormatException catch (error, stackTrace) {
+      log.warning(
+        'Loaded an invalid pending Bitcoin transaction',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      return const Err(SendStoredTransactionInvalidFailure());
+    }
+  }
+
+  @override
+  Stream<Result<PendingBitcoinTransactionSnapshot, SendFailure>> watchWallet(
+    String walletId,
+  ) async* {
+    try {
+      await for (final models in _datasource.watchWallet(walletId)) {
+        final transactions = <PendingBitcoinTransaction>[];
+        var invalidCount = 0;
+        for (final model in models) {
+          try {
+            transactions.add(PendingBitcoinTransactionMapper.toEntity(model));
+          } on ArgumentError catch (error, stackTrace) {
+            invalidCount++;
+            log.warning(
+              'Ignored an invalid pending Bitcoin transaction',
+              error: error.runtimeType,
+              trace: stackTrace,
+            );
+          } on FormatException catch (error, stackTrace) {
+            invalidCount++;
+            log.warning(
+              'Ignored an invalid pending Bitcoin transaction',
+              error: error.runtimeType,
+              trace: stackTrace,
+            );
+          }
+        }
+        yield Ok(
+          PendingBitcoinTransactionSnapshot(
+            transactions: transactions,
+            invalidCount: invalidCount,
+          ),
+        );
+      }
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to watch pending Bitcoin transactions',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      yield const Err(SendPersistenceFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, SendFailure>> delete(
+    String id, {
+    required int expectedRevision,
+  }) async {
+    try {
+      await _datasource.delete(id, expectedRevision: expectedRevision);
+      return const Ok(null);
+    } on PendingBitcoinTransactionChangedException catch (_, stackTrace) {
+      log.warning(
+        'A stale pending Bitcoin transaction delete was rejected',
+        trace: stackTrace,
+      );
+      return const Err(SendPendingTransactionChangedFailure());
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to delete a pending Bitcoin transaction',
+        error: error.runtimeType,
+        trace: stackTrace,
+      );
+      return const Err(SendPersistenceFailure());
+    }
+  }
+}

--- a/lib/features/send/domain/pending_bitcoin_transaction.dart
+++ b/lib/features/send/domain/pending_bitcoin_transaction.dart
@@ -143,3 +143,17 @@ final class PendingBitcoinTransaction {
     signersNeeded: signersNeeded ?? this.signersNeeded,
   );
 }
+
+final class PendingBitcoinTransactionSnapshot {
+  final List<PendingBitcoinTransaction> transactions;
+  final int invalidCount;
+
+  PendingBitcoinTransactionSnapshot({
+    required Iterable<PendingBitcoinTransaction> transactions,
+    this.invalidCount = 0,
+  }) : transactions = List.unmodifiable(transactions) {
+    if (invalidCount < 0) {
+      throw ArgumentError.value(invalidCount, 'invalidCount');
+    }
+  }
+}

--- a/lib/features/send/domain/pending_bitcoin_transaction.dart
+++ b/lib/features/send/domain/pending_bitcoin_transaction.dart
@@ -1,0 +1,145 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy_path.dart';
+
+enum PendingBitcoinTransactionStage { draft, needsSignatures, readyToBroadcast }
+
+final class PendingBitcoinTransaction {
+  final String id;
+  final String walletId;
+  final PendingBitcoinTransactionStage stage;
+  final String? label;
+  final String recipient;
+  final String amount;
+  final String amountCurrencyCode;
+  final bool sendMax;
+  final FeeSelection feeSelection;
+  final NetworkFee? customFee;
+  final bool replaceByFee;
+  final bool payjoinOptedOut;
+  final Set<String> selectedOutpoints;
+  final BitcoinPolicySelection policySelection;
+  final String? psbt;
+  final String? finalTransaction;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int revision;
+  final bool isConflict;
+  final bool isPolicyReady;
+  final int signersNeeded;
+
+  PendingBitcoinTransaction({
+    required this.id,
+    required this.walletId,
+    required this.stage,
+    this.label,
+    required this.recipient,
+    required this.amount,
+    required this.amountCurrencyCode,
+    required this.sendMax,
+    required this.feeSelection,
+    this.customFee,
+    required this.replaceByFee,
+    this.payjoinOptedOut = false,
+    Set<String> selectedOutpoints = const {},
+    this.policySelection = const BitcoinPolicySelection.empty(),
+    this.psbt,
+    this.finalTransaction,
+    required this.createdAt,
+    required this.updatedAt,
+    this.revision = 0,
+    this.isConflict = false,
+    this.isPolicyReady = true,
+    this.signersNeeded = 0,
+  }) : selectedOutpoints = Set.unmodifiable(selectedOutpoints) {
+    if (id.isEmpty) throw ArgumentError.value(id, 'id');
+    if (walletId.isEmpty) throw ArgumentError.value(walletId, 'walletId');
+    if (stage != PendingBitcoinTransactionStage.draft) {
+      if (psbt?.trim().isEmpty ?? true) {
+        throw ArgumentError('A signing transaction must contain a PSBT');
+      }
+      if (recipient.trim().isEmpty) {
+        throw ArgumentError('A signing transaction must contain a recipient');
+      }
+      final amountSat = BigInt.tryParse(amount);
+      if (amountSat == null || amountSat <= BigInt.zero) {
+        throw ArgumentError('A signing transaction must contain an amount');
+      }
+      if (amountCurrencyCode.isEmpty) {
+        throw ArgumentError(
+          'A signing transaction must contain an amount currency',
+        );
+      }
+      if (finalTransaction?.trim().isEmpty ?? false) {
+        throw ArgumentError.value(finalTransaction, 'finalTransaction');
+      }
+    }
+    if (signersNeeded < 0) {
+      throw ArgumentError.value(signersNeeded, 'signersNeeded');
+    }
+    if (revision < 0) throw ArgumentError.value(revision, 'revision');
+    if (feeSelection == FeeSelection.custom && customFee == null) {
+      throw ArgumentError('A custom fee selection must contain a fee');
+    }
+    if (customFee case AbsoluteFee(:final sats) when sats <= 0) {
+      throw ArgumentError.value(sats, 'customFee');
+    }
+    if (customFee case RelativeFee(:final satPerKwu) when satPerKwu <= 0) {
+      throw ArgumentError.value(satPerKwu, 'customFee');
+    }
+  }
+
+  bool get isDraft => stage == PendingBitcoinTransactionStage.draft;
+  bool get isReadyToBroadcast =>
+      stage == PendingBitcoinTransactionStage.readyToBroadcast;
+
+  PendingBitcoinTransaction copyWith({
+    PendingBitcoinTransactionStage? stage,
+    String? label,
+    bool clearLabel = false,
+    String? recipient,
+    String? amount,
+    String? amountCurrencyCode,
+    bool? sendMax,
+    FeeSelection? feeSelection,
+    NetworkFee? customFee,
+    bool clearCustomFee = false,
+    bool? replaceByFee,
+    bool? payjoinOptedOut,
+    Set<String>? selectedOutpoints,
+    BitcoinPolicySelection? policySelection,
+    String? psbt,
+    bool clearPsbt = false,
+    String? finalTransaction,
+    bool clearFinalTransaction = false,
+    DateTime? updatedAt,
+    int? revision,
+    bool? isConflict,
+    bool? isPolicyReady,
+    int? signersNeeded,
+  }) => PendingBitcoinTransaction(
+    id: id,
+    walletId: walletId,
+    stage: stage ?? this.stage,
+    label: clearLabel ? null : label ?? this.label,
+    recipient: recipient ?? this.recipient,
+    amount: amount ?? this.amount,
+    amountCurrencyCode: amountCurrencyCode ?? this.amountCurrencyCode,
+    sendMax: sendMax ?? this.sendMax,
+    feeSelection: feeSelection ?? this.feeSelection,
+    customFee: clearCustomFee ? null : customFee ?? this.customFee,
+    replaceByFee: replaceByFee ?? this.replaceByFee,
+    payjoinOptedOut: payjoinOptedOut ?? this.payjoinOptedOut,
+    selectedOutpoints: selectedOutpoints ?? this.selectedOutpoints,
+    policySelection: policySelection ?? this.policySelection,
+    psbt: clearPsbt ? null : psbt ?? this.psbt,
+    finalTransaction: clearFinalTransaction
+        ? null
+        : finalTransaction ?? this.finalTransaction,
+    createdAt: createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    revision: revision ?? this.revision,
+    isConflict: isConflict ?? this.isConflict,
+    isPolicyReady: isPolicyReady ?? this.isPolicyReady,
+    signersNeeded: signersNeeded ?? this.signersNeeded,
+  );
+}

--- a/lib/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart
+++ b/lib/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class PendingBitcoinTransactionRepository {
+  @useResult
+  Future<Result<PendingBitcoinTransaction, SendFailure>> save(
+    PendingBitcoinTransaction transaction, {
+    int? expectedRevision,
+  });
+
+  @useResult
+  Future<Result<PendingBitcoinTransaction?, SendFailure>> get(String id);
+
+  Stream<Result<PendingBitcoinTransactionSnapshot, SendFailure>> watchWallet(
+    String walletId,
+  );
+
+  @useResult
+  Future<Result<void, SendFailure>> delete(
+    String id, {
+    required int expectedRevision,
+  });
+}

--- a/lib/features/send/domain/send_failure.dart
+++ b/lib/features/send/domain/send_failure.dart
@@ -98,3 +98,15 @@ final class SendTransactionConfirmationFailure extends SendFailure {
 final class SendUnexpectedFailure extends SendFailure {
   const SendUnexpectedFailure([super.logMessage]);
 }
+
+final class SendPersistenceFailure extends SendFailure {
+  const SendPersistenceFailure([super.logMessage]);
+}
+
+final class SendPendingTransactionChangedFailure extends SendFailure {
+  const SendPendingTransactionChangedFailure([super.logMessage]);
+}
+
+final class SendStoredTransactionInvalidFailure extends SendFailure {
+  const SendStoredTransactionInvalidFailure([super.logMessage]);
+}

--- a/lib/features/send/domain/usecases/apply_bitcoin_policy_preimages_usecase.dart
+++ b/lib/features/send/domain/usecases/apply_bitcoin_policy_preimages_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+class ApplyBitcoinPolicyPreimagesUsecase {
+  final BitcoinSigningPort _bitcoinSigningPort;
+
+  ApplyBitcoinPolicyPreimagesUsecase(this._bitcoinSigningPort);
+
+  @useResult
+  Future<Result<String, BitcoinSigningFailure>> execute({
+    required String psbt,
+    required Iterable<BitcoinPolicyPreimage> preimages,
+  }) => _bitcoinSigningPort.applyPolicyPreimages(
+    psbt: psbt,
+    preimages: preimages.toList(growable: false),
+  );
+}

--- a/lib/features/send/domain/usecases/delete_pending_bitcoin_transaction_usecase.dart
+++ b/lib/features/send/domain/usecases/delete_pending_bitcoin_transaction_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:meta/meta.dart';
+
+class DeletePendingBitcoinTransactionUsecase {
+  final PendingBitcoinTransactionRepository _repository;
+
+  const DeletePendingBitcoinTransactionUsecase(this._repository);
+
+  @useResult
+  Future<Result<void, SendFailure>> execute(
+    String id, {
+    required int expectedRevision,
+  }) => _repository.delete(id, expectedRevision: expectedRevision);
+}

--- a/lib/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart
+++ b/lib/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart
@@ -1,0 +1,109 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+typedef BitcoinSigningPlanDetails = ({
+  BitcoinPolicyMaturity maturity,
+  BitcoinSigningPlan plan,
+  BitcoinPsbtReview? review,
+});
+
+class GetBitcoinSigningPlanUsecase {
+  final BitcoinSigningPort _bitcoinSigningPort;
+
+  GetBitcoinSigningPlanUsecase(this._bitcoinSigningPort);
+
+  @useResult
+  Future<Result<BitcoinSigningPlanDetails, BitcoinSigningFailure>> execute({
+    required Wallet wallet,
+    String? psbt,
+    BitcoinPolicySelection selection = const BitcoinPolicySelection.empty(),
+    Set<String> satisfiedPreimageKeys = const {},
+    bool allowSpentWalletInputs = false,
+  }) async {
+    if (!wallet.isBitcoin) {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unexpected),
+      );
+    }
+    final BitcoinWalletPolicy policy;
+    switch (await _bitcoinSigningPort.getPolicy(walletId: wallet.id)) {
+      case Ok(:final value):
+        policy = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final BitcoinPsbtReview? review;
+    if (psbt == null) {
+      review = null;
+    } else {
+      switch (await _bitcoinSigningPort.reviewPsbt(
+        psbt,
+        walletId: wallet.id,
+        requireLocalOrigin: false,
+        allowSpentWalletInputs: allowSpentWalletInputs,
+      )) {
+        case Ok(:final value):
+          review = value;
+        case Err(:final failure):
+          return Err(failure);
+      }
+    }
+    final maturityResult =
+        policy.hasTimelock ||
+            policy.requiresPath ||
+            (review?.hasTimingConstraint ?? false)
+        ? await _bitcoinSigningPort.getPolicyMaturity(
+            walletId: wallet.id,
+            includeTimeBasedLocks:
+                policy.hasTimeBasedTimelock ||
+                (review?.hasTimeBasedTimingConstraint ?? false),
+          )
+        : const Ok<BitcoinPolicyMaturity, BitcoinSigningFailure>(
+            BitcoinPolicyMaturity.empty(),
+          );
+    final BitcoinPolicyMaturity maturity;
+    switch (maturityResult) {
+      case Ok(:final value):
+        maturity = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final reviewInputs = review?.inputs ?? const <BitcoinPsbtInputReview>[];
+    final effectivePreimageKeys = {
+      ...?review?.satisfiedPreimageKeys,
+      ...satisfiedPreimageKeys,
+    };
+    try {
+      return Ok((
+        maturity: maturity,
+        review: review,
+        plan: BitcoinSigningPlan.fromPolicy(
+          policy: policy,
+          signers: wallet.signers,
+          selection: selection,
+          signedDescriptorKeyIdsByKeychain:
+              review?.signedDescriptorKeyIdsByKeychain ?? const {},
+          signedDescriptorKeyIdsByOutpoint:
+              review?.signedDescriptorKeyIdsByOutpoint ?? const {},
+          inputKeychainsByOutpoint: {
+            for (final input in reviewInputs) input.outpoint: ?input.keychain,
+          },
+          inputKeychains: reviewInputs
+              .map((input) => input.keychain)
+              .whereType<BitcoinPolicyKeychain>()
+              .toSet(),
+          satisfiedPreimageKeys: effectivePreimageKeys,
+        ),
+      ));
+    } on ArgumentError {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unsupportedPolicyPath),
+      );
+    }
+  }
+}

--- a/lib/features/send/domain/usecases/get_pending_bitcoin_transaction_usecase.dart
+++ b/lib/features/send/domain/usecases/get_pending_bitcoin_transaction_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:meta/meta.dart';
+
+class GetPendingBitcoinTransactionUsecase {
+  final PendingBitcoinTransactionRepository _repository;
+
+  const GetPendingBitcoinTransactionUsecase(this._repository);
+
+  @useResult
+  Future<Result<PendingBitcoinTransaction?, SendFailure>> execute(String id) =>
+      _repository.get(id);
+}

--- a/lib/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart
+++ b/lib/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
 
@@ -27,6 +28,7 @@ class PreviewBitcoinFeePresetsUsecase {
     required bool replaceByFee,
     required List<WalletUtxo> selectedInputs,
     required bool drain,
+    BitcoinPolicyPath? policyPath,
   }) async {
     String rateKey(NetworkFee fee) => switch (fee) {
       AbsoluteFee(:final sats) => 'abs:$sats',
@@ -43,6 +45,7 @@ class PreviewBitcoinFeePresetsUsecase {
         replaceByFee: replaceByFee,
         selectedInputs: selectedInputs,
         drain: drain,
+        policyPath: policyPath,
       ),
     );
     final results = await Future.wait([

--- a/lib/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart
+++ b/lib/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart
@@ -1,9 +1,10 @@
 import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
-import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bull_logger/bull_logger.dart';
 
 /// Builds one unsigned Bitcoin PSBT and reports the real `psbt.fee()` +
 /// vsize. No signing, no state mutation — pure compute. The PSBT and
@@ -33,6 +34,7 @@ class PreviewBitcoinFeeUsecase {
     required bool replaceByFee,
     required List<WalletUtxo> selectedInputs,
     required bool drain,
+    BitcoinPolicyPath? policyPath,
   }) async {
     try {
       final tx = await _prepare.execute(
@@ -43,6 +45,7 @@ class PreviewBitcoinFeeUsecase {
         replaceByFee: replaceByFee,
         selectedInputs: selectedInputs,
         drain: drain,
+        policyPath: policyPath,
       );
       final fee = await _calculateFees.execute(psbt: tx.unsignedPsbt);
       return BitcoinFeePreviewSlot(

--- a/lib/features/send/domain/usecases/process_bitcoin_signer_result_usecase.dart
+++ b/lib/features/send/domain/usecases/process_bitcoin_signer_result_usecase.dart
@@ -1,7 +1,10 @@
 import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart' as core;
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:meta/meta.dart';
 
@@ -9,13 +12,6 @@ enum BitcoinSignerResultKind { detect, psbt, transaction }
 
 sealed class ProcessedBitcoinSignerResult {
   const ProcessedBitcoinSignerResult();
-}
-
-final class ProcessedBitcoinPsbt extends ProcessedBitcoinSignerResult {
-  final String psbt;
-  final int txSize;
-
-  const ProcessedBitcoinPsbt({required this.psbt, required this.txSize});
 }
 
 final class ProcessedBitcoinTransaction extends ProcessedBitcoinSignerResult {
@@ -28,12 +24,30 @@ final class ProcessedBitcoinTransaction extends ProcessedBitcoinSignerResult {
   });
 }
 
+final class ProcessedBitcoinPsbt extends ProcessedBitcoinSignerResult {
+  final String psbt;
+  final bool isFinalized;
+  final int txSize;
+  final int absoluteFeesSat;
+  final BitcoinSigningPlan signingPlan;
+
+  const ProcessedBitcoinPsbt({
+    required this.psbt,
+    required this.isFinalized,
+    required this.txSize,
+    required this.absoluteFeesSat,
+    required this.signingPlan,
+  });
+}
+
 class ProcessBitcoinSignerResultUsecase {
   final SignBitcoinTxUsecase _signBitcoinTxUsecase;
+  final GetBitcoinSigningPlanUsecase _getBitcoinSigningPlanUsecase;
   final BitcoinSigningPort _bitcoinSigningPort;
 
   const ProcessBitcoinSignerResultUsecase(
     this._signBitcoinTxUsecase,
+    this._getBitcoinSigningPlanUsecase,
     this._bitcoinSigningPort,
   );
 
@@ -42,53 +56,46 @@ class ProcessBitcoinSignerResultUsecase {
     required String result,
     required BitcoinSignerResultKind kind,
     required String currentPsbt,
-    required String walletId,
+    required Wallet? wallet,
+    required BitcoinPolicySelection selection,
+    Set<String> satisfiedPreimageKeys = const {},
   }) async {
     final core.ParsedBitcoinSignerResult parsed;
     try {
       parsed = core.parseBitcoinSignerResult(result);
-      if (kind == BitcoinSignerResultKind.psbt &&
-          parsed.format != core.BitcoinSignerResultFormat.psbt) {
-        throw const FormatException('Expected a PSBT');
-      }
-      if (kind == BitcoinSignerResultKind.transaction &&
-          parsed.format != core.BitcoinSignerResultFormat.transaction) {
-        throw const FormatException('Expected a transaction');
-      }
     } on FormatException {
       return const Err(
         BitcoinSigningFailure(BitcoinSigningFailureKind.invalidPsbt),
       );
     }
-
+    final expectedFormat = switch (kind) {
+      BitcoinSignerResultKind.detect => null,
+      BitcoinSignerResultKind.psbt => core.BitcoinSignerResultFormat.psbt,
+      BitcoinSignerResultKind.transaction =>
+        core.BitcoinSignerResultFormat.transaction,
+    };
+    if (expectedFormat != null && parsed.format != expectedFormat) {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.invalidPsbt),
+      );
+    }
     return switch (parsed.format) {
-      core.BitcoinSignerResultFormat.psbt => _processPsbt(
-        psbt: parsed.value,
-        currentPsbt: currentPsbt,
-        walletId: walletId,
-      ),
+      core.BitcoinSignerResultFormat.psbt =>
+        wallet == null
+            ? const Err(
+                BitcoinSigningFailure(BitcoinSigningFailureKind.unexpected),
+              )
+            : _processPsbt(
+                psbt: parsed.value,
+                currentPsbt: currentPsbt,
+                wallet: wallet,
+                selection: selection,
+                satisfiedPreimageKeys: satisfiedPreimageKeys,
+              ),
       core.BitcoinSignerResultFormat.transaction => _processTransaction(
         transaction: parsed.value,
         currentPsbt: currentPsbt,
       ),
-    };
-  }
-
-  Future<Result<ProcessedBitcoinPsbt, BitcoinSigningFailure>> _processPsbt({
-    required String psbt,
-    required String currentPsbt,
-    required String walletId,
-  }) async {
-    final result = await _signBitcoinTxUsecase.execute(
-      psbt: currentPsbt,
-      externalPsbt: psbt,
-      walletId: walletId,
-    );
-    return switch (result) {
-      Ok(:final value) => Ok(
-        ProcessedBitcoinPsbt(psbt: value.signedPsbt, txSize: value.txSize),
-      ),
-      Err(:final failure) => Err(failure),
     };
   }
 
@@ -97,11 +104,11 @@ class ProcessBitcoinSignerResultUsecase {
     required String transaction,
     required String currentPsbt,
   }) async {
-    final result = await _bitcoinSigningPort.verifyFinalTransaction(
+    final verifiedResult = await _bitcoinSigningPort.verifyFinalTransaction(
       psbt: currentPsbt,
       transaction: transaction,
     );
-    return switch (result) {
+    return switch (verifiedResult) {
       Ok(:final value) => Ok(
         ProcessedBitcoinTransaction(
           transaction: value.transaction,
@@ -110,5 +117,73 @@ class ProcessBitcoinSignerResultUsecase {
       ),
       Err(:final failure) => Err(failure),
     };
+  }
+
+  Future<Result<ProcessedBitcoinPsbt, BitcoinSigningFailure>> _processPsbt({
+    required String psbt,
+    required String currentPsbt,
+    required Wallet wallet,
+    required BitcoinPolicySelection selection,
+    required Set<String> satisfiedPreimageKeys,
+  }) async {
+    final signingResultValue = await _signBitcoinTxUsecase.execute(
+      psbt: currentPsbt,
+      externalPsbt: psbt,
+      walletId: wallet.id,
+      requireFinalized: false,
+      tryFinalize: false,
+    );
+    final SignedBitcoinTransaction signingResult;
+    switch (signingResultValue) {
+      case Ok(:final value):
+        signingResult = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final planResult = await _getBitcoinSigningPlanUsecase.execute(
+      wallet: wallet,
+      psbt: signingResult.signedPsbt,
+      selection: selection,
+      satisfiedPreimageKeys: satisfiedPreimageKeys,
+    );
+    final BitcoinSigningPlanDetails details;
+    switch (planResult) {
+      case Ok(:final value):
+        details = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final review = details.review;
+    if (review == null) {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unexpected),
+      );
+    }
+    final signingPlan = details.plan;
+    var finalized = (psbt: signingResult.signedPsbt, isFinalized: false);
+    if (signingPlan.isSatisfied) {
+      switch (await _bitcoinSigningPort.finalizePsbt(
+        signingResult.signedPsbt,
+      )) {
+        case Ok(:final value):
+          finalized = value;
+        case Err(:final failure):
+          return Err(failure);
+      }
+      if (!finalized.isFinalized) {
+        return const Err(
+          BitcoinSigningFailure(BitcoinSigningFailureKind.incomplete),
+        );
+      }
+    }
+    return Ok(
+      ProcessedBitcoinPsbt(
+        psbt: finalized.psbt,
+        isFinalized: finalized.isFinalized,
+        txSize: signingResult.txSize,
+        absoluteFeesSat: review.feeSat.toInt(),
+        signingPlan: signingPlan,
+      ),
+    );
   }
 }

--- a/lib/features/send/domain/usecases/resolve_bitcoin_policy_usecase.dart
+++ b/lib/features/send/domain/usecases/resolve_bitcoin_policy_usecase.dart
@@ -1,0 +1,113 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
+import 'package:meta/meta.dart';
+
+final class ResolvedBitcoinPolicy {
+  final BitcoinSigningPlan signingPlan;
+  final BitcoinPolicyMaturity maturity;
+  final BitcoinPolicySelection selection;
+  final BitcoinPolicyPath? path;
+  final bool selectionAvailable;
+  final bool canBuildTransaction;
+
+  const ResolvedBitcoinPolicy({
+    required this.signingPlan,
+    required this.maturity,
+    required this.selection,
+    required this.path,
+    required this.selectionAvailable,
+    required this.canBuildTransaction,
+  });
+}
+
+class ResolveBitcoinPolicyUsecase {
+  final GetBitcoinSigningPlanUsecase _getBitcoinSigningPlanUsecase;
+
+  const ResolveBitcoinPolicyUsecase(this._getBitcoinSigningPlanUsecase);
+
+  @useResult
+  Future<Result<ResolvedBitcoinPolicy, BitcoinSigningFailure>> execute({
+    required Wallet wallet,
+    required BitcoinPolicySelection selection,
+    required Set<String> selectedOutpoints,
+    required Set<String> satisfiedHashlocks,
+  }) async {
+    final BitcoinSigningPlanDetails initial;
+    switch (await _getBitcoinSigningPlanUsecase.execute(
+      wallet: wallet,
+      selection: selection,
+      satisfiedPreimageKeys: satisfiedHashlocks,
+    )) {
+      case Ok(:final value):
+        initial = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    try {
+      final resolvedSelection = initial.plan.policy.selectOnlyAvailablePaths(
+        current: selection,
+        maturity: initial.maturity,
+        selectedOutpoints: selectedOutpoints,
+      );
+      final signingPlan = BitcoinSigningPlan.fromPolicy(
+        policy: initial.plan.policy,
+        signers: wallet.signers,
+        selection: resolvedSelection,
+        signedDescriptorKeyIdsByKeychain:
+            initial.plan.signedDescriptorKeyIdsByKeychain,
+        signedDescriptorKeyIdsByOutpoint:
+            initial.plan.signedDescriptorKeyIdsByOutpoint,
+        inputKeychainsByOutpoint: initial.plan.inputKeychainsByOutpoint,
+        inputKeychains: initial.plan.inputKeychains,
+        satisfiedPreimageKeys: satisfiedHashlocks,
+      );
+
+      final selectionComplete = signingPlan.policy
+          .pathRequirements(resolvedSelection)
+          .isEmpty;
+      final selectionAvailable = signingPlan.policy.selectionIsAvailable(
+        selection: resolvedSelection,
+        maturity: initial.maturity,
+        selectedOutpoints: selectedOutpoints,
+      );
+      final hasRequiredPreimages =
+          selectionComplete &&
+          signingPlan.policy
+              .requiredHashlocks(resolvedSelection)
+              .every(
+                (hashlock) => satisfiedHashlocks.contains(
+                  '${hashlock.type.name}:${hashlock.hash.toLowerCase()}',
+                ),
+              );
+      final canBuildTransaction =
+          selectionComplete && selectionAvailable && hasRequiredPreimages;
+      final path =
+          canBuildTransaction &&
+              (signingPlan.policy.requiresPath ||
+                  signingPlan.policy.hasTimelock)
+          ? signingPlan.policy.buildPath(
+              resolvedSelection,
+              maturity: initial.maturity,
+            )
+          : null;
+
+      return Ok(
+        ResolvedBitcoinPolicy(
+          signingPlan: signingPlan,
+          maturity: initial.maturity,
+          selection: resolvedSelection,
+          path: path,
+          selectionAvailable: selectionAvailable,
+          canBuildTransaction: canBuildTransaction,
+        ),
+      );
+    } on ArgumentError {
+      return const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unsupportedPolicyPath),
+      );
+    }
+  }
+}

--- a/lib/features/send/domain/usecases/save_pending_bitcoin_transaction_usecase.dart
+++ b/lib/features/send/domain/usecases/save_pending_bitcoin_transaction_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:meta/meta.dart';
+
+class SavePendingBitcoinTransactionUsecase {
+  final PendingBitcoinTransactionRepository _repository;
+
+  const SavePendingBitcoinTransactionUsecase(this._repository);
+
+  @useResult
+  Future<Result<PendingBitcoinTransaction, SendFailure>> execute(
+    PendingBitcoinTransaction transaction, {
+    int? expectedRevision,
+  }) => _repository.save(transaction, expectedRevision: expectedRevision);
+}

--- a/lib/features/send/domain/usecases/validate_bitcoin_policy_preimage_usecase.dart
+++ b/lib/features/send/domain/usecases/validate_bitcoin_policy_preimage_usecase.dart
@@ -1,0 +1,33 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+class ValidateBitcoinPolicyPreimageUsecase {
+  final BitcoinSigningPort _bitcoinSigningPort;
+
+  ValidateBitcoinPolicyPreimageUsecase(this._bitcoinSigningPort);
+
+  @useResult
+  Future<Result<BitcoinPolicyPreimage?, BitcoinSigningFailure>> execute({
+    required BitcoinHashlockPolicyNode hashlock,
+    required String preimageHex,
+  }) async {
+    try {
+      final preimage = BitcoinPolicyPreimage(
+        type: hashlock.type,
+        hash: hashlock.hash,
+        preimageHex: preimageHex.trim(),
+      );
+      return switch (await _bitcoinSigningPort.validatePolicyPreimage(
+        preimage,
+      )) {
+        Ok(:final value) => Ok(value ? preimage : null),
+        Err(:final failure) => Err(failure),
+      };
+    } on ArgumentError {
+      return const Ok(null);
+    }
+  }
+}

--- a/lib/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase.dart
+++ b/lib/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase.dart
@@ -1,0 +1,169 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bull_logger/bull_logger.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
+import 'package:meta/meta.dart';
+
+class ValidatePendingBitcoinTransactionUsecase {
+  final GetWalletUsecase _getWalletUsecase;
+  final GetWalletUtxosUsecase _getWalletUtxosUsecase;
+  final BitcoinSigningPort _bitcoinSigningPort;
+  final GetBitcoinSigningPlanUsecase _getBitcoinSigningPlanUsecase;
+
+  const ValidatePendingBitcoinTransactionUsecase(
+    this._getWalletUsecase,
+    this._getWalletUtxosUsecase,
+    this._bitcoinSigningPort,
+    this._getBitcoinSigningPlanUsecase,
+  );
+
+  @useResult
+  Future<Result<PendingBitcoinTransaction, SendFailure>> execute(
+    PendingBitcoinTransaction transaction,
+  ) async {
+    if (transaction.isDraft) return Ok(transaction);
+    try {
+      final wallet = await _getWalletUsecase.execute(transaction.walletId);
+      if (wallet == null || !wallet.isBitcoin) {
+        return const Err(SendStoredTransactionInvalidFailure());
+      }
+      final psbt = transaction.psbt!;
+      final BitcoinSigningPlanDetails planDetails;
+      switch (await _getBitcoinSigningPlanUsecase.execute(
+        wallet: wallet,
+        psbt: psbt,
+        selection: transaction.policySelection,
+        allowSpentWalletInputs: true,
+      )) {
+        case Ok(:final value):
+          planDetails = value;
+        case Err(:final failure):
+          return Err(_storedTransactionFailure(failure));
+      }
+      final review = planDetails.review;
+      if (review == null) {
+        return const Err(SendStoredTransactionInvalidFailure());
+      }
+      final plan = planDetails.plan;
+      final amountSat = BigInt.parse(transaction.amount);
+      final matchingOutputs = review.outputs
+          .where(
+            (output) =>
+                _sameBitcoinAddress(output.address, transaction.recipient) &&
+                output.amountSat == amountSat,
+          )
+          .toList(growable: false);
+      if (matchingOutputs.length != 1) {
+        return const Err(SendStoredTransactionInvalidFailure());
+      }
+      final recipientOutput = matchingOutputs.single;
+      final unexpectedExternalOutput = recipientOutput.isWalletOwned
+          ? review.recipients.isNotEmpty
+          : review.recipients.length != 1 ||
+                review.recipients.single.index != recipientOutput.index;
+      if (unexpectedExternalOutput) {
+        return const Err(SendStoredTransactionInvalidFailure());
+      }
+      final hasRequiredPreimages = plan.policy
+          .requiredHashlocks(transaction.policySelection)
+          .every(
+            (hashlock) => plan.satisfiedPreimageKeys.contains(
+              '${hashlock.type.name}:${hashlock.hash.toLowerCase()}',
+            ),
+          );
+      final policyReady =
+          plan.policy.pathRequirements(transaction.policySelection).isEmpty &&
+          plan.policy.selectionIsAvailable(
+            selection: transaction.policySelection,
+            maturity: planDetails.maturity,
+            selectedOutpoints: review.outpoints,
+          ) &&
+          review.timingIsSatisfied(planDetails.maturity) &&
+          hasRequiredPreimages;
+      final utxos = await _getWalletUtxosUsecase.execute(walletId: wallet.id);
+      final availableOutpoints = {
+        for (final utxo in utxos) '${utxo.txId}:${utxo.vout}',
+      };
+      final conflict = review.outpoints.any(
+        (outpoint) => !availableOutpoints.contains(outpoint),
+      );
+      if (transaction.selectedOutpoints.isNotEmpty &&
+          !_sameOutpoints(transaction.selectedOutpoints, review.outpoints)) {
+        return const Err(SendStoredTransactionInvalidFailure());
+      }
+      if (transaction.finalTransaction case final finalTransaction?) {
+        switch (await _bitcoinSigningPort.verifyFinalTransaction(
+          psbt: psbt,
+          transaction: finalTransaction,
+        )) {
+          case Ok():
+            break;
+          case Err(:final failure):
+            return Err(_storedTransactionFailure(failure));
+        }
+      }
+      final ({String psbt, bool isFinalized}) finalized;
+      if (review.isFinalized) {
+        finalized = (psbt: psbt, isFinalized: true);
+      } else {
+        switch (await _bitcoinSigningPort.finalizePsbt(psbt)) {
+          case Ok(:final value):
+            finalized = value;
+          case Err(:final failure):
+            return Err(_storedTransactionFailure(failure));
+        }
+      }
+      final ready =
+          transaction.finalTransaction != null || finalized.isFinalized;
+      return Ok(
+        transaction.copyWith(
+          psbt: finalized.psbt,
+          stage: ready
+              ? PendingBitcoinTransactionStage.readyToBroadcast
+              : PendingBitcoinTransactionStage.needsSignatures,
+          isConflict: conflict,
+          isPolicyReady: policyReady,
+          signersNeeded: ready ? 0 : plan.signersNeeded,
+        ),
+      );
+    } on FormatException {
+      return const Err(SendStoredTransactionInvalidFailure());
+    } on ArgumentError {
+      return const Err(SendStoredTransactionInvalidFailure());
+    } on Exception catch (error, stackTrace) {
+      log.severe(
+        message: 'Failed to validate a pending Bitcoin transaction',
+        error: error,
+        trace: stackTrace,
+      );
+      return Err(SendUnexpectedFailure(error.runtimeType.toString()));
+    }
+  }
+}
+
+bool _sameOutpoints(Set<String> first, Set<String> second) =>
+    first.length == second.length && first.containsAll(second);
+
+bool _sameBitcoinAddress(String? first, String second) {
+  if (first == null) return false;
+  if (first == second) return true;
+  final normalizedFirst = first.toLowerCase();
+  final normalizedSecond = second.toLowerCase();
+  return normalizedFirst == normalizedSecond &&
+      (normalizedFirst.startsWith('bc1') ||
+          normalizedFirst.startsWith('tb1') ||
+          normalizedFirst.startsWith('bcrt1'));
+}
+
+SendFailure _storedTransactionFailure(BitcoinSigningFailure failure) =>
+    switch (failure.kind) {
+      BitcoinSigningFailureKind.unexpected => SendUnexpectedFailure(
+        failure.kind.name,
+      ),
+      _ => const SendStoredTransactionInvalidFailure(),
+    };

--- a/lib/features/send/domain/usecases/watch_pending_bitcoin_transactions_usecase.dart
+++ b/lib/features/send/domain/usecases/watch_pending_bitcoin_transactions_usecase.dart
@@ -1,0 +1,46 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase.dart';
+
+class WatchPendingBitcoinTransactionsUsecase {
+  final PendingBitcoinTransactionRepository _repository;
+  final ValidatePendingBitcoinTransactionUsecase
+  _validatePendingBitcoinTransactionUsecase;
+
+  const WatchPendingBitcoinTransactionsUsecase(
+    this._repository,
+    this._validatePendingBitcoinTransactionUsecase,
+  );
+
+  Stream<Result<PendingBitcoinTransactionSnapshot, SendFailure>> execute(
+    String walletId,
+  ) => _repository.watchWallet(walletId).asyncMap((result) async {
+    switch (result) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        final validated = <PendingBitcoinTransaction>[];
+        var invalidCount = value.invalidCount;
+        for (final transaction in value.transactions) {
+          switch (await _validatePendingBitcoinTransactionUsecase.execute(
+            transaction,
+          )) {
+            case Ok(:final value):
+              validated.add(value);
+            case Err(failure: SendStoredTransactionInvalidFailure()):
+              invalidCount++;
+            case Err(:final failure):
+              return Err(failure);
+          }
+        }
+        return Ok(
+          PendingBitcoinTransactionSnapshot(
+            transactions: validated,
+            invalidCount: invalidCount,
+          ),
+        );
+    }
+  });
+}

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -22,6 +22,7 @@ import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/utils/payment_request.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
@@ -315,7 +316,7 @@ class SendCubit extends Cubit<SendState>
     try {
       final rawPaymentRequest = state.copiedRawPaymentRequest;
       final cachedPaymentRequest = state.paymentRequest;
-      if (rawPaymentRequest.isEmpty) {
+      if (rawPaymentRequest.isEmpty && cachedPaymentRequest == null) {
         emit(
           state.copyWith(
             paymentRequest: null,
@@ -2370,7 +2371,8 @@ class SendCubit extends Cubit<SendState>
       result: signerResult,
       kind: kind,
       currentPsbt: unsignedPsbt,
-      walletId: wallet.id,
+      wallet: wallet,
+      selection: const BitcoinPolicySelection.empty(),
     );
     if (!_isCurrentBitcoinSignerResult(
       generation: generation,
@@ -2394,6 +2396,17 @@ class SendCubit extends Cubit<SendState>
           ),
         );
         return false;
+    }
+    if (verified case ProcessedBitcoinPsbt(isFinalized: false)) {
+      emit(
+        state.copyWith(
+          signedBitcoinPsbt: null,
+          signedBitcoinTx: null,
+          hasExternalBitcoinSignerResult: false,
+          failure: const SendTransactionConfirmationFailure(),
+        ),
+      );
+      return false;
     }
     final signedTransaction = switch (verified) {
       ProcessedBitcoinPsbt(:final psbt) => psbt,

--- a/lib/features/send/presentation/send_failure_l10n.dart
+++ b/lib/features/send/presentation/send_failure_l10n.dart
@@ -45,5 +45,8 @@ extension SendFailureL10n on SendFailure {
           ? context.loc.sendErrorBroadcastFailed
           : context.loc.sendErrorConfirmationFailed,
     SendUnexpectedFailure() => context.loc.oopsSomethingWentWrong,
+    SendPersistenceFailure() ||
+    SendPendingTransactionChangedFailure() ||
+    SendStoredTransactionInvalidFailure() => context.loc.oopsSomethingWentWrong,
   };
 }

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -28,6 +28,7 @@ import 'package:bb_mobile/features/send/domain/usecases/create_send_cross_chain_
 import 'package:bb_mobile/features/send/domain/usecases/create_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/get_send_payjoin_enabled_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/verify_exchange_payin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/get_send_swap_quote_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/get_send_cross_chain_quote_usecase.dart';
@@ -86,9 +87,13 @@ class SendLocator {
     locator.registerFactory<SignBitcoinTxUsecase>(
       () => SignBitcoinTxUsecase(locator<BitcoinSigningPort>()),
     );
+    locator.registerFactory<GetBitcoinSigningPlanUsecase>(
+      () => GetBitcoinSigningPlanUsecase(locator<BitcoinSigningPort>()),
+    );
     locator.registerFactory<ProcessBitcoinSignerResultUsecase>(
       () => ProcessBitcoinSignerResultUsecase(
         locator<SignBitcoinTxUsecase>(),
+        locator<GetBitcoinSigningPlanUsecase>(),
         locator<BitcoinSigningPort>(),
       ),
     );

--- a/test/core_test/wallet/data/datasources/bdk_wallet_coin_selection_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_coin_selection_test.dart
@@ -317,6 +317,16 @@ void main() {
       parsedOriginal.dispose();
       wallet.dispose();
 
+      await expectLater(
+        datasource.validateWalletPsbtInputs(originalPsbt, wallet: walletModel),
+        throwsA(isA<BitcoinPsbtMissingUtxoException>()),
+      );
+      await datasource.validateWalletPsbtInputs(
+        originalPsbt,
+        wallet: walletModel,
+        allowSpentWalletInputs: true,
+      );
+
       final metadata = WalletMetadataModel(
         id: walletModel.id,
         network: Network.bitcoinTestnet,

--- a/test/core_test/wallet/data/datasources/bdk_wallet_signing_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_signing_test.dart
@@ -1194,6 +1194,27 @@ void main() {
       expect(verified.transaction, transaction);
       expect(verified.txSize, greaterThan(0));
 
+      final changedVersion = hex.decode(transaction);
+      changedVersion[0] ^= 0x01;
+      final substitutedInput = hex.decode(transaction);
+      // version (4), SegWit marker/flag (2), input count (1), then prevout.
+      substitutedInput[7] ^= 0x01;
+      final changedLocktime = hex.decode(transaction);
+      changedLocktime[changedLocktime.length - 1] ^= 0x01;
+      for (final changedTransaction in [
+        changedVersion,
+        substitutedInput,
+        changedLocktime,
+      ]) {
+        expect(
+          () => datasource.verifyFinalTransaction(
+            psbtBase64: unsignedPsbt,
+            transactionHex: hex.encode(changedTransaction),
+          ),
+          throwsFormatException,
+        );
+      }
+
       final differentPsbt = buildUnsignedPsbt(
         descriptor: twoPathDescriptor(
           externalPublicDescriptor,
@@ -1354,6 +1375,15 @@ void main() {
         ).input().single.sha256Preimages.values.single,
         hex.decode(preimageHex),
       );
+      final preimageReview = await datasource.inspectPsbt(
+        withPreimage,
+        wallet: wallet,
+        walletFingerprints: {signers[0].fingerprint},
+      );
+      expect(preimageReview.isFinalized, isFalse);
+      expect(preimageReview.inputs.single.satisfiedPreimageKeys, {
+        'sha256:$hash',
+      });
       final signed = datasource.signPsbtWithDescriptor(
         withPreimage,
         descriptor: twoPathDescriptor(externalPrivate, internalPrivate),
@@ -1361,10 +1391,15 @@ void main() {
       );
 
       expect(signed.isFinalized, isTrue);
-      await datasource.inspectPsbt(
+      final finalizedReview = await datasource.inspectPsbt(
         signed.psbt,
         wallet: wallet,
         walletFingerprints: {signers[0].fingerprint},
+      );
+      expect(finalizedReview.isFinalized, isTrue);
+      expect(
+        finalizedReview.inputs.single.satisfiedPreimageKeys,
+        contains('sha256:$hash'),
       );
       final finalizedPsbt = bdk.Psbt(psbtBase64: signed.psbt);
       try {

--- a/test/core_test/wallet/data/repositories/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/data/repositories/bitcoin_wallet_repository_test.dart
@@ -38,6 +38,7 @@ class _SigningTestBdkWalletDatasource extends BdkWalletDatasource {
     required PublicBdkWalletModel wallet,
     Set<String> frozenOutpoints = const {},
     String? replacingTxid,
+    bool allowSpentWalletInputs = false,
   }) async {}
 }
 

--- a/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
+++ b/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
@@ -50,7 +50,20 @@ void main() {
         },
       );
 
-      expect(() => policy.buildPath(selection), throwsStateError);
+      expect(() => policy.buildPath(selection), throwsArgumentError);
+    });
+
+    test('rejects a stored selection outside the policy bounds', () {
+      final policy = delayedPolicy(
+        BitcoinRelativeTimelockPolicyNode(id: 'delay', value: 10),
+      );
+      final selection = BitcoinPolicySelection(
+        choices: const {
+          'external:root': [2],
+        },
+      );
+
+      expect(() => policy.pathRequirements(selection), throwsArgumentError);
     });
 
     test('tracks relative path maturity per UTXO', () {

--- a/test/features/send/data/pending_bitcoin_transaction_datasource_test.dart
+++ b/test/features/send/data/pending_bitcoin_transaction_datasource_test.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/send/data/pending_bitcoin_transaction_datasource.dart';
+import 'package:bb_mobile/features/send/data/models/pending_bitcoin_transaction_model.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late SqliteDatabase database;
+  late PendingBitcoinTransactionDatasource datasource;
+
+  setUp(() async {
+    database = SqliteDatabase(NativeDatabase.memory());
+    datasource = PendingBitcoinTransactionDatasource(database);
+    await database
+        .into(database.walletMetadatas)
+        .insert(
+          WalletMetadatasCompanion.insert(
+            id: 'wallet-id',
+            network: Network.bitcoinTestnet,
+            isEncryptedVaultTested: false,
+            isPhysicalBackupTested: false,
+            publicDescriptor: 'wpkh(tpub/<0;1>/*)#descriptor',
+            isDefault: false,
+          ),
+        );
+  });
+
+  tearDown(() => database.close());
+
+  test('stores and replaces normalized inputs and policy choices', () async {
+    final transaction = _transaction();
+
+    await datasource.save(transaction);
+    final stored = await datasource.get(transaction.id);
+
+    expect(stored?.selectedOutpoints, transaction.selectedOutpoints);
+    expect(stored?.policyChoices, transaction.policyChoices);
+
+    final savedUpdate = await datasource.save(
+      _transaction(
+        updatedAt: DateTime.utc(2026, 8, 14, 1, 0, 0, 500),
+        selectedOutpoints: {'replacement:3'},
+        policyChoices: {
+          'replacement-node': [2],
+        },
+      ),
+      expectedRevision: 0,
+    );
+    final updated = await datasource.get(transaction.id);
+
+    expect(updated?.selectedOutpoints, {'replacement:3'});
+    expect(updated?.policyChoices, {
+      'replacement-node': [2],
+    });
+    expect(savedUpdate.updatedAt, DateTime.utc(2026, 8, 14, 1));
+    expect(savedUpdate.revision, 1);
+    expect(updated?.updatedAt, savedUpdate.updatedAt);
+    expect(
+      await database.select(database.sendTransactionInputs).get(),
+      hasLength(1),
+    );
+    expect(
+      await database.select(database.sendTransactionPolicyChoices).get(),
+      hasLength(1),
+    );
+  });
+
+  test('rejects a stale update without replacing newer data', () async {
+    final original = _transaction();
+    final newer = _transaction(
+      updatedAt: DateTime.utc(2026, 8, 14, 2),
+      selectedOutpoints: {'newer:0'},
+    );
+    await datasource.save(original);
+    await datasource.save(newer, expectedRevision: 0);
+
+    await expectLater(
+      datasource.save(
+        _transaction(
+          updatedAt: DateTime.utc(2026, 8, 14, 3),
+          selectedOutpoints: {'stale:0'},
+        ),
+        expectedRevision: 0,
+      ),
+      throwsA(isA<PendingBitcoinTransactionChangedException>()),
+    );
+
+    expect((await datasource.get(original.id))?.selectedOutpoints, {'newer:0'});
+  });
+
+  test('rejects a stale delete without removing newer data', () async {
+    await datasource.save(_transaction());
+    await datasource.save(
+      _transaction(updatedAt: DateTime.utc(2026, 8, 14, 2)),
+      expectedRevision: 0,
+    );
+
+    await expectLater(
+      datasource.delete('pending-id', expectedRevision: 0),
+      throwsA(isA<PendingBitcoinTransactionChangedException>()),
+    );
+    expect(await datasource.get('pending-id'), isNotNull);
+
+    await datasource.delete('pending-id', expectedRevision: 1);
+    expect(await datasource.get('pending-id'), isNull);
+  });
+
+  test('deletes pending transactions with their wallet', () async {
+    final emissions = StreamIterator(datasource.watchWallet('wallet-id'));
+    addTearDown(emissions.cancel);
+
+    expect(await emissions.moveNext(), isTrue);
+    expect(emissions.current, isEmpty);
+
+    await datasource.save(_transaction());
+    expect(await emissions.moveNext(), isTrue);
+    expect(emissions.current, hasLength(1));
+
+    await database.delete(database.walletMetadatas).go();
+    expect(await emissions.moveNext(), isTrue);
+    expect(emissions.current, isEmpty);
+
+    expect(await database.select(database.sendTransactions).get(), isEmpty);
+    expect(
+      await database.select(database.sendTransactionInputs).get(),
+      isEmpty,
+    );
+    expect(
+      await database.select(database.sendTransactionPolicyChoices).get(),
+      isEmpty,
+    );
+  });
+}
+
+PendingBitcoinTransactionModel _transaction({
+  DateTime? updatedAt,
+  Set<String> selectedOutpoints = const {'transaction:0', 'transaction:1'},
+  Map<String, List<int>> policyChoices = const <String, List<int>>{
+    'threshold': <int>[0, 1],
+  },
+}) => PendingBitcoinTransactionModel(
+  id: 'pending-id',
+  walletId: 'wallet-id',
+  stage: 'needsSignatures',
+  label: 'Shared payment',
+  recipient: 'tb1qrecipient',
+  amount: '50000',
+  amountCurrencyCode: 'sats',
+  sendMax: false,
+  feeSelection: 'fastest',
+  replaceByFee: true,
+  selectedOutpoints: selectedOutpoints,
+  policyChoices: policyChoices,
+  psbt: 'cHNidP8=',
+  createdAt: DateTime.utc(2026, 8, 14),
+  updatedAt: updatedAt ?? DateTime.utc(2026, 8, 14, 1),
+);

--- a/test/features/send/data/pending_bitcoin_transaction_repository_impl_test.dart
+++ b/test/features/send/data/pending_bitcoin_transaction_repository_impl_test.dart
@@ -1,0 +1,83 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/data/models/pending_bitcoin_transaction_model.dart';
+import 'package:bb_mobile/features/send/data/pending_bitcoin_transaction_datasource.dart';
+import 'package:bb_mobile/features/send/data/pending_bitcoin_transaction_repository_impl.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockPendingBitcoinTransactionDatasource extends Mock
+    implements PendingBitcoinTransactionDatasource {}
+
+void main() {
+  test('maps an invalid stored policy selection to a typed failure', () async {
+    final datasource = _MockPendingBitcoinTransactionDatasource();
+    when(() => datasource.get('pending-id')).thenAnswer(
+      (_) async => PendingBitcoinTransactionModel(
+        id: 'pending-id',
+        walletId: 'wallet-id',
+        stage: 'needsSignatures',
+        recipient: 'tb1qrecipient',
+        amount: '50000',
+        amountCurrencyCode: 'sats',
+        sendMax: false,
+        feeSelection: 'fastest',
+        replaceByFee: true,
+        selectedOutpoints: const {},
+        policyChoices: const {
+          'external:root': [-1],
+        },
+        psbt: 'cHNidP8=',
+        createdAt: DateTime.utc(2026, 8, 14),
+        updatedAt: DateTime.utc(2026, 8, 14),
+      ),
+    );
+
+    final result = await PendingBitcoinTransactionRepositoryImpl(
+      datasource,
+    ).get('pending-id');
+
+    expect(result, isA<Err<PendingBitcoinTransaction?, SendFailure>>());
+    expect(
+      (result as Err<PendingBitcoinTransaction?, SendFailure>).failure,
+      isA<SendStoredTransactionInvalidFailure>(),
+    );
+  });
+
+  test(
+    'maps malformed custom fee storage to an invalid-record failure',
+    () async {
+      final datasource = _MockPendingBitcoinTransactionDatasource();
+      when(() => datasource.get('pending-id')).thenAnswer(
+        (_) async => PendingBitcoinTransactionModel(
+          id: 'pending-id',
+          walletId: 'wallet-id',
+          stage: 'draft',
+          recipient: '',
+          amount: '',
+          amountCurrencyCode: '',
+          sendMax: false,
+          feeSelection: 'custom',
+          customFeeKind: 'unknown',
+          customFeeValue: 1,
+          replaceByFee: true,
+          selectedOutpoints: const {},
+          policyChoices: const {},
+          createdAt: DateTime.utc(2026, 8, 14),
+          updatedAt: DateTime.utc(2026, 8, 14),
+        ),
+      );
+
+      final result = await PendingBitcoinTransactionRepositoryImpl(
+        datasource,
+      ).get('pending-id');
+
+      expect(result, isA<Err<PendingBitcoinTransaction?, SendFailure>>());
+      expect(
+        (result as Err<PendingBitcoinTransaction?, SendFailure>).failure,
+        isA<SendStoredTransactionInvalidFailure>(),
+      );
+    },
+  );
+}

--- a/test/features/send/domain/pending_bitcoin_transaction_test.dart
+++ b/test/features/send/domain/pending_bitcoin_transaction_test.dart
@@ -1,0 +1,75 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('allows incomplete drafts but rejects incomplete signing records', () {
+    expect(
+      () => _transaction(stage: PendingBitcoinTransactionStage.draft),
+      returnsNormally,
+    );
+    expect(
+      () => _transaction(stage: PendingBitcoinTransactionStage.needsSignatures),
+      throwsArgumentError,
+    );
+    expect(
+      () => _transaction(
+        stage: PendingBitcoinTransactionStage.needsSignatures,
+        psbt: 'cHNidP8=',
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => _transaction(
+        stage: PendingBitcoinTransactionStage.needsSignatures,
+        psbt: 'cHNidP8=',
+        recipient: 'tb1qrecipient',
+        amount: '0',
+        amountCurrencyCode: 'sats',
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('requires a positive fee for a custom selection', () {
+    expect(
+      () => _transaction(
+        stage: PendingBitcoinTransactionStage.draft,
+        feeSelection: FeeSelection.custom,
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => _transaction(
+        stage: PendingBitcoinTransactionStage.draft,
+        feeSelection: FeeSelection.custom,
+        customFee: NetworkFee.absolute(1),
+      ),
+      returnsNormally,
+    );
+  });
+}
+
+PendingBitcoinTransaction _transaction({
+  required PendingBitcoinTransactionStage stage,
+  String? psbt,
+  String recipient = '',
+  String amount = '',
+  String amountCurrencyCode = '',
+  FeeSelection feeSelection = FeeSelection.fastest,
+  NetworkFee? customFee,
+}) => PendingBitcoinTransaction(
+  id: 'pending-id',
+  walletId: 'wallet-id',
+  stage: stage,
+  recipient: recipient,
+  amount: amount,
+  amountCurrencyCode: amountCurrencyCode,
+  sendMax: false,
+  feeSelection: feeSelection,
+  customFee: customFee,
+  replaceByFee: true,
+  psbt: psbt,
+  createdAt: DateTime.utc(2026, 8, 14),
+  updatedAt: DateTime.utc(2026, 8, 14),
+);

--- a/test/features/send/domain/usecases/get_bitcoin_signing_plan_usecase_test.dart
+++ b/test/features/send/domain/usecases/get_bitcoin_signing_plan_usecase_test.dart
@@ -1,0 +1,302 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockBitcoinSigningPort extends Mock implements BitcoinSigningPort {}
+
+void main() {
+  test(
+    'loads maturity and existing signatures for a selectable policy',
+    () async {
+      final port = _MockBitcoinSigningPort();
+      final wallet = _wallet();
+      final policy = _policy();
+      final maturity = BitcoinPolicyMaturity(
+        tipHeight: 100,
+        medianTimePast: null,
+        utxos: [
+          BitcoinPolicyUtxoMaturity(
+            outpoint: '00:0',
+            keychain: BitcoinPolicyKeychain.external,
+            amountSat: BigInt.from(10000),
+            confirmations: 1,
+          ),
+        ],
+      );
+      when(
+        () => port.getPolicy(walletId: wallet.id),
+      ).thenAnswer((_) async => Ok(policy));
+      when(
+        () => port.getPolicyMaturity(
+          walletId: wallet.id,
+          includeTimeBasedLocks: false,
+        ),
+      ).thenAnswer((_) async => Ok(maturity));
+      when(
+        () => port.reviewPsbt(
+          'psbt',
+          walletId: wallet.id,
+          requireLocalOrigin: false,
+          allowSpentWalletInputs: false,
+        ),
+      ).thenAnswer(
+        (_) async => Ok(
+          _review(
+            signedDescriptorKeyIds: const {'key-0'},
+            keychain: BitcoinPolicyKeychain.external,
+          ),
+        ),
+      );
+
+      final result = await GetBitcoinSigningPlanUsecase(
+        port,
+      ).execute(wallet: wallet, psbt: 'psbt');
+      final details =
+          (result as Ok<BitcoinSigningPlanDetails, BitcoinSigningFailure>)
+              .value;
+      final plan = details.plan;
+
+      expect(plan.policy, same(policy));
+      expect(details.maturity, same(maturity));
+      expect(plan.signedDescriptorKeyIdsByOutpoint, const {
+        '00:0': {'key-0'},
+      });
+      verify(
+        () => port.getPolicyMaturity(
+          walletId: wallet.id,
+          includeTimeBasedLocks: false,
+        ),
+      ).called(1);
+    },
+  );
+
+  test('rejects a non-Bitcoin wallet before loading its policy', () async {
+    final port = _MockBitcoinSigningPort();
+    final wallet = _wallet(network: Network.liquidTestnet);
+
+    final result = await GetBitcoinSigningPlanUsecase(
+      port,
+    ).execute(wallet: wallet);
+
+    expect(
+      (result as Err<BitcoinSigningPlanDetails, BitcoinSigningFailure>)
+          .failure
+          .kind,
+      BitcoinSigningFailureKind.unexpected,
+    );
+    verifyNever(() => port.getPolicy(walletId: any(named: 'walletId')));
+  });
+
+  test('loads maturity for a PSBT transaction-level timelock', () async {
+    final port = _MockBitcoinSigningPort();
+    final wallet = _wallet();
+    final policy = _thresholdPolicy(
+      threshold: 1,
+      fingerprints: const ['aabbccdd'],
+    );
+    final maturity = BitcoinPolicyMaturity(
+      tipHeight: 100,
+      medianTimePast: null,
+      utxos: [
+        BitcoinPolicyUtxoMaturity(
+          outpoint: '00:0',
+          keychain: BitcoinPolicyKeychain.external,
+          amountSat: BigInt.one,
+          confirmations: 1,
+        ),
+      ],
+    );
+    when(
+      () => port.getPolicy(walletId: wallet.id),
+    ).thenAnswer((_) async => Ok(policy));
+    when(
+      () => port.reviewPsbt(
+        'psbt',
+        walletId: wallet.id,
+        requireLocalOrigin: false,
+        allowSpentWalletInputs: false,
+      ),
+    ).thenAnswer(
+      (_) async => Ok(
+        _review(
+          signedDescriptorKeyIds: const {},
+          keychain: BitcoinPolicyKeychain.external,
+          lockTime: 100,
+          sequence: 0xfffffffd,
+        ),
+      ),
+    );
+    when(
+      () => port.getPolicyMaturity(
+        walletId: wallet.id,
+        includeTimeBasedLocks: false,
+      ),
+    ).thenAnswer((_) async => Ok(maturity));
+
+    final result = await GetBitcoinSigningPlanUsecase(
+      port,
+    ).execute(wallet: wallet, psbt: 'psbt');
+    final details =
+        (result as Ok<BitcoinSigningPlanDetails, BitcoinSigningFailure>).value;
+
+    expect(details.maturity, same(maturity));
+    verify(
+      () => port.getPolicyMaturity(
+        walletId: wallet.id,
+        includeTimeBasedLocks: false,
+      ),
+    ).called(1);
+  });
+
+  test('restores satisfied preimages from the reviewed PSBT', () async {
+    final port = _MockBitcoinSigningPort();
+    final wallet = _wallet();
+    final policy = _thresholdPolicy(
+      threshold: 1,
+      fingerprints: const ['aabbccdd'],
+    );
+    when(
+      () => port.getPolicy(walletId: wallet.id),
+    ).thenAnswer((_) async => Ok(policy));
+    when(
+      () => port.reviewPsbt(
+        'psbt',
+        walletId: wallet.id,
+        requireLocalOrigin: false,
+        allowSpentWalletInputs: false,
+      ),
+    ).thenAnswer(
+      (_) async => Ok(
+        _review(
+          signedDescriptorKeyIds: const {},
+          keychain: BitcoinPolicyKeychain.external,
+          satisfiedPreimageKeys: const {'sha256:aa'},
+        ),
+      ),
+    );
+
+    final result = await GetBitcoinSigningPlanUsecase(
+      port,
+    ).execute(wallet: wallet, psbt: 'psbt');
+    final details =
+        (result as Ok<BitcoinSigningPlanDetails, BitcoinSigningFailure>).value;
+
+    expect(details.plan.satisfiedPreimageKeys, const {'sha256:aa'});
+  });
+}
+
+BitcoinPsbtReview _review({
+  required Set<String> signedDescriptorKeyIds,
+  required BitcoinPolicyKeychain keychain,
+  int lockTime = 0,
+  int sequence = 0xffffffff,
+  Set<String> satisfiedPreimageKeys = const {},
+}) => BitcoinPsbtReview(
+  transactionId: '00',
+  inputs: [
+    BitcoinPsbtInputReview(
+      outpoint: '00:0',
+      amountSat: BigInt.zero,
+      keychain: keychain,
+      localDescriptorKeyIds: const {'key-0'},
+      satisfiedPreimageKeys: satisfiedPreimageKeys,
+      sequence: sequence,
+      signedDescriptorKeyIds: signedDescriptorKeyIds,
+    ),
+  ],
+  outputs: [
+    BitcoinPsbtOutputReview(
+      index: 0,
+      amountSat: BigInt.one,
+      address: 'address',
+      scriptHex: '00',
+      isWalletOwned: false,
+    ),
+  ],
+  feeSat: BigInt.zero,
+  estimatedTransactionVsize: 1,
+  lockTime: lockTime,
+  version: 2,
+);
+
+Wallet _wallet({Network network = Network.bitcoinTestnet}) => Wallet(
+  origin: 'wallet',
+  network: network,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: 'aabbccdd',
+      xpubFingerprint: 'aabbccdd',
+      xpub: 'tpub-local',
+      derivationPath: "m/48'/1'/0'/2'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: null,
+  publicDescriptor: 'wsh(pk(...))',
+  balanceSat: BigInt.zero,
+);
+
+BitcoinWalletPolicy _policy() {
+  final key = BitcoinPolicyKey(
+    kind: BitcoinPolicyKeyKind.fingerprint,
+    value: 'aabbccdd',
+  );
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: true,
+    root: BitcoinThresholdPolicyNode(
+      id: 'root',
+      threshold: 1,
+      requiresPath: true,
+      children: [
+        BitcoinSignaturePolicyNode(id: 'local', key: key),
+        BitcoinAbsoluteTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinAbsoluteTimelockType.blockHeight,
+          value: 200,
+        ),
+      ],
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
+}
+
+BitcoinWalletPolicy _thresholdPolicy({
+  required int threshold,
+  required Iterable<String> fingerprints,
+  bool requiresPath = false,
+}) {
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: requiresPath,
+    root: BitcoinThresholdPolicyNode(
+      id: 'threshold',
+      threshold: threshold,
+      requiresPath: requiresPath,
+      children: [
+        for (final fingerprint in fingerprints)
+          BitcoinSignaturePolicyNode(
+            id: fingerprint,
+            key: BitcoinPolicyKey(
+              kind: BitcoinPolicyKeyKind.fingerprint,
+              value: fingerprint,
+            ),
+          ),
+      ],
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
+}

--- a/test/features/send/domain/usecases/process_bitcoin_signer_result_usecase_test.dart
+++ b/test/features/send/domain/usecases/process_bitcoin_signer_result_usecase_test.dart
@@ -1,6 +1,13 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/bitcoin_signer_result.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/process_bitcoin_signer_result_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,71 +24,65 @@ const _transaction =
 
 class _MockSignBitcoinTxUsecase extends Mock implements SignBitcoinTxUsecase {}
 
+class _MockGetBitcoinSigningPlanUsecase extends Mock
+    implements GetBitcoinSigningPlanUsecase {}
+
 class _MockBitcoinSigningPort extends Mock implements BitcoinSigningPort {}
 
 void main() {
   late _MockSignBitcoinTxUsecase signBitcoin;
+  late _MockGetBitcoinSigningPlanUsecase getSigningPlan;
   late _MockBitcoinSigningPort signingPort;
   late ProcessBitcoinSignerResultUsecase usecase;
 
   setUp(() {
     signBitcoin = _MockSignBitcoinTxUsecase();
+    getSigningPlan = _MockGetBitcoinSigningPlanUsecase();
     signingPort = _MockBitcoinSigningPort();
-    usecase = ProcessBitcoinSignerResultUsecase(signBitcoin, signingPort);
+    usecase = ProcessBitcoinSignerResultUsecase(
+      signBitcoin,
+      getSigningPlan,
+      signingPort,
+    );
   });
 
-  test('combines a returned PSBT with the prepared PSBT', () async {
-    when(
-      () => signBitcoin.execute(
-        psbt: 'current',
-        walletId: 'wallet',
-        externalPsbt: _psbt,
-      ),
-    ).thenAnswer(
-      (_) async =>
-          const Ok((signedPsbt: 'combined', txSize: 120, isFinalized: true)),
-    );
+  test(
+    'detects and verifies a final transaction against the prepared PSBT',
+    () async {
+      when(
+        () => signingPort.verifyFinalTransaction(
+          psbt: 'current-psbt',
+          transaction: _transaction,
+        ),
+      ).thenAnswer(
+        (_) async =>
+            const Ok((transaction: 'verified-transaction', txSize: 123)),
+      );
 
-    final result = await usecase.execute(
-      result: _psbt,
-      kind: BitcoinSignerResultKind.detect,
-      currentPsbt: 'current',
-      walletId: 'wallet',
-    );
+      final result = await usecase.execute(
+        result: _transaction,
+        kind: BitcoinSignerResultKind.detect,
+        currentPsbt: 'current-psbt',
+        wallet: _wallet(),
+        selection: const BitcoinPolicySelection.empty(),
+      );
 
-    final processed = (result as Ok).value as ProcessedBitcoinPsbt;
-    expect(processed.psbt, 'combined');
-    expect(processed.txSize, 120);
-  });
+      final transaction =
+          (result as Ok<ProcessedBitcoinSignerResult, BitcoinSigningFailure>)
+                  .value
+              as ProcessedBitcoinTransaction;
+      expect(transaction.transaction, 'verified-transaction');
+      expect(transaction.txSize, 123);
+    },
+  );
 
-  test('verifies a returned raw transaction against the PSBT', () async {
-    when(
-      () => signingPort.verifyFinalTransaction(
-        psbt: 'current',
-        transaction: _transaction,
-      ),
-    ).thenAnswer(
-      (_) async => const Ok((transaction: 'verified-transaction', txSize: 100)),
-    );
-
-    final result = await usecase.execute(
-      result: _transaction,
-      kind: BitcoinSignerResultKind.transaction,
-      currentPsbt: 'current',
-      walletId: 'wallet',
-    );
-
-    final processed = (result as Ok).value as ProcessedBitcoinTransaction;
-    expect(processed.transaction, 'verified-transaction');
-    expect(processed.txSize, 100);
-  });
-
-  test('rejects a raw transaction in a PSBT-only flow', () async {
+  test('rejects a transaction from a PSBT-only flow', () async {
     final result = await usecase.execute(
       result: _transaction,
       kind: BitcoinSignerResultKind.psbt,
-      currentPsbt: 'current',
-      walletId: 'wallet',
+      currentPsbt: 'current-psbt',
+      wallet: _wallet(),
+      selection: const BitcoinPolicySelection.empty(),
     );
 
     expect(
@@ -95,4 +96,192 @@ void main() {
       ),
     );
   });
+
+  test('applies the transport limit to explicitly typed results', () async {
+    final result = await usecase.execute(
+      result: 'x' * (maxBitcoinPsbtTransportBytes + 1),
+      kind: BitcoinSignerResultKind.psbt,
+      currentPsbt: 'current-psbt',
+      wallet: _wallet(),
+      selection: const BitcoinPolicySelection.empty(),
+    );
+
+    expect(
+      result,
+      isA<Err<ProcessedBitcoinSignerResult, BitcoinSigningFailure>>(),
+    );
+  });
+
+  test('combines and reviews a partial PSBT', () async {
+    final wallet = _wallet();
+    final signingPlan = BitcoinSigningPlan.fromPolicy(
+      policy: _policy(),
+      signers: wallet.signers,
+    );
+    when(
+      () => signBitcoin.execute(
+        psbt: 'current-psbt',
+        walletId: wallet.id,
+        externalPsbt: _psbt,
+        requireFinalized: false,
+        tryFinalize: false,
+      ),
+    ).thenAnswer(
+      (_) async => const Ok((
+        signedPsbt: 'combined-psbt',
+        txSize: 234,
+        isFinalized: false,
+      )),
+    );
+    when(
+      () => getSigningPlan.execute(
+        wallet: wallet,
+        psbt: 'combined-psbt',
+        selection: const BitcoinPolicySelection.empty(),
+        satisfiedPreimageKeys: const {'sha256:aa'},
+      ),
+    ).thenAnswer(
+      (_) async => Ok((
+        plan: signingPlan,
+        maturity: const BitcoinPolicyMaturity.empty(),
+        review: _review(),
+      )),
+    );
+    final result = await usecase.execute(
+      result: _psbt,
+      kind: BitcoinSignerResultKind.psbt,
+      currentPsbt: 'current-psbt',
+      wallet: wallet,
+      selection: const BitcoinPolicySelection.empty(),
+      satisfiedPreimageKeys: const {'sha256:aa'},
+    );
+
+    final psbt =
+        (result as Ok<ProcessedBitcoinSignerResult, BitcoinSigningFailure>)
+                .value
+            as ProcessedBitcoinPsbt;
+    expect(psbt.psbt, 'combined-psbt');
+    expect(psbt.isFinalized, isFalse);
+    expect(psbt.txSize, 234);
+    expect(psbt.absoluteFeesSat, 1000);
+    expect(psbt.signingPlan, same(signingPlan));
+  });
+
+  test('finalizes as soon as the returned PSBT satisfies the policy', () async {
+    final wallet = _wallet();
+    final signingPlan = BitcoinSigningPlan.fromPolicy(
+      policy: _policy(),
+      signers: wallet.signers,
+      signedDescriptorKeyIdsByKeychain: const {
+        BitcoinPolicyKeychain.external: {'key-0'},
+      },
+      inputKeychains: const {BitcoinPolicyKeychain.external},
+    );
+    when(
+      () => signBitcoin.execute(
+        psbt: 'current-psbt',
+        walletId: wallet.id,
+        externalPsbt: _psbt,
+        requireFinalized: false,
+        tryFinalize: false,
+      ),
+    ).thenAnswer(
+      (_) async => const Ok((
+        signedPsbt: 'combined-psbt',
+        txSize: 234,
+        isFinalized: false,
+      )),
+    );
+    when(
+      () => getSigningPlan.execute(
+        wallet: wallet,
+        psbt: 'combined-psbt',
+        selection: const BitcoinPolicySelection.empty(),
+        satisfiedPreimageKeys: const {},
+      ),
+    ).thenAnswer(
+      (_) async => Ok((
+        plan: signingPlan,
+        maturity: const BitcoinPolicyMaturity.empty(),
+        review: _review(),
+      )),
+    );
+    when(() => signingPort.finalizePsbt('combined-psbt')).thenAnswer(
+      (_) async => const Ok((psbt: 'final-psbt', isFinalized: true)),
+    );
+    final result = await usecase.execute(
+      result: _psbt,
+      kind: BitcoinSignerResultKind.psbt,
+      currentPsbt: 'current-psbt',
+      wallet: wallet,
+      selection: const BitcoinPolicySelection.empty(),
+    );
+
+    final psbt =
+        (result as Ok<ProcessedBitcoinSignerResult, BitcoinSigningFailure>)
+                .value
+            as ProcessedBitcoinPsbt;
+    expect(psbt.psbt, 'final-psbt');
+    expect(psbt.isFinalized, isTrue);
+  });
+}
+
+BitcoinPsbtReview _review() => BitcoinPsbtReview(
+  transactionId: 'transaction-id',
+  inputs: [
+    BitcoinPsbtInputReview(
+      outpoint: 'funding:0',
+      amountSat: BigInt.from(2000),
+      keychain: BitcoinPolicyKeychain.external,
+      sequence: 0xffffffff,
+    ),
+  ],
+  outputs: [
+    BitcoinPsbtOutputReview(
+      index: 0,
+      amountSat: BigInt.from(1000),
+      address: 'tb1qrecipient',
+      scriptHex: '0014',
+      isWalletOwned: false,
+    ),
+  ],
+  feeSat: BigInt.from(1000),
+  estimatedTransactionVsize: 100,
+  lockTime: 0,
+  version: 2,
+);
+
+Wallet _wallet() => Wallet(
+  origin: 'wallet',
+  network: Network.bitcoinTestnet,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: 'aabbccdd',
+      xpubFingerprint: 'aabbccdd',
+      xpub: 'tpub-local',
+      derivationPath: "m/48'/1'/0'/2'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: null,
+  publicDescriptor: 'wsh(pk(...))',
+  balanceSat: BigInt.zero,
+);
+
+BitcoinWalletPolicy _policy() {
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: false,
+    root: BitcoinSignaturePolicyNode(
+      id: 'local',
+      key: BitcoinPolicyKey(
+        kind: BitcoinPolicyKeyKind.fingerprint,
+        value: 'aabbccdd',
+      ),
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
 }

--- a/test/features/send/domain/usecases/resolve_bitcoin_policy_usecase_test.dart
+++ b/test/features/send/domain/usecases/resolve_bitcoin_policy_usecase_test.dart
@@ -1,0 +1,190 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/resolve_bitcoin_policy_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetBitcoinSigningPlanUsecase extends Mock
+    implements GetBitcoinSigningPlanUsecase {}
+
+void main() {
+  late _MockGetBitcoinSigningPlanUsecase getSigningPlan;
+  late ResolveBitcoinPolicyUsecase usecase;
+
+  setUp(() {
+    getSigningPlan = _MockGetBitcoinSigningPlanUsecase();
+    usecase = ResolveBitcoinPolicyUsecase(getSigningPlan);
+  });
+
+  test('selects the only available path and returns its BDK path', () async {
+    final wallet = _wallet();
+    final policy = _selectablePolicy();
+    final maturity = BitcoinPolicyMaturity(
+      tipHeight: 100,
+      medianTimePast: null,
+      utxos: [
+        BitcoinPolicyUtxoMaturity(
+          outpoint: '00:0',
+          keychain: BitcoinPolicyKeychain.external,
+          amountSat: BigInt.from(10000),
+          confirmations: 1,
+        ),
+      ],
+    );
+    when(
+      () => getSigningPlan.execute(
+        wallet: wallet,
+        selection: const BitcoinPolicySelection.empty(),
+        satisfiedPreimageKeys: const {'sha256:aa'},
+      ),
+    ).thenAnswer(
+      (_) async => Ok((
+        maturity: maturity,
+        review: null,
+        plan: BitcoinSigningPlan.fromPolicy(
+          policy: policy,
+          signers: wallet.signers,
+        ),
+      )),
+    );
+
+    final resolved = await usecase.execute(
+      wallet: wallet,
+      selection: const BitcoinPolicySelection.empty(),
+      selectedOutpoints: const {'00:0'},
+      satisfiedHashlocks: const {'sha256:aa'},
+    );
+
+    final value =
+        (resolved as Ok<ResolvedBitcoinPolicy, BitcoinSigningFailure>).value;
+    expect(value.canBuildTransaction, isTrue);
+    expect(value.selectionAvailable, isTrue);
+    expect(value.path, isNotNull);
+    expect(value.signingPlan.satisfiedPreimageKeys, const {'sha256:aa'});
+    expect(
+      value.selection.choiceFor(
+        keychain: BitcoinPolicyKeychain.external,
+        nodePath: 'root',
+      ),
+      [0],
+    );
+  });
+
+  test('does not build an unavailable mandatory delayed path', () async {
+    final wallet = _wallet();
+    final policy = _mandatoryDelayedPolicy();
+    final maturity = BitcoinPolicyMaturity(
+      tipHeight: 100,
+      medianTimePast: null,
+      utxos: [
+        BitcoinPolicyUtxoMaturity(
+          outpoint: '00:0',
+          keychain: BitcoinPolicyKeychain.external,
+          amountSat: BigInt.from(10000),
+          confirmations: 1,
+        ),
+      ],
+    );
+    when(
+      () => getSigningPlan.execute(
+        wallet: wallet,
+        selection: const BitcoinPolicySelection.empty(),
+        satisfiedPreimageKeys: const {},
+      ),
+    ).thenAnswer(
+      (_) async => Ok((
+        maturity: maturity,
+        review: null,
+        plan: BitcoinSigningPlan.fromPolicy(
+          policy: policy,
+          signers: wallet.signers,
+        ),
+      )),
+    );
+
+    final resolved = await usecase.execute(
+      wallet: wallet,
+      selection: const BitcoinPolicySelection.empty(),
+      selectedOutpoints: const {'00:0'},
+      satisfiedHashlocks: const {},
+    );
+
+    final value =
+        (resolved as Ok<ResolvedBitcoinPolicy, BitcoinSigningFailure>).value;
+    expect(value.canBuildTransaction, isFalse);
+    expect(value.selectionAvailable, isFalse);
+    expect(value.path, isNull);
+  });
+}
+
+Wallet _wallet() => Wallet(
+  origin: 'wallet',
+  network: Network.bitcoinTestnet,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: 'aabbccdd',
+      xpubFingerprint: 'aabbccdd',
+      xpub: 'tpub-local',
+      derivationPath: "m/48'/1'/0'/2'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: null,
+  publicDescriptor: 'wsh(pk(...))',
+  balanceSat: BigInt.zero,
+);
+
+BitcoinWalletPolicy _selectablePolicy() {
+  final key = BitcoinPolicyKey(
+    kind: BitcoinPolicyKeyKind.fingerprint,
+    value: 'aabbccdd',
+  );
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: true,
+    root: BitcoinThresholdPolicyNode(
+      id: 'root',
+      threshold: 1,
+      requiresPath: true,
+      children: [
+        BitcoinSignaturePolicyNode(id: 'local', key: key),
+        BitcoinAbsoluteTimelockPolicyNode(
+          id: 'delay',
+          type: BitcoinAbsoluteTimelockType.blockHeight,
+          value: 200,
+        ),
+      ],
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
+}
+
+BitcoinWalletPolicy _mandatoryDelayedPolicy() {
+  final key = BitcoinPolicyKey(
+    kind: BitcoinPolicyKeyKind.fingerprint,
+    value: 'aabbccdd',
+  );
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: false,
+    root: BitcoinThresholdPolicyNode(
+      id: 'root',
+      threshold: 2,
+      children: [
+        BitcoinSignaturePolicyNode(id: 'local', key: key),
+        BitcoinRelativeTimelockPolicyNode(id: 'delay', value: 10),
+      ],
+    ),
+  );
+  return BitcoinWalletPolicy(
+    external: spendingPolicy(),
+    internal: spendingPolicy(),
+  );
+}

--- a/test/features/send/domain/usecases/sign_bitcoin_tx_usecase_test.dart
+++ b/test/features/send/domain/usecases/sign_bitcoin_tx_usecase_test.dart
@@ -46,6 +46,7 @@ final class _FakeBitcoinSigningPort implements BitcoinSigningPort {
     String psbt, {
     required String walletId,
     bool requireLocalOrigin = true,
+    bool allowSpentWalletInputs = false,
   }) => throw UnimplementedError();
 
   @override

--- a/test/features/send/domain/usecases/validate_bitcoin_policy_preimage_usecase_test.dart
+++ b/test/features/send/domain/usecases/validate_bitcoin_policy_preimage_usecase_test.dart
@@ -1,0 +1,83 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_bitcoin_policy_preimage_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockBitcoinSigningPort extends Mock implements BitcoinSigningPort {}
+
+void main() {
+  setUpAll(() => registerFallbackValue(_preimage(_repeat('00', 32))));
+
+  test('normalizes and validates a hash preimage', () async {
+    final port = _MockBitcoinSigningPort();
+    when(
+      () => port.validatePolicyPreimage(any()),
+    ).thenAnswer((_) async => const Ok(true));
+
+    final result = await ValidateBitcoinPolicyPreimageUsecase(
+      port,
+    ).execute(hashlock: _hashlock(), preimageHex: '  ${_repeat('AABB', 16)}  ');
+
+    expect(
+      (result as Ok<BitcoinPolicyPreimage?, BitcoinSigningFailure>).value,
+      _preimage(_repeat('aabb', 16)),
+    );
+    verify(
+      () => port.validatePolicyPreimage(_preimage(_repeat('aabb', 16))),
+    ).called(1);
+  });
+
+  test('rejects malformed hex without calling the signing port', () async {
+    final port = _MockBitcoinSigningPort();
+
+    final result = await ValidateBitcoinPolicyPreimageUsecase(
+      port,
+    ).execute(hashlock: _hashlock(), preimageHex: 'not hex');
+
+    expect(
+      (result as Ok<BitcoinPolicyPreimage?, BitcoinSigningFailure>).value,
+      isNull,
+    );
+    verifyNever(() => port.validatePolicyPreimage(any()));
+  });
+
+  test('rejects preimages that are not 32 bytes', () async {
+    final port = _MockBitcoinSigningPort();
+    final usecase = ValidateBitcoinPolicyPreimageUsecase(port);
+
+    final tooShort = await usecase.execute(
+      hashlock: _hashlock(),
+      preimageHex: _repeat('00', 31),
+    );
+    final tooLong = await usecase.execute(
+      hashlock: _hashlock(),
+      preimageHex: _repeat('00', 33),
+    );
+    expect(
+      (tooShort as Ok<BitcoinPolicyPreimage?, BitcoinSigningFailure>).value,
+      isNull,
+    );
+    expect(
+      (tooLong as Ok<BitcoinPolicyPreimage?, BitcoinSigningFailure>).value,
+      isNull,
+    );
+    verifyNever(() => port.validatePolicyPreimage(any()));
+  });
+}
+
+BitcoinHashlockPolicyNode _hashlock() => BitcoinHashlockPolicyNode(
+  id: 'hashlock',
+  type: BitcoinHashlockType.sha256,
+  hash: List.filled(32, '11').join(),
+);
+
+BitcoinPolicyPreimage _preimage(String value) => BitcoinPolicyPreimage(
+  type: BitcoinHashlockType.sha256,
+  hash: List.filled(32, '11').join(),
+  preimageHex: value,
+);
+
+String _repeat(String value, int count) => List.filled(count, value).join();

--- a/test/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase_test.dart
+++ b/test/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase_test.dart
@@ -1,0 +1,299 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_psbt_review.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/get_bitcoin_signing_plan_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetWalletUsecase extends Mock implements GetWalletUsecase {}
+
+class _MockGetWalletUtxosUsecase extends Mock
+    implements GetWalletUtxosUsecase {}
+
+class _MockBitcoinSigningPort extends Mock implements BitcoinSigningPort {}
+
+class _MockGetBitcoinSigningPlanUsecase extends Mock
+    implements GetBitcoinSigningPlanUsecase {}
+
+void main() {
+  late _MockGetWalletUsecase getWalletUsecase;
+  late _MockGetWalletUtxosUsecase getWalletUtxosUsecase;
+  late _MockBitcoinSigningPort signingPort;
+  late _MockGetBitcoinSigningPlanUsecase getSigningPlanUsecase;
+  late ValidatePendingBitcoinTransactionUsecase usecase;
+
+  setUp(() {
+    getWalletUsecase = _MockGetWalletUsecase();
+    getWalletUtxosUsecase = _MockGetWalletUtxosUsecase();
+    signingPort = _MockBitcoinSigningPort();
+    getSigningPlanUsecase = _MockGetBitcoinSigningPlanUsecase();
+    usecase = ValidatePendingBitcoinTransactionUsecase(
+      getWalletUsecase,
+      getWalletUtxosUsecase,
+      signingPort,
+      getSigningPlanUsecase,
+    );
+
+    when(
+      () => getWalletUsecase.execute('wallet-id'),
+    ).thenAnswer((_) async => _wallet);
+    when(
+      () => getSigningPlanUsecase.execute(
+        wallet: _wallet,
+        psbt: 'cHNidP8=',
+        selection: const BitcoinPolicySelection.empty(),
+        allowSpentWalletInputs: true,
+      ),
+    ).thenAnswer((_) async => Ok(_details(_review())));
+  });
+
+  test(
+    'revalidates input conflicts and readiness from the stored PSBT',
+    () async {
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: 'wallet-id'),
+      ).thenAnswer((_) async => const []);
+      when(() => signingPort.finalizePsbt('cHNidP8=')).thenAnswer(
+        (_) async => const Ok((psbt: 'cHNidP8=', isFinalized: false)),
+      );
+
+      final conflicted = await usecase.execute(_pendingTransaction);
+
+      expect(conflicted, isA<Ok<PendingBitcoinTransaction, SendFailure>>());
+      final conflictedValue =
+          (conflicted as Ok<PendingBitcoinTransaction, SendFailure>).value;
+      expect(conflictedValue.isConflict, isTrue);
+      expect(
+        conflictedValue.stage,
+        PendingBitcoinTransactionStage.needsSignatures,
+      );
+      expect(conflictedValue.signersNeeded, 1);
+
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: 'wallet-id'),
+      ).thenAnswer((_) async => [_utxo]);
+      when(() => signingPort.finalizePsbt('cHNidP8=')).thenAnswer(
+        (_) async => const Ok((psbt: 'cHNidP8=', isFinalized: true)),
+      );
+
+      final ready = await usecase.execute(_pendingTransaction);
+
+      final readyValue =
+          (ready as Ok<PendingBitcoinTransaction, SendFailure>).value;
+      expect(readyValue.isConflict, isFalse);
+      expect(readyValue.stage, PendingBitcoinTransactionStage.readyToBroadcast);
+      expect(readyValue.signersNeeded, 0);
+    },
+  );
+
+  test(
+    'rejects a PSBT whose recipient differs from the stored transaction',
+    () async {
+      when(
+        () => getSigningPlanUsecase.execute(
+          wallet: _wallet,
+          psbt: 'cHNidP8=',
+          selection: const BitcoinPolicySelection.empty(),
+          allowSpentWalletInputs: true,
+        ),
+      ).thenAnswer(
+        (_) async => Ok(_details(_review(recipient: 'tb1qdifferent'))),
+      );
+
+      final result = await usecase.execute(_pendingTransaction);
+
+      expect(result, isA<Err<PendingBitcoinTransaction, SendFailure>>());
+      expect(
+        (result as Err<PendingBitcoinTransaction, SendFailure>).failure,
+        isA<SendStoredTransactionInvalidFailure>(),
+      );
+    },
+  );
+
+  test('accepts a recipient output owned by the same wallet', () async {
+    when(
+      () => getSigningPlanUsecase.execute(
+        wallet: _wallet,
+        psbt: 'cHNidP8=',
+        selection: const BitcoinPolicySelection.empty(),
+        allowSpentWalletInputs: true,
+      ),
+    ).thenAnswer(
+      (_) async => Ok(_details(_review(recipientWalletOwned: true))),
+    );
+    when(
+      () => getWalletUtxosUsecase.execute(walletId: 'wallet-id'),
+    ).thenAnswer((_) async => [_utxo]);
+    when(
+      () => signingPort.finalizePsbt('cHNidP8='),
+    ).thenAnswer((_) async => const Ok((psbt: 'cHNidP8=', isFinalized: false)));
+
+    final result = await usecase.execute(_pendingTransaction);
+
+    expect(result, isA<Ok<PendingBitcoinTransaction, SendFailure>>());
+  });
+
+  test('accepts an uppercase Bech32 recipient from the stored draft', () async {
+    when(
+      () => getSigningPlanUsecase.execute(
+        wallet: _wallet,
+        psbt: 'cHNidP8=',
+        selection: const BitcoinPolicySelection.empty(),
+        allowSpentWalletInputs: true,
+      ),
+    ).thenAnswer(
+      (_) async => Ok(_details(_review(recipient: 'TB1QRECIPIENT'))),
+    );
+    when(
+      () => getWalletUtxosUsecase.execute(walletId: 'wallet-id'),
+    ).thenAnswer((_) async => [_utxo]);
+    when(
+      () => signingPort.finalizePsbt('cHNidP8='),
+    ).thenAnswer((_) async => const Ok((psbt: 'cHNidP8=', isFinalized: false)));
+
+    final result = await usecase.execute(_pendingTransaction);
+
+    expect(result, isA<Ok<PendingBitcoinTransaction, SendFailure>>());
+  });
+
+  test(
+    'keeps a validated finalized PSBT ready across repeated restores',
+    () async {
+      when(
+        () => getSigningPlanUsecase.execute(
+          wallet: _wallet,
+          psbt: 'cHNidP8=',
+          selection: const BitcoinPolicySelection.empty(),
+          allowSpentWalletInputs: true,
+        ),
+      ).thenAnswer((_) async => Ok(_details(_review(isFinalized: true))));
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: 'wallet-id'),
+      ).thenAnswer((_) async => [_utxo]);
+
+      final first = await usecase.execute(_pendingTransaction);
+      final second = await usecase.execute(
+        (first as Ok<PendingBitcoinTransaction, SendFailure>).value,
+      );
+
+      expect(
+        (second as Ok<PendingBitcoinTransaction, SendFailure>).value.stage,
+        PendingBitcoinTransactionStage.readyToBroadcast,
+      );
+      verifyNever(() => signingPort.finalizePsbt(any()));
+    },
+  );
+}
+
+final _signer = WalletSigner.single(
+  masterFingerprint: '11111111',
+  xpubFingerprint: '11111112',
+  xpub: 'tpub',
+  derivationPath: "m/84'/1'/0'",
+  signer: SignerEntity.local,
+  signerDevice: null,
+);
+
+final _wallet = Wallet(
+  origin: 'wallet-id',
+  network: Network.bitcoinTestnet,
+  signers: [_signer],
+  scriptType: ScriptType.bip84,
+  publicDescriptor: 'wpkh(tpub/<0;1>/*)#descriptor',
+  balanceSat: BigInt.from(51000),
+);
+
+final _policyKey = BitcoinPolicyKey(
+  kind: BitcoinPolicyKeyKind.fingerprint,
+  value: '11111111',
+);
+
+BitcoinSpendingPolicy _spendingPolicy() => BitcoinSpendingPolicy(
+  root: BitcoinSignaturePolicyNode(id: 'signature', key: _policyKey),
+  requiresPath: false,
+);
+
+final _policy = BitcoinWalletPolicy(
+  external: _spendingPolicy(),
+  internal: _spendingPolicy(),
+);
+
+final _signingPlan = BitcoinSigningPlan.fromPolicy(
+  policy: _policy,
+  signers: [_signer],
+  inputKeychains: {BitcoinPolicyKeychain.external},
+);
+
+BitcoinSigningPlanDetails _details(BitcoinPsbtReview review) => (
+  plan: _signingPlan,
+  maturity: const BitcoinPolicyMaturity.empty(),
+  review: review,
+);
+
+final _pendingTransaction = PendingBitcoinTransaction(
+  id: 'pending-id',
+  walletId: 'wallet-id',
+  stage: PendingBitcoinTransactionStage.needsSignatures,
+  recipient: 'tb1qrecipient',
+  amount: '50000',
+  amountCurrencyCode: 'sats',
+  sendMax: false,
+  feeSelection: FeeSelection.fastest,
+  replaceByFee: true,
+  psbt: 'cHNidP8=',
+  createdAt: DateTime.utc(2026, 8, 14),
+  updatedAt: DateTime.utc(2026, 8, 14),
+);
+
+final _utxo = WalletUtxo.bitcoin(
+  walletId: 'wallet-id',
+  txId: 'funding',
+  vout: 0,
+  scriptPubkey: Uint8List(0),
+  amountSat: BigInt.from(51000),
+  address: 'tb1qchange',
+);
+
+BitcoinPsbtReview _review({
+  String recipient = 'tb1qrecipient',
+  bool recipientWalletOwned = false,
+  bool isFinalized = false,
+}) => BitcoinPsbtReview(
+  transactionId: 'transaction-id',
+  inputs: [
+    BitcoinPsbtInputReview(
+      outpoint: 'funding:0',
+      amountSat: BigInt.zero,
+      keychain: BitcoinPolicyKeychain.external,
+      localDescriptorKeyIds: const {'key-0'},
+      sequence: 0xffffffff,
+    ),
+  ],
+  outputs: [
+    BitcoinPsbtOutputReview(
+      index: 0,
+      amountSat: BigInt.from(50000),
+      address: recipient,
+      scriptHex: '0014',
+      isWalletOwned: recipientWalletOwned,
+    ),
+  ],
+  feeSat: BigInt.from(1000),
+  estimatedTransactionVsize: 100,
+  isFinalized: isFinalized,
+  lockTime: 0,
+  version: 2,
+);

--- a/test/features/send/domain/usecases/watch_pending_bitcoin_transactions_usecase_test.dart
+++ b/test/features/send/domain/usecases/watch_pending_bitcoin_transactions_usecase_test.dart
@@ -1,0 +1,66 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/send/domain/pending_bitcoin_transaction.dart';
+import 'package:bb_mobile/features/send/domain/repositories/pending_bitcoin_transaction_repository.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_pending_bitcoin_transaction_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/watch_pending_bitcoin_transactions_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockRepository extends Mock
+    implements PendingBitcoinTransactionRepository {}
+
+class _MockValidatePendingBitcoinTransactionUsecase extends Mock
+    implements ValidatePendingBitcoinTransactionUsecase {}
+
+void main() {
+  test(
+    'keeps valid transactions when another stored transaction is invalid',
+    () async {
+      final repository = _MockRepository();
+      final validate = _MockValidatePendingBitcoinTransactionUsecase();
+      final valid = _draft('valid');
+      final invalid = _draft('invalid');
+      when(() => repository.watchWallet('wallet-id')).thenAnswer(
+        (_) => Stream.value(
+          Ok(
+            PendingBitcoinTransactionSnapshot(
+              transactions: [valid, invalid],
+              invalidCount: 0,
+            ),
+          ),
+        ),
+      );
+      when(() => validate.execute(valid)).thenAnswer((_) async => Ok(valid));
+      when(() => validate.execute(invalid)).thenAnswer(
+        (_) async => const Err(SendStoredTransactionInvalidFailure()),
+      );
+
+      final result = await WatchPendingBitcoinTransactionsUsecase(
+        repository,
+        validate,
+      ).execute('wallet-id').first;
+
+      expect(result, isA<Ok<PendingBitcoinTransactionSnapshot, SendFailure>>());
+      final snapshot =
+          (result as Ok<PendingBitcoinTransactionSnapshot, SendFailure>).value;
+      expect(snapshot.transactions, [valid]);
+      expect(snapshot.invalidCount, 1);
+    },
+  );
+}
+
+PendingBitcoinTransaction _draft(String id) => PendingBitcoinTransaction(
+  id: id,
+  walletId: 'wallet-id',
+  stage: PendingBitcoinTransactionStage.draft,
+  recipient: '',
+  amount: '',
+  amountCurrencyCode: '',
+  sendMax: false,
+  feeSelection: FeeSelection.fastest,
+  replaceByFee: true,
+  createdAt: DateTime.utc(2026, 8, 14),
+  updatedAt: DateTime.utc(2026, 8, 14),
+);

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_coin_selection_exception.dart';
@@ -234,6 +235,31 @@ Wallet _bitcoinLocalWallet() => Wallet(
   balanceSat: BigInt.from(1000000),
 );
 
+ProcessedBitcoinPsbt _processedPsbt(String psbt, {bool isFinalized = true}) {
+  final key = BitcoinPolicyKey(
+    kind: BitcoinPolicyKeyKind.fingerprint,
+    value: '00000000',
+  );
+  BitcoinSpendingPolicy spendingPolicy() => BitcoinSpendingPolicy(
+    requiresPath: false,
+    root: BitcoinSignaturePolicyNode(id: 'local', key: key),
+  );
+  final wallet = _bitcoinLocalWallet();
+  return ProcessedBitcoinPsbt(
+    psbt: psbt,
+    isFinalized: isFinalized,
+    txSize: 100,
+    absoluteFeesSat: 0,
+    signingPlan: BitcoinSigningPlan.fromPolicy(
+      policy: BitcoinWalletPolicy(
+        external: spendingPolicy(),
+        internal: spendingPolicy(),
+      ),
+      signers: wallet.signers,
+    ),
+  );
+}
+
 Wallet _liquidWallet({required int balanceSat}) => Wallet(
   origin: 'w-liquid',
   network: Network.liquidMainnet,
@@ -433,6 +459,7 @@ void main() {
       const PaymentRequest.bitcoin(address: 'fallback', isTestnet: true),
     );
     registerFallbackValue(BitcoinSignerResultKind.detect);
+    registerFallbackValue(const BitcoinPolicySelection.empty());
     // For any(named: 'feeRate') on the prepare-send stubs.
     registerFallbackValue(NetworkFee.relativeFromSatPerVbyte(1));
   });
@@ -717,7 +744,8 @@ void main() {
           result: 'deadbeef',
           kind: BitcoinSignerResultKind.detect,
           currentPsbt: 'cHNidP8=',
-          walletId: 'w1',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
         ),
       ).thenAnswer(
         (_) async => const Err(
@@ -740,7 +768,8 @@ void main() {
           result: 'deadbeef',
           kind: BitcoinSignerResultKind.detect,
           currentPsbt: 'cHNidP8=',
-          walletId: 'w1',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
         ),
       ).thenAnswer(
         (_) async => const Ok(
@@ -833,12 +862,10 @@ void main() {
           result: 'signed-psbt',
           kind: BitcoinSignerResultKind.detect,
           currentPsbt: 'cHNidP8=',
-          walletId: 'w1',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
         ),
-      ).thenAnswer(
-        (_) async =>
-            const Ok(ProcessedBitcoinPsbt(psbt: 'combined-psbt', txSize: 100)),
-      );
+      ).thenAnswer((_) async => Ok(_processedPsbt('combined-psbt')));
 
       final accepted = await cubit.updateBitcoinSignerResult('signed-psbt');
 
@@ -846,6 +873,30 @@ void main() {
       expect(cubit.state.signedBitcoinPsbt, 'combined-psbt');
       expect(cubit.state.signedBitcoinTx, isNull);
       expect(cubit.state.failure, isNull);
+    });
+
+    test('a partial signer PSBT does not enter the broadcast path', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      cubit.setStateForTest(hardwareSignReadyState());
+      when(
+        () => processBitcoinSignerResultUsecase.execute(
+          result: 'partial-psbt',
+          kind: BitcoinSignerResultKind.detect,
+          currentPsbt: 'cHNidP8=',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
+        ),
+      ).thenAnswer(
+        (_) async => Ok(_processedPsbt('partial-psbt', isFinalized: false)),
+      );
+
+      final accepted = await cubit.updateBitcoinSignerResult('partial-psbt');
+
+      expect(accepted, isFalse);
+      expect(cubit.state.signedBitcoinPsbt, isNull);
+      expect(cubit.state.signedBitcoinTx, isNull);
+      expect(cubit.state.failure, isA<SendTransactionConfirmationFailure>());
     });
 
     test('a slower signer result cannot replace a newer one', () async {
@@ -862,7 +913,8 @@ void main() {
           result: any(named: 'result'),
           kind: BitcoinSignerResultKind.detect,
           currentPsbt: 'cHNidP8=',
-          walletId: 'w1',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
         ),
       ).thenAnswer((invocation) {
         final result = invocation.namedArguments[#result] as String;
@@ -874,13 +926,9 @@ void main() {
 
       final olderRequest = cubit.updateBitcoinSignerResult('older');
       final newerRequest = cubit.updateBitcoinSignerResult('newer');
-      newer.complete(
-        const Ok(ProcessedBitcoinPsbt(psbt: 'newer-psbt', txSize: 100)),
-      );
+      newer.complete(Ok(_processedPsbt('newer-psbt')));
       expect(await newerRequest, isTrue);
-      older.complete(
-        const Ok(ProcessedBitcoinPsbt(psbt: 'older-psbt', txSize: 100)),
-      );
+      older.complete(Ok(_processedPsbt('older-psbt')));
 
       expect(await olderRequest, isFalse);
       expect(cubit.state.signedBitcoinPsbt, 'newer-psbt');
@@ -898,7 +946,8 @@ void main() {
             result: 'deadbeef',
             kind: BitcoinSignerResultKind.detect,
             currentPsbt: 'cHNidP8=',
-            walletId: 'w1',
+            wallet: any(named: 'wallet'),
+            selection: const BitcoinPolicySelection.empty(),
           ),
         ).thenAnswer((_) => verification.future);
         final cubit = buildCubit();
@@ -927,7 +976,8 @@ void main() {
           result: any(named: 'result'),
           kind: BitcoinSignerResultKind.detect,
           currentPsbt: 'cHNidP8=',
-          walletId: 'w1',
+          wallet: any(named: 'wallet'),
+          selection: const BitcoinPolicySelection.empty(),
         ),
       ).thenAnswer((_) async {
         attempts++;
@@ -966,7 +1016,8 @@ void main() {
             result: any(named: 'result'),
             kind: any(named: 'kind'),
             currentPsbt: any(named: 'currentPsbt'),
-            walletId: any(named: 'walletId'),
+            wallet: any(named: 'wallet'),
+            selection: any(named: 'selection'),
           ),
         );
       },

--- a/test/migrations_test/bull_database/generated/schema_v16.dart
+++ b/test/migrations_test/bull_database/generated/schema_v16.dart
@@ -10871,6 +10871,1338 @@ class OrderSwapsCompanion extends UpdateCompanion<OrderSwapsData> {
   }
 }
 
+class SendTransactions extends Table
+    with TableInfo<SendTransactions, SendTransactionsData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  SendTransactions(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> walletId = GeneratedColumn<String>(
+    'wallet_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> stage = GeneratedColumn<String>(
+    'stage',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> label = GeneratedColumn<String>(
+    'label',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<String> recipient = GeneratedColumn<String>(
+    'recipient',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> amount = GeneratedColumn<String>(
+    'amount',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> amountCurrencyCode =
+      GeneratedColumn<String>(
+        'amount_currency_code',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+        $customConstraints: 'NOT NULL',
+      );
+  late final GeneratedColumn<int> sendMax = GeneratedColumn<int>(
+    'send_max',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL CHECK (send_max IN (0, 1))',
+  );
+  late final GeneratedColumn<String> feeSelection = GeneratedColumn<String>(
+    'fee_selection',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> customFeeKind = GeneratedColumn<String>(
+    'custom_fee_kind',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<int> customFeeValue = GeneratedColumn<int>(
+    'custom_fee_value',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<int> replaceByFee = GeneratedColumn<int>(
+    'replace_by_fee',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL CHECK (replace_by_fee IN (0, 1))',
+  );
+  late final GeneratedColumn<int> payjoinOptedOut = GeneratedColumn<int>(
+    'payjoin_opted_out',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints:
+        'NOT NULL DEFAULT 0 CHECK (payjoin_opted_out IN (0, 1))',
+    defaultValue: const CustomExpression('0'),
+  );
+  late final GeneratedColumn<String> psbt = GeneratedColumn<String>(
+    'psbt',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<String> finalTransaction = GeneratedColumn<String>(
+    'final_transaction',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    $customConstraints: 'NULL',
+  );
+  late final GeneratedColumn<String> createdAt = GeneratedColumn<String>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> updatedAt = GeneratedColumn<String>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> revision = GeneratedColumn<int>(
+    'revision',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    $customConstraints: 'NOT NULL DEFAULT 0',
+    defaultValue: const CustomExpression('0'),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    walletId,
+    stage,
+    label,
+    recipient,
+    amount,
+    amountCurrencyCode,
+    sendMax,
+    feeSelection,
+    customFeeKind,
+    customFeeValue,
+    replaceByFee,
+    payjoinOptedOut,
+    psbt,
+    finalTransaction,
+    createdAt,
+    updatedAt,
+    revision,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'send_transactions';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  SendTransactionsData map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SendTransactionsData(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      walletId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}wallet_id'],
+      )!,
+      stage: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}stage'],
+      )!,
+      label: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}label'],
+      ),
+      recipient: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}recipient'],
+      )!,
+      amount: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}amount'],
+      )!,
+      amountCurrencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}amount_currency_code'],
+      )!,
+      sendMax: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}send_max'],
+      )!,
+      feeSelection: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}fee_selection'],
+      )!,
+      customFeeKind: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}custom_fee_kind'],
+      ),
+      customFeeValue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}custom_fee_value'],
+      ),
+      replaceByFee: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}replace_by_fee'],
+      )!,
+      payjoinOptedOut: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}payjoin_opted_out'],
+      )!,
+      psbt: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}psbt'],
+      ),
+      finalTransaction: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}final_transaction'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      revision: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}revision'],
+      )!,
+    );
+  }
+
+  @override
+  SendTransactions createAlias(String alias) {
+    return SendTransactions(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const [
+    'PRIMARY KEY(id)',
+    'FOREIGN KEY(wallet_id)REFERENCES wallet_metadatas(id)ON DELETE CASCADE',
+    'CHECK(stage IN (\'draft\', \'needsSignatures\', \'readyToBroadcast\'))',
+    'CHECK(custom_fee_kind IS NULL OR custom_fee_kind IN (\'absolute\', \'relative\'))',
+    'CHECK((custom_fee_kind IS NULL)=(custom_fee_value IS NULL))',
+    'CHECK(stage = \'draft\' OR psbt IS NOT NULL)',
+  ];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class SendTransactionsData extends DataClass
+    implements Insertable<SendTransactionsData> {
+  final String id;
+  final String walletId;
+  final String stage;
+  final String? label;
+  final String recipient;
+  final String amount;
+  final String amountCurrencyCode;
+  final int sendMax;
+  final String feeSelection;
+  final String? customFeeKind;
+  final int? customFeeValue;
+  final int replaceByFee;
+  final int payjoinOptedOut;
+  final String? psbt;
+  final String? finalTransaction;
+  final String createdAt;
+  final String updatedAt;
+  final int revision;
+  const SendTransactionsData({
+    required this.id,
+    required this.walletId,
+    required this.stage,
+    this.label,
+    required this.recipient,
+    required this.amount,
+    required this.amountCurrencyCode,
+    required this.sendMax,
+    required this.feeSelection,
+    this.customFeeKind,
+    this.customFeeValue,
+    required this.replaceByFee,
+    required this.payjoinOptedOut,
+    this.psbt,
+    this.finalTransaction,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.revision,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['wallet_id'] = Variable<String>(walletId);
+    map['stage'] = Variable<String>(stage);
+    if (!nullToAbsent || label != null) {
+      map['label'] = Variable<String>(label);
+    }
+    map['recipient'] = Variable<String>(recipient);
+    map['amount'] = Variable<String>(amount);
+    map['amount_currency_code'] = Variable<String>(amountCurrencyCode);
+    map['send_max'] = Variable<int>(sendMax);
+    map['fee_selection'] = Variable<String>(feeSelection);
+    if (!nullToAbsent || customFeeKind != null) {
+      map['custom_fee_kind'] = Variable<String>(customFeeKind);
+    }
+    if (!nullToAbsent || customFeeValue != null) {
+      map['custom_fee_value'] = Variable<int>(customFeeValue);
+    }
+    map['replace_by_fee'] = Variable<int>(replaceByFee);
+    map['payjoin_opted_out'] = Variable<int>(payjoinOptedOut);
+    if (!nullToAbsent || psbt != null) {
+      map['psbt'] = Variable<String>(psbt);
+    }
+    if (!nullToAbsent || finalTransaction != null) {
+      map['final_transaction'] = Variable<String>(finalTransaction);
+    }
+    map['created_at'] = Variable<String>(createdAt);
+    map['updated_at'] = Variable<String>(updatedAt);
+    map['revision'] = Variable<int>(revision);
+    return map;
+  }
+
+  SendTransactionsCompanion toCompanion(bool nullToAbsent) {
+    return SendTransactionsCompanion(
+      id: Value(id),
+      walletId: Value(walletId),
+      stage: Value(stage),
+      label: label == null && nullToAbsent
+          ? const Value.absent()
+          : Value(label),
+      recipient: Value(recipient),
+      amount: Value(amount),
+      amountCurrencyCode: Value(amountCurrencyCode),
+      sendMax: Value(sendMax),
+      feeSelection: Value(feeSelection),
+      customFeeKind: customFeeKind == null && nullToAbsent
+          ? const Value.absent()
+          : Value(customFeeKind),
+      customFeeValue: customFeeValue == null && nullToAbsent
+          ? const Value.absent()
+          : Value(customFeeValue),
+      replaceByFee: Value(replaceByFee),
+      payjoinOptedOut: Value(payjoinOptedOut),
+      psbt: psbt == null && nullToAbsent ? const Value.absent() : Value(psbt),
+      finalTransaction: finalTransaction == null && nullToAbsent
+          ? const Value.absent()
+          : Value(finalTransaction),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      revision: Value(revision),
+    );
+  }
+
+  factory SendTransactionsData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SendTransactionsData(
+      id: serializer.fromJson<String>(json['id']),
+      walletId: serializer.fromJson<String>(json['walletId']),
+      stage: serializer.fromJson<String>(json['stage']),
+      label: serializer.fromJson<String?>(json['label']),
+      recipient: serializer.fromJson<String>(json['recipient']),
+      amount: serializer.fromJson<String>(json['amount']),
+      amountCurrencyCode: serializer.fromJson<String>(
+        json['amountCurrencyCode'],
+      ),
+      sendMax: serializer.fromJson<int>(json['sendMax']),
+      feeSelection: serializer.fromJson<String>(json['feeSelection']),
+      customFeeKind: serializer.fromJson<String?>(json['customFeeKind']),
+      customFeeValue: serializer.fromJson<int?>(json['customFeeValue']),
+      replaceByFee: serializer.fromJson<int>(json['replaceByFee']),
+      payjoinOptedOut: serializer.fromJson<int>(json['payjoinOptedOut']),
+      psbt: serializer.fromJson<String?>(json['psbt']),
+      finalTransaction: serializer.fromJson<String?>(json['finalTransaction']),
+      createdAt: serializer.fromJson<String>(json['createdAt']),
+      updatedAt: serializer.fromJson<String>(json['updatedAt']),
+      revision: serializer.fromJson<int>(json['revision']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'walletId': serializer.toJson<String>(walletId),
+      'stage': serializer.toJson<String>(stage),
+      'label': serializer.toJson<String?>(label),
+      'recipient': serializer.toJson<String>(recipient),
+      'amount': serializer.toJson<String>(amount),
+      'amountCurrencyCode': serializer.toJson<String>(amountCurrencyCode),
+      'sendMax': serializer.toJson<int>(sendMax),
+      'feeSelection': serializer.toJson<String>(feeSelection),
+      'customFeeKind': serializer.toJson<String?>(customFeeKind),
+      'customFeeValue': serializer.toJson<int?>(customFeeValue),
+      'replaceByFee': serializer.toJson<int>(replaceByFee),
+      'payjoinOptedOut': serializer.toJson<int>(payjoinOptedOut),
+      'psbt': serializer.toJson<String?>(psbt),
+      'finalTransaction': serializer.toJson<String?>(finalTransaction),
+      'createdAt': serializer.toJson<String>(createdAt),
+      'updatedAt': serializer.toJson<String>(updatedAt),
+      'revision': serializer.toJson<int>(revision),
+    };
+  }
+
+  SendTransactionsData copyWith({
+    String? id,
+    String? walletId,
+    String? stage,
+    Value<String?> label = const Value.absent(),
+    String? recipient,
+    String? amount,
+    String? amountCurrencyCode,
+    int? sendMax,
+    String? feeSelection,
+    Value<String?> customFeeKind = const Value.absent(),
+    Value<int?> customFeeValue = const Value.absent(),
+    int? replaceByFee,
+    int? payjoinOptedOut,
+    Value<String?> psbt = const Value.absent(),
+    Value<String?> finalTransaction = const Value.absent(),
+    String? createdAt,
+    String? updatedAt,
+    int? revision,
+  }) => SendTransactionsData(
+    id: id ?? this.id,
+    walletId: walletId ?? this.walletId,
+    stage: stage ?? this.stage,
+    label: label.present ? label.value : this.label,
+    recipient: recipient ?? this.recipient,
+    amount: amount ?? this.amount,
+    amountCurrencyCode: amountCurrencyCode ?? this.amountCurrencyCode,
+    sendMax: sendMax ?? this.sendMax,
+    feeSelection: feeSelection ?? this.feeSelection,
+    customFeeKind: customFeeKind.present
+        ? customFeeKind.value
+        : this.customFeeKind,
+    customFeeValue: customFeeValue.present
+        ? customFeeValue.value
+        : this.customFeeValue,
+    replaceByFee: replaceByFee ?? this.replaceByFee,
+    payjoinOptedOut: payjoinOptedOut ?? this.payjoinOptedOut,
+    psbt: psbt.present ? psbt.value : this.psbt,
+    finalTransaction: finalTransaction.present
+        ? finalTransaction.value
+        : this.finalTransaction,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    revision: revision ?? this.revision,
+  );
+  SendTransactionsData copyWithCompanion(SendTransactionsCompanion data) {
+    return SendTransactionsData(
+      id: data.id.present ? data.id.value : this.id,
+      walletId: data.walletId.present ? data.walletId.value : this.walletId,
+      stage: data.stage.present ? data.stage.value : this.stage,
+      label: data.label.present ? data.label.value : this.label,
+      recipient: data.recipient.present ? data.recipient.value : this.recipient,
+      amount: data.amount.present ? data.amount.value : this.amount,
+      amountCurrencyCode: data.amountCurrencyCode.present
+          ? data.amountCurrencyCode.value
+          : this.amountCurrencyCode,
+      sendMax: data.sendMax.present ? data.sendMax.value : this.sendMax,
+      feeSelection: data.feeSelection.present
+          ? data.feeSelection.value
+          : this.feeSelection,
+      customFeeKind: data.customFeeKind.present
+          ? data.customFeeKind.value
+          : this.customFeeKind,
+      customFeeValue: data.customFeeValue.present
+          ? data.customFeeValue.value
+          : this.customFeeValue,
+      replaceByFee: data.replaceByFee.present
+          ? data.replaceByFee.value
+          : this.replaceByFee,
+      payjoinOptedOut: data.payjoinOptedOut.present
+          ? data.payjoinOptedOut.value
+          : this.payjoinOptedOut,
+      psbt: data.psbt.present ? data.psbt.value : this.psbt,
+      finalTransaction: data.finalTransaction.present
+          ? data.finalTransaction.value
+          : this.finalTransaction,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      revision: data.revision.present ? data.revision.value : this.revision,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionsData(')
+          ..write('id: $id, ')
+          ..write('walletId: $walletId, ')
+          ..write('stage: $stage, ')
+          ..write('label: $label, ')
+          ..write('recipient: $recipient, ')
+          ..write('amount: $amount, ')
+          ..write('amountCurrencyCode: $amountCurrencyCode, ')
+          ..write('sendMax: $sendMax, ')
+          ..write('feeSelection: $feeSelection, ')
+          ..write('customFeeKind: $customFeeKind, ')
+          ..write('customFeeValue: $customFeeValue, ')
+          ..write('replaceByFee: $replaceByFee, ')
+          ..write('payjoinOptedOut: $payjoinOptedOut, ')
+          ..write('psbt: $psbt, ')
+          ..write('finalTransaction: $finalTransaction, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('revision: $revision')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    walletId,
+    stage,
+    label,
+    recipient,
+    amount,
+    amountCurrencyCode,
+    sendMax,
+    feeSelection,
+    customFeeKind,
+    customFeeValue,
+    replaceByFee,
+    payjoinOptedOut,
+    psbt,
+    finalTransaction,
+    createdAt,
+    updatedAt,
+    revision,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SendTransactionsData &&
+          other.id == this.id &&
+          other.walletId == this.walletId &&
+          other.stage == this.stage &&
+          other.label == this.label &&
+          other.recipient == this.recipient &&
+          other.amount == this.amount &&
+          other.amountCurrencyCode == this.amountCurrencyCode &&
+          other.sendMax == this.sendMax &&
+          other.feeSelection == this.feeSelection &&
+          other.customFeeKind == this.customFeeKind &&
+          other.customFeeValue == this.customFeeValue &&
+          other.replaceByFee == this.replaceByFee &&
+          other.payjoinOptedOut == this.payjoinOptedOut &&
+          other.psbt == this.psbt &&
+          other.finalTransaction == this.finalTransaction &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.revision == this.revision);
+}
+
+class SendTransactionsCompanion extends UpdateCompanion<SendTransactionsData> {
+  final Value<String> id;
+  final Value<String> walletId;
+  final Value<String> stage;
+  final Value<String?> label;
+  final Value<String> recipient;
+  final Value<String> amount;
+  final Value<String> amountCurrencyCode;
+  final Value<int> sendMax;
+  final Value<String> feeSelection;
+  final Value<String?> customFeeKind;
+  final Value<int?> customFeeValue;
+  final Value<int> replaceByFee;
+  final Value<int> payjoinOptedOut;
+  final Value<String?> psbt;
+  final Value<String?> finalTransaction;
+  final Value<String> createdAt;
+  final Value<String> updatedAt;
+  final Value<int> revision;
+  final Value<int> rowid;
+  const SendTransactionsCompanion({
+    this.id = const Value.absent(),
+    this.walletId = const Value.absent(),
+    this.stage = const Value.absent(),
+    this.label = const Value.absent(),
+    this.recipient = const Value.absent(),
+    this.amount = const Value.absent(),
+    this.amountCurrencyCode = const Value.absent(),
+    this.sendMax = const Value.absent(),
+    this.feeSelection = const Value.absent(),
+    this.customFeeKind = const Value.absent(),
+    this.customFeeValue = const Value.absent(),
+    this.replaceByFee = const Value.absent(),
+    this.payjoinOptedOut = const Value.absent(),
+    this.psbt = const Value.absent(),
+    this.finalTransaction = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.revision = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SendTransactionsCompanion.insert({
+    required String id,
+    required String walletId,
+    required String stage,
+    this.label = const Value.absent(),
+    required String recipient,
+    required String amount,
+    required String amountCurrencyCode,
+    required int sendMax,
+    required String feeSelection,
+    this.customFeeKind = const Value.absent(),
+    this.customFeeValue = const Value.absent(),
+    required int replaceByFee,
+    this.payjoinOptedOut = const Value.absent(),
+    this.psbt = const Value.absent(),
+    this.finalTransaction = const Value.absent(),
+    required String createdAt,
+    required String updatedAt,
+    this.revision = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       walletId = Value(walletId),
+       stage = Value(stage),
+       recipient = Value(recipient),
+       amount = Value(amount),
+       amountCurrencyCode = Value(amountCurrencyCode),
+       sendMax = Value(sendMax),
+       feeSelection = Value(feeSelection),
+       replaceByFee = Value(replaceByFee),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<SendTransactionsData> custom({
+    Expression<String>? id,
+    Expression<String>? walletId,
+    Expression<String>? stage,
+    Expression<String>? label,
+    Expression<String>? recipient,
+    Expression<String>? amount,
+    Expression<String>? amountCurrencyCode,
+    Expression<int>? sendMax,
+    Expression<String>? feeSelection,
+    Expression<String>? customFeeKind,
+    Expression<int>? customFeeValue,
+    Expression<int>? replaceByFee,
+    Expression<int>? payjoinOptedOut,
+    Expression<String>? psbt,
+    Expression<String>? finalTransaction,
+    Expression<String>? createdAt,
+    Expression<String>? updatedAt,
+    Expression<int>? revision,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (walletId != null) 'wallet_id': walletId,
+      if (stage != null) 'stage': stage,
+      if (label != null) 'label': label,
+      if (recipient != null) 'recipient': recipient,
+      if (amount != null) 'amount': amount,
+      if (amountCurrencyCode != null)
+        'amount_currency_code': amountCurrencyCode,
+      if (sendMax != null) 'send_max': sendMax,
+      if (feeSelection != null) 'fee_selection': feeSelection,
+      if (customFeeKind != null) 'custom_fee_kind': customFeeKind,
+      if (customFeeValue != null) 'custom_fee_value': customFeeValue,
+      if (replaceByFee != null) 'replace_by_fee': replaceByFee,
+      if (payjoinOptedOut != null) 'payjoin_opted_out': payjoinOptedOut,
+      if (psbt != null) 'psbt': psbt,
+      if (finalTransaction != null) 'final_transaction': finalTransaction,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (revision != null) 'revision': revision,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SendTransactionsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? walletId,
+    Value<String>? stage,
+    Value<String?>? label,
+    Value<String>? recipient,
+    Value<String>? amount,
+    Value<String>? amountCurrencyCode,
+    Value<int>? sendMax,
+    Value<String>? feeSelection,
+    Value<String?>? customFeeKind,
+    Value<int?>? customFeeValue,
+    Value<int>? replaceByFee,
+    Value<int>? payjoinOptedOut,
+    Value<String?>? psbt,
+    Value<String?>? finalTransaction,
+    Value<String>? createdAt,
+    Value<String>? updatedAt,
+    Value<int>? revision,
+    Value<int>? rowid,
+  }) {
+    return SendTransactionsCompanion(
+      id: id ?? this.id,
+      walletId: walletId ?? this.walletId,
+      stage: stage ?? this.stage,
+      label: label ?? this.label,
+      recipient: recipient ?? this.recipient,
+      amount: amount ?? this.amount,
+      amountCurrencyCode: amountCurrencyCode ?? this.amountCurrencyCode,
+      sendMax: sendMax ?? this.sendMax,
+      feeSelection: feeSelection ?? this.feeSelection,
+      customFeeKind: customFeeKind ?? this.customFeeKind,
+      customFeeValue: customFeeValue ?? this.customFeeValue,
+      replaceByFee: replaceByFee ?? this.replaceByFee,
+      payjoinOptedOut: payjoinOptedOut ?? this.payjoinOptedOut,
+      psbt: psbt ?? this.psbt,
+      finalTransaction: finalTransaction ?? this.finalTransaction,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      revision: revision ?? this.revision,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (walletId.present) {
+      map['wallet_id'] = Variable<String>(walletId.value);
+    }
+    if (stage.present) {
+      map['stage'] = Variable<String>(stage.value);
+    }
+    if (label.present) {
+      map['label'] = Variable<String>(label.value);
+    }
+    if (recipient.present) {
+      map['recipient'] = Variable<String>(recipient.value);
+    }
+    if (amount.present) {
+      map['amount'] = Variable<String>(amount.value);
+    }
+    if (amountCurrencyCode.present) {
+      map['amount_currency_code'] = Variable<String>(amountCurrencyCode.value);
+    }
+    if (sendMax.present) {
+      map['send_max'] = Variable<int>(sendMax.value);
+    }
+    if (feeSelection.present) {
+      map['fee_selection'] = Variable<String>(feeSelection.value);
+    }
+    if (customFeeKind.present) {
+      map['custom_fee_kind'] = Variable<String>(customFeeKind.value);
+    }
+    if (customFeeValue.present) {
+      map['custom_fee_value'] = Variable<int>(customFeeValue.value);
+    }
+    if (replaceByFee.present) {
+      map['replace_by_fee'] = Variable<int>(replaceByFee.value);
+    }
+    if (payjoinOptedOut.present) {
+      map['payjoin_opted_out'] = Variable<int>(payjoinOptedOut.value);
+    }
+    if (psbt.present) {
+      map['psbt'] = Variable<String>(psbt.value);
+    }
+    if (finalTransaction.present) {
+      map['final_transaction'] = Variable<String>(finalTransaction.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<String>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<String>(updatedAt.value);
+    }
+    if (revision.present) {
+      map['revision'] = Variable<int>(revision.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionsCompanion(')
+          ..write('id: $id, ')
+          ..write('walletId: $walletId, ')
+          ..write('stage: $stage, ')
+          ..write('label: $label, ')
+          ..write('recipient: $recipient, ')
+          ..write('amount: $amount, ')
+          ..write('amountCurrencyCode: $amountCurrencyCode, ')
+          ..write('sendMax: $sendMax, ')
+          ..write('feeSelection: $feeSelection, ')
+          ..write('customFeeKind: $customFeeKind, ')
+          ..write('customFeeValue: $customFeeValue, ')
+          ..write('replaceByFee: $replaceByFee, ')
+          ..write('payjoinOptedOut: $payjoinOptedOut, ')
+          ..write('psbt: $psbt, ')
+          ..write('finalTransaction: $finalTransaction, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('revision: $revision, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class SendTransactionInputs extends Table
+    with TableInfo<SendTransactionInputs, SendTransactionInputsData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  SendTransactionInputs(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> transactionId = GeneratedColumn<String>(
+    'transaction_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> txId = GeneratedColumn<String>(
+    'tx_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> vout = GeneratedColumn<int>(
+    'vout',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [transactionId, txId, vout];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'send_transaction_inputs';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {transactionId, txId, vout};
+  @override
+  SendTransactionInputsData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SendTransactionInputsData(
+      transactionId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}transaction_id'],
+      )!,
+      txId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}tx_id'],
+      )!,
+      vout: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}vout'],
+      )!,
+    );
+  }
+
+  @override
+  SendTransactionInputs createAlias(String alias) {
+    return SendTransactionInputs(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const [
+    'PRIMARY KEY(transaction_id, tx_id, vout)',
+    'FOREIGN KEY(transaction_id)REFERENCES send_transactions(id)ON DELETE CASCADE',
+  ];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class SendTransactionInputsData extends DataClass
+    implements Insertable<SendTransactionInputsData> {
+  final String transactionId;
+  final String txId;
+  final int vout;
+  const SendTransactionInputsData({
+    required this.transactionId,
+    required this.txId,
+    required this.vout,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['transaction_id'] = Variable<String>(transactionId);
+    map['tx_id'] = Variable<String>(txId);
+    map['vout'] = Variable<int>(vout);
+    return map;
+  }
+
+  SendTransactionInputsCompanion toCompanion(bool nullToAbsent) {
+    return SendTransactionInputsCompanion(
+      transactionId: Value(transactionId),
+      txId: Value(txId),
+      vout: Value(vout),
+    );
+  }
+
+  factory SendTransactionInputsData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SendTransactionInputsData(
+      transactionId: serializer.fromJson<String>(json['transactionId']),
+      txId: serializer.fromJson<String>(json['txId']),
+      vout: serializer.fromJson<int>(json['vout']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'transactionId': serializer.toJson<String>(transactionId),
+      'txId': serializer.toJson<String>(txId),
+      'vout': serializer.toJson<int>(vout),
+    };
+  }
+
+  SendTransactionInputsData copyWith({
+    String? transactionId,
+    String? txId,
+    int? vout,
+  }) => SendTransactionInputsData(
+    transactionId: transactionId ?? this.transactionId,
+    txId: txId ?? this.txId,
+    vout: vout ?? this.vout,
+  );
+  SendTransactionInputsData copyWithCompanion(
+    SendTransactionInputsCompanion data,
+  ) {
+    return SendTransactionInputsData(
+      transactionId: data.transactionId.present
+          ? data.transactionId.value
+          : this.transactionId,
+      txId: data.txId.present ? data.txId.value : this.txId,
+      vout: data.vout.present ? data.vout.value : this.vout,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionInputsData(')
+          ..write('transactionId: $transactionId, ')
+          ..write('txId: $txId, ')
+          ..write('vout: $vout')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(transactionId, txId, vout);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SendTransactionInputsData &&
+          other.transactionId == this.transactionId &&
+          other.txId == this.txId &&
+          other.vout == this.vout);
+}
+
+class SendTransactionInputsCompanion
+    extends UpdateCompanion<SendTransactionInputsData> {
+  final Value<String> transactionId;
+  final Value<String> txId;
+  final Value<int> vout;
+  final Value<int> rowid;
+  const SendTransactionInputsCompanion({
+    this.transactionId = const Value.absent(),
+    this.txId = const Value.absent(),
+    this.vout = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SendTransactionInputsCompanion.insert({
+    required String transactionId,
+    required String txId,
+    required int vout,
+    this.rowid = const Value.absent(),
+  }) : transactionId = Value(transactionId),
+       txId = Value(txId),
+       vout = Value(vout);
+  static Insertable<SendTransactionInputsData> custom({
+    Expression<String>? transactionId,
+    Expression<String>? txId,
+    Expression<int>? vout,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (transactionId != null) 'transaction_id': transactionId,
+      if (txId != null) 'tx_id': txId,
+      if (vout != null) 'vout': vout,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SendTransactionInputsCompanion copyWith({
+    Value<String>? transactionId,
+    Value<String>? txId,
+    Value<int>? vout,
+    Value<int>? rowid,
+  }) {
+    return SendTransactionInputsCompanion(
+      transactionId: transactionId ?? this.transactionId,
+      txId: txId ?? this.txId,
+      vout: vout ?? this.vout,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (transactionId.present) {
+      map['transaction_id'] = Variable<String>(transactionId.value);
+    }
+    if (txId.present) {
+      map['tx_id'] = Variable<String>(txId.value);
+    }
+    if (vout.present) {
+      map['vout'] = Variable<int>(vout.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionInputsCompanion(')
+          ..write('transactionId: $transactionId, ')
+          ..write('txId: $txId, ')
+          ..write('vout: $vout, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class SendTransactionPolicyChoices extends Table
+    with
+        TableInfo<
+          SendTransactionPolicyChoices,
+          SendTransactionPolicyChoicesData
+        > {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  SendTransactionPolicyChoices(this.attachedDatabase, [this._alias]);
+  late final GeneratedColumn<String> transactionId = GeneratedColumn<String>(
+    'transaction_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<String> node = GeneratedColumn<String>(
+    'node',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  late final GeneratedColumn<int> optionIndex = GeneratedColumn<int>(
+    'option_index',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    $customConstraints: 'NOT NULL',
+  );
+  @override
+  List<GeneratedColumn> get $columns => [transactionId, node, optionIndex];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'send_transaction_policy_choices';
+  @override
+  Set<GeneratedColumn> get $primaryKey => {transactionId, node, optionIndex};
+  @override
+  SendTransactionPolicyChoicesData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return SendTransactionPolicyChoicesData(
+      transactionId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}transaction_id'],
+      )!,
+      node: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}node'],
+      )!,
+      optionIndex: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}option_index'],
+      )!,
+    );
+  }
+
+  @override
+  SendTransactionPolicyChoices createAlias(String alias) {
+    return SendTransactionPolicyChoices(attachedDatabase, alias);
+  }
+
+  @override
+  List<String> get customConstraints => const [
+    'PRIMARY KEY(transaction_id, node, option_index)',
+    'FOREIGN KEY(transaction_id)REFERENCES send_transactions(id)ON DELETE CASCADE',
+  ];
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class SendTransactionPolicyChoicesData extends DataClass
+    implements Insertable<SendTransactionPolicyChoicesData> {
+  final String transactionId;
+  final String node;
+  final int optionIndex;
+  const SendTransactionPolicyChoicesData({
+    required this.transactionId,
+    required this.node,
+    required this.optionIndex,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['transaction_id'] = Variable<String>(transactionId);
+    map['node'] = Variable<String>(node);
+    map['option_index'] = Variable<int>(optionIndex);
+    return map;
+  }
+
+  SendTransactionPolicyChoicesCompanion toCompanion(bool nullToAbsent) {
+    return SendTransactionPolicyChoicesCompanion(
+      transactionId: Value(transactionId),
+      node: Value(node),
+      optionIndex: Value(optionIndex),
+    );
+  }
+
+  factory SendTransactionPolicyChoicesData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return SendTransactionPolicyChoicesData(
+      transactionId: serializer.fromJson<String>(json['transactionId']),
+      node: serializer.fromJson<String>(json['node']),
+      optionIndex: serializer.fromJson<int>(json['optionIndex']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'transactionId': serializer.toJson<String>(transactionId),
+      'node': serializer.toJson<String>(node),
+      'optionIndex': serializer.toJson<int>(optionIndex),
+    };
+  }
+
+  SendTransactionPolicyChoicesData copyWith({
+    String? transactionId,
+    String? node,
+    int? optionIndex,
+  }) => SendTransactionPolicyChoicesData(
+    transactionId: transactionId ?? this.transactionId,
+    node: node ?? this.node,
+    optionIndex: optionIndex ?? this.optionIndex,
+  );
+  SendTransactionPolicyChoicesData copyWithCompanion(
+    SendTransactionPolicyChoicesCompanion data,
+  ) {
+    return SendTransactionPolicyChoicesData(
+      transactionId: data.transactionId.present
+          ? data.transactionId.value
+          : this.transactionId,
+      node: data.node.present ? data.node.value : this.node,
+      optionIndex: data.optionIndex.present
+          ? data.optionIndex.value
+          : this.optionIndex,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionPolicyChoicesData(')
+          ..write('transactionId: $transactionId, ')
+          ..write('node: $node, ')
+          ..write('optionIndex: $optionIndex')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(transactionId, node, optionIndex);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SendTransactionPolicyChoicesData &&
+          other.transactionId == this.transactionId &&
+          other.node == this.node &&
+          other.optionIndex == this.optionIndex);
+}
+
+class SendTransactionPolicyChoicesCompanion
+    extends UpdateCompanion<SendTransactionPolicyChoicesData> {
+  final Value<String> transactionId;
+  final Value<String> node;
+  final Value<int> optionIndex;
+  final Value<int> rowid;
+  const SendTransactionPolicyChoicesCompanion({
+    this.transactionId = const Value.absent(),
+    this.node = const Value.absent(),
+    this.optionIndex = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  SendTransactionPolicyChoicesCompanion.insert({
+    required String transactionId,
+    required String node,
+    required int optionIndex,
+    this.rowid = const Value.absent(),
+  }) : transactionId = Value(transactionId),
+       node = Value(node),
+       optionIndex = Value(optionIndex);
+  static Insertable<SendTransactionPolicyChoicesData> custom({
+    Expression<String>? transactionId,
+    Expression<String>? node,
+    Expression<int>? optionIndex,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (transactionId != null) 'transaction_id': transactionId,
+      if (node != null) 'node': node,
+      if (optionIndex != null) 'option_index': optionIndex,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  SendTransactionPolicyChoicesCompanion copyWith({
+    Value<String>? transactionId,
+    Value<String>? node,
+    Value<int>? optionIndex,
+    Value<int>? rowid,
+  }) {
+    return SendTransactionPolicyChoicesCompanion(
+      transactionId: transactionId ?? this.transactionId,
+      node: node ?? this.node,
+      optionIndex: optionIndex ?? this.optionIndex,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (transactionId.present) {
+      map['transaction_id'] = Variable<String>(transactionId.value);
+    }
+    if (node.present) {
+      map['node'] = Variable<String>(node.value);
+    }
+    if (optionIndex.present) {
+      map['option_index'] = Variable<int>(optionIndex.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SendTransactionPolicyChoicesCompanion(')
+          ..write('transactionId: $transactionId, ')
+          ..write('node: $node, ')
+          ..write('optionIndex: $optionIndex, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class DatabaseAtV16 extends GeneratedDatabase {
   DatabaseAtV16(QueryExecutor e) : super(e);
   late final Transactions transactions = Transactions(this);
@@ -10896,6 +12228,11 @@ class DatabaseAtV16 extends GeneratedDatabase {
   late final DismissedAnnouncements dismissedAnnouncements =
       DismissedAnnouncements(this);
   late final OrderSwaps orderSwaps = OrderSwaps(this);
+  late final SendTransactions sendTransactions = SendTransactions(this);
+  late final SendTransactionInputs sendTransactionInputs =
+      SendTransactionInputs(this);
+  late final SendTransactionPolicyChoices sendTransactionPolicyChoices =
+      SendTransactionPolicyChoices(this);
   late final Index orderSwapsRequestId = Index(
     'order_swaps_request_id',
     'CREATE UNIQUE INDEX order_swaps_request_id ON order_swaps (request_id)',
@@ -10924,6 +12261,14 @@ class DatabaseAtV16 extends GeneratedDatabase {
     'order_swaps_local_payin_txid',
     'CREATE INDEX order_swaps_local_payin_txid ON order_swaps (local_payin_transaction_id)',
   );
+  late final Index sendTransactionsWallet = Index(
+    'send_transactions_wallet',
+    'CREATE INDEX send_transactions_wallet ON send_transactions (wallet_id)',
+  );
+  late final Index sendTransactionsUpdatedAt = Index(
+    'send_transactions_updated_at',
+    'CREATE INDEX send_transactions_updated_at ON send_transactions (updated_at)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -10949,6 +12294,9 @@ class DatabaseAtV16 extends GeneratedDatabase {
     frozenUtxos,
     dismissedAnnouncements,
     orderSwaps,
+    sendTransactions,
+    sendTransactionInputs,
+    sendTransactionPolicyChoices,
     orderSwapsRequestId,
     orderSwapsLocalStatus,
     orderSwapsSourceWallet,
@@ -10956,6 +12304,8 @@ class DatabaseAtV16 extends GeneratedDatabase {
     orderSwapsBitcoinTxid,
     orderSwapsLiquidTxid,
     orderSwapsLocalPayinTxid,
+    sendTransactionsWallet,
+    sendTransactionsUpdatedAt,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -10979,6 +12329,29 @@ class DatabaseAtV16 extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('wallet_descriptor_keys', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'wallet_metadatas',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('send_transactions', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'send_transactions',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('send_transaction_inputs', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'send_transactions',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [
+        TableUpdate('send_transaction_policy_choices', kind: UpdateKind.delete),
+      ],
     ),
   ]);
   @override


### PR DESCRIPTION
## Summary

- Add schema 16 storage for Bitcoin drafts and partially signed transactions.
- Preserve selected policy paths, signer evidence, hash-preimage evidence, fees, and transaction metadata.
- Use revision checks to prevent stale saves or deletes from overwriting newer state.
- Validate stored transactions, inputs, outputs, ownership, and signer results before restoring or merging them.
- Keep valid pending transactions available when another stored record is invalid.

## Database

This adds the pending Bitcoin transaction tables to the existing schema 16 migration. It does not add another schema version.
