### PR TITLE
feat(wallet): import and sign taproot descriptors

### DIFF
--- a/lib/core/ledger/data/datasources/ledger_device_datasource.dart
+++ b/lib/core/ledger/data/datasources/ledger_device_datasource.dart
@@ -5,9 +5,9 @@ import 'package:bb_mobile/core/entities/signer_device_entity.dart';
 import 'package:bb_mobile/core/ledger/data/models/ledger_device_model.dart';
 import 'package:bb_mobile/core/ledger/domain/entities/ledger_device_entity.dart';
 import 'package:bb_mobile/core/ledger/data/ledger_exception.dart';
-import 'package:bull_logger/bull_logger.dart';
-import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bull_logger/bull_logger.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:convert/convert.dart' as convert;
 import 'package:flutter/foundation.dart';
@@ -257,6 +257,16 @@ class LedgerDeviceDatasource {
     return BitcoinLedgerApp(
       connection,
     ).getXPubKey(derivationPath: derivationPath, displayPublicKey: false);
+  }
+
+  Future<String> getBitcoinAppVersion(LedgerDeviceModel device) async {
+    final connection = _getSdkConnection(device);
+    final ledgerDevice = _cachedDevice;
+    if (ledgerDevice == null) throw const DeviceNotFoundLedgerException();
+    final appVersion = await BitcoinLedgerApp(
+      connection,
+    ).getVersion(ledgerDevice);
+    return appVersion.version;
   }
 
   Future<Uint8List> registerWalletPolicy(

--- a/lib/core/ledger/data/ledger_exception.dart
+++ b/lib/core/ledger/data/ledger_exception.dart
@@ -46,3 +46,7 @@ final class WalletPolicyNotRegisteredLedgerException extends LedgerException {
 final class WalletAddressMismatchLedgerException extends LedgerException {
   const WalletAddressMismatchLedgerException();
 }
+
+final class BitcoinAppUpdateRequiredLedgerException extends LedgerException {
+  const BitcoinAppUpdateRequiredLedgerException();
+}

--- a/lib/core/ledger/data/ledger_wallet_policy_adapter.dart
+++ b/lib/core/ledger/data/ledger_wallet_policy_adapter.dart
@@ -4,7 +4,18 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart
 import 'package:ledger_bitcoin/ledger_bitcoin.dart';
 
 abstract final class LedgerWalletPolicyAdapter {
-  static WalletPolicy fromWallet(Wallet wallet) {
+  static String? minimumBitcoinAppVersion(
+    Wallet wallet, {
+    required bool hasUnspendablePolicyKey,
+  }) {
+    if (!wallet.publicDescriptor.toLowerCase().startsWith('tr(')) return null;
+    return hasUnspendablePolicyKey ? '2.2.2' : '2.2.1';
+  }
+
+  static WalletPolicy fromWallet(
+    Wallet wallet, {
+    required List<WalletDescriptorKey> descriptorPolicyKeys,
+  }) {
     if (!wallet.supportsLedgerWalletPolicy) {
       throw const FormatException('Unsupported Ledger wallet policy');
     }
@@ -16,7 +27,7 @@ abstract final class LedgerWalletPolicyAdapter {
     for (final atom in _descriptorAtoms(template)) {
       final key = _LedgerPolicyKey.tryParse(atom, wallet: wallet);
       if (key == null) continue;
-      if (!wallet.descriptorKeys.any(key.matches)) {
+      if (!descriptorPolicyKeys.any(key.matchesDescriptorKey)) {
         throw const FormatException('Descriptor key is missing from policy');
       }
       var index = policyKeyIndexes[key.keyInfo];
@@ -145,7 +156,7 @@ final class _LedgerPolicyKey {
     );
   }
 
-  bool matches(WalletDescriptorKey key) =>
+  bool matchesDescriptorKey(WalletDescriptorKey key) =>
       key.masterFingerprint.toLowerCase() == masterFingerprint &&
       _normalizePath(key.derivationPath) == _normalizePath(derivationPath) &&
       key.xpub == xpub;

--- a/lib/core/ledger/data/repositories/ledger_device_repository_impl.dart
+++ b/lib/core/ledger/data/repositories/ledger_device_repository_impl.dart
@@ -12,20 +12,24 @@ import 'package:bb_mobile/core/ledger/domain/ledger_failure.dart';
 import 'package:bb_mobile/core/ledger/domain/repositories/ledger_device_repository.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:ledger_bitcoin/ledger_bitcoin.dart';
 
 class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
   final LedgerDeviceDatasource _datasource;
   final LedgerWalletPolicyHmacDatasource _hmacDatasource;
+  final BitcoinDescriptorPort _descriptorPort;
 
   LedgerDeviceRepositoryImpl({
     required this._datasource,
     required this._hmacDatasource,
-  });
+    required BitcoinDescriptorPort bitcoinDescriptorPort,
+  }) : _descriptorPort = bitcoinDescriptorPort;
 
   @override
   Future<Result<List<LedgerDeviceEntity>, LedgerFailure>> scanDevices({
@@ -125,8 +129,14 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
   }) => _guard(() async {
     _ensureSupportedPolicy(wallet);
     final model = device.toModel();
-    final walletPolicy = _walletPolicy(wallet);
+    final descriptor = _analyzePolicyDescriptor(wallet);
+    final walletPolicy = _walletPolicy(wallet, descriptor.policyKeys);
     final policyId = hex.encode(walletPolicy.id);
+    await _ensureSupportedFirmware(
+      model,
+      wallet: wallet,
+      hasUnspendablePolicyKey: descriptor.hasUnspendablePolicyKey,
+    );
     final signer = await _matchWalletSigner(model, wallet: wallet);
     final hmac = await _datasource.registerWalletPolicy(
       model,
@@ -149,8 +159,14 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
   }) => _guard(() async {
     _ensureSupportedPolicy(wallet);
     final model = device.toModel();
-    final walletPolicy = _walletPolicy(wallet);
+    final descriptor = _analyzePolicyDescriptor(wallet);
+    final walletPolicy = _walletPolicy(wallet, descriptor.policyKeys);
     final policyId = hex.encode(walletPolicy.id);
+    await _ensureSupportedFirmware(
+      model,
+      wallet: wallet,
+      hasUnspendablePolicyKey: descriptor.hasUnspendablePolicyKey,
+    );
     final signer = await _matchWalletSigner(
       model,
       wallet: wallet,
@@ -175,8 +191,14 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
   }) => _guard(() async {
     _ensureSupportedPolicy(wallet);
     final model = device.toModel();
-    final walletPolicy = _walletPolicy(wallet);
+    final descriptor = _analyzePolicyDescriptor(wallet);
+    final walletPolicy = _walletPolicy(wallet, descriptor.policyKeys);
     final policyId = hex.encode(walletPolicy.id);
+    await _ensureSupportedFirmware(
+      model,
+      wallet: wallet,
+      hasUnspendablePolicyKey: descriptor.hasUnspendablePolicyKey,
+    );
     final signer = await _matchWalletSigner(model, wallet: wallet);
     final hmac = await _registeredHmac(wallet.id, signer.id, policyId);
     final verifiedAddress = await _datasource.verifyWalletAddress(
@@ -232,8 +254,36 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
     throw const DeviceMismatchLedgerException();
   }
 
-  WalletPolicy _walletPolicy(Wallet wallet) =>
-      LedgerWalletPolicyAdapter.fromWallet(wallet);
+  Future<void> _ensureSupportedFirmware(
+    LedgerDeviceModel device, {
+    required Wallet wallet,
+    required bool hasUnspendablePolicyKey,
+  }) async {
+    final minimumVersion = LedgerWalletPolicyAdapter.minimumBitcoinAppVersion(
+      wallet,
+      hasUnspendablePolicyKey: hasUnspendablePolicyKey,
+    );
+    if (minimumVersion == null) return;
+    final currentVersion = await _datasource.getBitcoinAppVersion(device);
+    if (_versionIsBefore(currentVersion, minimumVersion)) {
+      throw const BitcoinAppUpdateRequiredLedgerException();
+    }
+  }
+
+  ({List<WalletDescriptorKey> policyKeys, bool hasUnspendablePolicyKey})
+  _analyzePolicyDescriptor(Wallet wallet) =>
+      _descriptorPort.analyzeBitcoinPolicyDescriptor(
+        descriptor: wallet.publicDescriptor,
+        network: wallet.network,
+      );
+
+  WalletPolicy _walletPolicy(
+    Wallet wallet,
+    List<WalletDescriptorKey> policyKeys,
+  ) => LedgerWalletPolicyAdapter.fromWallet(
+    wallet,
+    descriptorPolicyKeys: policyKeys,
+  );
 
   Future<Uint8List> _registeredHmac(
     String walletId,
@@ -260,6 +310,24 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
   static bool _sameXpub(String first, String second) =>
       Bip32Derivation.getBip32Xpub(first).toBase58() ==
       Bip32Derivation.getBip32Xpub(second).toBase58();
+
+  static bool _versionIsBefore(String current, String minimum) {
+    final currentParts = _versionParts(current);
+    final minimumParts = _versionParts(minimum)!;
+    if (currentParts == null) return true;
+    for (var index = 0; index < minimumParts.length; index++) {
+      if (currentParts[index] != minimumParts[index]) {
+        return currentParts[index] < minimumParts[index];
+      }
+    }
+    return false;
+  }
+
+  static List<int>? _versionParts(String version) {
+    final match = RegExp(r'^(\d+)\.(\d+)\.(\d+)$').firstMatch(version);
+    if (match == null) return null;
+    return [for (var index = 1; index <= 3; index++) int.parse(match[index]!)];
+  }
 
   @override
   Future<Result<void, LedgerFailure>> disconnectConnection(
@@ -300,6 +368,8 @@ class LedgerDeviceRepositoryImpl implements LedgerDeviceRepository {
       return const Err(LedgerWalletPolicyNotRegisteredFailure());
     } on WalletAddressMismatchLedgerException {
       return const Err(LedgerAddressMismatchFailure());
+    } on BitcoinAppUpdateRequiredLedgerException {
+      return const Err(LedgerBitcoinAppUpdateRequiredFailure());
     } on FormatException catch (error) {
       return Err(LedgerUnsupportedWalletPolicyFailure(error.toString()));
     } on ConnectionTypeNotInitializedLedgerException {

--- a/lib/core/ledger/domain/ledger_failure.dart
+++ b/lib/core/ledger/domain/ledger_failure.dart
@@ -45,6 +45,10 @@ final class LedgerBitcoinAppNotOpenFailure extends LedgerFailure {
   const LedgerBitcoinAppNotOpenFailure([super.logMessage]);
 }
 
+final class LedgerBitcoinAppUpdateRequiredFailure extends LedgerFailure {
+  const LedgerBitcoinAppUpdateRequiredFailure([super.logMessage]);
+}
+
 /// No active connection to a device. Raised both by the datasource (when an
 /// operation needs a live connection it doesn't have) and by the UI pre-check
 /// before an operation is requested; both surface the same message.

--- a/lib/core/ledger/ledger_locator.dart
+++ b/lib/core/ledger/ledger_locator.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/core/ledger/domain/usecases/verify_wallet_address_ledg
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:get_it/get_it.dart';
 
 class LedgerLocator {
@@ -36,6 +37,7 @@ class LedgerLocator {
       () => LedgerDeviceRepositoryImpl(
         datasource: locator<LedgerDeviceDatasource>(),
         hmacDatasource: locator<LedgerWalletPolicyHmacDatasource>(),
+        bitcoinDescriptorPort: locator<BitcoinDescriptorPort>(),
       ),
     );
   }

--- a/lib/core/wallet/data/datasources/bdk_facade.dart
+++ b/lib/core/wallet/data/datasources/bdk_facade.dart
@@ -6,7 +6,11 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:convert/convert.dart';
 import 'package:path_provider/path_provider.dart';
+
+const _bip341NumsKey =
+    '0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0';
 
 final class BdkDescriptorKey {
   final String masterFingerprint;
@@ -31,6 +35,8 @@ final class BdkTwoPathDescriptor {
   final String scriptIdentity;
   final ScriptType? scriptType;
   final List<BdkDescriptorKey> keys;
+  final List<BdkDescriptorKey> policyKeys;
+  final Set<String> unspendablePolicyKeyIdentifiers;
   final bool inferredChangePath;
 
   const BdkTwoPathDescriptor({
@@ -40,6 +46,8 @@ final class BdkTwoPathDescriptor {
     required this.scriptIdentity,
     required this.scriptType,
     this.keys = const [],
+    this.policyKeys = const [],
+    this.unspendablePolicyKeyIdentifiers = const {},
     this.inferredChangePath = false,
   });
 }
@@ -325,10 +333,6 @@ class BdkFacade {
     try {
       parsed.sanityCheck();
 
-      if (parsed.descType() == bdk.DescriptorType.tr) {
-        throw const UnsupportedTaprootDescriptorException();
-      }
-
       if (!parsed.isMultipath()) {
         throw const FormatException(
           'Descriptor must define receiving and change paths',
@@ -364,6 +368,10 @@ class BdkFacade {
         }
 
         final externalDescriptor = singleDescriptors.first.toString();
+        final keyAnalysis = _descriptorKeys(
+          parsed.toString(),
+          descriptorType: parsed.descType(),
+        );
         return BdkTwoPathDescriptor(
           descriptor: parsed.toString(),
           externalDescriptor: externalDescriptor,
@@ -375,7 +383,10 @@ class BdkFacade {
             bdk.DescriptorType.pkh => ScriptType.bip44,
             _ => null,
           },
-          keys: _descriptorKeys(parsed.toString()),
+          keys: keyAnalysis.signingKeys,
+          policyKeys: keyAnalysis.policyKeys,
+          unspendablePolicyKeyIdentifiers:
+              keyAnalysis.unspendablePolicyKeyIdentifiers,
           inferredChangePath: normalized.inferredChangePath,
         );
       } finally {
@@ -415,9 +426,21 @@ class BdkFacade {
         },
       );
 
-  static List<BdkDescriptorKey> _descriptorKeys(String descriptor) {
-    final keys = <BdkDescriptorKey>[];
-    final seen = <String>{};
+  static ({
+    List<BdkDescriptorKey> signingKeys,
+    List<BdkDescriptorKey> policyKeys,
+    Set<String> unspendablePolicyKeyIdentifiers,
+  })
+  _descriptorKeys(
+    String descriptor, {
+    required bdk.DescriptorType descriptorType,
+  }) {
+    final parsedKeys = <({BdkDescriptorKey key, String expression})>[];
+    final taproot = descriptorType == bdk.DescriptorType.tr
+        ? _taprootInternalKey(descriptor)
+        : null;
+    final unspendableIdentifiers = <String>{};
+    var parsedFixedNumsInternalKey = false;
 
     for (final atom in _descriptorAtoms(descriptor)) {
       if (const {
@@ -459,6 +482,21 @@ class BdkFacade {
           : normalizedDescriptorKey.substring(keyEnd);
 
       if (!xpub.startsWith('xpub') && !xpub.startsWith('tpub')) {
+        final isBip341NumsInternalKey =
+            descriptorType == bdk.DescriptorType.tr &&
+            !parsedFixedNumsInternalKey &&
+            {
+              _bip341NumsKey,
+              _bip341NumsKey.substring(2),
+            }.contains(xpub.toLowerCase()) &&
+            candidate == taproot?.expression;
+        if (isBip341NumsInternalKey) {
+          parsedFixedNumsInternalKey = true;
+          unspendableIdentifiers
+            ..add(_bip341NumsKey)
+            ..add(_bip341NumsKey.substring(2));
+          continue;
+        }
         throw const UnsupportedFixedPublicKeyDescriptorException();
       }
       final xpubFingerprint = Bip32Derivation.getBip32Xpub(xpub).fingerprintHex;
@@ -475,21 +513,130 @@ class BdkFacade {
         }
       }
 
-      final identity =
-          '$masterFingerprint:$derivationPath:$xpub:$descriptorPath';
-      if (!seen.add(identity)) continue;
-      keys.add(
-        BdkDescriptorKey(
+      parsedKeys.add((
+        expression: candidate,
+        key: BdkDescriptorKey(
           masterFingerprint: masterFingerprint,
           xpubFingerprint: xpubFingerprint,
           xpub: xpub,
           derivationPath: derivationPath,
           descriptorPath: descriptorPath,
         ),
+      ));
+    }
+
+    final unspendableInternalKey = _unspendableTaprootInternalKey(
+      parsedKeys,
+      taprootInternalKey: taproot?.expression,
+    );
+    if (unspendableInternalKey != null) {
+      _validateUnspendableInternalKey(parsedKeys, unspendableInternalKey);
+      unspendableIdentifiers.addAll({
+        unspendableInternalKey.masterFingerprint.toLowerCase(),
+        unspendableInternalKey.xpubFingerprint.toLowerCase(),
+        unspendableInternalKey.xpub.toLowerCase(),
+      });
+    }
+    if ((parsedFixedNumsInternalKey || unspendableInternalKey != null) &&
+        taproot?.hasScriptTree != true) {
+      throw const FormatException(
+        'Unspendable Taproot internal keys require a script tree',
       );
     }
 
-    return List.unmodifiable(keys);
+    List<BdkDescriptorKey> uniqueKeys({required bool includeUnspendable}) {
+      final seen = <String>{};
+      return List.unmodifiable([
+        for (final parsed in parsedKeys)
+          if ((includeUnspendable ||
+                  !identical(parsed.key, unspendableInternalKey)) &&
+              seen.add(
+                '${parsed.key.masterFingerprint}:${parsed.key.derivationPath}:'
+                '${parsed.key.xpub}:${parsed.key.descriptorPath}',
+              ))
+            parsed.key,
+      ]);
+    }
+
+    return (
+      signingKeys: uniqueKeys(includeUnspendable: false),
+      policyKeys: uniqueKeys(includeUnspendable: true),
+      unspendablePolicyKeyIdentifiers: Set.unmodifiable(
+        unspendableIdentifiers.where((identifier) => identifier.isNotEmpty),
+      ),
+    );
+  }
+
+  static void _validateUnspendableInternalKey(
+    List<({BdkDescriptorKey key, String expression})> parsedKeys,
+    BdkDescriptorKey unspendableInternalKey,
+  ) {
+    final fingerprints = {
+      unspendableInternalKey.masterFingerprint.toLowerCase(),
+      unspendableInternalKey.xpubFingerprint.toLowerCase(),
+    }..remove('');
+    for (final parsed in parsedKeys) {
+      final key = parsed.key;
+      if (identical(key, unspendableInternalKey)) continue;
+      if (key.xpub == unspendableInternalKey.xpub) {
+        throw const FormatException(
+          'Unspendable Taproot internal keys cannot be used in scripts',
+        );
+      }
+      if (fingerprints.contains(key.masterFingerprint.toLowerCase()) ||
+          fingerprints.contains(key.xpubFingerprint.toLowerCase())) {
+        throw const FormatException(
+          'Unspendable Taproot internal key fingerprint is ambiguous',
+        );
+      }
+    }
+  }
+
+  static BdkDescriptorKey? _unspendableTaprootInternalKey(
+    List<({BdkDescriptorKey key, String expression})> parsedKeys, {
+    required String? taprootInternalKey,
+  }) {
+    if (taprootInternalKey == null) return null;
+    final internalIndex = parsedKeys.indexWhere(
+      (parsed) => parsed.expression == taprootInternalKey,
+    );
+    if (internalIndex < 0) return null;
+    final internal = parsedKeys[internalIndex];
+
+    final internalXpub = Bip32Derivation.getBip32Xpub(internal.key.xpub);
+    return hex.encode(internalXpub.public).toLowerCase() == _bip341NumsKey
+        ? internal.key
+        : null;
+  }
+
+  static ({String expression, bool hasScriptTree})? _taprootInternalKey(
+    String descriptor,
+  ) {
+    final withoutChecksum = descriptor.split('#').first.trim();
+    final match = RegExp(r'^tr\s*\(').firstMatch(withoutChecksum);
+    if (match == null) return null;
+    final start = match.end;
+    var nested = 0;
+    for (var index = start; index < withoutChecksum.length; index++) {
+      final character = withoutChecksum[index];
+      if (character == '(' || character == '{') nested++;
+      if (character == ')' || character == '}') {
+        if (nested == 0) {
+          return (
+            expression: withoutChecksum.substring(start, index).trim(),
+            hasScriptTree: false,
+          );
+        }
+        nested--;
+      }
+      if (character == ',' && nested == 0) {
+        return (
+          expression: withoutChecksum.substring(start, index).trim(),
+          hasScriptTree: true,
+        );
+      }
+    }
+    return null;
   }
 
   static Iterable<({String value, String? parent})> _descriptorAtoms(

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -27,6 +27,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
 import 'package:bitcoin_base/bitcoin_base.dart' as bitcoin_base;
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:convert/convert.dart';
@@ -429,9 +430,14 @@ class BdkWalletDatasource {
       }
     }
 
-    final serialized = psbt.serialize();
+    final inputs = psbt.input();
+    final outputs = psbt.output();
+    final serialized = _removeFixedBip341NumsKeyOrigins(
+      psbt.serialize(),
+      inputs: inputs,
+      outputs: outputs,
+    );
     if (requiredDescriptorKeys == null) return serialized;
-
     final transaction = psbt.extractTx();
     try {
       final keychainsByOutpoint = {
@@ -443,8 +449,14 @@ class BdkWalletDatasource {
           keychainsByOutpoint['${input.previousOutput.txid}:${input.previousOutput.vout}'] ??
               (throw StateError('Built transaction contains an unknown input')),
       ];
-      return _retainSelectedSegwitKeyOrigins(
+      final selectedOrigins = _retainSelectedSegwitKeyOrigins(
         serialized,
+        inputKeychains: inputKeychains,
+        requiredDescriptorKeys: requiredDescriptorKeys,
+      );
+      return _retainSelectedTaprootSpendPaths(
+        selectedOrigins,
+        inputs: inputs,
         inputKeychains: inputKeychains,
         requiredDescriptorKeys: requiredDescriptorKeys,
       );
@@ -478,7 +490,10 @@ class BdkWalletDatasource {
             final ownership = _descriptorOwnership(
               descriptorWallet,
               script: utxo.scriptPubkey,
-              keySources: input.bip32Derivation.values,
+              keySources: [
+                ...input.bip32Derivation.values,
+                ...input.tapKeyOrigins.values.map((origin) => origin.keySource),
+              ],
             );
             if (ownership == null) {
               throw const BitcoinPsbtWalletMismatchException();
@@ -541,6 +556,24 @@ class BdkWalletDatasource {
         try {
           final preparedInputs = prepared.input();
           final psbtInputs = psbt.input();
+          if (preparedInputs.length != psbtInputs.length) {
+            throw const FormatException('Invalid prepared PSBT');
+          }
+          final hasTaprootInput = Iterable<int>.generate(preparedInputs.length)
+              .any((index) {
+                final script = _inputUtxo(
+                  psbtInputs[index],
+                  preparedInputs[index].previousOutput,
+                ).scriptPubkey.toBytes();
+                return script.length == 34 &&
+                    script[0] == 0x51 &&
+                    script[1] == 0x20;
+              });
+          if (hasTaprootInput) {
+            throw const FormatException(
+              'Finalized Taproot transactions are not supported; return a PSBT',
+            );
+          }
           final signedInputs = signed.input();
           final preparedOutputs = prepared.output();
           final signedOutputs = signed.output();
@@ -644,12 +677,19 @@ class BdkWalletDatasource {
         inputs: inputs,
         allowFinalizedTaprootInputs: allowFinalizedForeignInputs,
       );
+      if (!allowFinalizedForeignInputs) {
+        _rejectFinalizedInputs(inputs);
+      }
+      final selectedUnsignedPsbt = _removeFixedBip341NumsKeyOrigins(
+        unsignedPsbt,
+        inputs: inputs,
+        outputs: psbt.output(),
+      );
+      final signWithTapInternalKey = _shouldSignWithTapInternalKey(inputs);
       final bdkWallet = await BdkFacade.createPrivateWallet(wallet);
       try {
         if (allowFinalizedForeignInputs) {
           _rejectFinalizedWalletInputs(psbt, inputs, bdkWallet);
-        } else {
-          _rejectFinalizedInputs(inputs);
         }
         bdkWallet.sign(
           psbt: psbt,
@@ -658,7 +698,7 @@ class BdkWalletDatasource {
             assumeHeight: null,
             allowAllSighashes: false,
             tryFinalize: false,
-            signWithTapInternalKey: false,
+            signWithTapInternalKey: signWithTapInternalKey,
             allowGrinding: true,
           ),
         );
@@ -670,7 +710,15 @@ class BdkWalletDatasource {
         } else {
           log.info('Signed PSBT is finalized');
         }
-        return signed;
+        return (
+          psbt: signed.isFinalized
+              ? signed.psbt
+              : _restoreSelectedTaprootMetadata(
+                  originalPsbtBase64: selectedUnsignedPsbt,
+                  signedPsbtBase64: signed.psbt,
+                ),
+          isFinalized: signed.isFinalized,
+        );
       } finally {
         bdkWallet.dispose();
       }
@@ -683,6 +731,10 @@ class BdkWalletDatasource {
     required PublicBdkWalletModel wallet,
     List<WalletDescriptorKeyModel> descriptorKeys = const [],
   }) {
+    final parsedDescriptor = BdkFacade.parsePublicTwoPathDescriptor(
+      descriptor: wallet.descriptor,
+      isTestnet: wallet.isTestnet,
+    );
     final bdkWallet = BdkFacade.createEphemeralDescriptorWallet(
       descriptor: wallet.descriptor,
       isTestnet: wallet.isTestnet,
@@ -717,6 +769,9 @@ class BdkWalletDatasource {
         externalKeyIdentities: externalKeyIdentities,
         internalKeyIdentities: internalKeyIdentities,
         descriptorKeys: descriptorKeys,
+        unspendablePolicyKeyIdentifiers:
+            parsedDescriptor.unspendablePolicyKeyIdentifiers,
+        isTaproot: parsedDescriptor.externalDescriptor.startsWith('tr('),
       );
     } finally {
       keyIdentityWallet?.dispose();
@@ -741,7 +796,13 @@ class BdkWalletDatasource {
             transactionOutputs.length != psbtOutputs.length) {
           throw const InvalidBitcoinPsbtException();
         }
-        _validatePartialSignatures(psbtBase64, inputs: psbtInputs);
+        _validatePartialSignatures(
+          psbtBase64,
+          inputs: psbtInputs,
+          previousOutputs: [
+            for (final input in transactionInputs) input.previousOutput,
+          ],
+        );
 
         final descriptorWallet = await BdkFacade.createWallet(wallet);
         try {
@@ -755,7 +816,10 @@ class BdkWalletDatasource {
             final ownership = _descriptorOwnership(
               descriptorWallet,
               script: utxo.scriptPubkey,
-              keySources: input.bip32Derivation.values,
+              keySources: [
+                ...input.bip32Derivation.values,
+                ...input.tapKeyOrigins.values.map((origin) => origin.keySource),
+              ],
             );
             if (ownership == null) {
               throw const BitcoinPsbtWalletMismatchException();
@@ -767,8 +831,26 @@ class BdkWalletDatasource {
                   publicKey: entry.key.toString().toLowerCase(),
                   fingerprint: entry.value.fingerprint.toLowerCase(),
                   derivationPath: entry.value.path.toString(),
+                  isXOnly: false,
+                  tapLeafHash: null,
                 ),
+              for (final entry in input.tapKeyOrigins.entries)
+                for (final leafHash
+                    in entry.value.tapLeafHashes.isEmpty
+                        ? const <String?>[null]
+                        : entry.value.tapLeafHashes)
+                  (
+                    publicKey: entry.key.toLowerCase(),
+                    fingerprint: entry.value.keySource.fingerprint
+                        .toLowerCase(),
+                    derivationPath: entry.value.keySource.path.toString(),
+                    isXOnly: true,
+                    tapLeafHash: leafHash?.toLowerCase(),
+                  ),
             ];
+            final selectedTapLeafHashes = input.tapScripts.values
+                .map(_tapLeafHash)
+                .toSet();
             final signedKeySources = [
               for (final publicKey in input.partialSigs.keys)
                 (
@@ -777,6 +859,40 @@ class BdkWalletDatasource {
                       .toLowerCase(),
                   derivationPath: input.bip32Derivation[publicKey]?.path
                       .toString(),
+                  isXOnly: false,
+                  tapLeafHash: null,
+                ),
+              if (input.tapKeySig != null && input.tapInternalKey != null)
+                (
+                  publicKey: input.tapInternalKey!.toLowerCase(),
+                  fingerprint: input
+                      .tapKeyOrigins[input.tapInternalKey]
+                      ?.keySource
+                      .fingerprint
+                      .toLowerCase(),
+                  derivationPath: input
+                      .tapKeyOrigins[input.tapInternalKey]
+                      ?.keySource
+                      .path
+                      .toString(),
+                  isXOnly: true,
+                  tapLeafHash: null,
+                ),
+              for (final signature in input.tapScriptSigs.keys)
+                (
+                  publicKey: signature.xonlyPubkey.toLowerCase(),
+                  fingerprint: input
+                      .tapKeyOrigins[signature.xonlyPubkey]
+                      ?.keySource
+                      .fingerprint
+                      .toLowerCase(),
+                  derivationPath: input
+                      .tapKeyOrigins[signature.xonlyPubkey]
+                      ?.keySource
+                      .path
+                      .toString(),
+                  isXOnly: true,
+                  tapLeafHash: signature.tapLeafHash.toLowerCase(),
                 ),
             ];
             inputs.add((
@@ -789,6 +905,7 @@ class BdkWalletDatasource {
               satisfiedPreimageKeys: _satisfiedPreimageKeys(input),
               sequence: transactionInputs[index].sequence,
               signedKeySources: signedKeySources,
+              tapLeafHashes: Set.unmodifiable(selectedTapLeafHashes),
             ));
           }
 
@@ -798,11 +915,17 @@ class BdkWalletDatasource {
             final ownership = _descriptorOwnership(
               descriptorWallet,
               script: txOut.scriptPubkey,
-              keySources: output.bip32Derivation.values,
+              keySources: [
+                ...output.bip32Derivation.values,
+                ...output.tapKeyOrigins.values.map(
+                  (origin) => origin.keySource,
+                ),
+              ],
             );
-            final originFingerprints = output.bip32Derivation.values
-                .map((source) => source.fingerprint.toLowerCase())
-                .toSet();
+            final originFingerprints = [
+              ...output.bip32Derivation.values,
+              ...output.tapKeyOrigins.values.map((origin) => origin.keySource),
+            ].map((source) => source.fingerprint.toLowerCase()).toSet();
             if (ownership == null &&
                 originFingerprints
                     .intersection(normalizedWalletFingerprints)
@@ -1036,6 +1159,12 @@ class BdkWalletDatasource {
       final inputs = psbt.input();
       _validatePartialSignatures(psbtBase64, inputs: inputs);
       _rejectFinalizedInputs(inputs);
+      final selectedUnsignedPsbt = _removeFixedBip341NumsKeyOrigins(
+        psbtBase64,
+        inputs: inputs,
+        outputs: psbt.output(),
+      );
+      final signWithTapInternalKey = _shouldSignWithTapInternalKey(inputs);
       final wallet = BdkFacade.createEphemeralDescriptorWallet(
         descriptor: descriptor,
         isTestnet: isTestnet,
@@ -1048,13 +1177,27 @@ class BdkWalletDatasource {
             assumeHeight: null,
             allowAllSighashes: false,
             tryFinalize: false,
-            signWithTapInternalKey: false,
+            signWithTapInternalKey: signWithTapInternalKey,
             allowGrinding: true,
           ),
         );
-        return tryFinalize
+        final signed = tryFinalize
             ? _finalizeCompletePsbt(psbt)
             : (psbt: psbt.serialize(), isFinalized: false);
+        final normalizedSignedPsbt = _removeFixedBip341NumsKeyOrigins(
+          signed.psbt,
+          inputs: psbt.input(),
+          outputs: psbt.output(),
+        );
+        return (
+          psbt: signed.isFinalized
+              ? normalizedSignedPsbt
+              : _restoreSelectedTaprootMetadata(
+                  originalPsbtBase64: selectedUnsignedPsbt,
+                  signedPsbtBase64: normalizedSignedPsbt,
+                ),
+          isFinalized: signed.isFinalized,
+        );
       } finally {
         wallet.dispose();
       }
@@ -1103,18 +1246,79 @@ class BdkWalletDatasource {
 
         var hasNewSignature = false;
         for (final (index, input) in signedInputs.indexed) {
-          if (input.tapKeySig != null || input.tapScriptSigs.isNotEmpty) {
-            throw const BitcoinPsbtUnsupportedSighashException();
+          final currentInput = currentInputs[index];
+          if (input.tapInternalKey != currentInput.tapInternalKey ||
+              input.tapMerkleRoot != currentInput.tapMerkleRoot ||
+              !setEquals(
+                _tapScriptIdentifiers(input),
+                _tapScriptIdentifiers(currentInput),
+              )) {
+            throw const InvalidBitcoinPsbtException();
+          }
+          final allowedTaprootSpendModes = _taprootSpendModes(currentInput);
+          if ((input.tapKeySig != null &&
+                  !allowedTaprootSpendModes.contains(
+                    _TaprootSpendMode.keyPath,
+                  )) ||
+              (input.tapScriptSigs.isNotEmpty &&
+                  !allowedTaprootSpendModes.contains(
+                    _TaprootSpendMode.scriptPath,
+                  ))) {
+            throw const InvalidBitcoinPsbtException();
           }
           for (final entry in input.partialSigs.entries) {
             final signature = entry.value;
             if (signature.isEmpty || signature.last != 0x01) {
               throw const BitcoinPsbtUnsupportedSighashException();
             }
-            final currentSignature =
-                currentInputs[index].partialSigs[entry.key];
+            final currentSignature = currentInput.partialSigs[entry.key];
             if (currentSignature == null ||
                 !listEquals(currentSignature, signature)) {
+              hasNewSignature = true;
+            }
+          }
+          final tapKeySignature = input.tapKeySig;
+          if (tapKeySignature != null) {
+            _validateTaprootSignatureSighash(
+              tapKeySignature,
+              requestedSighash: currentInput.sighashType,
+            );
+            final currentSignature = currentInput.tapKeySig;
+            if (currentSignature == null ||
+                !listEquals(currentSignature, tapKeySignature)) {
+              hasNewSignature = true;
+            }
+          }
+          for (final entry in input.tapScriptSigs.entries) {
+            final currentOrigin = currentInput.tapKeyOrigins.entries
+                .where(
+                  (origin) =>
+                      origin.key.toLowerCase() ==
+                      entry.key.xonlyPubkey.toLowerCase(),
+                )
+                .firstOrNull
+                ?.value;
+            if (currentOrigin == null ||
+                !currentOrigin.tapLeafHashes.any(
+                  (hash) =>
+                      hash.toLowerCase() == entry.key.tapLeafHash.toLowerCase(),
+                )) {
+              throw const InvalidBitcoinPsbtException();
+            }
+            _validateTaprootSignatureSighash(
+              entry.value,
+              requestedSighash: currentInput.sighashType,
+            );
+            final currentSignature = currentInput.tapScriptSigs.entries
+                .where(
+                  (candidate) =>
+                      candidate.key.xonlyPubkey == entry.key.xonlyPubkey &&
+                      candidate.key.tapLeafHash == entry.key.tapLeafHash,
+                )
+                .firstOrNull
+                ?.value;
+            if (currentSignature == null ||
+                !listEquals(currentSignature, entry.value)) {
               hasNewSignature = true;
             }
           }
@@ -1138,16 +1342,24 @@ class BdkWalletDatasource {
     String psbtBase64, {
     List<bdk.Input>? inputs,
     bool allowFinalizedTaprootInputs = false,
+    List<bdk.OutPoint>? previousOutputs,
   }) {
-    final parsedPsbt = inputs == null ? _parsePsbt(psbtBase64) : null;
+    if (inputs == null && previousOutputs != null) {
+      throw StateError('PSBT inputs and previous outputs must be provided');
+    }
+    final parsedPsbt = inputs == null || previousOutputs == null
+        ? _parsePsbt(psbtBase64)
+        : null;
+    final transaction = previousOutputs == null
+        ? parsedPsbt!.extractTx()
+        : null;
     try {
       final bdkInputs = inputs ?? parsedPsbt!.input();
-      for (final input in bdkInputs) {
-        _validateSighash(input.sighashType);
-        if ((input.tapKeySig != null || input.tapScriptSigs.isNotEmpty) &&
-            !(allowFinalizedTaprootInputs && _isFinalizedInput(input))) {
-          throw const BitcoinPsbtUnsupportedSighashException();
-        }
+      final outpoints =
+          previousOutputs ??
+          [for (final input in transaction!.input()) input.previousOutput];
+      if (bdkInputs.length != outpoints.length) {
+        throw const InvalidBitcoinPsbtException();
       }
       final finalizedInputIndexes = [
         for (final (index, input) in bdkInputs.indexed)
@@ -1176,7 +1388,22 @@ class BdkWalletDatasource {
           if (!identical(finalizedPsbt, parsedPsbt)) finalizedPsbt.dispose();
         }
       }
-      if (bdkInputs.every((input) => input.partialSigs.isEmpty)) return;
+      for (final (index, input) in bdkInputs.indexed) {
+        _validateSighash(
+          input.sighashType,
+          isTaproot: _isTaprootPsbtInput(input, outpoints[index]),
+        );
+      }
+      final hasSignatures = bdkInputs.any(
+        (input) =>
+            input.partialSigs.isNotEmpty ||
+            input.tapKeySig != null ||
+            input.tapScriptSigs.isNotEmpty,
+      );
+      final hasTaprootScripts = bdkInputs.any(
+        (input) => input.tapScripts.isNotEmpty,
+      );
+      if (!hasSignatures && !hasTaprootScripts) return;
 
       final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
       final builder = bitcoin_base.PsbtBuilder.fromPsbt(psbt);
@@ -1184,13 +1411,61 @@ class BdkWalletDatasource {
       if (txInputs.length != bdkInputs.length) {
         throw const InvalidBitcoinPsbtException();
       }
-      final unsignedTransaction = builder.buildUnsignedTransaction();
-      for (final index in Iterable<int>.generate(txInputs.length)) {
+      for (final (index, input) in bdkInputs.indexed) {
+        if (input.tapScripts.isEmpty) continue;
         final inputInfo = bitcoin_base.PsbtUtils.getPsbtInputInfo(
           psbt: psbt,
           inputIndex: index,
           txInputs: txInputs,
         );
+        _validateTaprootLeafScripts(
+          psbt: psbt,
+          index: index,
+          expectedScriptPubKey: inputInfo.scriptPubKey,
+        );
+      }
+      if (!hasSignatures) return;
+      final unsignedTransaction = builder.buildUnsignedTransaction();
+      for (final index in Iterable<int>.generate(txInputs.length)) {
+        final bdkInput = bdkInputs[index];
+        final isTaproot = _isTaprootPsbtInput(bdkInput, outpoints[index]);
+        if (isTaproot &&
+            (bdkInput.tapScripts.isEmpty || bdkInput.tapKeySig != null)) {
+          _validateTaprootKeyPathSignature(
+            psbt: psbt,
+            index: index,
+            input: bdkInput,
+            txInputs: txInputs,
+            unsignedTransaction: unsignedTransaction,
+          );
+          if (bdkInput.partialSigs.isNotEmpty ||
+              bdkInput.tapScriptSigs.isNotEmpty) {
+            throw const InvalidBitcoinPsbtException();
+          }
+          continue;
+        }
+        if (isTaproot) {
+          _validateTaprootScriptPathSignatures(
+            psbt: psbt,
+            index: index,
+            input: bdkInput,
+            txInputs: txInputs,
+            unsignedTransaction: unsignedTransaction,
+          );
+          if (bdkInput.partialSigs.isNotEmpty) {
+            throw const InvalidBitcoinPsbtException();
+          }
+          continue;
+        }
+        final inputInfo = bitcoin_base.PsbtUtils.getPsbtInputInfo(
+          psbt: psbt,
+          inputIndex: index,
+          txInputs: txInputs,
+        );
+        if (bdkInputs[index].tapKeySig != null ||
+            bdkInputs[index].tapScriptSigs.isNotEmpty) {
+          throw const InvalidBitcoinPsbtException();
+        }
         final digest = bitcoin_base.PsbtUtils.generateInputTransactionDigest(
           index: index,
           unsignedTx: unsignedTransaction,
@@ -1228,7 +1503,156 @@ class BdkWalletDatasource {
         }
       }
     } finally {
+      transaction?.dispose();
       parsedPsbt?.dispose();
+    }
+  }
+
+  void _validateTaprootScriptPathSignatures({
+    required bitcoin_base.Psbt psbt,
+    required int index,
+    required bdk.Input input,
+    required List<bitcoin_base.TxInput> txInputs,
+    required bitcoin_base.BtcTransaction unsignedTransaction,
+  }) {
+    final inputInfo = bitcoin_base.PsbtUtils.getPsbtInputInfo(
+      psbt: psbt,
+      inputIndex: index,
+      txInputs: txInputs,
+    );
+    final scriptPathSignatures =
+        psbt.input.getInputs<bitcoin_base.PsbtInputTaprootScriptSpendSignature>(
+          index,
+          bitcoin_base.PsbtInputTypes.taprootScriptSpentSignature,
+        ) ??
+        const <bitcoin_base.PsbtInputTaprootScriptSpendSignature>[];
+    for (final signature in scriptPathSignatures) {
+      _validateTaprootSignatureSighash(
+        signature.signature,
+        requestedSighash: input.sighashType,
+      );
+      final origin = input.tapKeyOrigins[signature.xOnlyPubKeyHex];
+      if (origin == null ||
+          !origin.tapLeafHashes.any(
+            (hash) => hash.toLowerCase() == hex.encode(signature.leafHash),
+          )) {
+        throw const InvalidBitcoinPsbtException();
+      }
+      try {
+        final digest = bitcoin_base.PsbtUtils.generateInputTransactionDigest(
+          index: index,
+          unsignedTx: unsignedTransaction,
+          params: inputInfo,
+          tapleafHash: signature.leafHash,
+          input: psbt.input,
+          psbt: psbt,
+          sighashType: _taprootSignatureSighash(signature.signature),
+        );
+        final leafScript = digest.leafScript;
+        if (leafScript == null ||
+            !bitcoin_base.PsbtUtils.keyInScript(
+              keyStr: signature.xOnlyPubKeyHex,
+              script: leafScript.leafScript.script,
+              type: inputInfo.type,
+            )) {
+          throw const InvalidBitcoinPsbtException();
+        }
+        final valid = digest.getTaprootScriptSignatures([
+          signature.xOnlyPubKeyHex,
+        ]);
+        if (!valid.any(
+          (candidate) =>
+              _sameBytes(candidate.leafHash, signature.leafHash) &&
+              _sameBytes(candidate.signature, signature.signature),
+        )) {
+          throw const InvalidBitcoinPsbtException();
+        }
+      } on BitcoinPsbtReviewException {
+        rethrow;
+      } on Exception {
+        throw const InvalidBitcoinPsbtException();
+      }
+    }
+  }
+
+  void _validateTaprootKeyPathSignature({
+    required bitcoin_base.Psbt psbt,
+    required int index,
+    required bdk.Input input,
+    required List<bitcoin_base.TxInput> txInputs,
+    required bitcoin_base.BtcTransaction unsignedTransaction,
+  }) {
+    final signatures =
+        psbt.input.getInputs<bitcoin_base.PsbtInputTaprootKeySpendSignature>(
+          index,
+          bitcoin_base.PsbtInputTypes.taprootKeySpentSignature,
+        ) ??
+        const <bitcoin_base.PsbtInputTaprootKeySpendSignature>[];
+    if (signatures.isEmpty) return;
+    if (signatures.length != 1) throw const InvalidBitcoinPsbtException();
+
+    final signature = signatures.single.signature;
+    _validateTaprootSignatureSighash(
+      signature,
+      requestedSighash: input.sighashType,
+    );
+    final internalKeyHex = input.tapInternalKey;
+    if (internalKeyHex == null ||
+        !input.tapKeyOrigins.containsKey(internalKeyHex)) {
+      throw const InvalidBitcoinPsbtException();
+    }
+
+    try {
+      final internalKey = hex.decode(internalKeyHex);
+      final merkleRoot = input.tapMerkleRoot == null
+          ? null
+          : hex.decode(input.tapMerkleRoot!);
+      final scriptPubKeys = <bitcoin_base.Script>[];
+      final amounts = <BigInt>[];
+      for (final (inputIndex, txInput) in txInputs.indexed) {
+        scriptPubKeys.add(
+          bitcoin_base.PsbtUtils.getInputScriptPubKey(
+            psbtInput: psbt.input,
+            input: txInput,
+            index: inputIndex,
+          ),
+        );
+        amounts.add(
+          bitcoin_base.PsbtUtils.getInputAmount(
+            psbt: psbt,
+            input: txInput,
+            index: inputIndex,
+          ),
+        );
+      }
+      final address = bitcoin_base.P2trAddress.fromInternalKey(
+        internalKey: internalKey,
+        merkleRoot: merkleRoot,
+      );
+      if (address.toScriptPubKey() != scriptPubKeys[index]) {
+        throw const InvalidBitcoinPsbtException();
+      }
+      final digest = unsignedTransaction.getTransactionTaprootDigset(
+        txIndex: index,
+        scriptPubKeys: scriptPubKeys,
+        amounts: amounts,
+        sighash: _taprootSignatureSighash(signature),
+      );
+      final schnorrSignature = signature.length == 65
+          ? signature.sublist(0, 64)
+          : signature;
+      final publicKey = bitcoin_base.ECPublic.fromBytes([0x02, ...internalKey]);
+      if (!publicKey.verifyBip340Signature(
+        digest: digest,
+        signature: schnorrSignature,
+        merkleRoot: merkleRoot,
+      )) {
+        throw const InvalidBitcoinPsbtException();
+      }
+    } on BitcoinPsbtReviewException {
+      rethrow;
+    } on Exception {
+      throw const InvalidBitcoinPsbtException();
     }
   }
 
@@ -1640,7 +2064,30 @@ typedef _DescriptorOwnership = ({int index, BitcoinPolicyKeychain keychain});
 
 bdk.Psbt _parsePsbt(String psbtBase64) {
   try {
-    return bdk.Psbt(psbtBase64: normalizeBitcoinPsbt(psbtBase64));
+    final normalized = normalizeBitcoinPsbt(psbtBase64);
+    final psbt = bitcoin_base.Psbt.fromBase64(normalized);
+    final hasMuSig2Fields = psbt.input.entries.any(
+      (entries) => entries.any(
+        (entry) => const {
+          bitcoin_base.PsbtInputTypes.muSig2ParticipantPublicKeys,
+          bitcoin_base.PsbtInputTypes.muSig2PublicNonce,
+          bitcoin_base.PsbtInputTypes.muSig2ParticipantPartialSignature,
+        }.contains(entry.type),
+      ),
+    );
+    final hasMuSig2Output = psbt.output.entries.any(
+      (entries) => entries.any(
+        (entry) =>
+            entry.type ==
+            bitcoin_base.PsbtOutputTypes.muSig2ParticipantPublicKeys,
+      ),
+    );
+    if (hasMuSig2Fields || hasMuSig2Output) {
+      throw const InvalidBitcoinPsbtException();
+    }
+    return bdk.Psbt(psbtBase64: normalized);
+  } on BitcoinPsbtReviewException {
+    rethrow;
   } on Exception {
     throw const InvalidBitcoinPsbtException();
   }
@@ -1813,11 +2260,7 @@ void _rejectFinalizedWalletInputs(
     }
     for (final (index, input) in inputs.indexed) {
       if (!_isFinalizedInput(input)) continue;
-      final utxo = _inputUtxo(
-        input,
-        transactionInputs[index].previousOutput,
-        allowTaprootWitnessUtxo: true,
-      );
+      final utxo = _inputUtxo(input, transactionInputs[index].previousOutput);
       if (wallet.isMine(script: utxo.scriptPubkey)) {
         throw const InvalidBitcoinPsbtException();
       }
@@ -1867,11 +2310,7 @@ void _validateFinalizedInputSignatures(
 }
 
 List<Uint8List>? _inputTaprootSignatures(bdk.TxIn input, bdk.Input psbtInput) {
-  final utxo = _inputUtxo(
-    psbtInput,
-    input.previousOutput,
-    allowTaprootWitnessUtxo: true,
-  );
+  final utxo = _inputUtxo(psbtInput, input.previousOutput);
   if (!_isV1TaprootProgram(utxo.scriptPubkey.toBytes())) return null;
   final witness = input.witness.toList();
   if (witness.length >= 2 &&
@@ -2073,11 +2512,382 @@ bool _isSegwitDescriptor(bdk.DescriptorType type) => switch (type) {
   bdk.DescriptorType.shSortedMulti => false,
 };
 
-bdk.TxOut _inputUtxo(
-  bdk.Input input,
-  bdk.OutPoint previousOutput, {
-  bool allowTaprootWitnessUtxo = false,
+bool _shouldSignWithTapInternalKey(List<bdk.Input> inputs) {
+  var hasKeyPathInput = false;
+  var hasScriptPathInput = false;
+  for (final input in inputs.where((input) => input.tapInternalKey != null)) {
+    final modes = _taprootSpendModes(input);
+    if (modes.length > 1) {
+      throw const BitcoinPsbtUnsupportedSpendModeException();
+    }
+    hasKeyPathInput |= modes.contains(_TaprootSpendMode.keyPath);
+    hasScriptPathInput |= modes.contains(_TaprootSpendMode.scriptPath);
+  }
+  if (hasKeyPathInput && hasScriptPathInput) {
+    // TODO(taproot): Configure internal-key signing per input once bdk-ffi
+    // exposes that control instead of one PSBT-wide signing option.
+    throw const BitcoinPsbtUnsupportedSpendModeException();
+  }
+  return hasKeyPathInput;
+}
+
+enum _TaprootSpendMode { keyPath, scriptPath }
+
+Set<_TaprootSpendMode> _taprootSpendModes(bdk.Input input) {
+  final internalKey = input.tapInternalKey?.toLowerCase();
+  final hasInternalKeyOrigin =
+      internalKey != null &&
+      internalKey != _bip341NumsXOnlyKey &&
+      input.tapKeyOrigins.entries.any(
+        (origin) =>
+            origin.key.toLowerCase() == internalKey &&
+            origin.value.tapLeafHashes.isEmpty,
+      );
+  final hasScriptPathOrigin = input.tapKeyOrigins.values.any(
+    (origin) => origin.tapLeafHashes.isNotEmpty,
+  );
+  return {
+    if (hasInternalKeyOrigin) _TaprootSpendMode.keyPath,
+    if (hasScriptPathOrigin) _TaprootSpendMode.scriptPath,
+  };
+}
+
+void _validateTaprootLeafScripts({
+  required bitcoin_base.Psbt psbt,
+  required int index,
+  required bitcoin_base.Script expectedScriptPubKey,
 }) {
+  final leaves =
+      psbt.input.getInputs<bitcoin_base.PsbtInputTaprootLeafScript>(
+        index,
+        bitcoin_base.PsbtInputTypes.taprootLeafScript,
+      ) ??
+      const <bitcoin_base.PsbtInputTaprootLeafScript>[];
+  for (final leaf in leaves) {
+    try {
+      final control = bitcoin_base.TaprootControlBlock.deserialize(
+        leaf.controllBlock,
+      );
+      if ((control.leafVersion & 0xfe) != leaf.leafVersion) {
+        throw const InvalidBitcoinPsbtException();
+      }
+      var merkleRoot = leaf.leafScript.hash();
+      for (var offset = 0; offset < control.merklePath.length; offset += 32) {
+        merkleRoot = bitcoin_base.TaprootUtils.tapbranchTaggedHash(
+          merkleRoot,
+          control.merklePath.sublist(offset, offset + 32),
+        );
+      }
+      final tweakedKey = bitcoin_base.TaprootUtils.tweakPublicKey(
+        control.xOnly,
+        merkleRoot: merkleRoot,
+      ).toBytes();
+      final expected = bitcoin_base.P2trAddress.fromInternalKey(
+        internalKey: control.xOnly,
+        merkleRoot: merkleRoot,
+      ).toScriptPubKey();
+      if ((tweakedKey.first & 1) != (control.leafVersion & 1) ||
+          expected != expectedScriptPubKey) {
+        throw const InvalidBitcoinPsbtException();
+      }
+    } on BitcoinPsbtReviewException {
+      rethrow;
+    } on Exception {
+      throw const InvalidBitcoinPsbtException();
+    }
+  }
+}
+
+String _tapLeafHash(bdk.TapScriptEntry entry) {
+  final script = bitcoin_base.Script.deserialize(bytes: entry.script.toBytes());
+  return hex.encode(
+    bitcoin_base.TaprootUtils.tapleafTaggedHash(
+      script: script,
+      leafVersion: entry.leafVersion,
+    ),
+  );
+}
+
+Set<String> _tapScriptIdentifiers(bdk.Input input) => {
+  for (final entry in input.tapScripts.entries)
+    '${hex.encode(entry.key.internalKey)}:'
+        '${entry.key.merkleBranch.map((hash) => hash.toLowerCase()).join(',')}:'
+        '${entry.key.outputKeyParity}:${entry.key.leafVersion}:'
+        '${_tapLeafHash(entry.value)}',
+};
+
+const _bip341NumsXOnlyKey =
+    '50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0';
+
+String _removeFixedBip341NumsKeyOrigins(
+  String psbtBase64, {
+  required List<bdk.Input> inputs,
+  required List<bdk.Output> outputs,
+}) {
+  final affectedInputIndexes = {
+    for (final (index, input) in inputs.indexed)
+      if (input.tapInternalKey?.toLowerCase() == _bip341NumsXOnlyKey &&
+          input.tapKeyOrigins.entries.any(
+            (origin) =>
+                origin.key.toLowerCase() == _bip341NumsXOnlyKey &&
+                origin.value.tapLeafHashes.isEmpty,
+          ))
+        index,
+  };
+  final affectedOutputIndexes = {
+    for (final (index, output) in outputs.indexed)
+      if (output.tapInternalKey?.toLowerCase() == _bip341NumsXOnlyKey &&
+          output.tapKeyOrigins.entries.any(
+            (origin) =>
+                origin.key.toLowerCase() == _bip341NumsXOnlyKey &&
+                origin.value.tapLeafHashes.isEmpty,
+          ))
+        index,
+  };
+  if (affectedInputIndexes.isEmpty && affectedOutputIndexes.isEmpty) {
+    return psbtBase64;
+  }
+
+  // rust-miniscript emits a synthetic Taproot key origin for raw no-origin
+  // keys (rust-bitcoin/rust-miniscript#998). A fixed BIP341 NUMS key has no
+  // signing derivation, so omit only that metadata entry.
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  for (final index in affectedInputIndexes) {
+    final entries = psbt.input.entries[index].where((entry) {
+      if (entry
+          case final bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath
+              derivation) {
+        return derivation.leavesHashes.isNotEmpty ||
+            hex.encode(derivation.xOnlyPubKey) != _bip341NumsXOnlyKey;
+      }
+      return true;
+    }).toList();
+    psbt.input.replaceInput(index, entries);
+  }
+  for (final index in affectedOutputIndexes) {
+    final entries = psbt.output.entries[index].where((entry) {
+      if (entry
+          case final bitcoin_base.PsbtOutputTaprootKeyBip32DerivationPath
+              derivation) {
+        return derivation.leavesHashes.isNotEmpty ||
+            hex.encode(derivation.xOnlyPubKey) != _bip341NumsXOnlyKey;
+      }
+      return true;
+    }).toList();
+    psbt.output.replaceOutput(index, entries);
+  }
+  return psbt.toBase64();
+}
+
+String _restoreSelectedTaprootMetadata({
+  required String originalPsbtBase64,
+  required String signedPsbtBase64,
+}) {
+  final original = bitcoin_base.Psbt.fromBase64(originalPsbtBase64);
+  final signed = bitcoin_base.Psbt.fromBase64(signedPsbtBase64);
+  if (original.input.entries.length != signed.input.entries.length) {
+    throw StateError('Signed PSBT input count changed');
+  }
+  for (final (index, originalEntries) in original.input.entries.indexed) {
+    final selectedMetadata = originalEntries.where(
+      (entry) =>
+          entry.type == bitcoin_base.PsbtInputTypes.taprootLeafScript ||
+          entry.type == bitcoin_base.PsbtInputTypes.taprootBip32Derivation,
+    );
+    final signedEntries =
+        signed.input.entries[index]
+            .where(
+              (entry) =>
+                  entry.type != bitcoin_base.PsbtInputTypes.taprootLeafScript &&
+                  entry.type !=
+                      bitcoin_base.PsbtInputTypes.taprootBip32Derivation,
+            )
+            .toList()
+          ..addAll(selectedMetadata);
+    signed.input.replaceInput(index, signedEntries);
+  }
+  return signed.toBase64();
+}
+
+String _retainSelectedTaprootSpendPaths(
+  String psbtBase64, {
+  required List<bdk.Input> inputs,
+  required List<bdk.KeychainKind> inputKeychains,
+  required ({
+    List<WalletDescriptorKeyModel> external,
+    List<WalletDescriptorKeyModel> internal,
+  })
+  requiredDescriptorKeys,
+}) {
+  if (inputs.length != inputKeychains.length) {
+    throw StateError('Taproot input keychains do not match the PSBT');
+  }
+  final selections = [
+    for (final (index, input) in inputs.indexed)
+      _selectedTaprootSpendPath(
+        input,
+        keychain: inputKeychains[index] == bdk.KeychainKind.external_
+            ? BitcoinPolicyKeychainModel.external
+            : BitcoinPolicyKeychainModel.internal,
+        requiredKeys: inputKeychains[index] == bdk.KeychainKind.external_
+            ? requiredDescriptorKeys.external
+            : requiredDescriptorKeys.internal,
+      ),
+  ];
+  if (selections.every((selection) => !selection.shouldFilterScripts)) {
+    return psbtBase64;
+  }
+
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  for (final (index, selection) in selections.indexed) {
+    if (!selection.shouldFilterScripts) continue;
+    final leafHash = selection.leafHash;
+    final keychain = inputKeychains[index] == bdk.KeychainKind.external_
+        ? BitcoinPolicyKeychainModel.external
+        : BitcoinPolicyKeychainModel.internal;
+    final requiredKeys = inputKeychains[index] == bdk.KeychainKind.external_
+        ? requiredDescriptorKeys.external
+        : requiredDescriptorKeys.internal;
+    final entries = <bitcoin_base.PsbtInputData>[];
+    for (final entry in psbt.input.entries[index]) {
+      if (entry.type == bitcoin_base.PsbtInputTypes.taprootLeafScript) {
+        continue;
+      }
+      if (entry
+          case final bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath
+              derivation) {
+        if (leafHash == null) {
+          if (hex.encode(derivation.xOnlyPubKey) ==
+              inputs[index].tapInternalKey?.toLowerCase()) {
+            entries.add(
+              bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath(
+                xOnlyPubKey: derivation.xOnlyPubKey,
+                leavesHashes: const [],
+                fingerprint: derivation.fingerprint,
+                indexes: derivation.indexes,
+              ),
+            );
+          }
+          continue;
+        }
+        final matchingLeafHashes = derivation.leavesHashes
+            .where((hash) => hex.encode(hash) == leafHash)
+            .toList();
+        final origin =
+            inputs[index].tapKeyOrigins[hex.encode(derivation.xOnlyPubKey)];
+        if (matchingLeafHashes.isNotEmpty &&
+            origin != null &&
+            requiredKeys.any(
+              (key) => _tapOriginMatchesDescriptorKey(
+                MapEntry(hex.encode(derivation.xOnlyPubKey), origin),
+                key,
+                keychain: keychain,
+              ),
+            )) {
+          entries.add(
+            bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath(
+              xOnlyPubKey: derivation.xOnlyPubKey,
+              leavesHashes: matchingLeafHashes,
+              fingerprint: derivation.fingerprint,
+              indexes: derivation.indexes,
+            ),
+          );
+        }
+        continue;
+      }
+      entries.add(entry);
+    }
+    if (leafHash != null) {
+      final leaves =
+          psbt.input.getInputs<bitcoin_base.PsbtInputTaprootLeafScript>(
+            index,
+            bitcoin_base.PsbtInputTypes.taprootLeafScript,
+          ) ??
+          const <bitcoin_base.PsbtInputTaprootLeafScript>[];
+      final selected = leaves.singleWhere(
+        (leaf) => hex.encode(leaf.leafScript.hash()) == leafHash,
+        orElse: () => throw StateError('Selected Taproot leaf is missing'),
+      );
+      entries.add(selected);
+    }
+    psbt.input.replaceInput(index, entries);
+  }
+  return psbt.toBase64();
+}
+
+({bool shouldFilterScripts, String? leafHash}) _selectedTaprootSpendPath(
+  bdk.Input input, {
+  required BitcoinPolicyKeychainModel keychain,
+  required List<WalletDescriptorKeyModel> requiredKeys,
+}) {
+  if (input.tapInternalKey == null || input.tapScripts.isEmpty) {
+    return (shouldFilterScripts: false, leafHash: null);
+  }
+  if (requiredKeys.isEmpty) {
+    if (input.tapScripts.length == 1) {
+      return (
+        shouldFilterScripts: true,
+        leafHash: _tapLeafHash(input.tapScripts.values.single),
+      );
+    }
+    // TODO(taproot): Map keyless policy nodes to exact TapLeafHash values once
+    // bdk-ffi exposes policy-to-TapLeafHash mapping.
+    throw const UnsupportedBitcoinPolicyPathException();
+  }
+
+  final candidates = <String>{};
+  for (final entry in input.tapScripts.entries) {
+    final leafHash = _tapLeafHash(entry.value);
+    final containsEveryRequiredKey = requiredKeys.every(
+      (key) => input.tapKeyOrigins.entries.any(
+        (origin) =>
+            origin.value.tapLeafHashes.any(
+              (hash) => hash.toLowerCase() == leafHash,
+            ) &&
+            _tapOriginMatchesDescriptorKey(origin, key, keychain: keychain),
+      ),
+    );
+    if (containsEveryRequiredKey) candidates.add(leafHash);
+  }
+
+  final internalOrigin = input.tapKeyOrigins.entries.where(
+    (origin) => origin.key.toLowerCase() == input.tapInternalKey!.toLowerCase(),
+  );
+  final isKeyPath =
+      internalOrigin.length == 1 &&
+      requiredKeys.every(
+        (key) => _tapOriginMatchesDescriptorKey(
+          internalOrigin.single,
+          key,
+          keychain: keychain,
+        ),
+      );
+  if (isKeyPath && candidates.isEmpty) {
+    return (shouldFilterScripts: true, leafHash: null);
+  }
+  if (!isKeyPath && candidates.length == 1) {
+    return (shouldFilterScripts: true, leafHash: candidates.single);
+  }
+  // TODO(taproot): Support separate Tapleaves using the same descriptor keys
+  // once bdk-ffi exposes exact policy-to-TapLeafHash mapping and signing for a
+  // specific leaf. Until then, reject these paths to avoid signing the wrong one.
+  throw const UnsupportedBitcoinPolicyPathException();
+}
+
+bool _tapOriginMatchesDescriptorKey(
+  MapEntry<String, bdk.TapKeyOrigin> origin,
+  WalletDescriptorKeyModel key, {
+  required BitcoinPolicyKeychainModel keychain,
+}) => walletDescriptorKeyMatches(
+  key: key,
+  publicKey: origin.key,
+  fingerprint: origin.value.keySource.fingerprint,
+  derivationPath: origin.value.keySource.path.toString(),
+  keychain: keychain,
+  isXOnly: true,
+);
+
+bdk.TxOut _inputUtxo(bdk.Input input, bdk.OutPoint previousOutput) {
   final witnessUtxo = input.witnessUtxo;
   final previousTransaction = input.nonWitnessUtxo;
   if (previousTransaction != null) {
@@ -2105,13 +2915,16 @@ bdk.TxOut _inputUtxo(
     throw const BitcoinPsbtMissingUtxoException();
   }
   final script = witnessUtxo.scriptPubkey.toBytes();
-  if (!_isV0WitnessProgram(script) &&
-      !_isNestedSegwitInput(input, script) &&
-      !(allowTaprootWitnessUtxo && _isV1TaprootProgram(script))) {
+  if (!_isWitnessProgram(script) && !_isNestedSegwitInput(input, script)) {
     throw const BitcoinPsbtMissingUtxoException();
   }
   return witnessUtxo;
 }
+
+bool _isWitnessProgram(List<int> script) =>
+    script.length >= 4 &&
+    (script.first == 0 || script.first == 0x51) &&
+    script[1] + 2 == script.length;
 
 bool _isV0WitnessProgram(List<int> script) =>
     script.length >= 4 &&
@@ -2145,13 +2958,51 @@ bool _isNestedSegwitInput(bdk.Input input, List<int> scriptPubkey) {
   return _sameBytes(redeemHash, scriptPubkey.sublist(2, 22));
 }
 
-void _validateSighash(String? sighashType) {
+void _validateSighash(String? sighashType, {required bool isTaproot}) {
   if (sighashType == null) return;
   final normalized = sighashType.toUpperCase().replaceFirst('SIGHASH_', '');
-  if (normalized != 'ALL' && normalized != '1') {
+  final supported = isTaproot
+      ? normalized == 'DEFAULT' ||
+            normalized == '0' ||
+            normalized == 'ALL' ||
+            normalized == '1'
+      : normalized == 'ALL' || normalized == '1';
+  if (!supported) {
     throw const BitcoinPsbtUnsupportedSighashException();
   }
 }
+
+bool _isTaprootPsbtInput(bdk.Input input, bdk.OutPoint previousOutput) {
+  final script = _inputUtxo(input, previousOutput).scriptPubkey.toBytes();
+  return script.length == 34 && script[0] == 0x51 && script[1] == 0x20;
+}
+
+void _validateTaprootSignatureSighash(
+  List<int> signature, {
+  String? requestedSighash,
+}) {
+  final signatureSighash = switch (signature.length) {
+    64 => 0,
+    65 when signature.last == 0x01 => 1,
+    _ => throw const BitcoinPsbtUnsupportedSighashException(),
+  };
+  final requested = _taprootRequestedSighash(requestedSighash);
+  if (requested != null && signatureSighash != requested) {
+    throw const BitcoinPsbtUnsupportedSighashException();
+  }
+}
+
+int? _taprootRequestedSighash(String? sighashType) {
+  if (sighashType == null) return null;
+  return switch (sighashType.toUpperCase().replaceFirst('SIGHASH_', '')) {
+    'DEFAULT' || '0' => 0,
+    'ALL' || '1' => 1,
+    _ => throw const BitcoinPsbtUnsupportedSighashException(),
+  };
+}
+
+int _taprootSignatureSighash(List<int> signature) =>
+    signature.length == 64 ? 0 : signature.last;
 
 _DescriptorOwnership? _descriptorOwnership(
   bdk.Wallet wallet, {

--- a/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart
@@ -42,13 +42,23 @@ class BitcoinPsbtReviewMapper {
     required List<WalletDescriptorKeyModel> descriptorKeys,
     required Set<String> localSignerIds,
   }) {
+    final relevantOriginSources = input.originKeySources.where(
+      (source) =>
+          source.tapLeafHash == null ||
+          input.tapLeafHashes.contains(source.tapLeafHash),
+    );
     final originKeyIds = _resolveKeyIds(
-      input.originKeySources,
+      relevantOriginSources,
       descriptorKeys,
       keychain: input.keychain,
     );
+    final relevantSignedSources = input.signedKeySources.where(
+      (source) =>
+          source.tapLeafHash == null ||
+          input.tapLeafHashes.contains(source.tapLeafHash),
+    );
     final signedKeyIds = _resolveKeyIds(
-      input.signedKeySources,
+      relevantSignedSources,
       descriptorKeys,
       keychain: input.keychain,
     );
@@ -74,7 +84,7 @@ class BitcoinPsbtReviewMapper {
   }
 
   static Set<String> _resolveKeyIds(
-    List<BitcoinPsbtKeySourceRecord> sources,
+    Iterable<BitcoinPsbtKeySourceRecord> sources,
     List<WalletDescriptorKeyModel> keys, {
     required BitcoinPolicyKeychainModel? keychain,
   }) => Set.unmodifiable({
@@ -86,6 +96,7 @@ class BitcoinPsbtReviewMapper {
           fingerprint: source.fingerprint,
           derivationPath: source.derivationPath,
           keychain: keychain,
+          isXOnly: source.isXOnly,
         ))
           key.id,
   });

--- a/lib/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart
+++ b/lib/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart
@@ -11,16 +11,22 @@ class BitcoinWalletPolicyMapper {
     bdk.Policy? externalKeyIdentities,
     bdk.Policy? internalKeyIdentities,
     required List<WalletDescriptorKeyModel> descriptorKeys,
+    Set<String> unspendablePolicyKeyIdentifiers = const {},
+    bool isTaproot = false,
   }) => BitcoinWalletPolicyModel(
     external: _spendingPolicy(
       external,
       externalKeyIdentities ?? external,
       _PolicyKeyResolver(descriptorKeys),
+      unspendablePolicyKeyIdentifiers,
+      isTaproot: isTaproot,
     ),
     internal: _spendingPolicy(
       internal,
       internalKeyIdentities ?? internal,
       _PolicyKeyResolver(descriptorKeys),
+      unspendablePolicyKeyIdentifiers,
+      isTaproot: isTaproot,
     ),
   );
 
@@ -34,10 +40,62 @@ class BitcoinWalletPolicyMapper {
     bdk.Policy policy,
     bdk.Policy keyIdentities,
     _PolicyKeyResolver keys,
-  ) => BitcoinSpendingPolicyModel(
-    root: _node(policy, keyIdentities, keys),
-    requiresPath: policy.requiresPath(),
-  );
+    Set<String> unspendablePolicyKeyIdentifiers, {
+    required bool isTaproot,
+  }) {
+    final identifiers = unspendablePolicyKeyIdentifiers
+        .map((identifier) => identifier.toLowerCase())
+        .toSet();
+    var root = _withoutUnspendableInternalKey(
+      _node(policy, keyIdentities, keys),
+      identifiers,
+    );
+    final requiresTaprootChoice =
+        isTaproot &&
+        root.type == BitcoinPolicyNodeModelType.threshold &&
+        root.threshold == 1 &&
+        root.children.length > 1;
+    if (requiresTaprootChoice) {
+      root = BitcoinPolicyNodeModel(
+        id: root.id,
+        type: root.type,
+        threshold: root.threshold,
+        requiresPath: true,
+        children: root.children,
+        pathChildIndices: root.pathChildIndices,
+      );
+    }
+    return BitcoinSpendingPolicyModel(
+      root: root,
+      requiresPath: policy.requiresPath() || requiresTaprootChoice,
+    );
+  }
+
+  static BitcoinPolicyNodeModel _withoutUnspendableInternalKey(
+    BitcoinPolicyNodeModel root,
+    Set<String> identifiers,
+  ) {
+    if (identifiers.isEmpty ||
+        root.type != BitcoinPolicyNodeModelType.threshold ||
+        root.threshold != 1) {
+      return root;
+    }
+    final spendable = [
+      for (final (index, child) in root.children.indexed)
+        if (child.type != BitcoinPolicyNodeModelType.signature ||
+            !identifiers.contains(child.key?.value.toLowerCase()))
+          (child: child, pathIndex: root.pathChildIndices[index]),
+    ];
+    if (spendable.length == root.children.length) return root;
+    return BitcoinPolicyNodeModel(
+      id: root.id,
+      type: root.type,
+      threshold: spendable.length == 1 ? 1 : root.threshold,
+      requiresPath: true,
+      children: spendable.map((entry) => entry.child).toList(),
+      pathChildIndices: spendable.map((entry) => entry.pathIndex).toList(),
+    );
+  }
 
   static BitcoinPolicyNodeModel _node(
     bdk.Policy policy,
@@ -271,6 +329,7 @@ class BitcoinWalletPolicyMapper {
           threshold: model.threshold!,
           requiresPath: model.requiresPath,
           children: model.children.map(_nodeEntity).toList(),
+          pathChildIndices: model.pathChildIndices,
         ),
       };
 
@@ -312,7 +371,13 @@ final class _PolicyKeyResolver {
       ifAbsent: () => 0,
     );
     if (offset >= matches.length) {
-      throw StateError('Policy contains an unmatched descriptor key');
+      if (matches.length == 1) {
+        return BitcoinPolicyKeyModel(
+          type: BitcoinPolicyKeyModelType.descriptorKey,
+          value: matches.single.id,
+        );
+      }
+      throw const UnsupportedBitcoinPolicyPathException();
     }
     final match = matches[offset];
     return BitcoinPolicyKeyModel(

--- a/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_psbt_review_model.dart
@@ -4,6 +4,8 @@ typedef BitcoinPsbtKeySourceRecord = ({
   String publicKey,
   String? fingerprint,
   String? derivationPath,
+  bool isXOnly,
+  String? tapLeafHash,
 });
 
 typedef BitcoinPsbtInputReviewRecord = ({
@@ -12,6 +14,7 @@ typedef BitcoinPsbtInputReviewRecord = ({
   List<BitcoinPsbtKeySourceRecord> originKeySources,
   Set<String> satisfiedPreimageKeys,
   List<BitcoinPsbtKeySourceRecord> signedKeySources,
+  Set<String> tapLeafHashes,
   String outpoint,
   int sequence,
 });

--- a/lib/core/wallet/data/models/bitcoin_wallet_policy_model.dart
+++ b/lib/core/wallet/data/models/bitcoin_wallet_policy_model.dart
@@ -34,6 +34,7 @@ final class BitcoinPolicyNodeModel {
   final int? threshold;
   final bool requiresPath;
   final List<BitcoinPolicyNodeModel> children;
+  final List<int> pathChildIndices;
 
   BitcoinPolicyNodeModel({
     required this.id,
@@ -44,7 +45,15 @@ final class BitcoinPolicyNodeModel {
     this.threshold,
     this.requiresPath = false,
     List<BitcoinPolicyNodeModel> children = const [],
-  }) : children = List.unmodifiable(children);
+    List<int>? pathChildIndices,
+  }) : children = List.unmodifiable(children),
+       pathChildIndices = List.unmodifiable(
+         pathChildIndices ?? List.generate(children.length, (index) => index),
+       ) {
+    if (this.pathChildIndices.length != children.length) {
+      throw ArgumentError.value(pathChildIndices, 'pathChildIndices');
+    }
+  }
 }
 
 final class BitcoinSpendingPolicyModel {

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -144,13 +144,19 @@ class BitcoinWalletRepository implements BitcoinSendPort, BitcoinSigningPort {
     final descriptorKeys = metadata.signers
         .expand((signer) => signer.descriptorKeys)
         .toList();
-    return [
-      for (final descriptorKey in descriptorKeys)
-        if (policyKeys.any(
-          (policyKey) => policyKey.matches(descriptorKey.toEntity()),
-        ))
-          descriptorKey,
-    ];
+    final matched = <WalletDescriptorKeyModel>[];
+    for (final policyKey in policyKeys) {
+      final matches = descriptorKeys.where(
+        (key) => policyKey.matches(key.toEntity()),
+      );
+      if (matches.isEmpty) {
+        throw StateError('Selected policy key does not match the descriptor');
+      }
+      for (final match in matches) {
+        if (!matched.any((key) => key.id == match.id)) matched.add(match);
+      }
+    }
+    return matched;
   }
 
   @override
@@ -705,4 +711,6 @@ BitcoinSigningFailureKind _signingFailureKind(
   BitcoinPsbtFrozenUtxoException() => BitcoinSigningFailureKind.frozenUtxo,
   BitcoinPsbtUnsupportedSighashException() =>
     BitcoinSigningFailureKind.unsupportedSighash,
+  BitcoinPsbtUnsupportedSpendModeException() =>
+    BitcoinSigningFailureKind.unsupportedSpendMode,
 };

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -174,6 +174,24 @@ class WalletRepository
   }
 
   @override
+  ({List<WalletDescriptorKey> policyKeys, bool hasUnspendablePolicyKey})
+  analyzeBitcoinPolicyDescriptor({
+    required String descriptor,
+    required Network network,
+  }) {
+    _requireBitcoinNetwork(network);
+    final parsed = _bdkWallet.parsePublicTwoPathDescriptor(
+      descriptor: descriptor,
+      isTestnet: network.isTestnet,
+    );
+    return (
+      policyKeys: _descriptorKeys(parsed.policyKeys),
+      hasUnspendablePolicyKey:
+          parsed.unspendablePolicyKeyIdentifiers.isNotEmpty,
+    );
+  }
+
+  @override
   Future<Wallet> importDescriptor({
     required String descriptor,
     required Network network,

--- a/lib/core/wallet/domain/bitcoin_descriptor_port.dart
+++ b/lib/core/wallet/domain/bitcoin_descriptor_port.dart
@@ -14,6 +14,12 @@ abstract interface class BitcoinDescriptorPort {
     required Network network,
   });
 
+  ({List<WalletDescriptorKey> policyKeys, bool hasUnspendablePolicyKey})
+  analyzeBitcoinPolicyDescriptor({
+    required String descriptor,
+    required Network network,
+  });
+
   Future<Wallet> importDescriptor({
     required String descriptor,
     required Network network,

--- a/lib/core/wallet/domain/bitcoin_descriptor_port.dart
+++ b/lib/core/wallet/domain/bitcoin_descriptor_port.dart
@@ -23,11 +23,6 @@ abstract interface class BitcoinDescriptorPort {
   });
 }
 
-final class UnsupportedTaprootDescriptorException extends FormatException {
-  const UnsupportedTaprootDescriptorException()
-    : super('Taproot descriptors are not supported');
-}
-
 final class UnsupportedFixedPublicKeyDescriptorException
     extends FormatException {
   const UnsupportedFixedPublicKeyDescriptorException()

--- a/lib/core/wallet/domain/bitcoin_psbt_review_exception.dart
+++ b/lib/core/wallet/domain/bitcoin_psbt_review_exception.dart
@@ -28,3 +28,8 @@ final class BitcoinPsbtUnsupportedSighashException
     extends BitcoinPsbtReviewException {
   const BitcoinPsbtUnsupportedSighashException();
 }
+
+final class BitcoinPsbtUnsupportedSpendModeException
+    extends BitcoinPsbtReviewException {
+  const BitcoinPsbtUnsupportedSpendModeException();
+}

--- a/lib/core/wallet/domain/entities/bitcoin_policy_node.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_policy_node.dart
@@ -133,16 +133,28 @@ final class BitcoinThresholdPolicyNode extends BitcoinPolicyNode {
   final int threshold;
   final List<BitcoinPolicyNode> children;
   final bool requiresPath;
+  final List<int> pathChildIndices;
 
   BitcoinThresholdPolicyNode({
     required super.id,
     required this.threshold,
     required List<BitcoinPolicyNode> children,
     this.requiresPath = false,
-  }) : children = List.unmodifiable(children) {
+    List<int>? pathChildIndices,
+  }) : children = List.unmodifiable(children),
+       pathChildIndices = List.unmodifiable(
+         pathChildIndices ?? List.generate(children.length, (index) => index),
+       ) {
     if (children.isEmpty) throw ArgumentError.value(children, 'children');
     if (threshold < 1 || threshold > children.length) {
       throw ArgumentError.value(threshold, 'threshold');
+    }
+    if (this.pathChildIndices.length != children.length) {
+      throw ArgumentError.value(pathChildIndices, 'pathChildIndices');
+    }
+    if (this.pathChildIndices.any((index) => index < 0) ||
+        this.pathChildIndices.toSet().length != children.length) {
+      throw ArgumentError.value(pathChildIndices, 'pathChildIndices');
     }
   }
 

--- a/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
+++ b/lib/core/wallet/domain/entities/bitcoin_wallet_policy.dart
@@ -840,7 +840,11 @@ void _collectPath({
   final List<int> childIndices = node.requiresSelection
       ? selection.choiceFor(keychain: keychain, nodePath: nodePath)!
       : List<int>.generate(node.children.length, (index) => index);
-  if (node.requiresSelection) path[node.id] = childIndices;
+  if (node.requiresPath) {
+    path[node.id] = [
+      for (final index in childIndices) node.pathChildIndices[index],
+    ];
+  }
   for (final index in childIndices) {
     _collectPath(
       node: node.children[index],

--- a/lib/core/wallet/domain/entities/wallet.dart
+++ b/lib/core/wallet/domain/entities/wallet.dart
@@ -160,6 +160,7 @@ abstract class Wallet with _$Wallet {
     if (isLiquid) {
       return 'Confidential Segwit';
     }
+    if (publicDescriptor.toLowerCase().startsWith('tr(')) return 'Taproot';
 
     return switch (scriptType) {
       ScriptType.bip84 => 'Native Segwit',

--- a/lib/core/wallet/domain/entities/wallet.dart
+++ b/lib/core/wallet/domain/entities/wallet.dart
@@ -160,8 +160,6 @@ abstract class Wallet with _$Wallet {
     if (isLiquid) {
       return 'Confidential Segwit';
     }
-    if (publicDescriptor.toLowerCase().startsWith('tr(')) return 'Taproot';
-
     return switch (scriptType) {
       ScriptType.bip84 => 'Native Segwit',
       ScriptType.bip49 => 'Nested Segwit',
@@ -224,6 +222,9 @@ abstract class Wallet with _$Wallet {
     if (!isBitcoin || descriptorKeys.isEmpty) return false;
     final descriptor = publicDescriptor.split('#').first.toLowerCase();
     if (descriptor.startsWith('wsh(')) return true;
+    if (descriptor.startsWith('tr(')) {
+      return _hasExtendedTaprootInternalKey(descriptor);
+    }
     return descriptor.startsWith('sh(wsh(sortedmulti(') ||
         descriptor.startsWith('sh(wsh(multi(');
   }
@@ -232,6 +233,9 @@ abstract class Wallet with _$Wallet {
     if (!isBitcoin || descriptorKeys.isEmpty) return false;
     final descriptor = publicDescriptor.split('#').first.toLowerCase();
     if (_containsMiniscriptHashlock(descriptor)) return false;
+    if (descriptor.startsWith('tr(')) {
+      return _hasExtendedTaprootInternalKey(descriptor);
+    }
     return descriptor.startsWith('wsh(') ||
         descriptor.startsWith('sh(wsh(sortedmulti(');
   }
@@ -260,6 +264,31 @@ abstract class Wallet with _$Wallet {
         supportsWalletPolicySigner(signer),
   );
 
+  bool get isTaprootKeyPathOnly {
+    final descriptor = publicDescriptor.split('#').first.toLowerCase();
+    return descriptor.startsWith('tr(') && !descriptor.contains(',');
+  }
+
+  bool supportsQrSigningFor(WalletSigner signer) {
+    final device = signer.signerDevice;
+    if (device == null || device.supportedQrType == QrType.none) return false;
+    final descriptor = publicDescriptor.split('#').first.toLowerCase();
+    if (!descriptor.startsWith('tr(')) return true;
+    return switch (device) {
+      SignerDeviceEntity.krux || SignerDeviceEntity.specter => true,
+      SignerDeviceEntity.passport => isTaprootKeyPathOnly,
+      _ => false,
+    };
+  }
+
+  bool supportsDevicePsbtFlowFor(WalletSigner signer) {
+    if (signer.signerDevice == SignerDeviceEntity.coldcardMk4) {
+      final descriptor = publicDescriptor.split('#').first.toLowerCase();
+      return !descriptor.startsWith('tr(');
+    }
+    return supportsQrSigningFor(signer);
+  }
+
   static bool _haveWalletPolicyKeyOrigins(Iterable<WalletDescriptorKey> keys) =>
       keys.isNotEmpty &&
       keys.every(
@@ -268,6 +297,15 @@ abstract class Wallet with _$Wallet {
             key.xpub.isNotEmpty &&
             key.derivationPath != null,
       );
+
+  static bool _hasExtendedTaprootInternalKey(String descriptor) {
+    final separator = descriptor.indexOf(',');
+    final close = descriptor.indexOf(')');
+    final end = separator < 0 ? close : separator;
+    if (end <= 3) return false;
+    final internalKey = descriptor.substring(3, end);
+    return internalKey.contains('xpub') || internalKey.contains('tpub');
+  }
 
   static bool _containsMiniscriptHashlock(String descriptor) =>
       descriptor.contains('sha256(') ||
@@ -282,7 +320,6 @@ abstract class Wallet with _$Wallet {
     final descriptorKey = singleDescriptorKey;
     if (descriptorKey != null) return descriptorKey.derivationPath;
     if (descriptorKeys.isNotEmpty) return null;
-
     // Find the content between [ and ]
     final startBracket = publicDescriptor.indexOf('[');
     final endBracket = publicDescriptor.indexOf(']');

--- a/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
 import 'package:primitives/primitives.dart' show Err, Ok, Outpoint;
 
@@ -81,6 +82,8 @@ class PrepareBitcoinSendUsecase {
     } on InsufficientFundsException {
       rethrow;
     } on BitcoinCoinSelectionException {
+      rethrow;
+    } on UnsupportedBitcoinPolicyPathException {
       rethrow;
     } catch (e) {
       throw PrepareBitcoinSendException(e.toString());

--- a/lib/core/wallet/domain/wallet_failure.dart
+++ b/lib/core/wallet/domain/wallet_failure.dart
@@ -15,6 +15,7 @@ enum BitcoinSigningFailureKind {
   missingUtxo,
   frozenUtxo,
   unsupportedSighash,
+  unsupportedSpendMode,
   unsupportedPolicyPath,
   incomplete,
   unexpected,

--- a/lib/features/import_watch_only_wallet/domain/import_watch_only_failure.dart
+++ b/lib/features/import_watch_only_wallet/domain/import_watch_only_failure.dart
@@ -20,10 +20,6 @@ final class InvalidFormatFailure extends ImportWatchOnlyFailure {
   const InvalidFormatFailure();
 }
 
-final class TaprootUnsupportedFailure extends ImportWatchOnlyFailure {
-  const TaprootUnsupportedFailure();
-}
-
 final class FixedPublicKeyUnsupportedFailure extends ImportWatchOnlyFailure {
   const FixedPublicKeyUnsupportedFailure();
 }

--- a/lib/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart
+++ b/lib/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart
@@ -25,9 +25,6 @@ class ImportWatchOnlyDescriptorUsecase {
         signers: watchOnlyDescriptor.signers,
       );
       return Ok(wallet);
-    } on UnsupportedTaprootDescriptorException catch (_, st) {
-      log.warning('Taproot descriptor import is not supported', trace: st);
-      return const Err(TaprootUnsupportedFailure());
     } on Exception catch (_, st) {
       // Descriptor parser errors can contain key material.
       log.warning('Failed to import watch-only descriptor', trace: st);

--- a/lib/features/import_watch_only_wallet/parse_watch_only_input_usecase.dart
+++ b/lib/features/import_watch_only_wallet/parse_watch_only_input_usecase.dart
@@ -66,9 +66,6 @@ class ParseWatchOnlyInputUsecase {
         normalizedInput,
         preferredNetwork: network,
       );
-    } on UnsupportedTaprootDescriptorException catch (_, st) {
-      log.warning('Taproot descriptor import is not supported', trace: st);
-      return const Err(TaprootUnsupportedFailure());
     } on UnsupportedFixedPublicKeyDescriptorException catch (_, st) {
       log.warning(
         'Fixed public key descriptor import is not supported',

--- a/lib/features/import_watch_only_wallet/presentation/import_watch_only_failure_l10n.dart
+++ b/lib/features/import_watch_only_wallet/presentation/import_watch_only_failure_l10n.dart
@@ -11,8 +11,6 @@ extension ImportWatchOnlyFailureL10n on ImportWatchOnlyFailure {
       context.loc.importWatchOnlyErrorNoWalletSelected,
     LabelRequiredFailure() => context.loc.importWatchOnlyErrorLabelRequired,
     InvalidFormatFailure() => context.loc.importWatchOnlyErrorInvalidFormat,
-    TaprootUnsupportedFailure() =>
-      context.loc.importWatchOnlyErrorTaprootUnsupported,
     FixedPublicKeyUnsupportedFailure() =>
       context.loc.importWatchOnlyErrorFixedPublicKeyUnsupported,
     SignerOriginRequiredFailure() =>

--- a/lib/features/import_watch_only_wallet/watch_only_input_parser.dart
+++ b/lib/features/import_watch_only_wallet/watch_only_input_parser.dart
@@ -74,8 +74,6 @@ class WatchOnlyInputParser {
 
     try {
       return parse(preferredNetwork);
-    } on UnsupportedTaprootDescriptorException {
-      rethrow;
     } on UnsupportedFixedPublicKeyDescriptorException {
       rethrow;
     } on Exception catch (error, stackTrace) {
@@ -84,8 +82,6 @@ class WatchOnlyInputParser {
           : Network.bitcoinTestnet;
       try {
         return parse(otherNetwork);
-      } on UnsupportedTaprootDescriptorException {
-        rethrow;
       } on UnsupportedFixedPublicKeyDescriptorException {
         rethrow;
       } on Exception {

--- a/lib/features/ledger/presentation/ledger_failure_l10n.dart
+++ b/lib/features/ledger/presentation/ledger_failure_l10n.dart
@@ -19,6 +19,8 @@ extension LedgerFailureL10n on LedgerFailure {
     LedgerDeviceLockedFailure() => context.loc.ledgerErrorDeviceLocked,
     LedgerBitcoinAppNotOpenFailure() =>
       context.loc.ledgerErrorBitcoinAppNotOpen,
+    LedgerBitcoinAppUpdateRequiredFailure() =>
+      context.loc.ledgerErrorBitcoinAppUpdateRequired,
     LedgerMissingPsbtFailure() => context.loc.ledgerErrorMissingPsbt,
     LedgerMissingAddressFailure() => context.loc.ledgerErrorMissingAddress,
     LedgerMissingDerivationPathFailure() =>

--- a/lib/features/psbt_signing/domain/psbt_signing_failure.dart
+++ b/lib/features/psbt_signing/domain/psbt_signing_failure.dart
@@ -19,6 +19,8 @@ sealed class PsbtSigningFailure extends Failure {
       const PsbtSigningFrozenUtxoFailure(),
     BitcoinSigningFailureKind.unsupportedSighash =>
       const PsbtSigningUnsupportedSighashFailure(),
+    BitcoinSigningFailureKind.unsupportedSpendMode =>
+      const PsbtSigningUnsupportedSpendModeFailure(),
     BitcoinSigningFailureKind.incomplete =>
       const PsbtSigningNoSignatureAddedFailure(),
     BitcoinSigningFailureKind.unsupportedPolicyPath ||
@@ -53,6 +55,10 @@ final class PsbtSigningFrozenUtxoFailure extends PsbtSigningFailure {
 
 final class PsbtSigningUnsupportedSighashFailure extends PsbtSigningFailure {
   const PsbtSigningUnsupportedSighashFailure([super.logMessage]);
+}
+
+final class PsbtSigningUnsupportedSpendModeFailure extends PsbtSigningFailure {
+  const PsbtSigningUnsupportedSpendModeFailure([super.logMessage]);
 }
 
 final class PsbtSigningNoSignatureAddedFailure extends PsbtSigningFailure {

--- a/lib/features/psbt_signing/presentation/psbt_signing_failure_l10n.dart
+++ b/lib/features/psbt_signing/presentation/psbt_signing_failure_l10n.dart
@@ -14,6 +14,8 @@ extension PsbtSigningFailureL10n on PsbtSigningFailure {
     PsbtSigningFrozenUtxoFailure() => context.loc.psbtSigningFrozenUtxo,
     PsbtSigningUnsupportedSighashFailure() =>
       context.loc.psbtSigningUnsupportedSighash,
+    PsbtSigningUnsupportedSpendModeFailure() =>
+      context.loc.psbtSigningUnsupportedSpendMode,
     PsbtSigningNoSignatureAddedFailure() =>
       context.loc.psbtSigningNoSignatureAdded,
     PsbtSigningUnexpectedFailure() => context.loc.oopsSomethingWentWrong,

--- a/lib/features/send/domain/send_failure.dart
+++ b/lib/features/send/domain/send_failure.dart
@@ -86,6 +86,10 @@ final class SendTransactionSigningFailure extends SendFailure {
   const SendTransactionSigningFailure([super.logMessage]);
 }
 
+final class SendUnsupportedPolicyPathFailure extends SendFailure {
+  const SendUnsupportedPolicyPathFailure([super.logMessage]);
+}
+
 final class SendTransactionConfirmationFailure extends SendFailure {
   final bool isBroadcastFailure;
 

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -28,6 +28,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
@@ -2588,6 +2589,15 @@ class SendCubit extends Cubit<SendState>
         emit(
           state.copyWith(
             failure: SendTransactionBuildFailure(e.message),
+            buildingTransaction: false,
+          ),
+        );
+        return;
+      }
+      if (e is UnsupportedBitcoinPolicyPathException) {
+        emit(
+          state.copyWith(
+            failure: const SendUnsupportedPolicyPathFailure(),
             buildingTransaction: false,
           ),
         );

--- a/lib/features/send/presentation/send_failure_l10n.dart
+++ b/lib/features/send/presentation/send_failure_l10n.dart
@@ -40,6 +40,8 @@ extension SendFailureL10n on SendFailure {
       context.loc.swapErrorRateLimited(retryAfter?.inSeconds ?? 30),
     SendTransactionBuildFailure() => context.loc.sendErrorBuildFailed,
     SendTransactionSigningFailure() => context.loc.sendErrorConfirmationFailed,
+    SendUnsupportedPolicyPathFailure() =>
+      context.loc.sendErrorUnsupportedPolicyPath,
     SendTransactionConfirmationFailure(:final isBroadcastFailure) =>
       isBroadcastFailure
           ? context.loc.sendErrorBroadcastFailed

--- a/lib/features/send/ui/widgets/send_action_buttons.dart
+++ b/lib/features/send/ui/widgets/send_action_buttons.dart
@@ -222,11 +222,13 @@ class _BitcoinSignerTile extends StatelessWidget {
       return;
     }
 
+    final usesDevicePsbtFlow =
+        wallet?.supportsDevicePsbtFlowFor(signer) == true;
     final result = await context.pushNamed<String>(
       PsbtFlowRoutes.show.name,
       extra: (
         psbt: context.read<SendCubit>().state.unsignedPsbt,
-        signerDevice: signer.signerDevice,
+        signerDevice: usesDevicePsbtFlow ? signer.signerDevice : null,
       ),
     );
     if (result != null && context.mounted) {
@@ -252,13 +254,21 @@ class ShowPsbtButton extends StatelessWidget {
     final unsignedPsbt = context.select(
       (SendCubit cubit) => cubit.state.unsignedPsbt,
     );
+    final wallet = context.select(
+      (SendCubit cubit) => cubit.state.selectedWallet,
+    );
+    final usesDeviceSpecificFlow =
+        signer != null && wallet?.supportsDevicePsbtFlowFor(signer!) == true;
 
     return BBButton.big(
       label: context.loc.psbtFlowSharePsbt,
       onPressed: () async {
         final result = await context.pushNamed<String>(
           PsbtFlowRoutes.show.name,
-          extra: (psbt: unsignedPsbt, signerDevice: signer?.signerDevice),
+          extra: (
+            psbt: unsignedPsbt,
+            signerDevice: usesDeviceSpecificFlow ? signer?.signerDevice : null,
+          ),
         );
         if (result != null && context.mounted) {
           await context.read<SendCubit>().applyExternalBitcoinSigningResult(

--- a/lib/features/settings/domain/wallet_registration_export_builder.dart
+++ b/lib/features/settings/domain/wallet_registration_export_builder.dart
@@ -69,7 +69,8 @@ abstract final class WalletRegistrationExportBuilder {
         device: device,
         fileName: fileName,
         encoding: WalletRegistrationQrEncoding.urBytes,
-        supportsPolicy: regularMultisig != null || _isNativeSegwit(wallet),
+        supportsPolicy:
+            regularMultisig != null || _supportsDescriptorRegistration(wallet),
       ),
       SignerDeviceEntity.specter => _specterOption(
         wallet: wallet,
@@ -94,19 +95,23 @@ abstract final class WalletRegistrationExportBuilder {
       SignerDeviceEntity.keystone => _commonMultisigOption(
         wallet: wallet,
         device: device,
-        regularMultisig: regularMultisig,
+        regularMultisig: _isTaproot(wallet) ? null : regularMultisig,
         fileName: fileName,
         allowLegacy: true,
         nameMaxLength: device == SignerDeviceEntity.jade ? 15 : 16,
       ),
       SignerDeviceEntity.passport =>
-        regularMultisig == null
+        _isTaproot(wallet)
+            ? _unsupportedPolicy(device)
+            : regularMultisig == null
             ? _descriptorOption(
                 wallet: wallet,
                 device: device,
                 fileName: fileName,
                 encoding: WalletRegistrationQrEncoding.urBytes,
-                supportsPolicy: _isNativeSegwit(wallet) && !policy.hasHashlock,
+                supportsPolicy:
+                    _supportsDescriptorRegistration(wallet) &&
+                    !policy.hasHashlock,
               )
             : _commonMultisigOption(
                 wallet: wallet,
@@ -119,7 +124,7 @@ abstract final class WalletRegistrationExportBuilder {
       SignerDeviceEntity.seedsigner => _commonMultisigOption(
         wallet: wallet,
         device: device,
-        regularMultisig: regularMultisig,
+        regularMultisig: _isTaproot(wallet) ? null : regularMultisig,
         fileName: fileName,
         allowLegacy: false,
         nameMaxLength: 16,
@@ -158,6 +163,9 @@ abstract final class WalletRegistrationExportBuilder {
     required String fileName,
     required WalletRegistrationQrEncoding qrEncoding,
   }) {
+    if (_isTaproot(wallet)) {
+      return _unsupportedPolicy(device);
+    }
     if (regularMultisig == null) return _unsupportedPolicy(device);
     if (!wallet.hasWalletPolicyKeyOrigins) {
       return UnavailableWalletRegistration(
@@ -295,8 +303,13 @@ abstract final class WalletRegistrationExportBuilder {
     return null;
   }
 
-  static bool _isNativeSegwit(Wallet wallet) =>
-      wallet.publicDescriptor.toLowerCase().startsWith('wsh(');
+  static bool _supportsDescriptorRegistration(Wallet wallet) {
+    final descriptor = wallet.publicDescriptor.toLowerCase();
+    return descriptor.startsWith('wsh(') || descriptor.startsWith('tr(');
+  }
+
+  static bool _isTaproot(Wallet wallet) =>
+      wallet.publicDescriptor.toLowerCase().startsWith('tr(');
 
   static UnavailableWalletRegistration _unsupportedPolicy(
     SignerDeviceEntity device,

--- a/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/wallet_details_screen.dart
@@ -299,6 +299,9 @@ class _DescriptorWalletDetails extends StatelessWidget {
 
 String _descriptorAddressType(BuildContext context, Wallet wallet) {
   final descriptor = wallet.publicDescriptor.trim().toLowerCase();
+  if (descriptor.startsWith('tr(')) {
+    return context.loc.walletAddressTypeTaproot;
+  }
   if (descriptor.startsWith('sh(wsh(')) {
     return context.loc.walletDetailsNestedSegwitP2wsh;
   }

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -15296,6 +15296,10 @@
   "@psbtSigningUnsupportedSighash": {
     "description": "Error shown when a PSBT uses an unsupported signature hash mode."
   },
+  "psbtSigningUnsupportedSpendMode": "This PSBT mixes Taproot key-path and script-path inputs, which Bull cannot sign together yet.",
+  "@psbtSigningUnsupportedSpendMode": {
+    "description": "Shown when a PSBT combines Taproot input spend modes that Bull cannot safely sign in one operation."
+  },
   "psbtSigningWalletMismatch": "This PSBT does not belong to the selected wallet.",
   "@psbtSigningWalletMismatch": {
     "description": "Error shown when a PSBT does not belong to the selected wallet."
@@ -15385,6 +15389,10 @@
   "psbtSigningFrozenUtxo": "This PSBT spends a frozen coin. Unfreeze it before signing.",
   "@psbtSigningFrozenUtxo": {
     "description": "Shown when standalone PSBT signing is blocked because an input coin is frozen"
+  },
+  "sendErrorUnsupportedPolicyPath": "This Taproot spending option isn’t supported yet. Choose another option.",
+  "@sendErrorUnsupportedPolicyPath": {
+    "description": "Error shown when Bull cannot unambiguously construct the selected Taproot spending path"
   },
   "sendLoadingTransaction": "Loading transaction...",
   "@sendLoadingTransaction": {

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -11441,6 +11441,10 @@
   "@ledgerErrorBitcoinAppNotOpen": {
     "description": "Error message when Bitcoin app is not open on Ledger (error codes 6e01, 6a87, 6d02, 6511, 6e00)"
   },
+  "ledgerErrorBitcoinAppUpdateRequired": "Update the Bitcoin app on your Ledger and try again.",
+  "@ledgerErrorBitcoinAppUpdateRequired": {
+    "description": "Error shown when the connected Ledger Bitcoin app is too old for the wallet policy"
+  },
   "ledgerErrorMissingPsbt": "PSBT is required for signing",
   "@ledgerErrorMissingPsbt": {
     "description": "Error message when PSBT parameter is missing for signing"

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -3478,6 +3478,10 @@
   "@walletAddressTypeNativeSegwit": {
     "description": "Address type for BIP84 wallets"
   },
+  "walletAddressTypeTaproot": "Taproot",
+  "@walletAddressTypeTaproot": {
+    "description": "Address type for Taproot descriptor wallets"
+  },
   "walletAddressTypeNestedSegwit": "Nested Segwit",
   "@walletAddressTypeNestedSegwit": {
     "description": "Address type for BIP49 wallets"
@@ -14943,10 +14947,6 @@
   "importWatchOnlyErrorFixedPublicKeyUnsupported": "This descriptor contains fixed public keys, which Bull does not support yet. Use extended public keys for every signer.",
   "@importWatchOnlyErrorFixedPublicKeyUnsupported": {
     "description": "Error shown when a descriptor contains a fixed public key instead of an extended public key"
-  },
-  "importWatchOnlyErrorTaprootUnsupported": "Taproot descriptors aren’t supported yet.",
-  "@importWatchOnlyErrorTaprootUnsupported": {
-    "description": "Error shown when a user tries to import a Taproot descriptor"
   },
   "importWatchOnlyErrorSignerOriginRequired": "This hardware signer export is missing its fingerprint and account path. Export a descriptor or an account xpub with key origin information.",
   "@importWatchOnlyErrorSignerOriginRequired": {

--- a/test/core_test/ledger/ledger_device_repository_test.dart
+++ b/test/core_test/ledger/ledger_device_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/ledger/domain/entities/ledger_device_entity.dart'
 import 'package:bb_mobile/core/ledger/data/ledger_exception.dart';
 import 'package:bb_mobile/core/ledger/domain/ledger_failure.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -17,9 +18,13 @@ class _MockLedgerDeviceDatasource extends Mock
 class _MockLedgerWalletPolicyHmacDatasource extends Mock
     implements LedgerWalletPolicyHmacDatasource {}
 
+class _MockBitcoinDescriptorPort extends Mock
+    implements BitcoinDescriptorPort {}
+
 void main() {
   late _MockLedgerDeviceDatasource datasource;
   late _MockLedgerWalletPolicyHmacDatasource hmacDatasource;
+  late _MockBitcoinDescriptorPort bitcoinDescriptorPort;
   late LedgerDeviceRepositoryImpl repository;
 
   const device = LedgerDeviceEntity(
@@ -37,9 +42,11 @@ void main() {
   setUp(() {
     datasource = _MockLedgerDeviceDatasource();
     hmacDatasource = _MockLedgerWalletPolicyHmacDatasource();
+    bitcoinDescriptorPort = _MockBitcoinDescriptorPort();
     repository = LedgerDeviceRepositoryImpl(
       datasource: datasource,
       hmacDatasource: hmacDatasource,
+      bitcoinDescriptorPort: bitcoinDescriptorPort,
     );
   });
 

--- a/test/core_test/ledger/ledger_wallet_policy_test.dart
+++ b/test/core_test/ledger/ledger_wallet_policy_test.dart
@@ -11,6 +11,8 @@ import 'package:bb_mobile/core/ledger/domain/entities/ledger_device_entity.dart'
 import 'package:bb_mobile/core/ledger/domain/ledger_failure.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
@@ -25,6 +27,8 @@ class _MockDatasource extends Mock implements LedgerDeviceDatasource {}
 class _MockHmacDatasource extends Mock
     implements LedgerWalletPolicyHmacDatasource {}
 
+class _MockDescriptorPort extends Mock implements BitcoinDescriptorPort {}
+
 const _device = LedgerDeviceEntity(
   id: 'ledger-1',
   name: 'Nano X',
@@ -36,6 +40,13 @@ const _xpub =
     'xpub6DJwRncrB8eNrzUq8XxgjwCZsEeWP8FeqBJbJQZ8JfuDwLdAzyjhHiHJieNuar1wjQTyihhMWtaKGE4DUd8uBgtyrNJqF5drwbNVUqb83b7';
 const _otherXpub =
     'tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ';
+const _unspendableInternalTpub =
+    'tpubD6NzVbkrYhZ4WN8Bo3ctMrx2y6tPVNfjjgUdvRfHaCvm2sikpbhp3edE5wRXjtUZTpVeUkSLCqqikz1KF18b4Ra6FnMpT6wygdamccSAUkh';
+const _taprootPolicyDescriptor =
+    'tr($_unspendableInternalTpub/<0;1>/*,'
+    "multi_a(2,[73c5da0a/48'/1'/0'/2']tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/<0;1>/*,"
+    "[b8688df1/48'/1'/0'/2']tpubDEfobrrtptRTbKf4gysDhoabneABDTAcdj3Vbn4XwPsLE2pmqpizSPRG6zHsbAMuiSgWmWPsYCLHTKTPpyrGJ5rAoTpKoQNZcxodiPf2tSJ/<0;1>/*,"
+    "[28645006/48'/1'/0'/2']tpubDEwqCvJxKwKWX9xvRe48uofWJn1Y89Jn8UeH1Efrjb1UEVjUDy3URYTiqWaVCW7WdvHrL8XrSihHEhTwv5H3VDJoakjuCHiAnr6xcF2Xm4s/<0;1>/*))";
 
 void main() {
   test('builds a BIP388 policy for nested SegWit multisig', () {
@@ -44,33 +55,63 @@ void main() {
       nestedMultisig: true,
     );
 
-    final policy = LedgerWalletPolicyAdapter.fromWallet(wallet);
+    final policy = LedgerWalletPolicyAdapter.fromWallet(
+      wallet,
+      descriptorPolicyKeys: _policyAnalysis(wallet).policyKeys,
+    );
 
     expect(policy.name, 'Policy wallet');
     expect(policy.descriptorTemplate, 'sh(wsh(sortedmulti(1,@0/**)))');
     expect(policy.keys, ["[aabbccdd/48'/0'/0'/2']$_xpub"]);
   });
 
-  test('derives key suffixes into the Ledger policy key', () {
-    final wallet = _policyWallet(
-      SignerDeviceEntity.ledgerNanoX,
-      keySuffix: '/5',
-    );
+  test('maps only Ledger-supported derivation roles', () {
+    final key = '[aabbccdd/48h/0h/0h/2h]$_xpub/5';
+    final wallet =
+        _policyWallet(SignerDeviceEntity.ledgerNanoX, keySuffix: '/5').copyWith(
+          publicDescriptor:
+              'wsh(or_d(pk($key/<0;1>/*),'
+              'and_v(v:older(10),pk($key/<2;3>/*))))',
+        );
     final derivedXpub = Bip32Derivation.getBip32Xpub(
       _xpub,
     ).derivePath('5').toBase58();
 
-    final policy = LedgerWalletPolicyAdapter.fromWallet(wallet);
+    final policy = LedgerWalletPolicyAdapter.fromWallet(
+      wallet,
+      descriptorPolicyKeys: _policyAnalysis(wallet).policyKeys,
+    );
 
     expect(wallet.supportsLedgerWalletPolicy, isTrue);
-    expect(policy.descriptorTemplate, 'wsh(pk(@0/**))');
+    expect(
+      policy.descriptorTemplate,
+      'wsh(or_d(pk(@0/**),'
+      'and_v(v:older(10),pk(@0/<2;3>/*))))',
+    );
     expect(policy.keys, ["[aabbccdd/48'/0'/0'/2'/5]$derivedXpub"]);
+    final descriptorPolicyKeys = _policyAnalysis(wallet).policyKeys;
+
+    for (final unsupportedDescriptor in ['wsh(pk($key/<0;1>/2/*))']) {
+      final unsupported = wallet.copyWith(
+        publicDescriptor: unsupportedDescriptor,
+      );
+      expect(
+        () => LedgerWalletPolicyAdapter.fromWallet(
+          unsupported,
+          descriptorPolicyKeys: descriptorPolicyKeys,
+        ),
+        throwsFormatException,
+      );
+    }
   });
 
   test('reuses a Ledger key across disjoint BIP389 branch pairs', () {
     final wallet = _disjointRolePolicyWallet(SignerDeviceEntity.ledgerNanoX);
 
-    final policy = LedgerWalletPolicyAdapter.fromWallet(wallet);
+    final policy = LedgerWalletPolicyAdapter.fromWallet(
+      wallet,
+      descriptorPolicyKeys: wallet.descriptorKeys,
+    );
 
     expect(
       policy.descriptorTemplate,
@@ -85,12 +126,14 @@ void main() {
       'wsh(or_d(pk($origin/<0;1>/*),pk($origin/<0;1>/*)))',
       'wsh(or_d(pk($origin/<0;1>/*),pk($origin/<1;2>/*)))',
     ]) {
-      final wallet = _policyWallet(
-        SignerDeviceEntity.ledgerNanoX,
-      ).copyWith(publicDescriptor: descriptor);
+      final baseWallet = _policyWallet(SignerDeviceEntity.ledgerNanoX);
+      final wallet = baseWallet.copyWith(publicDescriptor: descriptor);
 
       expect(
-        () => LedgerWalletPolicyAdapter.fromWallet(wallet),
+        () => LedgerWalletPolicyAdapter.fromWallet(
+          wallet,
+          descriptorPolicyKeys: baseWallet.descriptorKeys,
+        ),
         throwsFormatException,
       );
     }
@@ -101,18 +144,37 @@ void main() {
 
     expect(wallet.supportsWalletPolicySigner(wallet.signers.first), isTrue);
     expect(
-      LedgerWalletPolicyAdapter.fromWallet(wallet).keys.last,
+      LedgerWalletPolicyAdapter.fromWallet(
+        wallet,
+        descriptorPolicyKeys: _policyAnalysis(wallet).policyKeys,
+      ).keys.last,
       Bip32Derivation.getBip32Xpub(_otherXpub).toBase58(),
     );
+  });
+
+  test('keeps an unspendable internal key in the Ledger policy only', () {
+    final wallet = _taprootPolicyWallet();
+
+    final policy = LedgerWalletPolicyAdapter.fromWallet(
+      wallet,
+      descriptorPolicyKeys: _policyAnalysis(wallet).policyKeys,
+    );
+
+    expect(policy.descriptorTemplate, 'tr(@0/**,multi_a(2,@1/**,@2/**,@3/**))');
+    expect(policy.keys, hasLength(4));
+    expect(policy.keys.first, _unspendableInternalTpub);
+    expect(wallet.signers, hasLength(3));
   });
 
   group('LedgerDeviceRepositoryImpl', () {
     late _MockDatasource datasource;
     late _MockHmacDatasource hmacDatasource;
+    late _MockDescriptorPort descriptorPort;
     late LedgerDeviceRepositoryImpl repository;
 
     setUpAll(() {
       registerFallbackValue(_device.toModel());
+      registerFallbackValue(Network.bitcoinMainnet);
       registerFallbackValue(
         WalletPolicy('Fallback', 'wpkh(@0/**)', ["[aabbccdd/84'/0'/0']$_xpub"]),
       );
@@ -121,9 +183,21 @@ void main() {
     setUp(() {
       datasource = _MockDatasource();
       hmacDatasource = _MockHmacDatasource();
+      descriptorPort = _MockDescriptorPort();
+      when(
+        () => descriptorPort.analyzeBitcoinPolicyDescriptor(
+          descriptor: any(named: 'descriptor'),
+          network: any(named: 'network'),
+        ),
+      ).thenAnswer((invocation) {
+        final descriptor = invocation.namedArguments[#descriptor] as String;
+        final network = invocation.namedArguments[#network] as Network;
+        return _policyAnalysisDescriptor(descriptor, network: network);
+      });
       repository = LedgerDeviceRepositoryImpl(
         datasource: datasource,
         hmacDatasource: hmacDatasource,
+        bitcoinDescriptorPort: descriptorPort,
       );
     });
 
@@ -189,6 +263,42 @@ void main() {
           hmac: hmac,
         ),
       ).called(1);
+    });
+
+    test('rejects Taproot before the safe Bitcoin app version', () async {
+      final wallet = _taprootKeyPathPolicyWallet();
+      when(
+        () => datasource.getBitcoinAppVersion(any()),
+      ).thenAnswer((_) async => '2.2.0');
+
+      final result = await repository.registerWalletPolicy(
+        _device,
+        wallet: wallet,
+      );
+
+      expect(
+        (result as Err).failure,
+        isA<LedgerBitcoinAppUpdateRequiredFailure>(),
+      );
+      verifyNever(() => datasource.getMasterFingerprint(any()));
+    });
+
+    test('requires NUMS recognition for a dummy internal key', () async {
+      final wallet = _taprootPolicyWallet();
+      when(
+        () => datasource.getBitcoinAppVersion(any()),
+      ).thenAnswer((_) async => '2.2.1');
+
+      final result = await repository.registerWalletPolicy(
+        _device,
+        wallet: wallet,
+      );
+
+      expect(
+        (result as Err).failure,
+        isA<LedgerBitcoinAppUpdateRequiredFailure>(),
+      );
+      verifyNever(() => datasource.getMasterFingerprint(any()));
     });
 
     test('maps unsupported firmware to an unsupported policy error', () async {
@@ -431,5 +541,85 @@ Wallet _policyWalletWithOriginlessSigner() {
   );
 }
 
-String _policyId(Wallet wallet) =>
-    hex.encode(LedgerWalletPolicyAdapter.fromWallet(wallet).id);
+Wallet _taprootKeyPathPolicyWallet() {
+  final key = '[aabbccdd/48h/0h/0h/2h]$_xpub/<0;1>/*';
+  return Wallet(
+    origin: 'taproot-key-path-wallet',
+    label: 'Taproot key path',
+    network: Network.bitcoinMainnet,
+    signers: [
+      WalletSigner.single(
+        masterFingerprint: 'aabbccdd',
+        xpubFingerprint: '',
+        xpub: _xpub,
+        derivationPath: _accountPath,
+        signer: SignerEntity.remote,
+        signerDevice: SignerDeviceEntity.ledgerNanoX,
+      ),
+    ],
+    scriptType: null,
+    publicDescriptor: 'tr($key)',
+    balanceSat: BigInt.zero,
+  );
+}
+
+Wallet _taprootPolicyWallet() {
+  final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+    descriptor: _taprootPolicyDescriptor,
+    isTestnet: true,
+  );
+  return Wallet(
+    origin: 'taproot-policy-wallet',
+    label: 'Taproot policy',
+    network: Network.bitcoinTestnet,
+    signers: [
+      for (final (index, key) in parsed.keys.indexed)
+        WalletSigner.single(
+          id: 'signer-$index',
+          descriptorKeyId: 'key-$index',
+          masterFingerprint: key.masterFingerprint,
+          xpubFingerprint: key.xpubFingerprint,
+          xpub: key.xpub,
+          derivationPath: key.derivationPath,
+          signer: SignerEntity.remote,
+          signerDevice: index == 0 ? SignerDeviceEntity.ledgerNanoX : null,
+        ),
+    ],
+    scriptType: null,
+    publicDescriptor: _taprootPolicyDescriptor,
+    balanceSat: BigInt.zero,
+  );
+}
+
+({List<WalletDescriptorKey> policyKeys, bool hasUnspendablePolicyKey})
+_policyAnalysis(Wallet wallet) =>
+    _policyAnalysisDescriptor(wallet.publicDescriptor, network: wallet.network);
+
+String _policyId(Wallet wallet) => hex.encode(
+  LedgerWalletPolicyAdapter.fromWallet(
+    wallet,
+    descriptorPolicyKeys: _policyAnalysis(wallet).policyKeys,
+  ).id,
+);
+
+({List<WalletDescriptorKey> policyKeys, bool hasUnspendablePolicyKey})
+_policyAnalysisDescriptor(String descriptor, {required Network network}) {
+  final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+    descriptor: descriptor,
+    isTestnet: network.isTestnet,
+  );
+  return (
+    policyKeys: [
+      for (final (index, key) in parsed.policyKeys.indexed)
+        WalletDescriptorKey(
+          id: 'policy-key-$index',
+          signerId: 'policy-signer-$index',
+          masterFingerprint: key.masterFingerprint,
+          xpubFingerprint: key.xpubFingerprint,
+          xpub: key.xpub,
+          derivationPath: key.derivationPath,
+        ),
+    ],
+    hasUnspendablePolicyKey: parsed.unspendablePolicyKeyIdentifiers.isNotEmpty,
+  );
+}

--- a/test/core_test/wallet/data/datasources/bdk_facade_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_facade_test.dart
@@ -252,18 +252,48 @@ void main() {
       expect(parsed.keys.single.xpub, signers.first.xpub.split(']').last);
     });
 
-    test('rejects Taproot descriptors explicitly', () {
+    test('accepts a two-path Taproot key-path descriptor', () {
       final descriptor = bdk.Descriptor.newTr(
         key: signers.first.externalPublic,
         script: null,
       ).toString();
 
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+
+      expect(parsed.descriptor, contains('/<0;1>/*'));
+      expect(parsed.keys, hasLength(1));
+      expect(parsed.policyKeys, hasLength(1));
+      expect(parsed.unspendablePolicyKeyIdentifiers, isEmpty);
+    });
+
+    test('accepts the BIP341 unspendable Taproot internal key', () {
+      const bip341NumsKey =
+          '50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0';
+      final key = signers.first.externalPublic.replaceAll('/0/*', '/<0;1>/*');
+
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: 'tr($bip341NumsKey,pk($key))',
+        isTestnet: true,
+      );
+
+      expect(parsed.keys, hasLength(1));
+      expect(parsed.policyKeys, hasLength(1));
+      expect(parsed.unspendablePolicyKeyIdentifiers, isNotEmpty);
+    });
+
+    test('rejects an unspendable Taproot key without a script tree', () {
+      const bip341NumsKey =
+          '50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0';
+
       expect(
         () => BdkFacade.parsePublicTwoPathDescriptor(
-          descriptor: descriptor,
+          descriptor: 'tr($bip341NumsKey)',
           isTestnet: true,
         ),
-        throwsA(isA<UnsupportedTaprootDescriptorException>()),
+        throwsFormatException,
       );
     });
 

--- a/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
@@ -397,6 +397,55 @@ void main() {
       );
     });
 
+    test('maps a reused key beside another account from the same seed', () {
+      final account0 = deriveSignerKeysAtAccount(
+        testMnemonics.first,
+        account: 0,
+      );
+      final account1 = deriveSignerKeysAtAccount(
+        testMnemonics.first,
+        account: 1,
+      );
+      final descriptor = twoPathDescriptor(
+        'tr(${account0.externalPublic},{pk(${account0.externalPublic}),pk(${account1.externalPublic})})',
+        'tr(${account0.internalPublic},{pk(${account0.internalPublic}),pk(${account1.internalPublic})})',
+      );
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = [
+        for (final (index, key) in parsed.keys.indexed)
+          WalletDescriptorKeyModel(
+            id: 'key-$index',
+            signerId: 'signer-$index',
+            masterFingerprint: key.masterFingerprint,
+            xpubFingerprint: key.xpubFingerprint,
+            xpub: key.xpub,
+            derivationPath: key.derivationPath,
+          ),
+      ];
+
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet:
+              WalletModel.publicBdk(
+                    id: 'same-seed-accounts',
+                    descriptor: descriptor,
+                    isTestnet: true,
+                  )
+                  as PublicBdkWalletModel,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+
+      expect(_signatureKeyValues(policy.external.root), [
+        'key-0',
+        'key-0',
+        'key-1',
+      ]);
+    });
+
     test('decodes time-based relative timelocks', () {
       const oneTimeUnit = (1 << 22) + 1;
       final policy = analyzePolicy(

--- a/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_policy_test.dart
@@ -355,6 +355,48 @@ void main() {
       );
     });
 
+    test('maps one descriptor key reused across Taproot leaves', () {
+      final descriptor = twoPathDescriptor(
+        'tr(${signers[1].externalPublic},{pk(${signers[0].externalPublic}),and_v(v:pk(${signers[0].externalPublic}),older(1000))})',
+        'tr(${signers[1].internalPublic},{pk(${signers[0].internalPublic}),and_v(v:pk(${signers[0].internalPublic}),older(1000))})',
+      );
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = [
+        for (final (index, key) in parsed.keys.indexed)
+          WalletDescriptorKeyModel(
+            id: 'key-$index',
+            signerId: 'signer-$index',
+            masterFingerprint: key.masterFingerprint,
+            xpubFingerprint: key.xpubFingerprint,
+            xpub: key.xpub,
+            derivationPath: key.derivationPath,
+          ),
+      ];
+
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet:
+              WalletModel.publicBdk(
+                    id: 'reused-taproot-key',
+                    descriptor: descriptor,
+                    isTestnet: true,
+                  )
+                  as PublicBdkWalletModel,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+
+      expect(
+        _signatureKeyValues(
+          policy.external.root,
+        ).where((value) => value == 'key-1'),
+        hasLength(2),
+      );
+    });
+
     test('decodes time-based relative timelocks', () {
       const oneTimeUnit = (1 << 22) + 1;
       final policy = analyzePolicy(

--- a/test/core_test/wallet/data/datasources/bdk_wallet_taproot_test.dart
+++ b/test/core_test/wallet/data/datasources/bdk_wallet_taproot_test.dart
@@ -1,0 +1,1392 @@
+import 'dart:io';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_psbt_review_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/bitcoin_wallet_policy_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/mappers/wallet_signer_mapper.dart';
+import 'package:bb_mobile/core/wallet/data/models/bitcoin_psbt_review_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_descriptor_key_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/bitcoin_psbt_review_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
+import 'package:bitcoin_base/bitcoin_base.dart' as bitcoin_base;
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:bip32_keys/bip32_keys.dart' as bip32;
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+
+import '../../bdk_wallet_test_fixture.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<SignerDescriptorKeys> signers;
+  late BdkWalletDatasource datasource;
+  late Directory tempDirectory;
+
+  setUpAll(() {
+    signers = testMnemonics.map(deriveSignerKeys).toList();
+  });
+
+  setUp(() {
+    datasource = BdkWalletDatasource();
+    tempDirectory = Directory.systemTemp.createTempSync('bdk_taproot_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => call.method == 'getApplicationDocumentsDirectory'
+              ? tempDirectory.path
+              : null,
+        );
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await tempDirectory.delete(recursive: true);
+  });
+
+  test('completes a Taproot key-path round trip', () {
+    final publicDescriptor = _taprootKeyPathDescriptor(
+      externalKey: signers.first.externalPublic,
+      internalKey: signers.first.internalPublic,
+    );
+    final privateDescriptor = _taprootKeyPathDescriptor(
+      externalKey: signers.first.externalPrivate,
+      internalKey: signers.first.internalPrivate,
+    );
+    final unsigned = buildUnsignedPsbt(descriptor: publicDescriptor);
+
+    final signed = datasource.signPsbtWithDescriptor(
+      unsigned,
+      descriptor: privateDescriptor,
+      isTestnet: true,
+      tryFinalize: false,
+    );
+    final finalized = datasource.finalizePsbt(signed.psbt);
+
+    expect(signed.isFinalized, isFalse);
+    expect(
+      bdk.Psbt(psbtBase64: signed.psbt).input().single.tapKeySig,
+      isNotNull,
+    );
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: signed.psbt,
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: _replaceTaprootKeySignature(
+          signed.psbt,
+          (signature) => signature[0] ^= 1,
+        ),
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+    final signedWithAll = datasource.signPsbtWithDescriptor(
+      _withInputSighash(unsigned, bitcoin_base.BitcoinOpCodeConst.sighashAll),
+      descriptor: privateDescriptor,
+      isTestnet: true,
+      tryFinalize: false,
+    );
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: _withoutInputSighash(signedWithAll.psbt),
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: _withInputSighash(
+          unsigned,
+          bitcoin_base.BitcoinOpCodeConst.sighashDefault,
+        ),
+        signedPsbtBase64: _withInputSighash(
+          signedWithAll.psbt,
+          bitcoin_base.BitcoinOpCodeConst.sighashDefault,
+        ),
+      ),
+      throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+    );
+    expect(finalized.isFinalized, isTrue);
+    final transaction = hex.encode(
+      bdk.Psbt(psbtBase64: finalized.psbt).extractTx().serialize(),
+    );
+    expect(
+      () => datasource.verifyFinalTransaction(
+        psbtBase64: unsigned,
+        transactionHex: transaction,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('validates an explicitly selected key-path signature', () async {
+    final publicDescriptor = _taprootKeyAndScriptDescriptor(
+      externalInternalKey: signers[0].externalPublic,
+      externalLeafKey: signers[1].externalPublic,
+      internalInternalKey: signers[0].internalPublic,
+      internalLeafKey: signers[1].internalPublic,
+    );
+    final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+      descriptor: publicDescriptor,
+      isTestnet: true,
+    );
+    final descriptorKeys = _descriptorKeyModels(parsed.keys);
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'taproot-key-path-selection',
+              descriptor: publicDescriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(wallet: wallet, descriptorKeys: descriptorKeys),
+    );
+    final requirement = policy
+        .pathSelectors(const BitcoinPolicySelection.empty())
+        .first;
+    final internalKeyIndex = requirement.options.indexWhere(
+      (option) => _signatureKeyValues(option).contains('key-0'),
+    );
+    final selection = policy.select(
+      current: const BitcoinPolicySelection.empty(),
+      requirement: requirement,
+      selectedIndices: {internalKeyIndex},
+    );
+    final path = policy.buildPath(selection);
+    final recipient = await _fundStoredWallet(wallet);
+    final unsigned = await datasource.buildPsbt(
+      wallet: wallet,
+      address: recipient,
+      amountSat: 50000,
+      networkFee: const NetworkFee.absolute(1000),
+      policyPath: path,
+      requiredDescriptorKeys: (
+        external: descriptorKeys
+            .where(
+              (key) => path.requiredExternalKeys.any(
+                (required) => required.value == key.id,
+              ),
+            )
+            .toList(),
+        internal: descriptorKeys
+            .where(
+              (key) => path.requiredInternalKeys.any(
+                (required) => required.value == key.id,
+              ),
+            )
+            .toList(),
+      ),
+    );
+    final unsignedPsbt = bdk.Psbt(psbtBase64: unsigned);
+    try {
+      expect(unsignedPsbt.input().single.tapScripts, isEmpty);
+    } finally {
+      unsignedPsbt.dispose();
+    }
+    final signed = datasource.signPsbtWithDescriptor(
+      unsigned,
+      descriptor: _taprootKeyAndScriptDescriptor(
+        externalInternalKey: signers[0].externalPrivate,
+        externalLeafKey: signers[1].externalPublic,
+        internalInternalKey: signers[0].internalPrivate,
+        internalLeafKey: signers[1].internalPublic,
+      ),
+      isTestnet: true,
+      tryFinalize: false,
+    );
+    final signedPsbt = bdk.Psbt(psbtBase64: signed.psbt);
+    try {
+      expect(signedPsbt.input().single.tapScripts, isEmpty);
+    } finally {
+      signedPsbt.dispose();
+    }
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: signed.psbt,
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('keeps key-path signer status when Tapleaf metadata remains', () async {
+    final descriptor = _taprootKeyPathDescriptor(
+      externalKey: signers.first.externalPublic,
+      internalKey: signers.first.internalPublic,
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'taproot-key-path-review',
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final descriptorKeys = _descriptorKeyModels(
+      BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      ).keys,
+    );
+    final signed = datasource.signPsbtWithDescriptor(
+      buildUnsignedPsbt(descriptor: descriptor),
+      descriptor: _taprootKeyPathDescriptor(
+        externalKey: signers.first.externalPrivate,
+        internalKey: signers.first.internalPrivate,
+      ),
+      isTestnet: true,
+      tryFinalize: false,
+    );
+    final inspected = await datasource.inspectPsbt(
+      signed.psbt,
+      wallet: wallet,
+      walletFingerprints: {signers.first.fingerprint},
+    );
+    final input = inspected.inputs.single;
+    final withRetainedLeaf = BitcoinPsbtReviewModel(
+      transactionId: inspected.transactionId,
+      inputs: [
+        (
+          amountSat: input.amountSat,
+          keychain: input.keychain,
+          originKeySources: input.originKeySources,
+          satisfiedPreimageKeys: input.satisfiedPreimageKeys,
+          signedKeySources: input.signedKeySources,
+          tapLeafHashes: const {'retained-leaf'},
+          outpoint: input.outpoint,
+          sequence: input.sequence,
+        ),
+      ],
+      outputs: inspected.outputs,
+      feeSat: inspected.feeSat,
+      estimatedTransactionVsize: inspected.estimatedTransactionVsize,
+      isFinalized: inspected.isFinalized,
+      lockTime: inspected.lockTime,
+      version: inspected.version,
+    );
+
+    final review = BitcoinPsbtReviewMapper.toEntity(
+      withRetainedLeaf,
+      descriptorKeys: descriptorKeys,
+      localSignerIds: const {},
+    );
+
+    expect(review.signedDescriptorKeyIds, {'key-0'});
+  });
+
+  test('accepts a Taproot input with only its non-witness UTXO', () async {
+    final descriptor = _taprootKeyPathDescriptor(
+      externalKey: signers.first.externalPublic,
+      internalKey: signers.first.internalPublic,
+    );
+    final unsigned = buildUnsignedPsbt(descriptor: descriptor);
+    final bdkPsbt = bdk.Psbt(psbtBase64: unsigned);
+    final script = bdk.Script(
+      rawOutputScript: bdkPsbt
+          .input()
+          .single
+          .witnessUtxo!
+          .scriptPubkey
+          .toBytes(),
+    );
+    bdkPsbt.dispose();
+    final previousTransaction = bitcoin_base.BtcTransaction.deserialize(
+      fundingTransaction(script).serialize(),
+    );
+    final psbt = bitcoin_base.Psbt.fromBase64(unsigned);
+    psbt.input.removeInputKeys(0, [
+      bitcoin_base.PsbtInputTypes.nonWitnessUTXO,
+      bitcoin_base.PsbtInputTypes.witnessUTXO,
+      bitcoin_base.PsbtInputTypes.sighashType,
+    ]);
+    psbt.input.updateInputs(0, [
+      bitcoin_base.PsbtInputNonWitnessUtxo(previousTransaction),
+      bitcoin_base.PsbtInputSigHash(
+        bitcoin_base.BitcoinOpCodeConst.sighashDefault,
+      ),
+    ]);
+
+    await expectLater(
+      datasource.inspectPsbt(
+        psbt.toBase64(),
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'taproot-non-witness-utxo',
+                  descriptor: descriptor,
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+        walletFingerprints: {signers.first.fingerprint},
+      ),
+      completes,
+    );
+  });
+
+  test('rejects mixed Taproot key-path and script-path inputs', () {
+    final publicDescriptor = _taprootKeyAndScriptDescriptor(
+      externalInternalKey: signers[0].externalPublic,
+      externalLeafKey: signers[1].externalPublic,
+      internalInternalKey: signers[0].internalPublic,
+      internalLeafKey: signers[1].internalPublic,
+    );
+    final psbt = bitcoin_base.Psbt.fromBase64(
+      buildUnsignedPsbt(
+        descriptor: publicDescriptor,
+        amountSat: 150000,
+        inputCount: 2,
+      ),
+    );
+    _retainTaprootSpendMode(psbt, index: 0, keyPath: true);
+    _retainTaprootSpendMode(psbt, index: 1, keyPath: false);
+    expect(
+      () => datasource.signPsbtWithDescriptor(
+        psbt.toBase64(),
+        descriptor: _taprootKeyAndScriptDescriptor(
+          externalInternalKey: signers[0].externalPrivate,
+          externalLeafKey: signers[1].externalPublic,
+          internalInternalKey: signers[0].internalPrivate,
+          internalLeafKey: signers[1].internalPublic,
+        ),
+        isTestnet: true,
+      ),
+      throwsA(isA<BitcoinPsbtUnsupportedSpendModeException>()),
+    );
+  });
+
+  test('excludes a provably unspendable internal key from signers', () {
+    final descriptor = _descriptorWithUnspendableInternalKey(signers);
+    final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+      descriptor: descriptor,
+      isTestnet: true,
+    );
+    final descriptorKeys = _descriptorKeyModels(parsed.keys);
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'unspendable-internal-key',
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(wallet: wallet, descriptorKeys: descriptorKeys),
+    );
+
+    expect(parsed.keys, hasLength(signers.length));
+    expect(parsed.policyKeys, hasLength(signers.length + 1));
+    expect(parsed.unspendablePolicyKeyIdentifiers, isNotEmpty);
+    expect(_signatureKeyValues(policy.external.root), {
+      for (var index = 0; index < signers.length; index++) 'key-$index',
+    });
+  });
+
+  test('omits only a fixed BIP341 NUMS key origin from built PSBTs', () async {
+    await _withTemporaryBdkDirectory('bdk_taproot_nums_', () async {
+      final fixedNumsWallet =
+          WalletModel.publicBdk(
+                id: 'fixed-nums-origin',
+                descriptor: _taprootScriptDescriptor(
+                  externalKeys: signers
+                      .map((signer) => signer.externalPublic)
+                      .toList(),
+                  internalKeys: signers
+                      .map((signer) => signer.internalPublic)
+                      .toList(),
+                ),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final fixedNumsRecipient = await _fundStoredWallet(fixedNumsWallet);
+      final fixedNumsPsbt = bdk.Psbt(
+        psbtBase64: await datasource.buildPsbt(
+          wallet: fixedNumsWallet,
+          address: fixedNumsRecipient,
+          amountSat: 50000,
+          networkFee: const NetworkFee.absolute(1000),
+        ),
+      );
+      try {
+        final origins = fixedNumsPsbt.input().single.tapKeyOrigins;
+        expect(origins, isNot(contains(_numsKey.substring(2))));
+        expect(origins, hasLength(signers.length));
+        expect(
+          origins.values.every((origin) => origin.tapLeafHashes.isNotEmpty),
+          isTrue,
+        );
+        for (final output in fixedNumsPsbt.output()) {
+          expect(output.tapKeyOrigins, isNot(contains(_numsKey.substring(2))));
+          expect(output.tapKeyOrigins, hasLength(signers.length));
+        }
+
+        final unnormalizedPsbt = bitcoin_base.Psbt.fromBase64(
+          fixedNumsPsbt.serialize(),
+        );
+        unnormalizedPsbt.input.updateInputs(0, [
+          bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath(
+            xOnlyPubKey: hex.decode(_numsKey.substring(2)),
+            leavesHashes: const [],
+            fingerprint: const [0, 0, 0, 0],
+            indexes: const [],
+          ),
+        ]);
+        final signedPsbt = bdk.Psbt(
+          psbtBase64: datasource
+              .signPsbtWithDescriptor(
+                unnormalizedPsbt.toBase64(),
+                descriptor: _privateTaprootScriptDescriptor(signers, 0),
+                isTestnet: true,
+                tryFinalize: false,
+              )
+              .psbt,
+        );
+        try {
+          expect(
+            signedPsbt.input().single.tapKeyOrigins,
+            isNot(contains(_numsKey.substring(2))),
+          );
+          for (final output in signedPsbt.output()) {
+            expect(
+              output.tapKeyOrigins,
+              isNot(contains(_numsKey.substring(2))),
+            );
+          }
+        } finally {
+          signedPsbt.dispose();
+        }
+      } finally {
+        fixedNumsPsbt.dispose();
+      }
+
+      final numsXpubWallet =
+          WalletModel.publicBdk(
+                id: 'nums-xpub-origin',
+                descriptor: _descriptorWithUnspendableInternalKey(signers),
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final numsXpubRecipient = await _fundStoredWallet(numsXpubWallet);
+      final numsXpubPsbt = bdk.Psbt(
+        psbtBase64: await datasource.buildPsbt(
+          wallet: numsXpubWallet,
+          address: numsXpubRecipient,
+          amountSat: 50000,
+          networkFee: const NetworkFee.absolute(1000),
+        ),
+      );
+      try {
+        final origins = numsXpubPsbt.input().single.tapKeyOrigins.values;
+        expect(
+          origins.where((origin) => origin.tapLeafHashes.isEmpty),
+          hasLength(1),
+        );
+        expect(
+          origins.where((origin) => origin.tapLeafHashes.isNotEmpty),
+          hasLength(signers.length),
+        );
+        for (final output in numsXpubPsbt.output()) {
+          expect(
+            output.tapKeyOrigins.values.where(
+              (origin) => origin.tapLeafHashes.isEmpty,
+            ),
+            hasLength(1),
+          );
+        }
+      } finally {
+        numsXpubPsbt.dispose();
+      }
+    });
+  });
+
+  test('rejects ambiguous unspendable internal-key metadata', () {
+    final numsXpub = _unspendableInternalXpub();
+    final fingerprint = signers.first.fingerprint;
+    final descriptor = twoPathDescriptor(
+      'tr([$fingerprint]$numsXpub/0/*,pk(${signers.first.externalPublic}))',
+      'tr([$fingerprint]$numsXpub/1/*,pk(${signers.first.internalPublic}))',
+    );
+
+    expect(
+      () => BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('rejects an unspendable internal xpub reused in a script', () {
+    final numsXpub = _unspendableInternalXpub();
+    final descriptor = twoPathDescriptor(
+      'tr([00000000]$numsXpub/0/*,pk([00000000]$numsXpub/0/*))',
+      'tr([00000000]$numsXpub/1/*,pk([00000000]$numsXpub/1/*))',
+    );
+
+    expect(
+      () => BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('requires a choice between separate Taproot leaves', () {
+    final descriptor = twoPathDescriptor(
+      'tr($_numsKey,{pk(${signers[0].externalPublic}),pk(${signers[1].externalPublic})})',
+      'tr($_numsKey,{pk(${signers[0].internalPublic}),pk(${signers[1].internalPublic})})',
+    );
+    final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+      descriptor: descriptor,
+      isTestnet: true,
+    );
+    final descriptorKeys = _descriptorKeyModels(parsed.keys);
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'taproot-leaves',
+                  descriptor: descriptor,
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+        descriptorKeys: descriptorKeys,
+      ),
+    );
+
+    final requirement = policy
+        .pathSelectors(const BitcoinPolicySelection.empty())
+        .single;
+    final selection = policy.select(
+      current: const BitcoinPolicySelection.empty(),
+      requirement: requirement,
+      selectedIndices: const {0},
+    );
+    final path = policy.buildPath(selection);
+
+    expect(requirement.options, hasLength(2));
+    expect(path.requiredExternalKeys.single.value, 'key-0');
+    expect(path.requiredInternalKeys.single.value, 'key-0');
+  });
+
+  test('preserves the BDK root path for a single Taproot leaf', () async {
+    await _withTemporaryBdkDirectory('bdk_taproot_single_leaf_', () async {
+      final descriptor = twoPathDescriptor(
+        'tr($_numsKey,pk(${signers.first.externalPublic}))',
+        'tr($_numsKey,pk(${signers.first.internalPublic}))',
+      );
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = _descriptorKeyModels(parsed.keys);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'taproot-single-leaf',
+                descriptor: descriptor,
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet: wallet,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+      final path = policy.buildPath(const BitcoinPolicySelection.empty());
+      final recipient = await _fundStoredWallet(wallet);
+
+      expect(path.external.values.single, [1]);
+      expect(path.internal.values.single, [1]);
+      await expectLater(
+        datasource.buildPsbt(
+          wallet: wallet,
+          address: recipient,
+          amountSat: 50000,
+          networkFee: const NetworkFee.absolute(1000),
+          policyPath: path,
+          requiredDescriptorKeys: (
+            external: descriptorKeys,
+            internal: descriptorKeys,
+          ),
+        ),
+        completes,
+      );
+    });
+  });
+
+  test('removes unselected keys from a selected Taproot leaf', () async {
+    await _withTemporaryBdkDirectory('bdk_taproot_selected_keys_', () async {
+      final descriptor = twoPathDescriptor(
+        'tr($_numsKey,{pk(${signers[0].externalPublic}),pk(${signers[1].externalPublic})})',
+        'tr($_numsKey,{pk(${signers[0].internalPublic}),pk(${signers[1].internalPublic})})',
+      );
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = _descriptorKeyModels(parsed.keys);
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'taproot-selected-keys',
+                descriptor: descriptor,
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet: wallet,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+      final requirement = policy
+          .pathSelectors(const BitcoinPolicySelection.empty())
+          .single;
+      final selection = policy.select(
+        current: const BitcoinPolicySelection.empty(),
+        requirement: requirement,
+        selectedIndices: const {0},
+      );
+      final path = policy.buildPath(selection);
+      final requiredKeyIds = path.requiredExternalKeys
+          .map((key) => key.value)
+          .toSet();
+      final requiredInternalKeyIds = path.requiredInternalKeys
+          .map((key) => key.value)
+          .toSet();
+      final recipient = await _fundStoredWallet(wallet);
+      final psbt = bdk.Psbt(
+        psbtBase64: await datasource.buildPsbt(
+          wallet: wallet,
+          address: recipient,
+          amountSat: 50000,
+          networkFee: const NetworkFee.absolute(1000),
+          policyPath: path,
+          requiredDescriptorKeys: (
+            external: descriptorKeys
+                .where((key) => requiredKeyIds.contains(key.id))
+                .toList(),
+            internal: descriptorKeys
+                .where((key) => requiredInternalKeyIds.contains(key.id))
+                .toList(),
+          ),
+        ),
+      );
+      try {
+        final origins = psbt.input().single.tapKeyOrigins.values;
+        expect(origins, hasLength(1));
+        expect(origins.single.tapLeafHashes, hasLength(1));
+      } finally {
+        psbt.dispose();
+      }
+    });
+  });
+
+  test('builds and satisfies a selected Taproot hashlock path', () async {
+    await _withTemporaryBdkDirectory('bdk_taproot_path_', () async {
+      final descriptor = _taprootConditionalDescriptor(
+        externalKeys: signers.map((signer) => signer.externalPublic).toList(),
+        internalKeys: signers.map((signer) => signer.internalPublic).toList(),
+      );
+      final wallet =
+          WalletModel.publicBdk(
+                id: 'taproot-conditions',
+                descriptor: descriptor,
+                isTestnet: true,
+              )
+              as PublicBdkWalletModel;
+      final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      );
+      final descriptorKeys = _descriptorKeyModels(parsed.keys);
+      final policy = BitcoinWalletPolicyMapper.toEntity(
+        datasource.analyzePolicy(
+          wallet: wallet,
+          descriptorKeys: descriptorKeys,
+        ),
+      );
+      final selection = _selectOptionContaining<BitcoinHashlockPolicyNode>(
+        policy,
+      );
+      final recipientAddress = await _fundStoredWallet(wallet);
+
+      final policyPath = policy.buildPath(selection);
+      final unsigned = await datasource.buildPsbt(
+        wallet: wallet,
+        address: recipientAddress,
+        amountSat: 50000,
+        networkFee: const NetworkFee.absolute(1000),
+        policyPath: policyPath,
+        requiredDescriptorKeys: (
+          external: descriptorKeys
+              .where(
+                (key) => policyPath.requiredExternalKeys.any(
+                  (policyKey) => policyKey.matches(key.toEntity()),
+                ),
+              )
+              .toList(),
+          internal: descriptorKeys
+              .where(
+                (key) => policyPath.requiredInternalKeys.any(
+                  (policyKey) => policyKey.matches(key.toEntity()),
+                ),
+              )
+              .toList(),
+        ),
+      );
+      final withPreimage = datasource.applyPolicyPreimages(unsigned, [
+        BitcoinPolicyPreimage(
+          type: BitcoinHashlockType.sha256,
+          hash: _preimageHash,
+          preimageHex: _preimage,
+        ),
+      ]);
+      final review = BitcoinPsbtReviewMapper.toEntity(
+        await datasource.inspectPsbt(
+          unsigned,
+          wallet: wallet,
+          walletFingerprints: signers
+              .map((signer) => signer.fingerprint)
+              .toSet(),
+        ),
+        descriptorKeys: descriptorKeys,
+        localSignerIds: const {'signer-0'},
+      );
+
+      final psbt = bdk.Psbt(psbtBase64: withPreimage);
+      try {
+        expect(psbt.input().single.tapScripts, hasLength(1));
+        expect(psbt.extractTx().input().single.sequence, 10);
+      } finally {
+        psbt.dispose();
+      }
+      expect(policy.hasHashlock, isTrue);
+      expect(policy.hasTimelock, isTrue);
+      expect(review.inputs.single.hasLocalSignerOrigin, isFalse);
+      expect(
+        datasource
+            .signPsbtWithDescriptor(
+              withPreimage,
+              descriptor: _privateTaprootConditionalDescriptor(signers),
+              isTestnet: true,
+            )
+            .isFinalized,
+        isTrue,
+      );
+    });
+  });
+
+  test('validates signer status and both Taproot signing orders', () async {
+    final publicDescriptor = _taprootScriptDescriptor(
+      externalKeys: signers.map((signer) => signer.externalPublic).toList(),
+      internalKeys: signers.map((signer) => signer.internalPublic).toList(),
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'taproot-threshold',
+              descriptor: publicDescriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final descriptorKeys = _descriptorKeyModels(
+      BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: publicDescriptor,
+        isTestnet: true,
+      ).keys,
+    );
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(wallet: wallet, descriptorKeys: descriptorKeys),
+    );
+    final selection = _selectThresholdPath(policy);
+    final unsigned = buildUnsignedPsbt(
+      descriptor: publicDescriptor,
+      policyPath: policy.buildPath(selection),
+    );
+
+    expect(policy.requiresPath, isFalse);
+    for (final order in const [
+      [0, 1],
+      [1, 0],
+    ]) {
+      var current = unsigned;
+      final expectedSignedKeyIds = <String>{};
+      for (final signerIndex in order) {
+        final signed = datasource.signPsbtWithDescriptor(
+          current,
+          descriptor: _privateTaprootScriptDescriptor(signers, signerIndex),
+          isTestnet: true,
+          tryFinalize: false,
+        );
+        expect(
+          () => datasource.validateExternalPartialPsbt(
+            currentPsbtBase64: current,
+            signedPsbtBase64: signed.psbt,
+          ),
+          returnsNormally,
+        );
+        current = signed.psbt;
+        expectedSignedKeyIds.add('key-$signerIndex');
+        final review = BitcoinPsbtReviewMapper.toEntity(
+          await datasource.inspectPsbt(
+            current,
+            wallet: wallet,
+            walletFingerprints: signers
+                .map((signer) => signer.fingerprint)
+                .toSet(),
+          ),
+          descriptorKeys: descriptorKeys,
+          localSignerIds: const {},
+        );
+        expect(review.signedDescriptorKeyIds, expectedSignedKeyIds);
+      }
+      expect(datasource.finalizePsbt(current).isFinalized, isTrue);
+    }
+  });
+
+  test('rejects a Taproot signature not authorized by the current PSBT', () {
+    final descriptor = _taprootScriptDescriptor(
+      externalKeys: signers.map((signer) => signer.externalPublic).toList(),
+      internalKeys: signers.map((signer) => signer.internalPublic).toList(),
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'taproot-returned-origin',
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+    final descriptorKeys = _descriptorKeyModels(
+      BdkFacade.parsePublicTwoPathDescriptor(
+        descriptor: descriptor,
+        isTestnet: true,
+      ).keys,
+    );
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(wallet: wallet, descriptorKeys: descriptorKeys),
+    );
+    final unsigned = buildUnsignedPsbt(
+      descriptor: descriptor,
+      policyPath: policy.buildPath(_selectThresholdPath(policy)),
+    );
+    final current = bitcoin_base.Psbt.fromBase64(unsigned);
+    current.input.replaceInput(
+      0,
+      current.input.entries.single.where((entry) {
+        if (entry
+            case final bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath
+                origin) {
+          return hex.encode(origin.fingerprint) != signers[2].fingerprint;
+        }
+        return true;
+      }).toList(),
+    );
+    final returned = datasource.signPsbtWithDescriptor(
+      unsigned,
+      descriptor: _privateTaprootScriptDescriptor(signers, 2),
+      isTestnet: true,
+      tryFinalize: false,
+    );
+
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: current.toBase64(),
+        signedPsbtBase64: returned.psbt,
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+  });
+
+  test('rejects forged and unsupported Taproot signatures', () {
+    final descriptor = _taprootScriptDescriptor(
+      externalKeys: signers.map((signer) => signer.externalPublic).toList(),
+      internalKeys: signers.map((signer) => signer.internalPublic).toList(),
+    );
+    final unsigned = buildUnsignedPsbt(descriptor: descriptor);
+    final signed = datasource.signPsbtWithDescriptor(
+      unsigned,
+      descriptor: _privateTaprootScriptDescriptor(signers, 0),
+      isTestnet: true,
+      tryFinalize: false,
+    );
+
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: _replaceTaprootSignature(
+          signed.psbt,
+          (signature) => signature[0] ^= 1,
+        ),
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: unsigned,
+        signedPsbtBase64: _replaceTaprootSignature(
+          signed.psbt,
+          (signature) =>
+              signature.add(bitcoin_base.BitcoinOpCodeConst.sighashNone),
+        ),
+      ),
+      throwsA(isA<BitcoinPsbtUnsupportedSighashException>()),
+    );
+  });
+
+  test('rejects Tapleaf control blocks for another output key', () async {
+    final descriptor = _taprootScriptDescriptor(
+      externalKeys: signers.map((signer) => signer.externalPublic).toList(),
+      internalKeys: signers.map((signer) => signer.internalPublic).toList(),
+    );
+    final unsigned = buildUnsignedPsbt(descriptor: descriptor);
+    final signed = datasource.signPsbtWithDescriptor(
+      unsigned,
+      descriptor: _privateTaprootScriptDescriptor(signers, 0),
+      isTestnet: true,
+      tryFinalize: false,
+    );
+    final wallet =
+        WalletModel.publicBdk(
+              id: 'taproot-control-block',
+              descriptor: descriptor,
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+
+    await expectLater(
+      datasource.inspectPsbt(
+        _mutateTaprootControlBlock(unsigned),
+        wallet: wallet,
+        walletFingerprints: signers.map((signer) => signer.fingerprint).toSet(),
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+
+    expect(
+      () => datasource.validateExternalPartialPsbt(
+        currentPsbtBase64: _mutateTaprootControlBlock(unsigned),
+        signedPsbtBase64: _mutateTaprootControlBlock(signed.psbt),
+      ),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+  });
+
+  test('rejects key-path signatures for a selected script path', () {
+    final publicDescriptor = _taprootKeyAndScriptDescriptor(
+      externalInternalKey: signers[0].externalPublic,
+      externalLeafKey: signers[1].externalPublic,
+      internalInternalKey: signers[0].internalPublic,
+      internalLeafKey: signers[1].internalPublic,
+    );
+    final parsed = BdkFacade.parsePublicTwoPathDescriptor(
+      descriptor: publicDescriptor,
+      isTestnet: true,
+    );
+    final policy = BitcoinWalletPolicyMapper.toEntity(
+      datasource.analyzePolicy(
+        wallet:
+            WalletModel.publicBdk(
+                  id: 'script-path-intent',
+                  descriptor: publicDescriptor,
+                  isTestnet: true,
+                )
+                as PublicBdkWalletModel,
+        descriptorKeys: _descriptorKeyModels(parsed.keys),
+      ),
+    );
+    final requirement = policy
+        .pathSelectors(const BitcoinPolicySelection.empty())
+        .single;
+    final scriptPathIndex = requirement.options.indexWhere(
+      (option) => _signatureKeyValues(option).contains('key-1'),
+    );
+    final selection = policy.select(
+      current: const BitcoinPolicySelection.empty(),
+      requirement: requirement,
+      selectedIndices: {scriptPathIndex},
+    );
+    final unfilteredUnsigned = buildUnsignedPsbt(
+      descriptor: publicDescriptor,
+      policyPath: policy.buildPath(selection),
+    );
+    final signedPsbt = bdk.Psbt(psbtBase64: unfilteredUnsigned);
+    final signingWallet = BdkFacade.createEphemeralDescriptorWallet(
+      descriptor: _taprootKeyAndScriptDescriptor(
+        externalInternalKey: signers[0].externalPrivate,
+        externalLeafKey: signers[1].externalPublic,
+        internalInternalKey: signers[0].internalPrivate,
+        internalLeafKey: signers[1].internalPublic,
+      ),
+      isTestnet: true,
+    );
+    try {
+      signingWallet.sign(
+        psbt: signedPsbt,
+        signOptions: bdk.SignOptions(
+          trustWitnessUtxo: true,
+          assumeHeight: null,
+          allowAllSighashes: false,
+          tryFinalize: false,
+          signWithTapInternalKey: true,
+          allowGrinding: true,
+        ),
+      );
+      expect(signedPsbt.input().single.tapKeySig, isNotNull);
+      final currentPsbt = bitcoin_base.Psbt.fromBase64(unfilteredUnsigned);
+      _retainTaprootSpendMode(currentPsbt, index: 0, keyPath: false);
+      final returnedPsbt = bitcoin_base.Psbt.fromBase64(currentPsbt.toBase64());
+      final keySignature = bitcoin_base.Psbt.fromBase64(signedPsbt.serialize())
+          .input
+          .getInputs<bitcoin_base.PsbtInputTaprootKeySpendSignature>(
+            0,
+            bitcoin_base.PsbtInputTypes.taprootKeySpentSignature,
+          )!
+          .single;
+      returnedPsbt.input.updateInputs(0, [keySignature]);
+      expect(
+        () => datasource.validateExternalPartialPsbt(
+          currentPsbtBase64: currentPsbt.toBase64(),
+          signedPsbtBase64: returnedPsbt.toBase64(),
+        ),
+        throwsA(isA<InvalidBitcoinPsbtException>()),
+      );
+    } finally {
+      signingWallet.dispose();
+      signedPsbt.dispose();
+    }
+  });
+
+  test('rejects unsupported MuSig2 PSBT fields', () {
+    final descriptor = _taprootKeyPathDescriptor(
+      externalKey: signers.first.externalPublic,
+      internalKey: signers.first.internalPublic,
+    );
+    final psbt = bitcoin_base.Psbt.fromBase64(
+      buildUnsignedPsbt(descriptor: descriptor),
+    );
+    final publicKey = bitcoin_base.ECPublic.fromHex(_numsKey);
+    psbt.input.updateInputs(0, [
+      bitcoin_base.PsbtInputMuSig2ParticipantPublicKeys(
+        aggregatePubKey: publicKey,
+        pubKeys: [publicKey],
+      ),
+    ]);
+
+    expect(
+      () => datasource.finalizePsbt(psbt.toBase64()),
+      throwsA(isA<InvalidBitcoinPsbtException>()),
+    );
+  });
+}
+
+void _retainTaprootSpendMode(
+  bitcoin_base.Psbt psbt, {
+  required int index,
+  required bool keyPath,
+}) {
+  final entries = psbt.input.entries[index].where((entry) {
+    if (entry.type == bitcoin_base.PsbtInputTypes.taprootLeafScript) {
+      return !keyPath;
+    }
+    if (entry
+        case final bitcoin_base.PsbtInputTaprootKeyBip32DerivationPath
+            derivation) {
+      return keyPath
+          ? derivation.leavesHashes.isEmpty
+          : derivation.leavesHashes.isNotEmpty;
+    }
+    return true;
+  }).toList();
+  psbt.input.replaceInput(index, entries);
+}
+
+Future<void> _withTemporaryBdkDirectory(
+  String prefix,
+  Future<void> Function() body,
+) async {
+  final directory = await Directory.systemTemp.createTemp(prefix);
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return directory.path;
+        }
+        return null;
+      });
+  try {
+    await body();
+  } finally {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    await directory.delete(recursive: true);
+  }
+}
+
+Future<String> _fundStoredWallet(PublicBdkWalletModel wallet) async {
+  final bdkWallet = await BdkFacade.createWallet(wallet);
+  try {
+    final fundingAddress = bdkWallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 0,
+    );
+    final recipientAddress = bdkWallet.peekAddress(
+      keychain: bdk.KeychainKind.external_,
+      index: 1,
+    );
+    bdkWallet.applyUnconfirmedTxs(
+      unconfirmedTxs: [
+        bdk.UnconfirmedTx(
+          tx: fundingTransaction(fundingAddress.address.scriptPubkey()),
+          lastSeen: 1,
+        ),
+      ],
+    );
+    await BdkFacade.saveWallet(bdkWallet, wallet.hexId);
+    return recipientAddress.address.toString();
+  } finally {
+    bdkWallet.dispose();
+  }
+}
+
+const _numsKey =
+    '0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0';
+const _preimage =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+final _preimageHash = sha256.convert(hex.decode(_preimage)).toString();
+
+String _unspendableInternalXpub() {
+  final network = bip32.NetworkType(
+    wif: 0xef,
+    bip32: bip32.Bip32Type(public: 0x043587cf, private: 0x04358394),
+  );
+  final key = bip32.Bip32Keys.fromPublicKey(
+    Uint8List.fromList(hex.decode(_numsKey)),
+    Uint8List.fromList(List<int>.generate(32, (index) => index)),
+    network: network,
+  );
+  return key.toBase58();
+}
+
+String _descriptorWithUnspendableInternalKey(
+  List<SignerDescriptorKeys> signers,
+) {
+  final numsXpub = _unspendableInternalXpub();
+  return twoPathDescriptor(
+    'tr([00000000]$numsXpub/0/*,multi_a(2,${signers.map((signer) => signer.externalPublic).join(',')}))',
+    'tr([00000000]$numsXpub/1/*,multi_a(2,${signers.map((signer) => signer.internalPublic).join(',')}))',
+  );
+}
+
+List<WalletDescriptorKeyModel> _descriptorKeyModels(
+  List<BdkDescriptorKey> keys,
+) => [
+  for (final (index, key) in keys.indexed)
+    WalletDescriptorKeyModel(
+      id: 'key-$index',
+      signerId: 'signer-$index',
+      masterFingerprint: key.masterFingerprint,
+      xpubFingerprint: key.xpubFingerprint,
+      xpub: key.xpub,
+      derivationPath: key.derivationPath,
+    ),
+];
+
+Set<String> _signatureKeyValues(BitcoinPolicyNode node) => switch (node) {
+  BitcoinSignaturePolicyNode(:final key) => {key.value},
+  BitcoinThresholdPolicyNode(:final children) => {
+    for (final child in children) ..._signatureKeyValues(child),
+  },
+  _ => const {},
+};
+
+String _taprootKeyPathDescriptor({
+  required String externalKey,
+  required String internalKey,
+}) => twoPathDescriptor('tr($externalKey)', 'tr($internalKey)');
+
+String _taprootKeyAndScriptDescriptor({
+  required String externalInternalKey,
+  required String externalLeafKey,
+  required String internalInternalKey,
+  required String internalLeafKey,
+}) => twoPathDescriptor(
+  'tr($externalInternalKey,pk($externalLeafKey))',
+  'tr($internalInternalKey,pk($internalLeafKey))',
+);
+
+String _taprootScriptDescriptor({
+  required List<String> externalKeys,
+  required List<String> internalKeys,
+}) => twoPathDescriptor(
+  'tr($_numsKey,multi_a(2,${externalKeys.join(',')}))',
+  'tr($_numsKey,multi_a(2,${internalKeys.join(',')}))',
+);
+
+String _privateTaprootScriptDescriptor(
+  List<SignerDescriptorKeys> signers,
+  int privateSignerIndex,
+) => _taprootScriptDescriptor(
+  externalKeys: [
+    for (final (index, signer) in signers.indexed)
+      index == privateSignerIndex
+          ? signer.externalPrivate
+          : signer.externalPublic,
+  ],
+  internalKeys: [
+    for (final (index, signer) in signers.indexed)
+      index == privateSignerIndex
+          ? signer.internalPrivate
+          : signer.internalPublic,
+  ],
+);
+
+String _taprootConditionalDescriptor({
+  required List<String> externalKeys,
+  required List<String> internalKeys,
+}) => twoPathDescriptor(
+  'tr($_numsKey,{multi_a(2,${externalKeys.take(2).join(',')}),'
+      'and_v(v:pk(${externalKeys.last}),'
+      'and_v(v:older(10),sha256($_preimageHash)))})',
+  'tr($_numsKey,{multi_a(2,${internalKeys.take(2).join(',')}),'
+      'and_v(v:pk(${internalKeys.last}),'
+      'and_v(v:older(10),sha256($_preimageHash)))})',
+);
+
+String _privateTaprootConditionalDescriptor(
+  List<SignerDescriptorKeys> signers,
+) => _taprootConditionalDescriptor(
+  externalKeys: [
+    signers[0].externalPublic,
+    signers[1].externalPublic,
+    signers[2].externalPrivate,
+  ],
+  internalKeys: [
+    signers[0].internalPublic,
+    signers[1].internalPublic,
+    signers[2].internalPrivate,
+  ],
+);
+
+BitcoinPolicySelection _selectThresholdPath(BitcoinWalletPolicy policy) {
+  var selection = const BitcoinPolicySelection.empty();
+  while (policy.pathRequirements(selection).isNotEmpty) {
+    final requirement = policy.pathSelectors(selection).first;
+    final thresholdIndex = requirement.options.indexWhere(
+      (option) => option is BitcoinThresholdPolicyNode,
+    );
+    selection = policy.select(
+      current: selection,
+      requirement: requirement,
+      selectedIndices: {thresholdIndex},
+    );
+  }
+  return selection;
+}
+
+BitcoinPolicySelection _selectOptionContaining<T extends BitcoinPolicyNode>(
+  BitcoinWalletPolicy policy,
+) {
+  var selection = const BitcoinPolicySelection.empty();
+  while (policy.pathRequirements(selection).isNotEmpty) {
+    final requirement = policy.pathSelectors(selection).first;
+    final optionIndex = requirement.options.indexWhere(
+      (option) => containsPolicyNode<T>(option),
+    );
+    if (optionIndex < 0) {
+      throw StateError('No policy option contains $T');
+    }
+    selection = policy.select(
+      current: selection,
+      requirement: requirement,
+      selectedIndices: {optionIndex},
+    );
+  }
+  return selection;
+}
+
+String _replaceTaprootSignature(
+  String psbtBase64,
+  void Function(List<int> signature) mutate,
+) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  final partial = psbt.input
+      .getInputs<bitcoin_base.PsbtInputTaprootScriptSpendSignature>(
+        0,
+        bitcoin_base.PsbtInputTypes.taprootScriptSpentSignature,
+      )!
+      .single;
+  final signature = partial.signature.toList();
+  mutate(signature);
+  psbt.input.updateInputs(0, [
+    bitcoin_base.PsbtInputTaprootScriptSpendSignature(
+      signature: signature,
+      xOnlyPubKey: partial.xOnlyPubKey,
+      leafHash: partial.leafHash,
+    ),
+  ]);
+  return psbt.toBase64();
+}
+
+String _mutateTaprootControlBlock(String psbtBase64) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  final leaf = psbt.input
+      .getInputs<bitcoin_base.PsbtInputTaprootLeafScript>(
+        0,
+        bitcoin_base.PsbtInputTypes.taprootLeafScript,
+      )!
+      .single;
+  final controlBlock = leaf.controllBlock.toList()..[1] ^= 1;
+  psbt.input.removeInputKeys(0, [
+    bitcoin_base.PsbtInputTypes.taprootLeafScript,
+  ]);
+  psbt.input.updateInputs(0, [
+    bitcoin_base.PsbtInputTaprootLeafScript(
+      controllBlock: controlBlock,
+      script: leaf.script,
+      leafVersion: leaf.leafVersion,
+    ),
+  ]);
+  return psbt.toBase64();
+}
+
+String _replaceTaprootKeySignature(
+  String psbtBase64,
+  void Function(List<int> signature) mutate,
+) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  final partial = psbt.input
+      .getInputs<bitcoin_base.PsbtInputTaprootKeySpendSignature>(
+        0,
+        bitcoin_base.PsbtInputTypes.taprootKeySpentSignature,
+      )!
+      .single;
+  final signature = partial.signature.toList();
+  mutate(signature);
+  psbt.input.updateInputs(0, [
+    bitcoin_base.PsbtInputTaprootKeySpendSignature(signature),
+  ]);
+  return psbt.toBase64();
+}
+
+String _withInputSighash(String psbtBase64, int sighash) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  psbt.input.updateInputs(0, [bitcoin_base.PsbtInputSigHash(sighash)]);
+  return psbt.toBase64();
+}
+
+String _withoutInputSighash(String psbtBase64) {
+  final psbt = bitcoin_base.Psbt.fromBase64(psbtBase64);
+  psbt.input.removeInputKeys(0, [bitcoin_base.PsbtInputTypes.sighashType]);
+  return psbt.toBase64();
+}

--- a/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
+++ b/test/core_test/wallet/domain/entities/bitcoin_wallet_policy_test.dart
@@ -2,6 +2,32 @@ import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('rejects invalid threshold child mappings', () {
+    List<BitcoinPolicyNode> children() => [
+      BitcoinRelativeTimelockPolicyNode(id: 'first', value: 1),
+      BitcoinRelativeTimelockPolicyNode(id: 'second', value: 2),
+    ];
+
+    expect(
+      () => BitcoinThresholdPolicyNode(
+        id: 'duplicate',
+        threshold: 1,
+        children: children(),
+        pathChildIndices: const [0, 0],
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => BitcoinThresholdPolicyNode(
+        id: 'negative',
+        threshold: 1,
+        children: children(),
+        pathChildIndices: const [-1, 1],
+      ),
+      throwsArgumentError,
+    );
+  });
+
   group('BitcoinWalletPolicy maturity', () {
     test('rejects duplicate and out-of-range path choices', () {
       final policy = thresholdPolicy();

--- a/test/core_test/wallet/domain/entities/wallet_test.dart
+++ b/test/core_test/wallet/domain/entities/wallet_test.dart
@@ -1,5 +1,7 @@
+import 'package:bb_mobile/core/entities/signer_device_entity.dart';
 import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,6 +13,8 @@ void main() {
     String descriptorPath = '/<0;1>/*',
     ScriptType? scriptType = ScriptType.bip84,
     SignerEntity signer = SignerEntity.local,
+    SignerDeviceEntity? signerDevice,
+    int descriptorKeyCount = 1,
   }) {
     final expectedInternalDescriptor = externalDescriptor.replaceAll(
       '/0/*',
@@ -24,14 +28,22 @@ void main() {
       origin: 'wallet',
       network: Network.bitcoinMainnet,
       signers: [
-        WalletSigner.single(
-          masterFingerprint: '00000000',
-          xpubFingerprint: '00000000',
-          xpub: 'xpub',
-          derivationPath: derivationPath,
-          descriptorPath: descriptorPath,
+        WalletSigner(
+          id: 'signer-0',
           signer: signer,
-          signerDevice: null,
+          signerDevice: signerDevice,
+          descriptorKeys: [
+            for (var index = 0; index < descriptorKeyCount; index++)
+              WalletDescriptorKey(
+                id: 'key-$index',
+                signerId: 'signer-0',
+                masterFingerprint: '00000000',
+                xpubFingerprint: '00000000',
+                xpub: 'xpub-$index',
+                derivationPath: derivationPath,
+                descriptorPath: descriptorPath,
+              ),
+          ],
         ),
       ],
       scriptType: scriptType,
@@ -164,5 +176,122 @@ void main() {
         isTrue,
       );
     });
+  });
+
+  test('keeps device signing within supported Taproot policies', () {
+    final mk4 = wallet(
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.coldcardMk4,
+    );
+    final q = wallet(
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.coldcardQ,
+    );
+    final taprootMk4 = wallet(
+      externalDescriptor: 'tr(xpub/0/*)',
+      internalDescriptor: 'tr(xpub/1/*)',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.coldcardMk4,
+    );
+    final taprootQ = wallet(
+      externalDescriptor: 'tr(xpub/0/*)',
+      internalDescriptor: 'tr(xpub/1/*)',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.coldcardQ,
+    );
+    final taprootScriptMk4 = wallet(
+      externalDescriptor: 'tr(xpub/0/*,pk(xpub/0/*))',
+      internalDescriptor: 'tr(xpub/1/*,pk(xpub/1/*))',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.coldcardMk4,
+    );
+    final taprootPassport = wallet(
+      externalDescriptor: 'tr(xpub/0/*)',
+      internalDescriptor: 'tr(xpub/1/*)',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.passport,
+    );
+    final taprootScriptPassport = wallet(
+      externalDescriptor: 'tr(xpub/0/*,pk(xpub/0/*))',
+      internalDescriptor: 'tr(xpub/1/*,pk(xpub/1/*))',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.passport,
+    );
+
+    expect(mk4.supportsQrSigningFor(mk4.signers.single), isFalse);
+    expect(mk4.supportsDevicePsbtFlowFor(mk4.signers.single), isTrue);
+    expect(q.supportsQrSigningFor(q.signers.single), isTrue);
+    expect(q.supportsDevicePsbtFlowFor(q.signers.single), isTrue);
+    expect(
+      taprootMk4.supportsDevicePsbtFlowFor(taprootMk4.signers.single),
+      isFalse,
+    );
+    expect(
+      taprootQ.supportsDevicePsbtFlowFor(taprootQ.signers.single),
+      isFalse,
+    );
+    expect(
+      taprootScriptMk4.supportsDevicePsbtFlowFor(
+        taprootScriptMk4.signers.single,
+      ),
+      isFalse,
+    );
+    expect(
+      taprootPassport.supportsQrSigningFor(taprootPassport.signers.single),
+      isTrue,
+    );
+    expect(
+      taprootScriptPassport.supportsQrSigningFor(
+        taprootScriptPassport.signers.single,
+      ),
+      isFalse,
+    );
+  });
+
+  test('offers BitBox policies for only one controlled account key', () {
+    final singleAccount = wallet(
+      externalDescriptor: 'wsh(pk(xpub/0/*))',
+      internalDescriptor: 'wsh(pk(xpub/1/*))',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.bitbox02,
+    );
+    final multipleAccounts = wallet(
+      externalDescriptor: 'wsh(or_d(pk(xpub-a/0/*),pk(xpub-b/0/*)))',
+      internalDescriptor: 'wsh(or_d(pk(xpub-a/1/*),pk(xpub-b/1/*)))',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.bitbox02,
+      descriptorKeyCount: 2,
+    );
+    final hashlock = wallet(
+      externalDescriptor:
+          'wsh(and_v(v:pk(xpub/0/*),sha256(0000000000000000000000000000000000000000000000000000000000000000)))',
+      internalDescriptor:
+          'wsh(and_v(v:pk(xpub/1/*),sha256(0000000000000000000000000000000000000000000000000000000000000000)))',
+      scriptType: null,
+      signer: SignerEntity.remote,
+      signerDevice: SignerDeviceEntity.bitbox02,
+    );
+
+    expect(
+      singleAccount.supportsWalletPolicySigner(singleAccount.signers.single),
+      isTrue,
+    );
+    expect(
+      multipleAccounts.supportsWalletPolicySigner(
+        multipleAccounts.signers.single,
+      ),
+      isFalse,
+    );
+    expect(
+      hashlock.supportsWalletPolicySigner(hashlock.signers.single),
+      isFalse,
+    );
   });
 }

--- a/test/features/import_watch_only_wallet/import_watch_only_descriptor_usecase_test.dart
+++ b/test/features/import_watch_only_wallet/import_watch_only_descriptor_usecase_test.dart
@@ -79,24 +79,6 @@ void main() {
         same(wallet),
       );
     });
-
-    test('maps Taproot rejection to TaprootUnsupportedFailure', () async {
-      when(
-        () => descriptorPort.importDescriptor(
-          descriptor: entity.descriptor,
-          network: entity.network,
-          label: entity.label,
-          signers: entity.signers,
-        ),
-      ).thenThrow(const UnsupportedTaprootDescriptorException());
-
-      final result = await usecase.execute(watchOnlyDescriptor: entity);
-
-      expect(result, isA<Err<Wallet, ImportWatchOnlyFailure>>());
-      final failure = (result as Err<Wallet, ImportWatchOnlyFailure>).failure;
-      expect(failure, isA<TaprootUnsupportedFailure>());
-      expect(failure.logMessage, isNull);
-    });
   });
 }
 

--- a/test/features/import_watch_only_wallet/parse_watch_only_input_usecase_test.dart
+++ b/test/features/import_watch_only_wallet/parse_watch_only_input_usecase_test.dart
@@ -595,25 +595,6 @@ void main() {
       );
     });
 
-    test('maps Taproot input to TaprootUnsupportedFailure', () async {
-      const input = 'tr(xpub/<0;1>/*)';
-      when(
-        () => descriptorPort.parseBitcoinDescriptor(
-          descriptor: input,
-          network: Network.bitcoinMainnet,
-        ),
-      ).thenThrow(const UnsupportedTaprootDescriptorException());
-
-      final result = await usecase.execute(input);
-
-      expect(result, isA<Err<WatchOnlyWalletEntity, ImportWatchOnlyFailure>>());
-      final failure =
-          (result as Err<WatchOnlyWalletEntity, ImportWatchOnlyFailure>)
-              .failure;
-      expect(failure, isA<TaprootUnsupportedFailure>());
-      expect(failure.logMessage, isNull);
-    });
-
     test('maps fixed public keys to their unsupported failure', () async {
       const fixedPublicKey =
           '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';

--- a/test/features/psbt_signing/domain/usecases/sign_external_psbt_usecase_test.dart
+++ b/test/features/psbt_signing/domain/usecases/sign_external_psbt_usecase_test.dart
@@ -101,4 +101,31 @@ void main() {
       ),
     );
   });
+
+  test('rejects mixed Taproot input spend modes', () async {
+    final port = _MockBitcoinSigningPort();
+    final review = psbtSigningReview(
+      policy: singleLocalPolicy(),
+      wallet: psbtSigningWallet(includeRemoteSigner: false),
+      transaction: psbtReview(),
+    );
+    when(
+      () => port.signPsbt('unsigned', walletId: 'wallet', tryFinalize: false),
+    ).thenAnswer(
+      (_) async => const Err(
+        BitcoinSigningFailure(BitcoinSigningFailureKind.unsupportedSpendMode),
+      ),
+    );
+
+    final result = await SignExternalPsbtUsecase(port).execute(review);
+
+    expect(
+      result,
+      isA<Err<PsbtSigningResult, PsbtSigningFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<PsbtSigningUnsupportedSpendModeFailure>(),
+      ),
+    );
+  });
 }

--- a/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
+++ b/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repositor
 import 'package:bb_mobile/core/wallet/domain/entities/bitcoin_policy.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/unsupported_bitcoin_policy_path_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -226,6 +227,35 @@ void main() {
       );
     },
   );
+
+  test('unsupported policy paths are rethrown unchanged', () async {
+    when(() => walletUtxo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+    when(
+      () => payjoin.reservedOutpoints(),
+    ).thenAnswer((_) async => const Ok(<Outpoint>{}));
+    when(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenThrow(const UnsupportedBitcoinPolicyPathException());
+
+    await expectLater(
+      usecase.execute(
+        walletId: walletId,
+        address: address,
+        networkFee: networkFee,
+        amountSat: 50000,
+      ),
+      throwsA(isA<UnsupportedBitcoinPolicyPathException>()),
+    );
+  });
 
   test(
     'user-frozen ∪ payjoin-derived are merged + deduped into unspendable',

--- a/test/features/settings/domain/usecases/get_wallet_registration_options_usecase_test.dart
+++ b/test/features/settings/domain/usecases/get_wallet_registration_options_usecase_test.dart
@@ -159,6 +159,79 @@ void main() {
     },
   );
 
+  test('limits Taproot registration to verified device formats', () async {
+    final wallet = _wallet(
+      devices: const [
+        SignerDeviceEntity.krux,
+        SignerDeviceEntity.specter,
+        SignerDeviceEntity.passport,
+        SignerDeviceEntity.jade,
+        SignerDeviceEntity.seedsigner,
+        SignerDeviceEntity.coldcardQ,
+        SignerDeviceEntity.coldcardMk4,
+        SignerDeviceEntity.bitbox02,
+        SignerDeviceEntity.ledgerNanoSPlus,
+      ],
+      taproot: true,
+    );
+    when(
+      () => bitcoinSigningPort.getPolicy(walletId: wallet.id),
+    ).thenAnswer((_) async => Ok(_multisigPolicy(keyCount: 8)));
+
+    final result = await usecase.execute(wallet);
+
+    final options =
+        (result as Ok<List<WalletRegistrationOption>, SettingsFailure>).value;
+    expect(
+      options.whereType<AvailableWalletRegistration>().map(
+        (option) => option.device,
+      ),
+      [SignerDeviceEntity.krux, SignerDeviceEntity.specter],
+    );
+    expect(
+      options.whereType<UnavailableWalletRegistration>().map(
+        (option) => option.device,
+      ),
+      [
+        SignerDeviceEntity.passport,
+        SignerDeviceEntity.jade,
+        SignerDeviceEntity.seedsigner,
+        SignerDeviceEntity.coldcardQ,
+        SignerDeviceEntity.coldcardMk4,
+      ],
+    );
+    expect(
+      options.whereType<ConnectedWalletRegistration>().map(
+        (option) => option.device,
+      ),
+      [SignerDeviceEntity.bitbox02, SignerDeviceEntity.ledgerNanoSPlus],
+    );
+  });
+
+  test('does not offer Coldcard registration for Taproot', () async {
+    final wallet = _wallet(
+      devices: const [
+        SignerDeviceEntity.coldcardQ,
+        SignerDeviceEntity.coldcardMk4,
+      ],
+      taproot: true,
+    );
+    when(
+      () => bitcoinSigningPort.getPolicy(walletId: wallet.id),
+    ).thenAnswer((_) async => Ok(_multisigPolicy(keyCount: 2)));
+
+    final result = await usecase.execute(wallet);
+
+    final options =
+        (result as Ok<List<WalletRegistrationOption>, SettingsFailure>).value;
+    expect(
+      options.whereType<UnavailableWalletRegistration>().map(
+        (option) => option.device,
+      ),
+      [SignerDeviceEntity.coldcardQ, SignerDeviceEntity.coldcardMk4],
+    );
+  });
+
   test('does not offer BitBox for nested unsorted multisig', () async {
     final wallet = _wallet(
       devices: const [
@@ -332,6 +405,7 @@ Wallet _wallet({
   bool hashlock = false,
   bool nestedUnsortedMultisig = false,
   bool usesDisjointBranches = false,
+  bool taproot = false,
 }) {
   final signers = [
     for (final (index, device) in devices.indexed)
@@ -362,7 +436,9 @@ Wallet _wallet({
               'pk(${keys.last})',
               (policy, key) => 'or_d(pk($key),$policy)',
             );
-  final body = miniscript
+  final body = taproot
+      ? 'tr(${keys.first},multi_a($threshold,${keys.skip(1).join(',')}))'
+      : miniscript
       ? 'wsh($miniscriptPolicy)'
       : nestedUnsortedMultisig
       ? 'sh(wsh(multi($threshold,${keys.join(',')})))'


### PR DESCRIPTION
## Summary

- Import and analyze Taproot descriptor wallets.
- Support Taproot key-path signing.
- Support Tapscript policies using `multi_a`, thresholds, timelocks and hashlocks.
- Track script-path signatures using their exact Tapleaf hashes.
- Build PSBTs containing only the Tapleaf information needed for the selected spending option.
- Verify Taproot signatures before accepting them.
- Support Taproot wallet-policy registration, address verification and signing on compatible hardware wallets.
- Keep unsupported device actions hidden or clearly unavailable.

## Descriptor examples

Key-path wallet:

```text
tr([FINGERPRINT/86'/0'/0']XPUB/<0;1>/*)
```

Script-path multisig using the standard BIP341 NUMS internal key:

```text
tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,multi_a(2,KEY_A,KEY_B,KEY_C))
```

The recognized BIP341 NUMS internal key remains part of the descriptor and device wallet policy but is not presented as a signer.

## Scope

- Taproot key paths and supported Tapscript policies are included.
- MuSig2 is not supported.
- Device actions are offered only for policy and transport combinations supported by that device.
