### PR TITLE
fix(core): disable smart punctuation on the passphrase field

### DIFF
--- a/lib/core/widgets/inputs/labeled_text_input.dart
+++ b/lib/core/widgets/inputs/labeled_text_input.dart
@@ -15,6 +15,11 @@ class LabeledTextInput extends StatelessWidget {
   final bool enableSuggestions;
   final bool autocorrect;
 
+  /// iOS Smart Punctuation, on by default. Disable both when the value must
+  /// survive exactly as typed.
+  final SmartQuotesType? smartQuotesType;
+  final SmartDashesType? smartDashesType;
+
   const LabeledTextInput({
     super.key,
     required this.label,
@@ -24,6 +29,8 @@ class LabeledTextInput extends StatelessWidget {
     this.maxLines,
     this.enableSuggestions = true,
     this.autocorrect = true,
+    this.smartQuotesType,
+    this.smartDashesType,
   });
 
   @override
@@ -72,6 +79,8 @@ class LabeledTextInput extends StatelessWidget {
             maxLines: maxLines,
             enableSuggestions: enableSuggestions,
             autocorrect: autocorrect,
+            smartQuotesType: smartQuotesType,
+            smartDashesType: smartDashesType,
           ),
         ),
       ],

--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -217,6 +217,12 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
                       // IME's suggestion and autocorrect caches.
                       enableSuggestions: false,
                       autocorrect: false,
+                      // iOS Smart Punctuation turns `'` into `’`, which
+                      // would derive a different wallet. Disable it here
+                      // rather than cleaning up the submitted value: `’`
+                      // can be a real passphrase character.
+                      smartQuotesType: SmartQuotesType.disabled,
+                      smartDashesType: SmartDashesType.disabled,
                     ),
                   ],
 

--- a/packages/bull_ui/lib/src/inputs/bull_input_text.dart
+++ b/packages/bull_ui/lib/src/inputs/bull_input_text.dart
@@ -30,6 +30,8 @@ class BullInputText extends StatefulWidget {
     this.obscure = false,
     this.enableSuggestions = true,
     this.autocorrect = true,
+    this.smartQuotesType,
+    this.smartDashesType,
     this.style,
     this.hideBorder = false,
     this.maxLines,
@@ -89,6 +91,12 @@ class BullInputText extends StatefulWidget {
   /// the IME's suggestion and autocorrect caches must never see the value.
   final bool enableSuggestions;
   final bool autocorrect;
+
+  /// iOS Smart Punctuation, which rewrites `'` as `’` and `--` as `—`.
+  /// Left null, [TextField] enables it (unless [obscure]). Disable both when
+  /// the value must survive exactly as typed.
+  final SmartQuotesType? smartQuotesType;
+  final SmartDashesType? smartDashesType;
 
   /// Maximum lines.
   final int? maxLines;
@@ -182,6 +190,8 @@ class _BullInputTextState extends State<BullInputText> {
       enableIMEPersonalizedLearning: false,
       enableSuggestions: widget.enableSuggestions,
       autocorrect: widget.autocorrect,
+      smartQuotesType: widget.smartQuotesType,
+      smartDashesType: widget.smartDashesType,
       maxLength: widget.maxLength,
       minLines: widget.minLines ?? 1,
       maxLines: effectiveMaxLines,

--- a/test/core_test/widgets/mnemonic_widget_test.dart
+++ b/test/core_test/widgets/mnemonic_widget_test.dart
@@ -29,6 +29,7 @@ Future<void> pumpWidget(
   bool allowAutoFillWords = false,
   bool allowMultipleMnemonicLength = true,
   bool allowPassphrase = false,
+  bool allowLabel = false,
   String? externalError,
   required void Function(Mnemonic) onSubmit,
 }) async {
@@ -47,7 +48,7 @@ Future<void> pumpWidget(
           onSubmit: onSubmit,
           allowAutoFillWords: allowAutoFillWords,
           allowMultipleMnemonicLength: allowMultipleMnemonicLength,
-          allowLabel: false,
+          allowLabel: allowLabel,
           allowPassphrase: allowPassphrase,
           externalError: externalError,
         ),
@@ -57,6 +58,15 @@ Future<void> pumpWidget(
 }
 
 Finder wordField(int index) => find.byType(TextField).at(index);
+
+/// A labelled input's inner [TextField], found by its placeholder — the label
+/// itself is a sibling widget, not part of the field.
+TextField fieldByHint(WidgetTester tester, String hint) =>
+    tester.widget<TextField>(
+      find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == hint,
+      ),
+    );
 
 /// A key on the in-app keyboard, scoped so the letter is matched on the
 /// keyboard and not in a field or a suggestion chip.
@@ -518,22 +528,35 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('the passphrase field stays out of the IME suggestion caches', (
+    testWidgets('the passphrase field takes the value exactly as typed', (
       tester,
     ) async {
       await pumpWidget(tester, allowPassphrase: true, onSubmit: (_) {});
 
-      // The passphrase is key material too: the OS keyboard may serve it, but
-      // its autocorrect and prediction caches must never see the value.
-      final field = tester.widget<TextField>(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is TextField &&
-              widget.decoration?.hintText == 'Optional Passphrase',
-        ),
-      );
-      expect(field.enableSuggestions, isFalse);
+      final field = fieldByHint(tester, 'Optional Passphrase');
+
+      // The passphrase feeds seed derivation character by character, so iOS
+      // must not reformat it into a different wallet.
+      expect(field.smartQuotesType, SmartQuotesType.disabled);
+      expect(field.smartDashesType, SmartDashesType.disabled);
+
+      // It is key material too: the OS keyboard may serve it, but its
+      // autocorrect and prediction caches must never see the value.
       expect(field.autocorrect, isFalse);
+      expect(field.enableSuggestions, isFalse);
+    });
+
+    testWidgets('a non-secret labelled input keeps the platform defaults', (
+      tester,
+    ) async {
+      await pumpWidget(tester, allowLabel: true, onSubmit: (_) {});
+
+      // The hardening is opt-in: ordinary text still types normally.
+      final field = fieldByHint(tester, 'Required');
+      expect(field.smartQuotesType, SmartQuotesType.enabled);
+      expect(field.smartDashesType, SmartDashesType.enabled);
+      expect(field.enableSuggestions, isTrue);
+      expect(field.autocorrect, isTrue);
     });
   });
 


### PR DESCRIPTION
Fixes: #2548

Disables iOS Smart Punctuation on the BIP39 passphrase field, which was rewriting `'` as `’` and silently deriving a different wallet.

<img width="327" height="86" alt="Screenshot 2026-08-24 at 2 14 19 PM" src="https://github.com/user-attachments/assets/12fa3125-350f-4d0b-ad66-b9687b95cbdc" />
