### PR TITLE
feat: add wallet recovery manifest and Nostr key inventory

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,7 @@ graph TB
     NETWORK[Network]
     BIP85[BIP85]
     NOSTR_IDENTITY[Nostr Identity]
+    KEYCHAIN_MANIFEST[Keychain Manifest<br/>---<br/>Wallet inventory, Nostr keys,<br/>passphrase wallet records]
     FEES[Fees]
     WALLETS[Wallets]
     EXCHANGE[Exchange]
@@ -108,6 +109,7 @@ graph TB
     SEND --> WALLETS
     SETTINGS --> CORE
     SETTINGS --> BULL_PAYJOIN
+    SETTINGS --> KEYCHAIN_MANIFEST
     STATUS --> BULL_PAYJOIN
     SWAPS --> BULL_PAYJOIN
     SWAPS --> EXCHANGE

--- a/lib/core/widgets/address_viewer.dart
+++ b/lib/core/widgets/address_viewer.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/core/mempool/domain/services/mempool_url_builder.dart'
 import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/dialog/blurred_dialog.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/core/widgets/segment/segmented_full.dart';
 import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
@@ -28,6 +29,8 @@ class AddressViewer extends StatelessWidget {
     this.style,
     this.color,
     this.clipboardText,
+    this.qrData,
+    this.showExplorerActions = true,
     this.textAlign,
   });
 
@@ -37,6 +40,12 @@ class AddressViewer extends StatelessWidget {
 
   /// Text copied to clipboard on long press. Defaults to [data].
   final String? clipboardText;
+
+  /// Optional payload to render as a QR code in the detail view.
+  final String? qrData;
+
+  /// Whether the detail view should offer blockchain explorer actions.
+  final bool showExplorerActions;
 
   /// Alignment of the (possibly truncated) address text within its box.
   final TextAlign? textAlign;
@@ -53,8 +62,13 @@ class AddressViewer extends StatelessWidget {
     );
 
     return GestureDetector(
-      onTap: () =>
-          showDetail(context, data: data, clipboardText: clipboardText),
+      onTap: () => showDetail(
+        context,
+        data: data,
+        clipboardText: clipboardText,
+        qrData: qrData,
+        showExplorerActions: showExplorerActions,
+      ),
       onLongPress: () {
         Clipboard.setData(ClipboardData(text: clipboardText ?? data));
         SnackBarUtils.showCopiedSnackBar(context);
@@ -136,12 +150,16 @@ class AddressViewer extends StatelessWidget {
     BuildContext context, {
     required String data,
     String? clipboardText,
+    String? qrData,
+    bool showExplorerActions = true,
   }) {
     return BlurredDialog.show<void>(
       context: context,
       builder: (dialogContext) => _AddressDetailSheet(
         data: data,
         clipboardText: clipboardText ?? data,
+        qrData: qrData,
+        showExplorerActions: showExplorerActions,
         dialogContext: dialogContext,
         getExplorerUrl: () => _getExplorerUrlFor(data),
       ),
@@ -153,12 +171,16 @@ class _AddressDetailSheet extends StatefulWidget {
   const _AddressDetailSheet({
     required this.data,
     required this.clipboardText,
+    this.qrData,
+    required this.showExplorerActions,
     required this.dialogContext,
     required this.getExplorerUrl,
   });
 
   final String data;
   final String clipboardText;
+  final String? qrData;
+  final bool showExplorerActions;
   final BuildContext dialogContext;
   final Future<String?> Function() getExplorerUrl;
 
@@ -222,7 +244,7 @@ class _AddressDetailSheetState extends State<_AddressDetailSheet> {
           _buildBody(context),
           const Gap(24),
           _buildCopyAction(context),
-          if (!_showUri) ...[
+          if (!_showUri && widget.showExplorerActions) ...[
             const Gap(16),
             _buildCopyLinkAction(context),
             const Gap(16),
@@ -268,7 +290,7 @@ class _AddressDetailSheetState extends State<_AddressDetailSheet> {
     }
 
     final groups = _groupsOf(_activeText);
-    return Wrap(
+    final addressText = Wrap(
       spacing: 8,
       runSpacing: 6,
       alignment: WrapAlignment.center,
@@ -285,6 +307,15 @@ class _AddressDetailSheetState extends State<_AddressDetailSheet> {
               letterSpacing: 1.2,
             ),
           ),
+      ],
+    );
+    if (widget.qrData == null) return addressText;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        QrDisplayWidget(data: widget.qrData!, size: 240),
+        const Gap(16),
+        addressText,
       ],
     );
   }

--- a/lib/features/keychain_manifest/data/keychain_manifest_repository_impl.dart
+++ b/lib/features/keychain_manifest/data/keychain_manifest_repository_impl.dart
@@ -1,0 +1,733 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/storage/backup_revision_recorder.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:drift/drift.dart';
+import 'package:primitives/primitives.dart' show Err, Fingerprint, Ok, Result;
+
+final class KeychainManifestRepositoryImpl
+    implements KeychainManifestRepository {
+  final SqliteDatabase _database;
+
+  /// Bull backup's dirty signal, raised inside the same transaction as the
+  /// write that earned it (decision 7). Forgetting a wallet depends on it: a
+  /// signal lost to a crash would leave the forgotten wallet in the next
+  /// published snapshot.
+  final BackupRevisionRecorder _backupRevisions;
+  final StreamController<void> _localChanges = StreamController.broadcast();
+
+  KeychainManifestRepositoryImpl(
+    this._database, {
+    this._backupRevisions = const NoBackupRevisionRecorder(),
+  });
+
+  @override
+  Stream<void> watchLocalChanges() => _localChanges.stream;
+
+  @override
+  Future<Result<List<KeychainManifestEntry>, KeychainManifestFailure>> fetch(
+    Fingerprint parentFingerprint,
+  ) async {
+    try {
+      return Ok(
+        await _database.transaction(() async {
+          final query = _database.select(_database.keychainManifestEntries)
+            ..where(
+              (row) => row.parentFingerprint.equals(parentFingerprint.hex),
+            );
+          final rows = await query.get();
+          final entries = <KeychainManifestEntry>[];
+          for (final row in rows) {
+            final wallets = await _walletRowsOf(row.entryId);
+            final nostr = await _nostrRow(row.entryId);
+            final items = <KeychainManifestMaterialization>[
+              ...wallets.map(_walletEntity),
+              if (nostr != null) _nostrEntity(nostr),
+            ];
+            if (items.isNotEmpty) entries.add(_entryEntity(row, items));
+          }
+          entries.sort(KeychainManifestEntry.compare);
+          return entries;
+        }),
+      );
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to read keychain manifest',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> replaceSeedWalletInventory(
+    Fingerprint parentFingerprint,
+    List<KeychainManifestEntry> entries,
+  ) async {
+    if (entries.any(
+      (entry) =>
+          entry.parentFingerprint != parentFingerprint ||
+          entry.derivationKind != KeychainManifestDerivationKind.bip32,
+    )) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    try {
+      final current = await fetch(parentFingerprint);
+      final List<KeychainManifestEntry> existing;
+      switch (current) {
+        case Err(:final failure):
+          return Err(failure);
+        case Ok(:final value):
+          existing = value
+              .where(
+                (entry) =>
+                    entry.derivationKind ==
+                    KeychainManifestDerivationKind.bip32,
+              )
+              .toList(growable: false);
+      }
+      final replacementWalletIds = {
+        for (final entry in entries) _walletOf(entry).walletId,
+      };
+      // A record the user made rather than the app derived survives a
+      // re-derivation it is missing from; nothing else can bring it back.
+      final effective = [
+        ...entries,
+        for (final entry in existing)
+          if (_isUserOwned(_walletOf(entry)) &&
+              !replacementWalletIds.contains(_walletOf(entry).walletId))
+            entry,
+      ];
+      if (_sameWalletInventory(existing, effective)) return const Ok(null);
+
+      await _database.transaction(() async {
+        final query = _database.select(_database.keychainManifestEntries)
+          ..where(
+            (row) =>
+                row.parentFingerprint.equals(parentFingerprint.hex) &
+                row.derivationKind.equals(
+                  KeychainManifestDerivationKind.bip32.name,
+                ),
+          );
+        final entryIds = (await query.get())
+            .map((entry) => entry.entryId)
+            .toList(growable: false);
+        if (entryIds.isNotEmpty) {
+          await (_database.delete(
+            _database.keychainManifestWalletBindings,
+          )..where((row) => row.entryId.isIn(entryIds))).go();
+          await (_database.delete(
+            _database.keychainManifestEntries,
+          )..where((row) => row.entryId.isIn(entryIds))).go();
+        }
+        for (final entry in effective) {
+          await _insertEntry(entry);
+          await _insertWallet(_walletOf(entry));
+        }
+        await _backupRevisions.recordCommittedMutation();
+      });
+      _localChanges.add(null);
+      return const Ok(null);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to replace wallet recovery inventory',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> upsertPassphraseWallet(
+    KeychainManifestEntry record,
+  ) async {
+    final wallet = _tryWalletOf(record);
+    if (wallet == null) return const Err(KeychainManifestConflictFailure());
+    try {
+      final changed = await _database.transaction(() async {
+        final storedEntry = await _entryRow(record.entryId);
+        if (storedEntry == null) {
+          // The wallet id may still be bound under another entry, which would
+          // be a different wallet wearing the same identity.
+          if (await _walletRow(wallet.walletId) != null) {
+            throw const _ManifestConflictException();
+          }
+          await _insertEntry(record);
+          await _insertWallet(wallet);
+          await _backupRevisions.recordCommittedMutation();
+          return true;
+        }
+        final stored = await _matchingWalletRow(record, wallet, storedEntry);
+        if (stored == null) throw const _ManifestConflictException();
+        if (storedEntry.description == record.description &&
+            stored.label == wallet.label) {
+          return false;
+        }
+        // A local upsert is the newest statement about this wallet, so it takes
+        // the later of its own timestamp and one past the stored revision.
+        await _writeWalletMetadata(
+          entryId: record.entryId,
+          walletId: wallet.walletId,
+          description: record.description,
+          label: wallet.label,
+          updatedAt: record.updatedAt > storedEntry.updatedAt
+              ? record.updatedAt
+              : storedEntry.updatedAt + 1,
+        );
+        await _backupRevisions.recordCommittedMutation();
+        return true;
+      });
+      if (changed) _localChanges.add(null);
+      return const Ok(null);
+    } on _ManifestConflictException {
+      return const Err(KeychainManifestConflictFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to record wallet recovery record',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> updatePassphraseLabelHint({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+    KeychainManifestEdit<String?>? label,
+    KeychainManifestEdit<String?>? hint,
+    required int updatedAt,
+  }) async {
+    if (label == null && hint == null) return const Ok(null);
+    final newLabel = label == null ? null : _text(label.value);
+    final newHint = hint == null ? null : _text(hint.value);
+    if ((newHint?.length ?? 0) > KeychainManifestEntry.maxDescriptionLength ||
+        (newLabel?.length ?? 0) > KeychainManifestWallet.maxLabelLength ||
+        _hasControlCharacter(newLabel) ||
+        _hasControlCharacter(newHint) ||
+        !isValidKeychainManifestTimestamp(updatedAt)) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    try {
+      final outcome = await _database.transaction(() async {
+        final binding = await _walletRow(walletId);
+        if (binding == null) return (accepted: false, changed: false);
+        final entry = await _entryRow(binding.entryId);
+        if (entry == null || entry.parentFingerprint != parentFingerprint.hex) {
+          return (accepted: false, changed: false);
+        }
+        final description = hint == null ? entry.description : newHint;
+        final display = label == null ? binding.label : newLabel;
+        if (description == entry.description && display == binding.label) {
+          return (accepted: true, changed: false);
+        }
+        if (updatedAt <= _revisionOf(entry, binding)) {
+          return (accepted: false, changed: false);
+        }
+        await _writeWalletMetadata(
+          entryId: entry.entryId,
+          walletId: walletId,
+          description: description,
+          label: display,
+          updatedAt: updatedAt,
+        );
+        await _backupRevisions.recordCommittedMutation();
+        return (accepted: true, changed: true);
+      });
+      if (outcome.changed) _localChanges.add(null);
+      return outcome.accepted
+          ? const Ok(null)
+          : const Err(KeychainManifestConflictFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to update wallet recovery metadata',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> removePassphraseWallet({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+  }) async {
+    try {
+      final found = await _database.transaction(() async {
+        final wallet = await _walletRow(walletId);
+        if (wallet == null) return false;
+        final entry = await _entryRow(wallet.entryId);
+        if (entry == null || entry.parentFingerprint != parentFingerprint.hex) {
+          return false;
+        }
+        await (_database.delete(
+          _database.keychainManifestWalletBindings,
+        )..where((row) => row.walletId.equals(walletId))).go();
+        await (_database.delete(
+          _database.keychainManifestEntries,
+        )..where((row) => row.entryId.equals(entry.entryId))).go();
+        await _backupRevisions.recordCommittedMutation();
+        return true;
+      });
+      if (!found) return const Err(KeychainManifestConflictFailure());
+      _localChanges.add(null);
+      return const Ok(null);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to forget wallet recovery metadata',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<KeychainManifestRestoreReport, KeychainManifestFailure>>
+  restoreSnapshot(
+    KeychainManifest manifest, {
+    KeychainManifestRestorePolicy policy =
+        KeychainManifestRestorePolicy.keepNewest,
+  }) async {
+    try {
+      return Ok(
+        await _database.transaction(() async {
+          var applied = 0;
+          var unchanged = 0;
+          final conflicts = <String>[];
+          for (final record in manifest.entries) {
+            final wallet = _tryWalletOf(record);
+            switch (wallet == null
+                ? _Restored.conflict
+                : await _restoreWallet(record, wallet)) {
+              case _Restored.applied:
+                applied++;
+              case _Restored.unchanged:
+                unchanged++;
+              case _Restored.conflict:
+                conflicts.add(record.entryId);
+            }
+          }
+          return KeychainManifestRestoreReport(
+            applied: applied,
+            unchanged: unchanged,
+            conflicts: conflicts,
+          );
+        }),
+      );
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to restore keychain manifest',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> insertNostrKey(
+    KeychainManifestEntry record, {
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  }) async {
+    final key = record.materializations.length == 1
+        ? record.materializations.single
+        : null;
+    if (key is! KeychainManifestNostrKey) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    try {
+      final changed = await _database.transaction(() async {
+        final storedEntry = await _entryRow(record.entryId);
+        final storedKey = await _nostrRow(record.entryId);
+        if (storedEntry != null || storedKey != null) {
+          if (storedEntry == null ||
+              storedKey == null ||
+              !_sameEntryShape(storedEntry, record) ||
+              storedEntry.description != record.description ||
+              storedKey.publicKeyHex != key.publicKeyHex ||
+              storedKey.keyKind != key.keyKind.name ||
+              storedKey.purpose != key.purpose ||
+              storedKey.updatedAt != key.updatedAt) {
+            throw const _ManifestConflictException();
+          }
+          return false;
+        }
+        await _insertEntry(record);
+        await _database
+            .into(_database.keychainManifestNostrKeys)
+            .insert(
+              KeychainManifestNostrKeysCompanion.insert(
+                entryId: key.entryId,
+                publicKeyHex: key.publicKeyHex,
+                keyKind: key.keyKind.name,
+                purpose: key.purpose,
+                createdAt: key.createdAt,
+                updatedAt: key.updatedAt,
+              ),
+            );
+        if (origin == KeychainManifestWriteOrigin.local) {
+          await _backupRevisions.recordCommittedMutation();
+        }
+        return true;
+      });
+      if (changed && origin == KeychainManifestWriteOrigin.local) {
+        _localChanges.add(null);
+      }
+      return const Ok(null);
+    } on _ManifestConflictException {
+      return const Err(KeychainManifestConflictFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to record Nostr key materialization',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> updateNostrMetadata({
+    required Fingerprint parentFingerprint,
+    required String entryId,
+    required String purpose,
+    String? description,
+    required int updatedAt,
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  }) async {
+    final normalizedPurpose = KeychainManifestNostrKey.tryNormalizePurpose(
+      purpose,
+    );
+    final normalizedDescription = _text(description);
+    if (normalizedPurpose == null ||
+        (normalizedDescription?.length ?? 0) >
+            KeychainManifestEntry.maxDescriptionLength ||
+        _hasControlCharacter(normalizedDescription) ||
+        updatedAt < 0) {
+      throw ArgumentError('Invalid Nostr metadata');
+    }
+    try {
+      final outcome = await _database.transaction(() async {
+        final entry = await _entryRow(entryId);
+        final key = await _nostrRow(entryId);
+        if (entry == null ||
+            key == null ||
+            entry.parentFingerprint != parentFingerprint.hex) {
+          return (found: false, changed: false);
+        }
+        final metadataChanged =
+            key.purpose != normalizedPurpose ||
+            entry.description != normalizedDescription;
+        if (!metadataChanged && updatedAt <= key.updatedAt) {
+          return (found: true, changed: false);
+        }
+        final timestamp = metadataChanged && updatedAt <= key.updatedAt
+            ? key.updatedAt + 1
+            : updatedAt;
+        await (_database.update(
+          _database.keychainManifestNostrKeys,
+        )..where((row) => row.entryId.equals(entryId))).write(
+          KeychainManifestNostrKeysCompanion(
+            purpose: Value(normalizedPurpose),
+            updatedAt: Value(timestamp),
+          ),
+        );
+        await (_database.update(
+          _database.keychainManifestEntries,
+        )..where((row) => row.entryId.equals(entryId))).write(
+          KeychainManifestEntriesCompanion(
+            description: Value(normalizedDescription),
+            updatedAt: Value(timestamp),
+          ),
+        );
+        if (origin == KeychainManifestWriteOrigin.local) {
+          await _backupRevisions.recordCommittedMutation();
+        }
+        return (found: true, changed: true);
+      });
+      if (outcome.changed && origin == KeychainManifestWriteOrigin.local) {
+        _localChanges.add(null);
+      }
+      return outcome.found
+          ? const Ok(null)
+          : const Err(KeychainManifestConflictFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to update Nostr key metadata',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(KeychainManifestStorageFailure());
+    }
+  }
+
+  @override
+  Future<void> close() => _localChanges.close();
+
+  /// One restored wallet record under
+  /// [KeychainManifestRestorePolicy.keepNewest].
+  Future<_Restored> _restoreWallet(
+    KeychainManifestEntry record,
+    KeychainManifestWallet wallet,
+  ) async {
+    final storedEntry = await _entryRow(record.entryId);
+    if (storedEntry == null) {
+      if (await _walletRow(wallet.walletId) != null) return _Restored.conflict;
+      await _insertEntry(record);
+      await _insertWallet(wallet);
+      return _Restored.applied;
+    }
+    final stored = await _matchingWalletRow(record, wallet, storedEntry);
+    if (stored == null) return _Restored.conflict;
+    if (storedEntry.description == record.description &&
+        stored.label == wallet.label) {
+      return _Restored.unchanged;
+    }
+    final storedRevision = _revisionOf(storedEntry, stored);
+    final restoredRevision = record.updatedAt > wallet.updatedAt
+        ? record.updatedAt
+        : wallet.updatedAt;
+    // Older restored text never clobbers newer local text; two different texts
+    // stamped with the same instant cannot be ordered at all.
+    if (restoredRevision < storedRevision) return _Restored.unchanged;
+    if (restoredRevision == storedRevision) return _Restored.conflict;
+    await _writeWalletMetadata(
+      entryId: record.entryId,
+      walletId: wallet.walletId,
+      description: record.description,
+      label: wallet.label,
+      updatedAt: restoredRevision,
+    );
+    return _Restored.applied;
+  }
+
+  /// The stored binding of [record], or null when the stored state is a
+  /// different wallet rather than the same one restated.
+  Future<KeychainManifestWalletBindingRow?> _matchingWalletRow(
+    KeychainManifestEntry record,
+    KeychainManifestWallet wallet,
+    KeychainManifestEntryRow storedEntry,
+  ) async {
+    if (!_sameEntryShape(storedEntry, record)) return null;
+    final bound = await _walletRowsOf(record.entryId);
+    if (bound.length != 1 || bound.single.walletId != wallet.walletId) {
+      return null;
+    }
+    final stored = bound.single;
+    // The four-byte seed fingerprint that keys the entry id is a lookup hint,
+    // so two descriptors can land on one entry. They are separate wallets and
+    // must never be merged (spec 6.5).
+    return stored.childSeedFingerprint == wallet.childSeedFingerprint.hex &&
+            stored.network == wallet.network.name &&
+            stored.scriptType == wallet.scriptType.name &&
+            stored.provenance == wallet.provenance.name &&
+            stored.seedPassphraseUsed == wallet.seedPassphraseUsed &&
+            stored.descriptor == wallet.descriptor
+        ? stored
+        : null;
+  }
+
+  Future<void> _writeWalletMetadata({
+    required String entryId,
+    required String walletId,
+    required String? description,
+    required String? label,
+    required int updatedAt,
+  }) async {
+    await (_database.update(
+      _database.keychainManifestEntries,
+    )..where((row) => row.entryId.equals(entryId))).write(
+      KeychainManifestEntriesCompanion(
+        description: Value(description),
+        updatedAt: Value(updatedAt),
+      ),
+    );
+    await (_database.update(
+      _database.keychainManifestWalletBindings,
+    )..where((row) => row.walletId.equals(walletId))).write(
+      KeychainManifestWalletBindingsCompanion(
+        label: Value(label),
+        updatedAt: Value(updatedAt),
+      ),
+    );
+  }
+
+  Future<KeychainManifestEntryRow?> _entryRow(String entryId) =>
+      (_database.select(
+        _database.keychainManifestEntries,
+      )..where((row) => row.entryId.equals(entryId))).getSingleOrNull();
+
+  Future<KeychainManifestWalletBindingRow?> _walletRow(String walletId) =>
+      (_database.select(
+        _database.keychainManifestWalletBindings,
+      )..where((row) => row.walletId.equals(walletId))).getSingleOrNull();
+
+  Future<List<KeychainManifestWalletBindingRow>> _walletRowsOf(
+    String entryId,
+  ) => (_database.select(
+    _database.keychainManifestWalletBindings,
+  )..where((row) => row.entryId.equals(entryId))).get();
+
+  Future<KeychainManifestNostrKeyRow?> _nostrRow(String entryId) =>
+      (_database.select(
+        _database.keychainManifestNostrKeys,
+      )..where((row) => row.entryId.equals(entryId))).getSingleOrNull();
+
+  Future<void> _insertEntry(KeychainManifestEntry entry) => _database
+      .into(_database.keychainManifestEntries)
+      .insert(
+        KeychainManifestEntriesCompanion.insert(
+          entryId: entry.entryId,
+          parentFingerprint: entry.parentFingerprint.hex,
+          derivationKind: entry.derivationKind.name,
+          derivationPath: entry.derivationPath,
+          description: Value(entry.description),
+          createdAt: entry.createdAt,
+          updatedAt: entry.updatedAt,
+        ),
+      );
+
+  Future<void> _insertWallet(KeychainManifestWallet wallet) => _database
+      .into(_database.keychainManifestWalletBindings)
+      .insert(
+        KeychainManifestWalletBindingsCompanion.insert(
+          walletId: wallet.walletId,
+          entryId: wallet.entryId,
+          childSeedFingerprint: wallet.childSeedFingerprint.hex,
+          network: wallet.network.name,
+          scriptType: wallet.scriptType.name,
+          provenance: wallet.provenance.name,
+          seedPassphraseUsed: Value(wallet.seedPassphraseUsed),
+          descriptor: Value(wallet.descriptor),
+          label: Value(wallet.label),
+          createdAt: wallet.createdAt,
+          updatedAt: wallet.updatedAt,
+        ),
+      );
+
+  KeychainManifestEntry _entryEntity(
+    KeychainManifestEntryRow row,
+    List<KeychainManifestMaterialization> items,
+  ) => KeychainManifestEntry(
+    parentFingerprint: Fingerprint(row.parentFingerprint),
+    derivationKind: KeychainManifestDerivationKind.values.byName(
+      row.derivationKind,
+    ),
+    derivationPath: row.derivationPath,
+    description: row.description,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    materializations: items,
+  );
+
+  KeychainManifestWallet _walletEntity(KeychainManifestWalletBindingRow row) =>
+      KeychainManifestWallet(
+        walletId: row.walletId,
+        entryId: row.entryId,
+        childSeedFingerprint: Fingerprint(row.childSeedFingerprint),
+        network: Network.fromName(row.network),
+        scriptType: ScriptType.fromName(row.scriptType),
+        provenance: WalletProvenance.values.byName(row.provenance),
+        seedPassphraseUsed: row.seedPassphraseUsed,
+        descriptor: row.descriptor,
+        label: row.label,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      );
+
+  KeychainManifestNostrKey _nostrEntity(KeychainManifestNostrKeyRow row) =>
+      KeychainManifestNostrKey(
+        entryId: row.entryId,
+        publicKeyHex: row.publicKeyHex,
+        keyKind: KeychainManifestNostrKeyKind.values.byName(row.keyKind),
+        purpose: row.purpose,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      );
+}
+
+enum _Restored { applied, unchanged, conflict }
+
+final class _ManifestConflictException implements Exception {
+  const _ManifestConflictException();
+}
+
+bool _sameEntryShape(
+  KeychainManifestEntryRow stored,
+  KeychainManifestEntry record,
+) =>
+    stored.parentFingerprint == record.parentFingerprint.hex &&
+    stored.derivationKind == record.derivationKind.name &&
+    stored.derivationPath == record.derivationPath;
+
+/// Entry and binding are written in lockstep, so the later of the two is the
+/// revision the record actually stands at.
+int _revisionOf(
+  KeychainManifestEntryRow entry,
+  KeychainManifestWalletBindingRow binding,
+) => entry.updatedAt > binding.updatedAt ? entry.updatedAt : binding.updatedAt;
+
+bool _isUserOwned(KeychainManifestWallet wallet) =>
+    wallet.provenance == WalletProvenance.importedMnemonic ||
+    wallet.provenance == WalletProvenance.defaultSeedPassphrase;
+
+KeychainManifestWallet _walletOf(KeychainManifestEntry entry) =>
+    entry.materializations.single as KeychainManifestWallet;
+
+KeychainManifestWallet? _tryWalletOf(KeychainManifestEntry entry) {
+  final item = entry.materializations.length == 1
+      ? entry.materializations.single
+      : null;
+  return item is KeychainManifestWallet ? item : null;
+}
+
+String? _text(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+bool _hasControlCharacter(String? value) =>
+    value != null && KeychainManifestNostrKey.hasControlCharacter(value);
+
+bool _sameWalletInventory(
+  List<KeychainManifestEntry> left,
+  List<KeychainManifestEntry> right,
+) {
+  if (left.length != right.length) return false;
+  final leftById = {for (final entry in left) entry.entryId: entry};
+  for (final candidate in right) {
+    final current = leftById[candidate.entryId];
+    if (current == null ||
+        current.derivationPath != candidate.derivationPath ||
+        current.materializations.length != 1 ||
+        candidate.materializations.length != 1) {
+      return false;
+    }
+    final a = _walletOf(current);
+    final b = _walletOf(candidate);
+    if (a.walletId != b.walletId ||
+        a.childSeedFingerprint != b.childSeedFingerprint ||
+        a.network != b.network ||
+        a.scriptType != b.scriptType ||
+        a.provenance != b.provenance ||
+        a.seedPassphraseUsed != b.seedPassphraseUsed ||
+        a.descriptor != b.descriptor ||
+        a.label != b.label ||
+        current.description != candidate.description) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/features/keychain_manifest/data/models/keychain_manifest_file_model.dart
+++ b/lib/features/keychain_manifest/data/models/keychain_manifest_file_model.dart
@@ -1,0 +1,544 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:primitives/primitives.dart' show Err, Fingerprint, Ok, Result;
+
+final class KeychainManifestFileCodec {
+  static const maxPayloadSizeBytes = 1024 * 1024;
+  static const maxStringFieldLength = 512;
+
+  const KeychainManifestFileCodec();
+
+  String encode(KeychainManifest manifest) => jsonEncode(
+    _KeychainManifestFileModel.fromEntity(manifest.canonical()).toJson(),
+  );
+
+  Result<KeychainManifest, KeychainManifestFailure> decode(String payload) {
+    if (payload.length > maxPayloadSizeBytes ||
+        utf8.encode(payload).length > maxPayloadSizeBytes) {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    final Object? json;
+    try {
+      json = jsonDecode(payload);
+    } on FormatException {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    if (json is! Map<String, Object?>) {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    final version = json['version'];
+    if (version is! int) {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    if (version != KeychainManifest.currentVersion) {
+      return Err(KeychainManifestUnsupportedVersionFailure(version));
+    }
+    final model = _KeychainManifestFileModel.tryParse(json);
+    if (model == null) {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    return model.toEntity();
+  }
+}
+
+/// Pure wire representation for version 1 of a Keychain Manifest.
+final class _KeychainManifestFileModel {
+  final int version;
+  final String parentFingerprint;
+  final int generatedAt;
+  final List<_EntryModel> entries;
+
+  const _KeychainManifestFileModel({
+    required this.version,
+    required this.parentFingerprint,
+    required this.generatedAt,
+    required this.entries,
+  });
+
+  factory _KeychainManifestFileModel.fromEntity(KeychainManifest manifest) =>
+      _KeychainManifestFileModel(
+        version: manifest.version,
+        parentFingerprint: manifest.parentFingerprint.hex,
+        generatedAt: manifest.generatedAt,
+        entries: manifest.entries.map(_EntryModel.fromEntity).toList(),
+      );
+
+  static _KeychainManifestFileModel? tryParse(Map<String, Object?> json) {
+    if (!_onlyKeys(json, const {
+      'version',
+      'parentFingerprint',
+      'generatedAt',
+      'entries',
+    })) {
+      return null;
+    }
+    final version = _int(json, 'version');
+    final parentFingerprint = _string(json, 'parentFingerprint');
+    final generatedAt = _int(json, 'generatedAt');
+    final rawEntries = _list(json, 'entries');
+    if (version == null ||
+        parentFingerprint == null ||
+        generatedAt == null ||
+        rawEntries == null) {
+      return null;
+    }
+    final entries = <_EntryModel>[];
+    for (final raw in rawEntries) {
+      if (raw is! Map<String, Object?>) return null;
+      final entry = _EntryModel.tryParse(raw);
+      if (entry == null) return null;
+      entries.add(entry);
+    }
+    return _KeychainManifestFileModel(
+      version: version,
+      parentFingerprint: parentFingerprint,
+      generatedAt: generatedAt,
+      entries: entries,
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'version': version,
+    'parentFingerprint': parentFingerprint,
+    'generatedAt': generatedAt,
+    'entries': entries.map((entry) => entry.toJson()).toList(),
+  };
+
+  Result<KeychainManifest, KeychainManifestFailure> toEntity() {
+    final fingerprint = Fingerprint.tryParse(parentFingerprint);
+    if (fingerprint == null || !isValidKeychainManifestTimestamp(generatedAt)) {
+      return const Err(KeychainManifestMalformedFileFailure());
+    }
+    final entities = <KeychainManifestEntry>[];
+    final entryIds = <String>{};
+    final materializationIds = <String>{};
+    for (final entry in entries) {
+      final entity = entry.toEntity(fingerprint);
+      if (entity == null || !entryIds.add(entity.entryId)) {
+        return const Err(KeychainManifestMalformedFileFailure());
+      }
+      for (final item in entity.materializations) {
+        if (!materializationIds.add(item.identity)) {
+          return const Err(KeychainManifestMalformedFileFailure());
+        }
+      }
+      entities.add(entity);
+    }
+    return Ok(
+      KeychainManifest(
+        version: version,
+        parentFingerprint: fingerprint,
+        generatedAt: generatedAt,
+        entries: entities,
+      ),
+    );
+  }
+}
+
+final class _EntryModel {
+  final String derivationKind;
+  final String derivationPath;
+  final String? description;
+  final int createdAt;
+  final int updatedAt;
+  final List<_MaterializationModel> materializations;
+
+  const _EntryModel({
+    required this.derivationKind,
+    required this.derivationPath,
+    this.description,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.materializations,
+  });
+
+  factory _EntryModel.fromEntity(KeychainManifestEntry entry) => _EntryModel(
+    derivationKind: entry.derivationKind.name,
+    derivationPath: entry.derivationPath,
+    description: entry.description,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    materializations:
+        entry.materializations.map(_MaterializationModel.fromEntity).toList()
+          ..sort(_MaterializationModel.compare),
+  );
+
+  static _EntryModel? tryParse(Map<String, Object?> json) {
+    if (!_onlyKeys(json, const {
+      'derivationKind',
+      'derivationPath',
+      'description',
+      'createdAt',
+      'updatedAt',
+      'materializations',
+    })) {
+      return null;
+    }
+    final kind = _string(json, 'derivationKind');
+    final path = _string(json, 'derivationPath');
+    final createdAt = _int(json, 'createdAt');
+    final updatedAt = _int(json, 'updatedAt');
+    final rawItems = _list(json, 'materializations');
+    if (path == null ||
+        kind == null ||
+        createdAt == null ||
+        updatedAt == null ||
+        rawItems == null ||
+        rawItems.isEmpty ||
+        rawItems.length > 8) {
+      return null;
+    }
+    final items = <_MaterializationModel>[];
+    for (final raw in rawItems) {
+      if (raw is! Map<String, Object?>) return null;
+      final item = _MaterializationModel.tryParse(raw);
+      if (item == null) return null;
+      items.add(item);
+    }
+    return _EntryModel(
+      derivationKind: kind,
+      derivationPath: path,
+      description: _optionalString(json, 'description'),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      materializations: items,
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'derivationKind': derivationKind,
+    'derivationPath': derivationPath,
+    if (description != null) 'description': description,
+    'createdAt': createdAt,
+    'updatedAt': updatedAt,
+    'materializations': materializations.map((item) => item.toJson()).toList(),
+  };
+
+  KeychainManifestEntry? toEntity(Fingerprint parentFingerprint) {
+    final kind = KeychainManifestDerivationKind.values
+        .where((value) => value.name == derivationKind)
+        .firstOrNull;
+    if (kind == null ||
+        !_validPath(kind, derivationPath) ||
+        derivationPath.length > maxStringFieldLength ||
+        (description?.length ?? 0) >
+            KeychainManifestEntry.maxDescriptionLength ||
+        (description != null &&
+            KeychainManifestNostrKey.hasControlCharacter(description!)) ||
+        !isValidKeychainManifestTimestamp(createdAt) ||
+        !isValidKeychainManifestTimestamp(updatedAt) ||
+        updatedAt < createdAt) {
+      return null;
+    }
+    final seedFingerprint =
+        kind == KeychainManifestDerivationKind.bip32 &&
+            materializations.length == 1
+        ? Fingerprint.tryParse(
+            materializations.single.childSeedFingerprint ?? '',
+          )
+        : null;
+    if (kind == KeychainManifestDerivationKind.bip32 &&
+        seedFingerprint == null) {
+      return null;
+    }
+    final entryId = KeychainManifestEntry.entryIdFor(
+      parentFingerprint: parentFingerprint,
+      derivationKind: kind,
+      derivationPath: derivationPath,
+      seedFingerprint: seedFingerprint,
+    );
+    final items = <KeychainManifestMaterialization>[];
+    for (final item in materializations) {
+      final entity = item.toEntity(entryId);
+      if (entity == null) return null;
+      items.add(entity);
+    }
+    if (items.any((item) => item.entryId != entryId) ||
+        (kind == KeychainManifestDerivationKind.bip32 &&
+            (items.length != 1 || items.single is! KeychainManifestWallet))) {
+      return null;
+    }
+    return KeychainManifestEntry(
+      parentFingerprint: parentFingerprint,
+      derivationKind: kind,
+      derivationPath: derivationPath,
+      description: description,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      materializations: items,
+    );
+  }
+}
+
+final class _MaterializationModel {
+  final String type;
+  final String? walletId;
+  final String? childSeedFingerprint;
+  final String? network;
+  final String? scriptType;
+  final String? provenance;
+  final bool? seedPassphraseUsed;
+  final String? descriptor;
+  final String? label;
+  final String? publicKeyHex;
+  final String? keyKind;
+  final String? purpose;
+  final int createdAt;
+  final int updatedAt;
+
+  const _MaterializationModel({
+    required this.type,
+    this.walletId,
+    this.childSeedFingerprint,
+    this.network,
+    this.scriptType,
+    this.provenance,
+    this.seedPassphraseUsed,
+    this.descriptor,
+    this.label,
+    this.publicKeyHex,
+    this.keyKind,
+    this.purpose,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory _MaterializationModel.fromEntity(
+    KeychainManifestMaterialization item,
+  ) => switch (item) {
+    KeychainManifestWallet() => _MaterializationModel(
+      type: 'wallet',
+      walletId: item.walletId,
+      childSeedFingerprint: item.childSeedFingerprint.hex,
+      network: item.network.name,
+      scriptType: item.scriptType.name,
+      provenance: item.provenance.name,
+      seedPassphraseUsed: item.seedPassphraseUsed,
+      descriptor: item.descriptor,
+      label: item.label,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    ),
+    KeychainManifestNostrKey() => _MaterializationModel(
+      type: 'nostrKey',
+      publicKeyHex: item.publicKeyHex,
+      keyKind: item.keyKind.name,
+      purpose: item.purpose,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    ),
+  };
+
+  static _MaterializationModel? tryParse(Map<String, Object?> json) {
+    final type = _string(json, 'type');
+    final createdAt = _int(json, 'createdAt');
+    final updatedAt = _int(json, 'updatedAt');
+    if (type == null || createdAt == null || updatedAt == null) return null;
+    final allowedKeys = switch (type) {
+      'wallet' => const {
+        'type',
+        'walletId',
+        'childSeedFingerprint',
+        'network',
+        'scriptType',
+        'provenance',
+        'seedPassphraseUsed',
+        'descriptor',
+        'label',
+        'createdAt',
+        'updatedAt',
+      },
+      'nostrKey' => const {
+        'type',
+        'publicKeyHex',
+        'keyKind',
+        'purpose',
+        'createdAt',
+        'updatedAt',
+      },
+      _ => const <String>{},
+    };
+    if (allowedKeys.isEmpty || !_onlyKeys(json, allowedKeys)) return null;
+    if (type == 'wallet' &&
+        json['seedPassphraseUsed'] != null &&
+        json['seedPassphraseUsed'] is! bool) {
+      return null;
+    }
+    return switch (type) {
+      'wallet' => _MaterializationModel(
+        type: type,
+        walletId: _string(json, 'walletId'),
+        childSeedFingerprint: _string(json, 'childSeedFingerprint'),
+        network: _string(json, 'network'),
+        scriptType: _string(json, 'scriptType'),
+        provenance: _string(json, 'provenance'),
+        seedPassphraseUsed: _optionalBool(json, 'seedPassphraseUsed'),
+        descriptor: _optionalString(json, 'descriptor'),
+        label: _optionalString(json, 'label'),
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      ),
+      'nostrKey' => _MaterializationModel(
+        type: type,
+        publicKeyHex: _string(json, 'publicKeyHex'),
+        keyKind: _string(json, 'keyKind'),
+        purpose: _string(json, 'purpose'),
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      ),
+      _ => null,
+    };
+  }
+
+  Map<String, Object?> toJson() => switch (type) {
+    'wallet' => {
+      'type': type,
+      'walletId': walletId,
+      'childSeedFingerprint': childSeedFingerprint,
+      'network': network,
+      'scriptType': scriptType,
+      'provenance': provenance,
+      'seedPassphraseUsed': seedPassphraseUsed,
+      if (descriptor != null) 'descriptor': descriptor,
+      if (label != null) 'label': label,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+    },
+    'nostrKey' => {
+      'type': type,
+      'publicKeyHex': publicKeyHex,
+      'keyKind': keyKind,
+      'purpose': purpose,
+      'createdAt': createdAt,
+      'updatedAt': updatedAt,
+    },
+    _ => throw StateError('Unknown materialization type'),
+  };
+
+  KeychainManifestMaterialization? toEntity(String entryId) {
+    if (!isValidKeychainManifestTimestamp(createdAt) ||
+        !isValidKeychainManifestTimestamp(updatedAt) ||
+        updatedAt < createdAt) {
+      return null;
+    }
+    if (type == 'wallet') {
+      final fingerprint = Fingerprint.tryParse(childSeedFingerprint ?? '');
+      final parsedNetwork = Network.values
+          .where((value) => value.name == network)
+          .firstOrNull;
+      final parsedScript = ScriptType.values
+          .where((value) => value.name == scriptType)
+          .firstOrNull;
+      final parsedProvenance = WalletProvenance.values
+          .where((value) => value.name == provenance)
+          .firstOrNull;
+      if (!_validText(walletId) ||
+          fingerprint == null ||
+          parsedNetwork == null ||
+          parsedScript == null ||
+          parsedProvenance == null ||
+          !KeychainManifestWallet.isValid(
+            walletId: walletId!,
+            entryId: entryId,
+            provenance: parsedProvenance,
+            descriptor: descriptor,
+            label: label,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          )) {
+        return null;
+      }
+      return KeychainManifestWallet(
+        walletId: walletId!,
+        entryId: entryId,
+        childSeedFingerprint: fingerprint,
+        network: parsedNetwork,
+        scriptType: parsedScript,
+        provenance: parsedProvenance,
+        seedPassphraseUsed: seedPassphraseUsed,
+        descriptor: descriptor,
+        label: label,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+    }
+    final kind = KeychainManifestNostrKeyKind.values
+        .where((value) => value.name == keyKind)
+        .firstOrNull;
+    if (kind == null ||
+        publicKeyHex == null ||
+        purpose == null ||
+        !KeychainManifestNostrKey.isValid(
+          entryId: entryId,
+          publicKeyHex: publicKeyHex!,
+          purpose: purpose!,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+        )) {
+      return null;
+    }
+    return KeychainManifestNostrKey(
+      entryId: entryId,
+      publicKeyHex: publicKeyHex!,
+      keyKind: kind,
+      purpose: purpose!,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+
+  static int compare(_MaterializationModel left, _MaterializationModel right) {
+    final byType = left.type.compareTo(right.type);
+    if (byType != 0) return byType;
+    final byNetwork = (left.network ?? '').compareTo(right.network ?? '');
+    if (byNetwork != 0) return byNetwork;
+    return (left.walletId ?? left.publicKeyHex ?? '').compareTo(
+      right.walletId ?? right.publicKeyHex ?? '',
+    );
+  }
+}
+
+String? _string(Map<String, Object?> json, String key) {
+  final value = json[key];
+  return value is String && value.length <= maxStringFieldLength ? value : null;
+}
+
+String? _optionalString(Map<String, Object?> json, String key) =>
+    !json.containsKey(key) || json[key] == null ? null : _string(json, key);
+
+int? _int(Map<String, Object?> json, String key) =>
+    json[key] is int ? json[key]! as int : null;
+
+bool? _optionalBool(Map<String, Object?> json, String key) =>
+    json[key] is bool ? json[key]! as bool : null;
+
+List<Object?>? _list(Map<String, Object?> json, String key) =>
+    json[key] is List<Object?> ? json[key]! as List<Object?> : null;
+
+bool _validText(String? value) =>
+    value != null &&
+    value.trim().isNotEmpty &&
+    value.length <= maxStringFieldLength;
+
+bool _validPath(KeychainManifestDerivationKind kind, String path) {
+  final hasRoot = path.startsWith('m/');
+  if (kind == KeychainManifestDerivationKind.bip32 && !hasRoot) return false;
+  if (kind == KeychainManifestDerivationKind.bip85 && hasRoot) return false;
+  final parts = (hasRoot ? path.substring(2) : path).split('/');
+  return parts.length >= 2 && parts.every((part) => _pathNumber(part) != null);
+}
+
+int? _pathNumber(String segment) {
+  if (!RegExp(r"^(0|[1-9][0-9]*)'$").hasMatch(segment)) return null;
+  final value = int.tryParse(segment.substring(0, segment.length - 1));
+  return value != null && value <= 0x7fffffff ? value : null;
+}
+
+bool _onlyKeys(Map<String, Object?> json, Set<String> allowed) =>
+    json.keys.every(allowed.contains);
+
+const maxStringFieldLength = KeychainManifestFileCodec.maxStringFieldLength;

--- a/lib/features/keychain_manifest/domain/entities/keychain_manifest.dart
+++ b/lib/features/keychain_manifest/domain/entities/keychain_manifest.dart
@@ -1,0 +1,351 @@
+import 'package:bb_mobile/core/utils/nostr_bech32.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:convert/convert.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
+
+enum KeychainManifestNostrKeyKind { reserved, userGenerated }
+
+enum KeychainManifestDerivationKind { bip85, bip32 }
+
+const _maximumUnixSeconds = 8640000000000;
+
+bool isValidKeychainManifestTimestamp(int value) =>
+    value >= 0 && value <= _maximumUnixSeconds;
+
+final class KeychainManifest {
+  static const currentVersion = 1;
+
+  final int version;
+  final Fingerprint parentFingerprint;
+  final int generatedAt;
+  final List<KeychainManifestEntry> entries;
+
+  KeychainManifest({
+    this.version = currentVersion,
+    required this.parentFingerprint,
+    required this.generatedAt,
+    required Iterable<KeychainManifestEntry> entries,
+  }) : entries = List.unmodifiable(entries) {
+    if (version != currentVersion ||
+        !isValidKeychainManifestTimestamp(generatedAt)) {
+      throw ArgumentError('Invalid manifest metadata');
+    }
+    final entryIds = <String>{};
+    final materializationIds = <String>{};
+    for (final entry in this.entries) {
+      if (entry.parentFingerprint != parentFingerprint ||
+          !entryIds.add(entry.entryId)) {
+        throw ArgumentError('Invalid or duplicate manifest entry');
+      }
+      for (final item in entry.materializations) {
+        if (!materializationIds.add(item.identity)) {
+          throw ArgumentError('Duplicate manifest materialization');
+        }
+      }
+    }
+  }
+
+  KeychainManifest canonical() => KeychainManifest(
+    version: version,
+    parentFingerprint: parentFingerprint,
+    generatedAt: generatedAt,
+    entries: [...entries]..sort(KeychainManifestEntry.compare),
+  );
+
+  Iterable<KeychainManifestWallet> get wallets =>
+      entries.expand((entry) => entry.materializations).whereType();
+
+  Iterable<KeychainManifestNostrKey> get nostrKeys =>
+      entries.expand((entry) => entry.materializations).whereType();
+}
+
+final class KeychainManifestEntry {
+  static const maxDescriptionLength = 200;
+
+  final Fingerprint parentFingerprint;
+  final KeychainManifestDerivationKind derivationKind;
+  final String derivationPath;
+  final String? description;
+  final int createdAt;
+  final int updatedAt;
+  final List<KeychainManifestMaterialization> materializations;
+
+  KeychainManifestEntry({
+    required this.parentFingerprint,
+    this.derivationKind = KeychainManifestDerivationKind.bip85,
+    required String derivationPath,
+    String? description,
+    required this.createdAt,
+    required this.updatedAt,
+    required Iterable<KeychainManifestMaterialization> materializations,
+  }) : derivationPath = canonicalPath(derivationKind, derivationPath),
+       description = _optional(description),
+       materializations = List.unmodifiable(materializations) {
+    if ((this.description?.length ?? 0) > maxDescriptionLength ||
+        (this.description != null &&
+            KeychainManifestNostrKey.hasControlCharacter(this.description!)) ||
+        !isValidKeychainManifestTimestamp(createdAt) ||
+        !isValidKeychainManifestTimestamp(updatedAt) ||
+        updatedAt < createdAt ||
+        this.materializations.isEmpty ||
+        this.materializations.length > 8 ||
+        this.materializations.any((item) => item.entryId != entryId) ||
+        (derivationKind == KeychainManifestDerivationKind.bip32 &&
+            (this.materializations.length != 1 ||
+                this.materializations.single is! KeychainManifestWallet))) {
+      throw ArgumentError('Invalid manifest entry');
+    }
+  }
+
+  String get entryId => entryIdFor(
+    parentFingerprint: parentFingerprint,
+    derivationKind: derivationKind,
+    derivationPath: derivationPath,
+    seedFingerprint: derivationKind == KeychainManifestDerivationKind.bip32
+        ? (materializations.single as KeychainManifestWallet)
+              .childSeedFingerprint
+        : null,
+  );
+
+  static String entryIdFor({
+    required Fingerprint parentFingerprint,
+    required KeychainManifestDerivationKind derivationKind,
+    required String derivationPath,
+    Fingerprint? seedFingerprint,
+  }) {
+    final path = canonicalPath(derivationKind, derivationPath);
+    return derivationKind == KeychainManifestDerivationKind.bip85
+        ? '${parentFingerprint.hex}:$path'
+        : '${parentFingerprint.hex}:${seedFingerprint!.hex}:$path';
+  }
+
+  static String canonicalPath(
+    KeychainManifestDerivationKind kind,
+    String value,
+  ) => _canonicalPath(kind, value);
+
+  String get bip85DerivationPath {
+    if (derivationKind != KeychainManifestDerivationKind.bip85) {
+      throw StateError('Manifest entry is not a BIP85 derivation');
+    }
+    return derivationPath;
+  }
+
+  KeychainManifestEntry withMaterializations(
+    Iterable<KeychainManifestMaterialization> items, {
+    int? createdAt,
+    int? updatedAt,
+  }) => KeychainManifestEntry(
+    parentFingerprint: parentFingerprint,
+    derivationKind: derivationKind,
+    derivationPath: derivationPath,
+    description: description,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    materializations: items,
+  );
+
+  static int compare(KeychainManifestEntry left, KeychainManifestEntry right) {
+    final byKind = left.derivationKind.index.compareTo(
+      right.derivationKind.index,
+    );
+    if (byKind != 0) return byKind;
+    final byPath = left.derivationPath.compareTo(right.derivationPath);
+    return byPath != 0 ? byPath : left.entryId.compareTo(right.entryId);
+  }
+}
+
+sealed class KeychainManifestMaterialization {
+  String get entryId;
+  int get createdAt;
+  int get updatedAt;
+  String get identity;
+}
+
+final class KeychainManifestWallet extends KeychainManifestMaterialization {
+  static const maxDescriptorLength = 512;
+  static const maxLabelLength = 50;
+
+  final String walletId;
+  @override
+  final String entryId;
+  final Fingerprint childSeedFingerprint;
+  final Network network;
+  final ScriptType scriptType;
+  final WalletProvenance provenance;
+  final bool? seedPassphraseUsed;
+  final String? descriptor;
+  final String? label;
+  @override
+  final int createdAt;
+  @override
+  final int updatedAt;
+
+  KeychainManifestWallet({
+    required String walletId,
+    required String entryId,
+    required this.childSeedFingerprint,
+    required this.network,
+    required this.scriptType,
+    required this.provenance,
+    required this.seedPassphraseUsed,
+    this.descriptor,
+    String? label,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : walletId = _required(walletId),
+       entryId = _required(entryId),
+       label = _optional(label) {
+    if (!isValid(
+      walletId: this.walletId,
+      entryId: this.entryId,
+      provenance: provenance,
+      descriptor: descriptor,
+      label: this.label,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    )) {
+      throw ArgumentError('Invalid wallet materialization');
+    }
+  }
+
+  static bool isValid({
+    required String walletId,
+    required String entryId,
+    required WalletProvenance provenance,
+    required String? descriptor,
+    required String? label,
+    required int createdAt,
+    required int updatedAt,
+  }) =>
+      _tryRequired(walletId) != null &&
+      _tryRequired(entryId) != null &&
+      isValidKeychainManifestTimestamp(createdAt) &&
+      isValidKeychainManifestTimestamp(updatedAt) &&
+      updatedAt >= createdAt &&
+      (label == null ||
+          (label.length <= maxLabelLength &&
+              !KeychainManifestNostrKey.hasControlCharacter(label))) &&
+      provenance != WalletProvenance.watchOnly &&
+      provenance != WalletProvenance.externalSigner &&
+      (provenance != WalletProvenance.defaultSeedPassphrase ||
+          (descriptor != null &&
+              descriptor.trim().isNotEmpty &&
+              descriptor.length <= maxDescriptorLength));
+
+  @override
+  String get identity => 'wallet:$walletId';
+}
+
+final class KeychainManifestNostrKey extends KeychainManifestMaterialization {
+  static const maxPurposeLength = 80;
+  static final _publicKeyPattern = RegExp(r'^[0-9a-f]{64}$');
+  static final _controlPattern = RegExp(r'[\u0000-\u001F\u007F]');
+
+  @override
+  final String entryId;
+  final String publicKeyHex;
+  final KeychainManifestNostrKeyKind keyKind;
+  final String purpose;
+  @override
+  final int createdAt;
+  @override
+  final int updatedAt;
+
+  KeychainManifestNostrKey({
+    required String entryId,
+    required String publicKeyHex,
+    required this.keyKind,
+    required String purpose,
+    required this.createdAt,
+    required this.updatedAt,
+  }) : entryId = _required(entryId),
+       publicKeyHex = publicKeyHex.toLowerCase(),
+       purpose = purpose.trim() {
+    if (!isValid(
+      entryId: this.entryId,
+      publicKeyHex: this.publicKeyHex,
+      purpose: this.purpose,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    )) {
+      throw ArgumentError('Invalid Nostr materialization');
+    }
+  }
+
+  static bool isValid({
+    required String entryId,
+    required String publicKeyHex,
+    required String purpose,
+    required int createdAt,
+    required int updatedAt,
+  }) =>
+      _tryRequired(entryId) != null &&
+      _publicKeyPattern.hasMatch(publicKeyHex.toLowerCase()) &&
+      tryNormalizePurpose(purpose) != null &&
+      isValidKeychainManifestTimestamp(createdAt) &&
+      isValidKeychainManifestTimestamp(updatedAt) &&
+      updatedAt >= createdAt;
+
+  static String? tryNormalizePurpose(String purpose) {
+    final normalizedPurpose = purpose.trim();
+    if (normalizedPurpose.isEmpty ||
+        normalizedPurpose.length > maxPurposeLength ||
+        _controlPattern.hasMatch(normalizedPurpose)) {
+      return null;
+    }
+    return normalizedPurpose;
+  }
+
+  static bool hasControlCharacter(String value) =>
+      _controlPattern.hasMatch(value);
+
+  @override
+  String get identity => 'nostr:$entryId';
+
+  late final String npub = NostrBech32.npub(hex.decode(publicKeyHex));
+}
+
+String _required(String value) {
+  final result = _tryRequired(value);
+  if (result == null) {
+    throw ArgumentError('Required manifest text is invalid');
+  }
+  return result;
+}
+
+String? _tryRequired(String value) {
+  final result = value.trim();
+  return result.isEmpty || result.length > 512 ? null : result;
+}
+
+String? _optional(String? value) {
+  final result = value?.trim();
+  return result == null || result.isEmpty ? null : result;
+}
+
+String _canonicalPath(KeychainManifestDerivationKind kind, String value) {
+  final trimmed = value.trim();
+  final hasRoot = trimmed.startsWith('m/');
+  if (kind == KeychainManifestDerivationKind.bip32 && !hasRoot) {
+    throw ArgumentError('Invalid BIP32 path');
+  }
+  if (kind == KeychainManifestDerivationKind.bip85 && hasRoot) {
+    throw ArgumentError('Invalid BIP85 path');
+  }
+  final parts = (hasRoot ? trimmed.substring(2) : trimmed).split('/');
+  if (parts.length < 2) throw ArgumentError('Invalid derivation path');
+  final numbers = parts.map(_pathNumber).toList(growable: false);
+  final path = numbers.map((number) => "$number'").join('/');
+  return hasRoot ? 'm/$path' : path;
+}
+
+int _pathNumber(String segment) {
+  if (!RegExp(r"^(0|[1-9][0-9]*)(?:'|h|H)$").hasMatch(segment)) {
+    throw ArgumentError('Invalid derivation path');
+  }
+  final value = int.parse(segment.substring(0, segment.length - 1));
+  if (value > 0x7fffffff) throw ArgumentError('Invalid derivation path');
+  return value;
+}

--- a/lib/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart
+++ b/lib/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart
@@ -1,0 +1,107 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
+
+/// One optional field of an update.
+///
+/// Absent leaves the stored value alone; present carries the replacement, which
+/// may be null to clear the field. A plain nullable parameter cannot say the
+/// difference between "leave the hint" and "remove the hint".
+final class KeychainManifestEdit<T> {
+  final T value;
+
+  const KeychainManifestEdit(this.value);
+}
+
+final class KeychainManifestWalletInventoryBinding {
+  final String walletId;
+  final Fingerprint seedFingerprint;
+  final Network network;
+  final ScriptType scriptType;
+  final WalletProvenance provenance;
+  final String derivationPath;
+  final bool? seedPassphraseUsed;
+  final String? descriptor;
+  final String? label;
+  final String? description;
+  final int? createdAt;
+  final int? updatedAt;
+
+  const KeychainManifestWalletInventoryBinding({
+    required this.walletId,
+    required this.seedFingerprint,
+    required this.network,
+    required this.scriptType,
+    required this.provenance,
+    required this.derivationPath,
+    required this.seedPassphraseUsed,
+    this.descriptor,
+    this.label,
+    this.description,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  /// Whether the manifest may hold this binding at all.
+  ///
+  /// Watch-only and external-signer wallets have no seed to recover from, and a
+  /// passphrase wallet without its combined public descriptor cannot be
+  /// re-derived, so neither is recordable recovery truth (spec 20.1).
+  bool get isRecordable =>
+      (provenance == WalletProvenance.defaultSeed ||
+          provenance == WalletProvenance.defaultSeedPassphrase ||
+          provenance == WalletProvenance.importedMnemonic) &&
+      (label?.trim().length ?? 0) <= KeychainManifestWallet.maxLabelLength &&
+      (label == null ||
+          !KeychainManifestNostrKey.hasControlCharacter(label!)) &&
+      (description?.trim().length ?? 0) <=
+          KeychainManifestEntry.maxDescriptionLength &&
+      (description == null ||
+          !KeychainManifestNostrKey.hasControlCharacter(description!)) &&
+      (provenance != WalletProvenance.defaultSeedPassphrase ||
+          (descriptor != null &&
+              descriptor!.trim().isNotEmpty &&
+              descriptor!.length <=
+                  KeychainManifestWallet.maxDescriptorLength));
+
+  /// The manifest entry this binding stands for, or null when its timestamps
+  /// cannot make a valid entry.
+  KeychainManifestEntry? tryToEntry(
+    Fingerprint parentFingerprint, {
+    required int fallbackTimestamp,
+  }) {
+    final created = createdAt ?? fallbackTimestamp;
+    final updated = updatedAt ?? created;
+    if (created < 0 || updated < created) return null;
+    final entryId = KeychainManifestEntry.entryIdFor(
+      parentFingerprint: parentFingerprint,
+      derivationKind: KeychainManifestDerivationKind.bip32,
+      derivationPath: derivationPath,
+      seedFingerprint: seedFingerprint,
+    );
+    return KeychainManifestEntry(
+      parentFingerprint: parentFingerprint,
+      derivationKind: KeychainManifestDerivationKind.bip32,
+      derivationPath: derivationPath,
+      description: description,
+      createdAt: created,
+      updatedAt: updated,
+      materializations: [
+        KeychainManifestWallet(
+          walletId: walletId,
+          entryId: entryId,
+          childSeedFingerprint: seedFingerprint,
+          network: network,
+          scriptType: scriptType,
+          provenance: provenance,
+          seedPassphraseUsed: seedPassphraseUsed,
+          descriptor: descriptor,
+          label: label,
+          createdAt: created,
+          updatedAt: updated,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart
+++ b/lib/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart
@@ -1,0 +1,13 @@
+final class RevealedNostrSecret {
+  final String nsec;
+
+  const RevealedNostrSecret._(this.nsec);
+
+  factory RevealedNostrSecret(String nsec) {
+    if (!nsec.startsWith('nsec1')) throw ArgumentError('Invalid nsec');
+    return RevealedNostrSecret._(nsec);
+  }
+
+  @override
+  String toString() => 'RevealedNostrSecret([REDACTED])';
+}

--- a/lib/features/keychain_manifest/domain/keychain_manifest_failure.dart
+++ b/lib/features/keychain_manifest/domain/keychain_manifest_failure.dart
@@ -1,0 +1,51 @@
+import 'package:primitives/primitives.dart';
+
+sealed class KeychainManifestFailure extends Failure {
+  const KeychainManifestFailure();
+}
+
+final class KeychainManifestMalformedFileFailure
+    extends KeychainManifestFailure {
+  const KeychainManifestMalformedFileFailure();
+}
+
+final class KeychainManifestUnsupportedVersionFailure
+    extends KeychainManifestFailure {
+  final int version;
+
+  const KeychainManifestUnsupportedVersionFailure(this.version);
+}
+
+final class KeychainManifestParentMismatchFailure
+    extends KeychainManifestFailure {
+  const KeychainManifestParentMismatchFailure();
+}
+
+final class KeychainManifestUnknownReservationFailure
+    extends KeychainManifestFailure {
+  const KeychainManifestUnknownReservationFailure();
+}
+
+final class KeychainManifestEmptyFailure extends KeychainManifestFailure {
+  const KeychainManifestEmptyFailure();
+}
+
+final class KeychainManifestConflictFailure extends KeychainManifestFailure {
+  const KeychainManifestConflictFailure();
+}
+
+final class KeychainManifestStorageFailure extends KeychainManifestFailure {
+  const KeychainManifestStorageFailure();
+}
+
+final class KeychainManifestSeedFailure extends KeychainManifestFailure {
+  const KeychainManifestSeedFailure();
+}
+
+final class KeychainManifestDerivationFailure extends KeychainManifestFailure {
+  const KeychainManifestDerivationFailure();
+}
+
+final class KeychainManifestUnexpectedFailure extends KeychainManifestFailure {
+  const KeychainManifestUnexpectedFailure();
+}

--- a/lib/features/keychain_manifest/domain/nostr_key_deriver.dart
+++ b/lib/features/keychain_manifest/domain/nostr_key_deriver.dart
@@ -1,0 +1,73 @@
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/nostr_bech32.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:convert/convert.dart';
+import 'package:primitives/primitives.dart';
+
+final class KeychainManifestNostrKeyDeriver {
+  final GetSettingsUsecase _settings;
+  final GetDefaultSeedUsecase _defaultSeed;
+
+  const KeychainManifestNostrKeyDeriver(this._settings, this._defaultSeed);
+
+  Future<Result<KeychainManifestSeedSource, KeychainManifestFailure>>
+  source() async {
+    try {
+      final settings = await _settings.execute();
+      return switch (await _defaultSeed.execute(
+        environment: settings.environment,
+      )) {
+        Ok(:final value) => Ok(
+          KeychainManifestSeedSource(
+            value,
+            Fingerprint.tryParse(value.masterFingerprint)!,
+          ),
+        ),
+        Err() => const Err(KeychainManifestSeedFailure()),
+      };
+    } on Exception {
+      return const Err(KeychainManifestSeedFailure());
+    }
+  }
+
+  String derivePublicKey(Seed seed, String path) =>
+      hex.encode(_derivePrivateKey(seed, path).getPublic().toXOnly());
+
+  DerivedKeychainManifestNostrSecret revealSecret(Seed seed, String path) {
+    final key = _derivePrivateKey(seed, path);
+    return DerivedKeychainManifestNostrSecret(
+      publicKeyHex: hex.encode(key.getPublic().toXOnly()),
+      nsec: NostrBech32.nsec(hex.decode(key.toHex())),
+    );
+  }
+
+  ECPrivate _derivePrivateKey(Seed seed, String path) {
+    final entropy = bip85.Bip85Entropy.deriveFromHardenedPath(
+      xprvBase58: Bip32Derivation.getCanonicalRootXprvFromSeed(seed.bytes),
+      path: bip85.Bip85HardenedPath(path),
+    );
+    return ECPrivate.fromHex(entropy.substring(0, 64));
+  }
+}
+
+final class KeychainManifestSeedSource {
+  final Seed seed;
+  final Fingerprint fingerprint;
+
+  const KeychainManifestSeedSource(this.seed, this.fingerprint);
+}
+
+final class DerivedKeychainManifestNostrSecret {
+  final String publicKeyHex;
+  final String nsec;
+
+  const DerivedKeychainManifestNostrSecret({
+    required this.publicKeyHex,
+    required this.nsec,
+  });
+}

--- a/lib/features/keychain_manifest/domain/nostr_key_display.dart
+++ b/lib/features/keychain_manifest/domain/nostr_key_display.dart
@@ -1,0 +1,14 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+
+extension KeychainManifestNostrKeyDisplay on KeychainManifestEntry {
+  bool get isSystemNostrKey {
+    final key = materializations.singleOrNull;
+    return key is KeychainManifestNostrKey &&
+        key.keyKind == KeychainManifestNostrKeyKind.reserved;
+  }
+
+  bool get isMetadataBackupKey =>
+      Bip85Reservations.reservationByExactPath(derivationPath) ==
+      Bip85Reservations.nostrWalletBackupKey;
+}

--- a/lib/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart
+++ b/lib/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+enum KeychainManifestWriteOrigin { local, recovery }
+
+/// How [KeychainManifestRepository.restoreSnapshot] reconciles a restored
+/// record with the one already stored under the same entry id.
+enum KeychainManifestRestorePolicy {
+  /// Identical identity metadata: the newest `updatedAt` wins, so a restored
+  /// newer label or hint is applied and older restored text never clobbers
+  /// newer local text. Different identity metadata under the same entry id is
+  /// reported as a conflict and never merged (spec 6.5).
+  keepNewest,
+}
+
+/// What one [KeychainManifestRepository.restoreSnapshot] pass did.
+///
+/// [conflicts] holds the entry ids the policy refused, so recovery can report
+/// them instead of claiming a complete apply.
+final class KeychainManifestRestoreReport {
+  final int applied;
+  final int unchanged;
+  final List<String> conflicts;
+
+  KeychainManifestRestoreReport({
+    this.applied = 0,
+    this.unchanged = 0,
+    Iterable<String> conflicts = const [],
+  }) : conflicts = List.unmodifiable(conflicts);
+
+  int get restored => applied + unchanged;
+}
+
+/// The persistent recovery inventory.
+///
+/// Every write is one named intent (spec F11). There is deliberately no generic
+/// save: a local edit, a deterministic re-derivation, and a recovery apply want
+/// different conflict answers, and a shared helper can only guess.
+abstract interface class KeychainManifestRepository {
+  Stream<void> watchLocalChanges();
+
+  @useResult
+  Future<Result<List<KeychainManifestEntry>, KeychainManifestFailure>> fetch(
+    Fingerprint parentFingerprint,
+  );
+
+  /// Replaces the deterministic seed-derived wallet materializations of
+  /// [parentFingerprint] with [entries].
+  ///
+  /// Records the app can re-derive from the seed at any time are owned by this
+  /// operation. Imported-mnemonic and passphrase records are not: they exist
+  /// only because the user made them, so ones absent from [entries] are kept.
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> replaceSeedWalletInventory(
+    Fingerprint parentFingerprint,
+    List<KeychainManifestEntry> entries,
+  );
+
+  /// Inserts or updates one directly recorded wallet materialization.
+  ///
+  /// Identity is the combined public descriptor the record carries, or its
+  /// wallet id when it carries none. A stored record whose identity differs is
+  /// a conflict even when the four-byte seed fingerprint matches — that
+  /// fingerprint is a lookup hint, never an identity (spec 6.5). Label and hint
+  /// are not identity: changing them updates the stored record.
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> upsertPassphraseWallet(
+    KeychainManifestEntry record,
+  );
+
+  /// Updates the display label and passphrase hint the manifest owns
+  /// (decision 2).
+  ///
+  /// Monotonic: [updatedAt] must be newer than the stored revision. Two
+  /// different texts claiming the same instant cannot be ordered, so an equal
+  /// timestamp carrying different content is a conflict rather than a coin
+  /// toss. Writing back what is already stored succeeds and changes nothing.
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> updatePassphraseLabelHint({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+    KeychainManifestEdit<String?>? label,
+    KeychainManifestEdit<String?>? hint,
+    required int updatedAt,
+  });
+
+  /// Forgets one wallet's recovery record.
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> removePassphraseWallet({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+  });
+
+  /// Applies the wallet materializations of a recovered [manifest] under
+  /// [policy].
+  ///
+  /// Recovery-origin: it neither raises the backup dirty signal nor publishes a
+  /// local change, so restoring a snapshot cannot publish it straight back.
+  /// Entries that do not carry exactly one wallet materialization are reported
+  /// as conflicts; the Nostr materializations of a snapshot are restored by
+  /// their own use case, which has the deriver needed to verify them.
+  @useResult
+  Future<Result<KeychainManifestRestoreReport, KeychainManifestFailure>>
+  restoreSnapshot(
+    KeychainManifest manifest, {
+    KeychainManifestRestorePolicy policy,
+  });
+
+  /// Adds one deterministic Nostr key materialization.
+  ///
+  /// Writing back an identical record succeeds and changes nothing; a stored
+  /// record with different key material is a conflict. Later metadata edits go
+  /// through [updateNostrMetadata].
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> insertNostrKey(
+    KeychainManifestEntry record, {
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  });
+
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> updateNostrMetadata({
+    required Fingerprint parentFingerprint,
+    required String entryId,
+    required String purpose,
+    String? description,
+    required int updatedAt,
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  });
+
+  Future<void> close();
+}

--- a/lib/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+final class BuildKeychainManifestFileUsecase {
+  final KeychainManifestRepository _repository;
+
+  const BuildKeychainManifestFileUsecase(this._repository);
+
+  Future<Result<KeychainManifest, KeychainManifestFailure>> execute(
+    Fingerprint parentFingerprint, {
+    DateTime? now,
+  }) async => switch (await _repository.fetch(parentFingerprint)) {
+    Err(:final failure) => Err(failure),
+    Ok(:final value) => Ok(
+      KeychainManifest(
+        parentFingerprint: parentFingerprint,
+        generatedAt:
+            (now ?? DateTime.now().toUtc()).millisecondsSinceEpoch ~/ 1000,
+        entries: value,
+      ).canonical(),
+    ),
+  };
+}

--- a/lib/features/keychain_manifest/domain/usecases/create_keychain_manifest_nostr_key_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/create_keychain_manifest_nostr_key_usecase.dart
@@ -1,0 +1,89 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:primitives/primitives.dart';
+
+final class CreateKeychainManifestNostrKeyUsecase {
+  final KeychainManifestNostrKeyDeriver _deriver;
+  final KeychainManifestRepository _repository;
+  final RecordKeychainManifestNostrKeyUsecase _record;
+
+  const CreateKeychainManifestNostrKeyUsecase(
+    this._deriver,
+    this._repository,
+    this._record,
+  );
+
+  Future<Result<KeychainManifestEntry, KeychainManifestFailure>> execute({
+    required String purpose,
+    String? description,
+    DateTime? now,
+  }) async {
+    final sourceResult = await _deriver.source();
+    if (sourceResult case Err(:final failure)) return Err(failure);
+    final source =
+        (sourceResult
+                as Ok<KeychainManifestSeedSource, KeychainManifestFailure>)
+            .value;
+    while (true) {
+      final fetched = await _repository.fetch(source.fingerprint);
+      if (fetched case Err(:final failure)) return Err(failure);
+      final entries =
+          (fetched as Ok<List<KeychainManifestEntry>, KeychainManifestFailure>)
+              .value;
+      var identity =
+          entries
+              .where(
+                (entry) =>
+                    entry.derivationKind ==
+                        KeychainManifestDerivationKind.bip85 &&
+                    Bip85Reservations.isNostrUserKeyPath(entry.derivationPath),
+              )
+              .map(
+                (entry) => Bip85Reservations.nostrUserKeyIdentity(
+                  entry.derivationPath,
+                ),
+              )
+              .whereType<int>()
+              .fold(0, (largest, value) => value > largest ? value : largest) +
+          1;
+      if (Bip85Reservations.isNostrAppReservedIdentity(identity)) {
+        identity = Bip85Reservations.nostrAppReservedIdentityEnd + 1;
+      }
+      if (identity > Bip85Reservations.nostrUserIdentityEnd) {
+        return const Err(KeychainManifestConflictFailure());
+      }
+      final path = Bip85Reservations.nostrUserKeyPath(identity);
+      final recorded = await _record.execute(
+        reservationId: Bip85Reservations.nostrUserKeyReservationId,
+        parentFingerprint: source.fingerprint,
+        derivationPath: path,
+        publicKeyHex: _deriver.derivePublicKey(source.seed, path),
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: purpose,
+        description: description,
+        now: now,
+      );
+      switch (recorded) {
+        case Ok(:final value):
+          if (!value) continue;
+          final refreshed = await _repository.fetch(source.fingerprint);
+          return refreshed.map(
+            (entries) => entries.singleWhere(
+              (entry) =>
+                  entry.derivationKind ==
+                      KeychainManifestDerivationKind.bip85 &&
+                  entry.derivationPath == path,
+            ),
+          );
+        case Err(failure: KeychainManifestConflictFailure()):
+          continue;
+        case Err(:final failure):
+          return Err(failure);
+      }
+    }
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/get_default_wallet_nostr_keys_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/get_default_wallet_nostr_keys_usecase.dart
@@ -1,0 +1,29 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+final class GetDefaultWalletNostrKeysUsecase {
+  final KeychainManifestNostrKeyDeriver _deriver;
+  final KeychainManifestRepository _repository;
+
+  const GetDefaultWalletNostrKeysUsecase(this._deriver, this._repository);
+
+  Future<Result<List<KeychainManifestEntry>, KeychainManifestFailure>>
+  execute() async {
+    final source = await _deriver.source();
+    return switch (source) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => (await _repository.fetch(value.fingerprint)).map(
+        (entries) => entries
+            .where(
+              (entry) =>
+                  entry.materializations.singleOrNull
+                      is KeychainManifestNostrKey,
+            )
+            .toList(growable: false),
+      ),
+    };
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart
@@ -1,0 +1,85 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef DecodeKeychainManifestFile =
+    Result<KeychainManifest, KeychainManifestFailure> Function(String payload);
+
+final class ParseKeychainManifestFileUsecase {
+  final DecodeKeychainManifestFile _decode;
+
+  const ParseKeychainManifestFileUsecase(this._decode);
+
+  Result<KeychainManifest, KeychainManifestFailure> execute(
+    String payload, {
+    required Fingerprint expectedParentFingerprint,
+    bool allowEmpty = false,
+  }) => switch (_decode(payload)) {
+    Err(:final failure) => Err(failure),
+    Ok(:final value) => _validate(
+      value,
+      expectedParentFingerprint: expectedParentFingerprint,
+      allowEmpty: allowEmpty,
+    ),
+  };
+
+  Result<KeychainManifest, KeychainManifestFailure> _validate(
+    KeychainManifest manifest, {
+    required Fingerprint expectedParentFingerprint,
+    bool allowEmpty = false,
+  }) {
+    if (manifest.parentFingerprint != expectedParentFingerprint) {
+      return const Err(KeychainManifestParentMismatchFailure());
+    }
+    if (manifest.entries.isEmpty && !allowEmpty) {
+      return const Err(KeychainManifestEmptyFailure());
+    }
+    for (final entry in manifest.entries) {
+      if (!_validReservation(entry)) {
+        return const Err(KeychainManifestUnknownReservationFailure());
+      }
+    }
+    return Ok(manifest);
+  }
+
+  bool _validReservation(KeychainManifestEntry entry) {
+    if (entry.derivationKind == KeychainManifestDerivationKind.bip32) {
+      return entry.materializations.every(
+        (item) =>
+            item is KeychainManifestWallet &&
+            (item.provenance == WalletProvenance.defaultSeed ||
+                item.provenance == WalletProvenance.defaultSeedPassphrase ||
+                item.provenance == WalletProvenance.importedMnemonic) &&
+            (item.provenance != WalletProvenance.defaultSeed ||
+                item.childSeedFingerprint == entry.parentFingerprint),
+      );
+    }
+    final reservation = Bip85Reservations.reservationByExactPath(
+      entry.derivationPath,
+    );
+    final userKey = Bip85Reservations.isNostrUserKeyPath(entry.derivationPath);
+    if (reservation == null && !userKey) return false;
+    if (userKey) {
+      return entry.materializations.every(
+        (item) =>
+            item is KeychainManifestNostrKey &&
+            item.keyKind == KeychainManifestNostrKeyKind.userGenerated,
+      );
+    }
+    return switch (reservation!.purpose) {
+      Bip85ReservationPurpose.walletSeed => entry.materializations.every(
+        (item) =>
+            item is KeychainManifestWallet &&
+            item.provenance == WalletProvenance.bip85,
+      ),
+      Bip85ReservationPurpose.nonWalletNostrKey => entry.materializations.every(
+        (item) =>
+            item is KeychainManifestNostrKey &&
+            item.keyKind == KeychainManifestNostrKeyKind.reserved,
+      ),
+      Bip85ReservationPurpose.backupEncryptionKey => false,
+    };
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart
@@ -1,0 +1,93 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+final class RecordKeychainManifestNostrKeyUsecase {
+  final KeychainManifestRepository _repository;
+
+  const RecordKeychainManifestNostrKeyUsecase(this._repository);
+
+  Future<Result<bool, KeychainManifestFailure>> execute({
+    required String reservationId,
+    required Fingerprint parentFingerprint,
+    required String derivationPath,
+    required String publicKeyHex,
+    required KeychainManifestNostrKeyKind keyKind,
+    required String purpose,
+    String? description,
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+    DateTime? now,
+    DateTime? updatedAt,
+  }) async {
+    final reservation = Bip85Reservations.reservationById(reservationId);
+    final userKey =
+        reservationId == Bip85Reservations.nostrUserKeyReservationId &&
+        keyKind == KeychainManifestNostrKeyKind.userGenerated &&
+        Bip85Reservations.isNostrUserKeyPath(derivationPath);
+    final reservedKey =
+        keyKind == KeychainManifestNostrKeyKind.reserved &&
+        reservation?.purpose == Bip85ReservationPurpose.nonWalletNostrKey &&
+        reservation?.path == derivationPath;
+    if (!userKey && !reservedKey) {
+      return const Err(KeychainManifestUnknownReservationFailure());
+    }
+    final effectiveNow = now ?? DateTime.now().toUtc();
+    final timestamp = effectiveNow.millisecondsSinceEpoch ~/ 1000;
+    final revision = (updatedAt ?? effectiveNow).millisecondsSinceEpoch ~/ 1000;
+    final entryId = '${parentFingerprint.hex}:$derivationPath';
+    final key = KeychainManifestNostrKey(
+      entryId: entryId,
+      publicKeyHex: publicKeyHex,
+      keyKind: keyKind,
+      purpose: purpose,
+      createdAt: timestamp,
+      updatedAt: revision,
+    );
+    final entry = KeychainManifestEntry(
+      parentFingerprint: parentFingerprint,
+      derivationPath: derivationPath,
+      description: description,
+      createdAt: timestamp,
+      updatedAt: revision,
+      materializations: [key],
+    );
+    final current = await _repository.fetch(parentFingerprint);
+    if (current case Err(:final failure)) return Err(failure);
+    final storedEntry =
+        (current as Ok<List<KeychainManifestEntry>, KeychainManifestFailure>)
+            .value
+            .where((item) => item.entryId == entryId)
+            .firstOrNull;
+    final stored = storedEntry?.materializations
+        .whereType<KeychainManifestNostrKey>()
+        .firstOrNull;
+    if (stored == null) {
+      return (await _repository.insertNostrKey(
+        entry,
+        origin: origin,
+      )).map((_) => true);
+    }
+    if (stored.publicKeyHex != publicKeyHex.toLowerCase() ||
+        stored.keyKind != keyKind) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    final metadataMatches =
+        stored.purpose == key.purpose &&
+        storedEntry!.description == entry.description;
+    if (metadataMatches) return const Ok(false);
+    if (stored.updatedAt == revision) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    if (revision <= stored.updatedAt) return const Ok(false);
+    return (await _repository.updateNostrMetadata(
+      parentFingerprint: parentFingerprint,
+      entryId: entryId,
+      purpose: key.purpose,
+      description: entry.description,
+      updatedAt: revision,
+      origin: origin,
+    )).map((_) => true);
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart
@@ -1,0 +1,26 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+/// Records one wallet the user made rather than one the app derived: a
+/// passphrase wallet, or an imported mnemonic no re-derivation would produce.
+final class RecordPassphraseWalletUsecase {
+  final KeychainManifestRepository _repository;
+
+  const RecordPassphraseWalletUsecase(this._repository);
+
+  Future<Result<bool, KeychainManifestFailure>> execute({
+    required Fingerprint parentFingerprint,
+    required KeychainManifestWalletInventoryBinding wallet,
+    DateTime? now,
+  }) async {
+    final timestamp =
+        (now ?? DateTime.now().toUtc()).millisecondsSinceEpoch ~/ 1000;
+    final entry = wallet.isRecordable
+        ? wallet.tryToEntry(parentFingerprint, fallbackTimestamp: timestamp)
+        : null;
+    if (entry == null) return const Err(KeychainManifestConflictFailure());
+    return (await _repository.upsertPassphraseWallet(entry)).map((_) => true);
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+final class RemovePassphraseWalletUsecase {
+  final KeychainManifestRepository _repository;
+
+  const RemovePassphraseWalletUsecase(this._repository);
+
+  Future<Result<void, KeychainManifestFailure>> execute({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+  }) => _repository.removePassphraseWallet(
+    parentFingerprint: parentFingerprint,
+    walletId: walletId,
+  );
+}

--- a/lib/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart
@@ -1,0 +1,36 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+/// Restates the wallets this seed deterministically derives.
+///
+/// An empty list is legitimate — it says the seed derives nothing right now —
+/// so it replaces rather than being rejected.
+final class ReplaceSeedWalletInventoryUsecase {
+  final KeychainManifestRepository _repository;
+
+  const ReplaceSeedWalletInventoryUsecase(this._repository);
+
+  Future<Result<bool, KeychainManifestFailure>> execute({
+    required Fingerprint parentFingerprint,
+    required List<KeychainManifestWalletInventoryBinding> wallets,
+    DateTime? now,
+  }) async {
+    final timestamp =
+        (now ?? DateTime.now().toUtc()).millisecondsSinceEpoch ~/ 1000;
+    final entries = <KeychainManifestEntry>[];
+    for (final wallet in wallets) {
+      final entry = wallet.isRecordable
+          ? wallet.tryToEntry(parentFingerprint, fallbackTimestamp: timestamp)
+          : null;
+      if (entry == null) return const Err(KeychainManifestConflictFailure());
+      entries.add(entry);
+    }
+    return (await _repository.replaceSeedWalletInventory(
+      parentFingerprint,
+      entries,
+    )).map((_) => true);
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart
@@ -1,0 +1,49 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:primitives/primitives.dart';
+
+final class RestoreKeychainManifestNostrKeyUsecase {
+  final KeychainManifestNostrKeyDeriver _deriver;
+  final RecordKeychainManifestNostrKeyUsecase _record;
+
+  const RestoreKeychainManifestNostrKeyUsecase(this._deriver, this._record);
+
+  Future<Result<bool, KeychainManifestFailure>> execute({
+    required String reservationId,
+    required Fingerprint parentFingerprint,
+    required String derivationPath,
+    required String publicKeyHex,
+    required KeychainManifestNostrKeyKind keyKind,
+    required String purpose,
+    String? description,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) async {
+    final source = await _deriver.source();
+    switch (source) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        if (value.fingerprint != parentFingerprint ||
+            _deriver.derivePublicKey(value.seed, derivationPath) !=
+                publicKeyHex) {
+          return const Err(KeychainManifestConflictFailure());
+        }
+    }
+    return _record.execute(
+      reservationId: reservationId,
+      parentFingerprint: parentFingerprint,
+      derivationPath: derivationPath,
+      publicKeyHex: publicKeyHex,
+      keyKind: keyKind,
+      purpose: purpose,
+      description: description,
+      now: createdAt,
+      updatedAt: updatedAt,
+      origin: KeychainManifestWriteOrigin.recovery,
+    );
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+/// Applies the wallet records of a recovered manifest.
+///
+/// Recovery decides which records it is willing to admit; this only decides how
+/// an admitted record meets one already stored.
+final class RestoreManifestSnapshotUsecase {
+  final KeychainManifestRepository _repository;
+
+  const RestoreManifestSnapshotUsecase(this._repository);
+
+  Future<Result<KeychainManifestRestoreReport, KeychainManifestFailure>>
+  execute(
+    KeychainManifest manifest, {
+    KeychainManifestRestorePolicy policy =
+        KeychainManifestRestorePolicy.keepNewest,
+  }) => _repository.restoreSnapshot(manifest, policy: policy);
+}

--- a/lib/features/keychain_manifest/domain/usecases/reveal_keychain_manifest_nostr_key_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/reveal_keychain_manifest_nostr_key_usecase.dart
@@ -1,0 +1,37 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:primitives/primitives.dart';
+
+final class RevealKeychainManifestNostrKeyUsecase {
+  final KeychainManifestNostrKeyDeriver _deriver;
+
+  const RevealKeychainManifestNostrKeyUsecase(this._deriver);
+
+  Future<Result<RevealedNostrSecret, KeychainManifestFailure>> execute(
+    KeychainManifestEntry entry,
+  ) async {
+    final key = entry.materializations.singleOrNull;
+    if (key is! KeychainManifestNostrKey ||
+        entry.derivationKind != KeychainManifestDerivationKind.bip85) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    final source = await _deriver.source();
+    if (source case Err(:final failure)) return Err(failure);
+    final value =
+        (source as Ok<KeychainManifestSeedSource, KeychainManifestFailure>)
+            .value;
+    if (value.fingerprint != entry.parentFingerprint) {
+      return const Err(KeychainManifestSeedFailure());
+    }
+    final derived = _deriver.revealSecret(
+      value.seed,
+      entry.bip85DerivationPath,
+    );
+    if (derived.publicKeyHex != key.publicKeyHex) {
+      return const Err(KeychainManifestDerivationFailure());
+    }
+    return Ok(RevealedNostrSecret(derived.nsec));
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart
@@ -1,0 +1,55 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:primitives/primitives.dart';
+
+/// Edits the label and hint the manifest owns for one wallet (decision 2).
+final class UpdatePassphraseLabelHintUsecase {
+  final KeychainManifestRepository _repository;
+
+  const UpdatePassphraseLabelHintUsecase(this._repository);
+
+  /// A local edit is by definition the newest statement about the record, so
+  /// the revision it writes is derived from the stored one rather than taken
+  /// on trust from a clock that may be behind.
+  Future<Result<void, KeychainManifestFailure>> execute({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+    KeychainManifestEdit<String?>? label,
+    KeychainManifestEdit<String?>? hint,
+    DateTime? now,
+  }) async {
+    if (label == null && hint == null) return const Ok(null);
+    final current = await _repository.fetch(parentFingerprint);
+    final List<KeychainManifestEntry> entries;
+    switch (current) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        entries = value;
+    }
+    final stored = entries
+        .where(
+          (entry) => entry.materializations.any(
+            (item) =>
+                item is KeychainManifestWallet && item.walletId == walletId,
+          ),
+        )
+        .firstOrNull;
+    if (stored == null) return const Err(KeychainManifestConflictFailure());
+    final seconds =
+        (now ?? DateTime.now().toUtc()).millisecondsSinceEpoch ~/ 1000;
+    final revision = [
+      stored.updatedAt,
+      ...stored.materializations.map((item) => item.updatedAt),
+    ].reduce((a, b) => a > b ? a : b);
+    return _repository.updatePassphraseLabelHint(
+      parentFingerprint: parentFingerprint,
+      walletId: walletId,
+      label: label,
+      hint: hint,
+      updatedAt: seconds > revision ? seconds : revision + 1,
+    );
+  }
+}

--- a/lib/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart
+++ b/lib/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart
@@ -1,0 +1,11 @@
+import 'dart:async';
+
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+
+final class WatchKeychainManifestChangesUsecase {
+  final KeychainManifestRepository _repository;
+
+  const WatchKeychainManifestChangesUsecase(this._repository);
+
+  Stream<void> execute() => _repository.watchLocalChanges();
+}

--- a/lib/features/keychain_manifest/keychain_manifest_locator.dart
+++ b/lib/features/keychain_manifest/keychain_manifest_locator.dart
@@ -1,0 +1,88 @@
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/storage/backup_revision_recorder.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/keychain_manifest_repository_impl.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/create_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/get_default_wallet_nostr_keys_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/reveal_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/widgets/nostr_nsec_reveal_dialog.dart';
+import 'package:get_it/get_it.dart';
+
+abstract final class KeychainManifestLocator {
+  static void setup(GetIt locator) {
+    const codec = KeychainManifestFileCodec();
+    locator.registerLazySingleton<KeychainManifestRepository>(
+      () => KeychainManifestRepositoryImpl(
+        locator<SqliteDatabase>(),
+        backupRevisions: DriftBackupRevisionRecorder(locator<SqliteDatabase>()),
+      ),
+      dispose: (repository) => repository.close(),
+    );
+
+    KeychainManifestNostrKeyDeriver deriver() =>
+        KeychainManifestNostrKeyDeriver(
+          locator<GetSettingsUsecase>(),
+          locator<GetDefaultSeedUsecase>(),
+        );
+    RecordKeychainManifestNostrKeyUsecase recordNostr() =>
+        RecordKeychainManifestNostrKeyUsecase(
+          locator<KeychainManifestRepository>(),
+        );
+    ParseKeychainManifestFileUsecase parse() =>
+        ParseKeychainManifestFileUsecase(codec.decode);
+
+    locator.registerFactory<NostrKeysCubit>(
+      () => NostrKeysCubit(
+        GetDefaultWalletNostrKeysUsecase(
+          deriver(),
+          locator<KeychainManifestRepository>(),
+        ),
+        CreateKeychainManifestNostrKeyUsecase(
+          deriver(),
+          locator<KeychainManifestRepository>(),
+          recordNostr(),
+        ),
+      ),
+    );
+    locator.registerFactory<NostrNsecRevealPresenter>(
+      () => NostrNsecRevealPresenter(
+        RevealKeychainManifestNostrKeyUsecase(deriver()),
+      ),
+    );
+    locator.registerLazySingleton<KeychainManifestFacade>(
+      () => KeychainManifestFacade(
+        WatchKeychainManifestChangesUsecase(
+          locator<KeychainManifestRepository>(),
+        ),
+        codec.encode,
+        BuildKeychainManifestFileUsecase(locator<KeychainManifestRepository>()),
+        parse(),
+        ReplaceSeedWalletInventoryUsecase(
+          locator<KeychainManifestRepository>(),
+        ),
+        RecordPassphraseWalletUsecase(locator<KeychainManifestRepository>()),
+        RestoreManifestSnapshotUsecase(locator<KeychainManifestRepository>()),
+        recordNostr(),
+        RestoreKeychainManifestNostrKeyUsecase(deriver(), recordNostr()),
+        UpdatePassphraseLabelHintUsecase(locator<KeychainManifestRepository>()),
+        RemovePassphraseWalletUsecase(locator<KeychainManifestRepository>()),
+      ),
+    );
+  }
+}

--- a/lib/features/keychain_manifest/presentation/keychain_manifest_l10n.dart
+++ b/lib/features/keychain_manifest/presentation/keychain_manifest_l10n.dart
@@ -1,0 +1,51 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_display.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:flutter/widgets.dart';
+
+extension KeychainManifestFailureL10n on KeychainManifestFailure {
+  String toTranslated(BuildContext context) => switch (this) {
+    KeychainManifestMalformedFileFailure() ||
+    KeychainManifestUnsupportedVersionFailure() ||
+    KeychainManifestParentMismatchFailure() ||
+    KeychainManifestUnknownReservationFailure() ||
+    KeychainManifestEmptyFailure() ||
+    KeychainManifestConflictFailure() ||
+    KeychainManifestStorageFailure() ||
+    KeychainManifestSeedFailure() ||
+    KeychainManifestDerivationFailure() ||
+    KeychainManifestUnexpectedFailure() => context.loc.settingsNostrKeysFailure,
+  };
+}
+
+extension KeychainManifestEntryL10n on KeychainManifestEntry {
+  String displayName(BuildContext context) {
+    final key = materializations.single as KeychainManifestNostrKey;
+    return isMetadataBackupKey
+        ? context.loc.settingsNostrKeysSystemMetadataBackup
+        : key.purpose;
+  }
+
+  String? displayDescription(BuildContext context) {
+    final userDescription = description;
+    return isMetadataBackupKey
+        ? context.loc.settingsNostrKeysSystemMetadataBackupDescription
+        : userDescription;
+  }
+}
+
+extension NostrKeyFormErrorL10n on NostrKeyFormError {
+  String toTranslated(BuildContext context) => switch (this) {
+    NostrKeyFormError.nameRequired =>
+      context.loc.settingsNostrKeysNameRequiredError,
+    NostrKeyFormError.nameTooLong =>
+      context.loc.settingsNostrKeysNameTooLongError,
+    NostrKeyFormError.descriptionTooLong =>
+      context.loc.settingsNostrKeysDescriptionTooLongError,
+    NostrKeyFormError.invalidNameCharacters ||
+    NostrKeyFormError.invalidDescriptionCharacters =>
+      context.loc.settingsNostrKeysInvalidCharactersError,
+  };
+}

--- a/lib/features/keychain_manifest/presentation/nostr_keys_cubit.dart
+++ b/lib/features/keychain_manifest/presentation/nostr_keys_cubit.dart
@@ -1,0 +1,154 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_display.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/create_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/get_default_wallet_nostr_keys_usecase.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:primitives/primitives.dart';
+
+enum NostrKeyFormError {
+  nameRequired,
+  nameTooLong,
+  descriptionTooLong,
+  invalidNameCharacters,
+  invalidDescriptionCharacters,
+}
+
+final class NostrKeysState {
+  final List<KeychainManifestEntry> keys;
+  final bool loading;
+  final bool busy;
+  final bool showSystemKeys;
+  final KeychainManifestFailure? failure;
+  final NostrKeyFormError? formError;
+
+  const NostrKeysState({
+    this.keys = const [],
+    this.loading = false,
+    this.busy = false,
+    this.showSystemKeys = false,
+    this.failure,
+    this.formError,
+  });
+
+  List<KeychainManifestEntry> get userKeys =>
+      keys.where((key) => !key.isSystemNostrKey).toList(growable: false);
+
+  List<KeychainManifestEntry> get systemKeys =>
+      keys.where((key) => key.isSystemNostrKey).toList(growable: false);
+
+  NostrKeysState copyWith({
+    List<KeychainManifestEntry>? keys,
+    bool? loading,
+    bool? busy,
+    bool? showSystemKeys,
+    KeychainManifestFailure? failure,
+    NostrKeyFormError? formError,
+    bool clearFailure = false,
+    bool clearFormError = false,
+  }) => NostrKeysState(
+    keys: keys ?? this.keys,
+    loading: loading ?? this.loading,
+    busy: busy ?? this.busy,
+    showSystemKeys: showSystemKeys ?? this.showSystemKeys,
+    failure: clearFailure ? null : (failure ?? this.failure),
+    formError: clearFormError ? null : (formError ?? this.formError),
+  );
+}
+
+final class NostrKeysCubit extends Cubit<NostrKeysState> {
+  final GetDefaultWalletNostrKeysUsecase _load;
+  final CreateKeychainManifestNostrKeyUsecase _create;
+  NostrKeysCubit(this._load, this._create) : super(const NostrKeysState());
+
+  Future<void> load() async {
+    if (isClosed) return;
+    emit(state.copyWith(loading: true, clearFailure: true));
+    switch (await _load.execute()) {
+      case Ok(:final value):
+        if (!isClosed) {
+          emit(state.copyWith(keys: value, loading: false));
+        }
+      case Err(:final failure):
+        _fail(failure, loading: false);
+    }
+  }
+
+  void setShowSystemKeys(bool value) {
+    if (!isClosed && state.showSystemKeys != value) {
+      emit(state.copyWith(showSystemKeys: value));
+    }
+  }
+
+  Future<bool> create(String name, {String? description}) async {
+    if (isClosed || state.busy) return false;
+    final formError = validateNostrKeyForm(name, description);
+    if (formError != null) {
+      emit(state.copyWith(formError: formError));
+      return false;
+    }
+    emit(state.copyWith(busy: true, clearFailure: true, clearFormError: true));
+    return switch (await _create.execute(
+      purpose: name,
+      description: description,
+    )) {
+      Ok() => await _reloadAfterMutation(),
+      Err(:final failure) => _failedMutation(failure),
+    };
+  }
+
+  void clearFormError() {
+    if (!isClosed && state.formError != null) {
+      emit(state.copyWith(clearFormError: true));
+    }
+  }
+
+  Future<bool> _reloadAfterMutation() async {
+    switch (await _load.execute()) {
+      case Ok(:final value):
+        if (!isClosed) {
+          emit(state.copyWith(keys: value, busy: false));
+        }
+        return true;
+      case Err(:final failure):
+        return _failedMutation(failure);
+    }
+  }
+
+  bool _failedMutation(KeychainManifestFailure failure) {
+    _fail(failure, busy: false);
+    return false;
+  }
+
+  void _fail(KeychainManifestFailure failure, {bool? loading, bool? busy}) {
+    if (!isClosed) {
+      emit(state.copyWith(failure: failure, loading: loading, busy: busy));
+    }
+  }
+}
+
+NostrKeyFormError? validateNostrKeyForm(String name, String? description) {
+  final normalizedDescription = description?.trim();
+  if (KeychainManifestNostrKey.tryNormalizePurpose(name) != null &&
+      (normalizedDescription?.length ?? 0) <=
+          KeychainManifestEntry.maxDescriptionLength &&
+      !(normalizedDescription != null &&
+          KeychainManifestNostrKey.hasControlCharacter(
+            normalizedDescription,
+          ))) {
+    return null;
+  }
+  final trimmed = name.trim();
+  if (trimmed.isEmpty) return NostrKeyFormError.nameRequired;
+  if (trimmed.length > KeychainManifestNostrKey.maxPurposeLength) {
+    return NostrKeyFormError.nameTooLong;
+  }
+  if ((description?.trim().length ?? 0) >
+      KeychainManifestEntry.maxDescriptionLength) {
+    return NostrKeyFormError.descriptionTooLong;
+  }
+  if (KeychainManifestNostrKey.hasControlCharacter(trimmed)) {
+    return NostrKeyFormError.invalidNameCharacters;
+  }
+  return NostrKeyFormError.invalidDescriptionCharacters;
+}

--- a/lib/features/keychain_manifest/public/keychain_manifest_facade.dart
+++ b/lib/features/keychain_manifest/public/keychain_manifest_facade.dart
@@ -1,0 +1,179 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+export 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart'
+    show
+        KeychainManifest,
+        KeychainManifestDerivationKind,
+        KeychainManifestNostrKeyKind,
+        KeychainManifestEntry,
+        KeychainManifestWallet,
+        KeychainManifestNostrKey;
+export 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart'
+    show KeychainManifestEdit, KeychainManifestWalletInventoryBinding;
+export 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+export 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart'
+    show KeychainManifestRestorePolicy, KeychainManifestRestoreReport;
+export 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_routes.dart';
+
+final class KeychainManifestFacade {
+  final WatchKeychainManifestChangesUsecase _watchChanges;
+  final String Function(KeychainManifest manifest) _encode;
+  final BuildKeychainManifestFileUsecase _build;
+  final ParseKeychainManifestFileUsecase _parse;
+  final ReplaceSeedWalletInventoryUsecase _replaceSeedInventory;
+  final RecordPassphraseWalletUsecase _recordWallet;
+  final RestoreManifestSnapshotUsecase _restoreSnapshot;
+  final RecordKeychainManifestNostrKeyUsecase _recordNostrKey;
+  final RestoreKeychainManifestNostrKeyUsecase _restoreNostrKey;
+  final UpdatePassphraseLabelHintUsecase _updateLabelHint;
+  final RemovePassphraseWalletUsecase _removeWallet;
+
+  KeychainManifestFacade(
+    this._watchChanges,
+    this._encode,
+    this._build,
+    this._parse,
+    this._replaceSeedInventory,
+    this._recordWallet,
+    this._restoreSnapshot,
+    this._recordNostrKey,
+    this._restoreNostrKey,
+    this._updateLabelHint,
+    this._removeWallet,
+  );
+
+  Stream<void> watchCommittedChanges() => _watchChanges.execute();
+
+  @useResult
+  Future<Result<KeychainManifest, KeychainManifestFailure>> readManifest(
+    Fingerprint parentFingerprint,
+  ) => _build.execute(parentFingerprint);
+
+  @useResult
+  Future<Result<KeychainManifest, KeychainManifestFailure>> buildManifest(
+    Fingerprint parentFingerprint, {
+    bool allowEmpty = false,
+  }) async => switch (await _build.execute(parentFingerprint)) {
+    Err(:final failure) => Err(failure),
+    Ok(:final value) when value.entries.isEmpty && !allowEmpty => const Err(
+      KeychainManifestEmptyFailure(),
+    ),
+    Ok(:final value) => Ok(value),
+  };
+
+  String encodeManifestFilePayload(KeychainManifest manifest) =>
+      _encode(manifest);
+
+  @useResult
+  Result<KeychainManifest, KeychainManifestFailure> parseManifestFilePayload(
+    String payload, {
+    required Fingerprint expectedParentFingerprint,
+    bool allowEmpty = false,
+  }) => _parse.execute(
+    payload,
+    expectedParentFingerprint: expectedParentFingerprint,
+    allowEmpty: allowEmpty,
+  );
+
+  @useResult
+  Future<Result<bool, KeychainManifestFailure>> replaceSeedWalletInventory({
+    required Fingerprint parentFingerprint,
+    required List<KeychainManifestWalletInventoryBinding> wallets,
+  }) => _replaceSeedInventory.execute(
+    parentFingerprint: parentFingerprint,
+    wallets: wallets,
+  );
+
+  @useResult
+  Future<Result<bool, KeychainManifestFailure>> recordWallet({
+    required Fingerprint parentFingerprint,
+    required KeychainManifestWalletInventoryBinding wallet,
+  }) => _recordWallet.execute(
+    parentFingerprint: parentFingerprint,
+    wallet: wallet,
+  );
+
+  @useResult
+  Future<Result<KeychainManifestRestoreReport, KeychainManifestFailure>>
+  restoreSnapshot(
+    KeychainManifest manifest, {
+    KeychainManifestRestorePolicy policy =
+        KeychainManifestRestorePolicy.keepNewest,
+  }) => _restoreSnapshot.execute(manifest, policy: policy);
+
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> updatePassphraseLabelHint({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+    KeychainManifestEdit<String?>? label,
+    KeychainManifestEdit<String?>? hint,
+  }) => _updateLabelHint.execute(
+    parentFingerprint: parentFingerprint,
+    walletId: walletId,
+    label: label,
+    hint: hint,
+  );
+
+  @useResult
+  Future<Result<void, KeychainManifestFailure>> deleteWallet({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+  }) => _removeWallet.execute(
+    parentFingerprint: parentFingerprint,
+    walletId: walletId,
+  );
+
+  @useResult
+  Future<Result<bool, KeychainManifestFailure>> recordWalletBackupNostrKey({
+    required Fingerprint parentFingerprint,
+    required String publicKeyHex,
+    required DateTime now,
+  }) => _recordNostrKey.execute(
+    reservationId: Bip85Reservations.nostrWalletBackupKey.id,
+    parentFingerprint: parentFingerprint,
+    derivationPath: Bip85Reservations.nostrWalletBackupKey.path,
+    publicKeyHex: publicKeyHex,
+    keyKind: KeychainManifestNostrKeyKind.reserved,
+    purpose: 'Wallet backup',
+    now: now,
+  );
+
+  @useResult
+  Future<Result<bool, KeychainManifestFailure>> restoreNostrKey({
+    required String reservationId,
+    required Fingerprint parentFingerprint,
+    required String derivationPath,
+    required String publicKeyHex,
+    required KeychainManifestNostrKeyKind keyKind,
+    required String purpose,
+    String? description,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) => _restoreNostrKey.execute(
+    reservationId: reservationId,
+    parentFingerprint: parentFingerprint,
+    derivationPath: derivationPath,
+    publicKeyHex: publicKeyHex,
+    keyKind: keyKind,
+    purpose: purpose,
+    description: description,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+  );
+}

--- a/lib/features/keychain_manifest/public/keychain_manifest_routes.dart
+++ b/lib/features/keychain_manifest/public/keychain_manifest_routes.dart
@@ -1,0 +1,39 @@
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/screens/nostr_key_detail_screen.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/screens/nostr_key_form_screen.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/screens/nostr_keys_screen.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+abstract final class KeychainManifestRoutes {
+  static const listName = 'nostrKeys';
+  static const createName = 'nostrKeyCreate';
+  static const detailName = 'nostrKeyDetail';
+
+  static final route = GoRoute(
+    name: listName,
+    path: 'nostr-keys',
+    builder: (_, _) => BlocProvider(
+      create: (_) => locator<NostrKeysCubit>(),
+      child: const NostrKeysScreen(),
+    ),
+    routes: [
+      GoRoute(
+        name: createName,
+        path: 'create',
+        builder: (_, _) => BlocProvider(
+          create: (_) => locator<NostrKeysCubit>(),
+          child: const NostrKeyFormScreen(),
+        ),
+      ),
+      GoRoute(
+        name: detailName,
+        path: 'detail',
+        builder: (_, state) =>
+            NostrKeyDetailScreen(entry: state.extra! as KeychainManifestEntry),
+      ),
+    ],
+  );
+}

--- a/lib/features/keychain_manifest/ui/screens/nostr_key_detail_screen.dart
+++ b/lib/features/keychain_manifest/ui/screens/nostr_key_detail_screen.dart
@@ -1,0 +1,150 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/address_viewer.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/tables/details_table.dart';
+import 'package:bb_mobile/core/widgets/tables/details_table_item.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/core/widgets/warning_bottom_sheet.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/keychain_manifest_l10n.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/widgets/nostr_nsec_reveal_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:bull_ui/bull_ui.dart' show Gap;
+
+final class NostrKeyDetailScreen extends StatefulWidget {
+  final KeychainManifestEntry entry;
+
+  const NostrKeyDetailScreen({super.key, required this.entry});
+
+  @override
+  State<NostrKeyDetailScreen> createState() => _NostrKeyDetailScreenState();
+}
+
+final class _NostrKeyDetailScreenState extends State<NostrKeyDetailScreen> {
+  bool _showSystemNpub = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final entry = widget.entry;
+    final key = entry.materializations.single as KeychainManifestNostrKey;
+    final isUser = key.keyKind == KeychainManifestNostrKeyKind.userGenerated;
+    return Scaffold(
+      appBar: AppBar(title: Text(context.loc.settingsNostrKeysDetailTitle)),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            DetailsTable(
+              items: [
+                DetailsTableItem(
+                  label: context.loc.settingsNostrKeysName,
+                  displayValue: entry.displayName(context),
+                ),
+                if (entry.displayDescription(context) case final description?)
+                  DetailsTableItem(
+                    label: context.loc.settingsNostrKeysDescription,
+                    displayValue: description,
+                  ),
+                DetailsTableItem(
+                  label: context.loc.settingsNostrKeysDerivationPath,
+                  displayValue: entry.derivationPath,
+                  copyValue: entry.derivationPath,
+                ),
+                _npubItem(context, key.npub, isUser: isUser),
+              ],
+            ),
+            const Gap(16),
+            BBButton.big(
+              label: context.loc.settingsNostrKeysShowPrivate,
+              iconData: Icons.visibility,
+              iconFirst: true,
+              onPressed: () => _warnAndReveal(context, isUser: isUser),
+              outlined: true,
+              bgColor: context.appColors.transparent,
+              textColor: context.appColors.onSurface,
+              borderColor: context.appColors.outline,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _warnAndReveal(
+    BuildContext context, {
+    required bool isUser,
+  }) async {
+    var confirmed = false;
+    await WarningBottomSheet.show(
+      context,
+      title: isUser
+          ? context.loc.settingsNostrKeysUserNsecWarningTitle
+          : context.loc.settingsNostrKeysSystemNsecWarningTitle,
+      message: isUser
+          ? context.loc.settingsNostrKeysUserNsecWarningMessage
+          : context.loc.settingsNostrKeysSystemNsecWarningMessage,
+      confirmLabel: context.loc.settingsNostrKeysWarningUnderstand,
+      onConfirm: () => confirmed = true,
+    );
+    if (confirmed && context.mounted) {
+      await NostrNsecRevealPresenter.show(context, widget.entry);
+    }
+  }
+
+  Future<void> _warnAndShowSystemNpub(BuildContext context) =>
+      WarningBottomSheet.show(
+        context,
+        title: context.loc.settingsNostrKeysSystemNpubWarningTitle,
+        message: context.loc.settingsNostrKeysSystemNpubWarningMessage,
+        confirmLabel: context.loc.settingsNostrKeysWarningUnderstand,
+        onConfirm: () => setState(() => _showSystemNpub = true),
+      );
+
+  DetailsTableItem _npubItem(
+    BuildContext context,
+    String npub, {
+    required bool isUser,
+  }) {
+    if (isUser) {
+      return DetailsTableItem(
+        label: context.loc.settingsNostrKeysNpub,
+        copyValue: npub,
+        displayWidget: AddressViewer(
+          npub,
+          qrData: npub,
+          showExplorerActions: false,
+          textAlign: TextAlign.end,
+        ),
+      );
+    }
+    if (!_showSystemNpub) {
+      return DetailsTableItem(
+        label: context.loc.settingsNostrKeysNpub,
+        displayWidget: Align(
+          alignment: Alignment.centerRight,
+          child: InkWell(
+            onTap: () => _warnAndShowSystemNpub(context),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: BBText(
+                context.loc.settingsNostrKeysShowNpub,
+                style: context.font.bodyMedium,
+                color: context.appColors.primary,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    return DetailsTableItem(
+      label: context.loc.settingsNostrKeysNpub,
+      copyValue: npub,
+      displayWidget: AddressViewer(
+        npub,
+        showExplorerActions: false,
+        textAlign: TextAlign.end,
+      ),
+    );
+  }
+}

--- a/lib/features/keychain_manifest/ui/screens/nostr_key_form_screen.dart
+++ b/lib/features/keychain_manifest/ui/screens/nostr_key_form_screen.dart
@@ -1,0 +1,106 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/keychain_manifest_l10n.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:bull_ui/bull_ui.dart' show BullInputText;
+
+final class NostrKeyFormScreen extends StatefulWidget {
+  const NostrKeyFormScreen({super.key});
+
+  @override
+  State<NostrKeyFormScreen> createState() => _NostrKeyFormScreenState();
+}
+
+final class _NostrKeyFormScreenState extends State<NostrKeyFormScreen> {
+  late final TextEditingController _name;
+  late final TextEditingController _description;
+
+  @override
+  void initState() {
+    super.initState();
+    _name = TextEditingController();
+    _description = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final cubit = context.read<NostrKeysCubit>();
+    final success = await cubit.create(
+      _name.text,
+      description: _description.text,
+    );
+    if (success && mounted) Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<NostrKeysCubit, NostrKeysState>(
+      builder: (context, state) {
+        final error = state.formError;
+        final nameError =
+            error == NostrKeyFormError.nameRequired ||
+                error == NostrKeyFormError.nameTooLong ||
+                error == NostrKeyFormError.invalidNameCharacters
+            ? error!.toTranslated(context)
+            : null;
+        final descriptionError =
+            error == NostrKeyFormError.descriptionTooLong ||
+                error == NostrKeyFormError.invalidDescriptionCharacters
+            ? error!.toTranslated(context)
+            : null;
+        return Scaffold(
+          appBar: AppBar(title: Text(context.loc.settingsNostrKeysCreate)),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              BullInputText(
+                controller: _name,
+                value: _name.text,
+                maxLength: KeychainManifestNostrKey.maxPurposeLength,
+                onChanged: (_) =>
+                    context.read<NostrKeysCubit>().clearFormError(),
+                label: context.loc.settingsNostrKeysName,
+                hint: context.loc.settingsNostrKeysNameHint,
+                errorText: nameError,
+              ),
+              BullInputText(
+                controller: _description,
+                value: _description.text,
+                maxLength: KeychainManifestEntry.maxDescriptionLength,
+                minLines: 2,
+                maxLines: 4,
+                onChanged: (_) =>
+                    context.read<NostrKeysCubit>().clearFormError(),
+                label: context.loc.settingsNostrKeysDescription,
+                hint: context.loc.settingsNostrKeysDescriptionHint,
+                errorText: descriptionError,
+              ),
+            ],
+          ),
+          bottomNavigationBar: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: BBButton.big(
+                label: context.loc.settingsNostrKeysSave,
+                onPressed: _save,
+                disabled: state.busy,
+                bgColor: context.appColors.primary,
+                textColor: context.appColors.onPrimary,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/keychain_manifest/ui/screens/nostr_keys_screen.dart
+++ b/lib/features/keychain_manifest/ui/screens/nostr_keys_screen.dart
@@ -1,0 +1,173 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/core/widgets/warning_bottom_sheet.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/keychain_manifest_l10n.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_routes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+final class NostrKeysScreen extends StatefulWidget {
+  const NostrKeysScreen({super.key});
+
+  @override
+  State<NostrKeysScreen> createState() => _NostrKeysScreenState();
+}
+
+final class _NostrKeysScreenState extends State<NostrKeysScreen> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<NostrKeysCubit>().load();
+  }
+
+  Future<void> _openCreate() async {
+    final created = await context.pushNamed<bool>(
+      KeychainManifestRoutes.createName,
+    );
+    if (!mounted) return;
+    await context.read<NostrKeysCubit>().load();
+    if (mounted && created == true) {
+      SnackBarUtils.showSnackBar(context, context.loc.settingsNostrKeysCreated);
+    }
+  }
+
+  Future<void> _toggleSystemKeys(NostrKeysState state) async {
+    final cubit = context.read<NostrKeysCubit>();
+    if (state.showSystemKeys) {
+      cubit.setShowSystemKeys(false);
+      return;
+    }
+    await WarningBottomSheet.show(
+      context,
+      title: context.loc.settingsNostrKeysSystemKeysWarningTitle,
+      message: context.loc.settingsNostrKeysSystemKeysWarningMessage,
+      confirmLabel: context.loc.settingsNostrKeysWarningUnderstand,
+      onConfirm: () => cubit.setShowSystemKeys(true),
+    );
+  }
+
+  Future<void> _openDetail(KeychainManifestEntry entry) async {
+    await context.pushNamed(KeychainManifestRoutes.detailName, extra: entry);
+    if (mounted) await context.read<NostrKeysCubit>().load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<NostrKeysCubit, NostrKeysState>(
+      listenWhen: (previous, current) => previous.failure != current.failure,
+      listener: (context, state) {
+        final failure = state.failure;
+        if (failure != null) {
+          SnackBarUtils.showSnackBar(context, failure.toTranslated(context));
+        }
+      },
+      builder: (context, state) => Scaffold(
+        appBar: AppBar(title: Text(context.loc.settingsNostrKeysTitle)),
+        body: SafeArea(
+          child: state.loading
+              ? const Center(child: CircularProgressIndicator())
+              : _KeyList(
+                  state: state,
+                  onToggleSystem: _toggleSystemKeys,
+                  onOpen: _openDetail,
+                ),
+        ),
+        bottomNavigationBar: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: BBButton.big(
+              label: context.loc.settingsNostrKeysCreate,
+              onPressed: _openCreate,
+              disabled: state.loading || state.busy,
+              bgColor: context.appColors.primary,
+              textColor: context.appColors.onPrimary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _KeyList extends StatelessWidget {
+  final NostrKeysState state;
+  final Future<void> Function(NostrKeysState state) onToggleSystem;
+  final Future<void> Function(KeychainManifestEntry entry) onOpen;
+
+  const _KeyList({
+    required this.state,
+    required this.onToggleSystem,
+    required this.onOpen,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        if (state.userKeys.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+            child: BBText(
+              context.loc.settingsNostrKeysEmpty,
+              style: context.font.bodyMedium,
+              color: context.appColors.textMuted,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        for (final entry in state.userKeys) _entry(context, entry),
+        if (state.showSystemKeys && state.systemKeys.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.only(
+              left: 16,
+              right: 16,
+              top: 24,
+              bottom: 4,
+            ),
+            child: BBText(
+              context.loc.settingsNostrKeysSystemKeysWarningTitle,
+              style: context.font.labelSmall,
+              color: context.appColors.textMuted,
+            ),
+          ),
+          for (final entry in state.systemKeys) _entry(context, entry),
+        ],
+        if (state.systemKeys.isNotEmpty)
+          Align(
+            child: TextButton(
+              onPressed: () => onToggleSystem(state),
+              child: Text(
+                state.showSystemKeys
+                    ? context.loc.settingsNostrKeysHideSystemKeys
+                    : context.loc.settingsNostrKeysShowSystemKeys,
+                style: TextStyle(color: context.appColors.error),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _entry(BuildContext context, KeychainManifestEntry entry) {
+    final system = entry.materializations.single as KeychainManifestNostrKey;
+    return SettingsEntryItem(
+      icon: system.keyKind == KeychainManifestNostrKeyKind.reserved
+          ? Icons.settings_suggest
+          : Icons.key,
+      title: entry.displayName(context),
+      iconColor: system.keyKind == KeychainManifestNostrKeyKind.reserved
+          ? context.appColors.textMuted
+          : null,
+      textColor: system.keyKind == KeychainManifestNostrKeyKind.reserved
+          ? context.appColors.textMuted
+          : null,
+      onTap: () => onOpen(entry),
+    );
+  }
+}

--- a/lib/features/keychain_manifest/ui/widgets/nostr_nsec_reveal_dialog.dart
+++ b/lib/features/keychain_manifest/ui/widgets/nostr_nsec_reveal_dialog.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/mixins/privacy_screen.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/buttons/button.dart';
+import 'package:bb_mobile/core/widgets/dialog/blurred_dialog.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
+import 'package:bb_mobile/core/widgets/snackbar_utils.dart';
+import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/reveal_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/presentation/keychain_manifest_l10n.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:primitives/primitives.dart';
+
+final class NostrNsecRevealPresenter {
+  final Future<Result<RevealedNostrSecret, KeychainManifestFailure>> Function(
+    KeychainManifestEntry entry,
+  )
+  _reveal;
+
+  NostrNsecRevealPresenter(RevealKeychainManifestNostrKeyUsecase reveal)
+    : _reveal = reveal.execute;
+
+  @visibleForTesting
+  NostrNsecRevealPresenter.forTesting(this._reveal);
+
+  static Future<void> show(BuildContext context, KeychainManifestEntry entry) =>
+      locator<NostrNsecRevealPresenter>()._show(context, entry);
+
+  Future<void> _show(BuildContext context, KeychainManifestEntry entry) =>
+      BlurredDialog.show<void>(
+        context: context,
+        builder: (_) => _NostrNsecRevealDialog(entry, _reveal),
+      );
+}
+
+final class _NostrNsecRevealDialog extends StatefulWidget {
+  final KeychainManifestEntry entry;
+  final Future<Result<RevealedNostrSecret, KeychainManifestFailure>> Function(
+    KeychainManifestEntry entry,
+  )
+  reveal;
+
+  const _NostrNsecRevealDialog(this.entry, this.reveal);
+
+  @override
+  State<_NostrNsecRevealDialog> createState() => _NostrNsecRevealDialogState();
+}
+
+final class _NostrNsecRevealDialogState extends State<_NostrNsecRevealDialog>
+    with WidgetsBindingObserver, PrivacyScreen {
+  RevealedNostrSecret? _secret;
+  bool _dismissed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => unawaited(_protectAndReveal()),
+    );
+  }
+
+  @override
+  void dispose() {
+    _dismissed = true;
+    _secret = null;
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(disableScreenPrivacy());
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) _dismiss();
+  }
+
+  Future<void> _protectAndReveal() async {
+    try {
+      await enableScreenPrivacy();
+    } on Exception {
+      _fail(const KeychainManifestUnexpectedFailure());
+      return;
+    }
+    if (!mounted || _dismissed) {
+      await disableScreenPrivacy();
+      return;
+    }
+    switch (await widget.reveal(widget.entry)) {
+      case Ok(:final value):
+        if (mounted && !_dismissed) setState(() => _secret = value);
+      case Err(:final failure):
+        _fail(failure);
+    }
+  }
+
+  void _fail(KeychainManifestFailure failure) {
+    if (!mounted || _dismissed) return;
+    SnackBarUtils.showSnackBar(context, failure.toTranslated(context));
+    _dismiss();
+  }
+
+  Future<void> _copy() async {
+    final secret = _secret;
+    if (secret == null || _dismissed) return;
+    await Clipboard.setData(ClipboardData(text: secret.nsec));
+    if (mounted) SnackBarUtils.showCopiedSnackBar(context);
+    _dismiss();
+  }
+
+  void _dismiss() {
+    if (!mounted || _dismissed) return;
+    _dismissed = true;
+    _secret = null;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final secret = _secret;
+    return PopScope(
+      canPop: secret == null,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _dismiss();
+      },
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              BBText(
+                context.loc.settingsNostrKeysShowPrivate,
+                style: context.font.titleSmall,
+              ),
+              const SizedBox(height: 16),
+              if (secret == null)
+                const CircularProgressIndicator()
+              else ...[
+                ExcludeSemantics(
+                  child: QrDisplayWidget(data: secret.nsec, size: 240),
+                ),
+                const SizedBox(height: 16),
+                ExcludeSemantics(
+                  child: BBText(
+                    _group(secret.nsec),
+                    style: context.font.bodyLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                IconButton(
+                  key: const Key('nostr_nsec_copy_action'),
+                  icon: const Icon(Icons.copy),
+                  onPressed: _copy,
+                ),
+              ],
+              const SizedBox(height: 24),
+              BBButton.big(
+                label: MaterialLocalizations.of(context).closeButtonLabel,
+                onPressed: _dismiss,
+                outlined: true,
+                bgColor: context.appColors.transparent,
+                textColor: context.appColors.onSurface,
+                borderColor: context.appColors.outline,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _group(String value) => [
+    for (var index = 0; index < value.length; index += 4)
+      value.substring(
+        index,
+        index + 4 < value.length ? index + 4 : value.length,
+      ),
+  ].join(' ');
+}

--- a/lib/features/settings/ui/screens/all_settings_screen.dart
+++ b/lib/features/settings/ui/screens/all_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
 import 'package:bb_mobile/features/exchange/presentation/exchange_cubit.dart';
 import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_support_chat/public/exchange_support_chat_facade.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_routes.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
 import 'package:bb_mobile/features/settings/ui/settings_router.dart';
 import 'package:bb_mobile/features/status_check/presentation/cubit.dart';
@@ -125,6 +126,13 @@ class _AllSettingsScreenState extends State<AllSettingsScreen> {
                   title: context.loc.settingsAppSettingsTitle,
                   onTap: () {
                     context.pushNamed(SettingsRoute.appSettings.name);
+                  },
+                ),
+                SettingsEntryItem(
+                  icon: Icons.key,
+                  title: context.loc.settingsNostrKeysTitle,
+                  onTap: () {
+                    context.pushNamed(KeychainManifestRoutes.listName);
                   },
                 ),
 

--- a/lib/features/settings/ui/settings_router.dart
+++ b/lib/features/settings/ui/settings_router.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/features/exchange/ui/exchange_router.dart';
 import 'package:bb_mobile/features/exchange_settings/presentation/default_wallets_cubit.dart';
 import 'package:bb_mobile/features/exchange_settings/presentation/file_upload_cubit.dart';
 import 'package:bb_mobile/features/exchange_settings/presentation/statistics_cubit.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
 import 'package:bb_mobile/features/pin_code/ui/pin_code_setting_flow.dart';
 import 'package:bb_mobile/features/settings/ui/screens/all_settings_screen.dart';
 import 'package:bb_mobile/features/settings/ui/screens/app_settings/app_settings_screen.dart';
@@ -207,6 +208,7 @@ class SettingsRouter {
         path: SettingsRoute.theme.path,
         builder: (context, state) => const ThemeSettingsScreen(),
       ),
+      KeychainManifestRoutes.route,
 
       GoRoute(
         path: SettingsRoute.pinCode.path,

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -29,6 +29,7 @@ import 'package:bb_mobile/features/nostr_identity/nostr_identity_locator.dart';
 import 'package:bb_mobile/features/fund_exchange/fund_exchange_locator.dart';
 import 'package:bb_mobile/features/import_mnemonic/locator.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_locator.dart';
+import 'package:bb_mobile/features/keychain_manifest/keychain_manifest_locator.dart';
 import 'package:bb_mobile/features/ledger/ledger_locator.dart';
 import 'package:bb_mobile/features/onboarding/onboarding_locator.dart';
 import 'package:bb_mobile/features/pay/pay_locator.dart';
@@ -170,6 +171,7 @@ class AppLocator {
     DcaLocator.setup(locator);
     ReplaceByFeeLocator.setup(locator);
     NostrIdentityLocator.setup(locator);
+    KeychainManifestLocator.setup(locator);
     Bip85EntropyLocator.setup(locator);
     LedgerLocator.setup(locator);
     RecipientsLocator.setup(locator);

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14583,5 +14583,43 @@
   "@sendErrorTransactionChanged": {
     "description": "Message shown when a transaction must be rebuilt because its details changed."
   },
+  "settingsNostrKeysTitle": "Nostr keys",
+  "settingsNostrKeysEmpty": "No Nostr keys have been created yet.",
+  "settingsNostrKeysCreate": "Create Nostr key",
+  "settingsNostrKeysCreated": "Nostr key created",
+  "settingsNostrKeysFailure": "Nostr key action failed. Try again.",
+  "settingsNostrKeysName": "Name",
+  "settingsNostrKeysNameHint": "e.g. personal identity",
+  "settingsNostrKeysNameRequiredError": "Enter a name for this key.",
+  "settingsNostrKeysNameTooLongError": "Name must be 80 characters or fewer.",
+  "settingsNostrKeysDescription": "Description",
+  "settingsNostrKeysDescriptionHint": "Optional note about how you use this key",
+  "settingsNostrKeysDescriptionTooLongError": "Description must be 200 characters or fewer.",
+  "settingsNostrKeysInvalidCharactersError": "Remove line breaks or control characters.",
+  "settingsNostrKeysSave": "Save",
+  "settingsNostrKeysDetailTitle": "Nostr key",
+  "settingsNostrKeysDerivationPath": "Derivation path",
+  "settingsNostrKeysNpub": "npub",
+  "settingsNostrKeysShowNpub": "Show npub",
+  "settingsNostrKeysShowPrivate": "Show nsec",
+  "settingsNostrKeysShowSystemKeys": "Show system keys",
+  "settingsNostrKeysHideSystemKeys": "Hide system keys",
+  "settingsNostrKeysSystemKeysWarningTitle": "System keys",
+  "settingsNostrKeysSystemKeysWarningMessage": "These keys are managed by the app for troubleshooting and recovery. They are not your identities. Do not use or share them.",
+  "settingsNostrKeysSystemNpubWarningTitle": "System key npub",
+  "settingsNostrKeysSystemNpubWarningMessage": "Viewing this public key is only for troubleshooting. Do not use or share it as an identity.",
+  "settingsNostrKeysUserNsecWarningTitle": "Show your nsec",
+  "settingsNostrKeysUserNsecWarningMessage": "Your nsec is the private key for this identity. Anyone who has it controls the identity. DO NOT SHARE WITH ANYONE.",
+  "settingsNostrKeysWarningUnderstand": "I understand",
+  "settingsNostrKeysSystemMetadataBackup": "Metadata backup",
+  "settingsNostrKeysSystemMetadataBackupDescription": "Identifies and signs your encrypted metadata backup.",
+  "settingsNostrKeysSystemNsecWarningTitle": "Show system nsec",
+  "@settingsNostrKeysSystemNsecWarningTitle": {
+    "description": "Title shown before revealing a system Nostr private key."
+  },
+  "settingsNostrKeysSystemNsecWarningMessage": "This nsec is for debugging and advanced usage only. Anyone with it can control this system identity. Do not share it with anyone.",
+  "@settingsNostrKeysSystemNsecWarningMessage": {
+    "description": "Security warning shown before revealing a system Nostr private key."
+  },
   "walletBackupManifestPassphraseWallet": "Passphrase Wallet"
 }

--- a/packages/bull_ui/lib/src/inputs/bull_input_text.dart
+++ b/packages/bull_ui/lib/src/inputs/bull_input_text.dart
@@ -16,7 +16,9 @@ class BullInputText extends StatefulWidget {
     this.controller,
     required this.onChanged,
     required this.value,
+    this.label,
     this.hint,
+    this.errorText,
     this.hintStyle,
     this.rightIcon,
     this.onRightTap,
@@ -47,8 +49,14 @@ class BullInputText extends StatefulWidget {
   /// The current value (the field is controlled by the parent).
   final String value;
 
+  /// Optional field label.
+  final String? label;
+
   /// Placeholder text.
   final String? hint;
+
+  /// Validation message shown below the field.
+  final String? errorText;
 
   /// Placeholder style override.
   final TextStyle? hintStyle;
@@ -183,7 +191,9 @@ class _BullInputTextState extends State<BullInputText> {
       textAlign: TextAlign.left,
       textAlignVertical: TextAlignVertical.center,
       decoration: InputDecoration(
+        labelText: widget.label,
         hintText: widget.hint,
+        errorText: widget.errorText,
         hintStyle: widget.hintStyle ?? TextStyle(color: colors.textMuted),
         prefixIcon: widget.fixedPrefix != null
             ? Container(

--- a/packages/bull_ui/test/bull_input_text_test.dart
+++ b/packages/bull_ui/test/bull_input_text_test.dart
@@ -1,0 +1,22 @@
+import 'package:bull_ui/bull_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_app.dart';
+
+void main() {
+  testWidgets('shows its label and validation message', (tester) async {
+    await tester.pumpWidget(
+      wrapWithTheme(
+        BullInputText(
+          value: '',
+          label: 'Name',
+          errorText: 'Name is required',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Name'), findsOneWidget);
+    expect(find.text('Name is required'), findsOneWidget);
+  });
+}

--- a/test/features/keychain_manifest/keychain_manifest_backup_revision_test.dart
+++ b/test/features/keychain_manifest/keychain_manifest_backup_revision_test.dart
@@ -1,0 +1,143 @@
+import 'package:bb_mobile/core/storage/backup_revision_recorder.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/keychain_manifest_repository_impl.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+import 'support/manifest_fixtures.dart';
+
+/// The manifest raises Bull backup's dirty signal inside the transaction that
+/// earns it (decision 7).
+///
+/// Forget correctness depends on this: if a crash between the delete and the
+/// signal could lose the signal, the forgotten wallet would still be in the
+/// next published snapshot. These tests read the revision straight out of the
+/// database rather than through the backup feature, because what is being
+/// asserted is that the manifest wrote it, not that something else noticed.
+void main() {
+  late SqliteDatabase database;
+  late KeychainManifestRepositoryImpl repository;
+
+  setUp(() {
+    database = SqliteDatabase(NativeDatabase.memory());
+    repository = KeychainManifestRepositoryImpl(
+      database,
+      backupRevisions: DriftBackupRevisionRecorder(database),
+    );
+  });
+
+  tearDown(() async {
+    await repository.close();
+    await database.close();
+  });
+
+  Future<int> localRevision() async =>
+      (await database.select(database.walletBackupStates).getSingleOrNull())
+          ?.localRevision ??
+      0;
+
+  test('forgetting a wallet records a revision', () async {
+    expect(
+      await repository.upsertPassphraseWallet(passphraseWalletEntry()),
+      isA<Ok<void, KeychainManifestFailure>>(),
+    );
+    final afterSave = await localRevision();
+    expect(afterSave, greaterThan(0));
+
+    expect(
+      await repository.removePassphraseWallet(
+        parentFingerprint: manifestFingerprint,
+        walletId: 'passphrase-1',
+      ),
+      isA<Ok<void, KeychainManifestFailure>>(),
+    );
+
+    expect(await localRevision(), greaterThan(afterSave));
+  });
+
+  test('a write that changes nothing records nothing', () async {
+    expect(
+      await repository.upsertPassphraseWallet(passphraseWalletEntry()),
+      isA<Ok<void, KeychainManifestFailure>>(),
+    );
+    final afterSave = await localRevision();
+
+    expect(
+      await repository.upsertPassphraseWallet(passphraseWalletEntry()),
+      isA<Ok<void, KeychainManifestFailure>>(),
+    );
+
+    expect(await localRevision(), afterSave);
+  });
+
+  test('a recovery-originated write records nothing', () async {
+    expect(
+      await repository.restoreSnapshot(
+        manifest(entries: [passphraseWalletEntry()]),
+      ),
+      isA<Ok<KeychainManifestRestoreReport, KeychainManifestFailure>>(),
+    );
+
+    expect(
+      await localRevision(),
+      0,
+      reason: 'restoring a snapshot must not publish it straight back',
+    );
+  });
+
+  test('a recovery-originated edit records nothing', () async {
+    await repository.upsertPassphraseWallet(
+      passphraseWalletEntry(hint: 'Old hint'),
+    );
+    final afterSave = await localRevision();
+
+    await repository.restoreSnapshot(
+      manifest(
+        entries: [passphraseWalletEntry(hint: 'New hint', updatedAt: 7)],
+      ),
+    );
+
+    expect(await localRevision(), afterSave);
+  });
+
+  test('a failed delete leaves the revision alone', () async {
+    expect(
+      await repository.upsertPassphraseWallet(passphraseWalletEntry()),
+      isA<Ok<void, KeychainManifestFailure>>(),
+    );
+    final afterSave = await localRevision();
+
+    expect(
+      await repository.removePassphraseWallet(
+        parentFingerprint: manifestFingerprint,
+        walletId: 'never-existed',
+      ),
+      isA<Err<void, KeychainManifestFailure>>(),
+    );
+
+    expect(await localRevision(), afterSave);
+  });
+
+  test('a rejected edit leaves the revision alone', () async {
+    await repository.upsertPassphraseWallet(
+      passphraseWalletEntry(hint: 'Old hint'),
+    );
+    final afterSave = await localRevision();
+
+    expect(
+      await repository.updatePassphraseLabelHint(
+        parentFingerprint: manifestFingerprint,
+        walletId: 'passphrase-1',
+        hint: const KeychainManifestEdit('Rival hint'),
+        updatedAt: 2,
+      ),
+      isA<Err<void, KeychainManifestFailure>>(),
+    );
+
+    expect(await localRevision(), afterSave);
+  });
+}

--- a/test/features/keychain_manifest/keychain_manifest_codec_test.dart
+++ b/test/features/keychain_manifest/keychain_manifest_codec_test.dart
@@ -1,0 +1,322 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart' show Err, Fingerprint, Ok;
+
+import 'support/manifest_fixtures.dart';
+
+void main() {
+  const codec = KeychainManifestFileCodec();
+
+  test('writes the frozen v1 payload byte-for-byte', () {
+    expect(codec.encode(manifest()), canonicalWalletManifest);
+  });
+
+  test('round-trips through the one canonical model', () {
+    final decoded = codec.decode(canonicalWalletManifest);
+    expect(decoded, isA<Ok<KeychainManifest, KeychainManifestFailure>>());
+    expect(
+      codec.encode(
+        (decoded as Ok<KeychainManifest, KeychainManifestFailure>).value,
+      ),
+      canonicalWalletManifest,
+    );
+  });
+
+  test('accepts conventional JSON whitespace', () {
+    final formatted = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(jsonDecode(canonicalWalletManifest));
+
+    expect(
+      codec.decode(formatted),
+      isA<Ok<KeychainManifest, KeychainManifestFailure>>(),
+    );
+  });
+
+  test('preserves an absent Nostr description as an absent field', () {
+    final payload = codec.encode(
+      manifest(entries: [nostrManifestEntry(description: null)]),
+    );
+    expect(payload, isNot(contains('description')));
+    final decoded =
+        codec.decode(payload) as Ok<KeychainManifest, KeychainManifestFailure>;
+    expect(codec.encode(decoded.value), payload);
+  });
+
+  test('round-trips an optional wallet label', () {
+    final entry = manifest().entries.single;
+    final wallet = entry.materializations.single as KeychainManifestWallet;
+    final labeled = KeychainManifestEntry(
+      parentFingerprint: entry.parentFingerprint,
+      derivationKind: entry.derivationKind,
+      derivationPath: entry.derivationPath,
+      description: entry.description,
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+      materializations: [
+        KeychainManifestWallet(
+          walletId: wallet.walletId,
+          entryId: wallet.entryId,
+          childSeedFingerprint: wallet.childSeedFingerprint,
+          network: wallet.network,
+          scriptType: wallet.scriptType,
+          provenance: wallet.provenance,
+          seedPassphraseUsed: wallet.seedPassphraseUsed,
+          descriptor: wallet.descriptor,
+          label: 'Savings',
+          createdAt: wallet.createdAt,
+          updatedAt: wallet.updatedAt,
+        ),
+      ],
+    );
+
+    final payload = codec.encode(manifest(entries: [labeled]));
+    final decoded =
+        codec.decode(payload) as Ok<KeychainManifest, KeychainManifestFailure>;
+
+    expect(decoded.value.wallets.single.label, 'Savings');
+    expect(payload, contains('"label":"Savings"'));
+  });
+
+  test('checks version before later fields', () {
+    final result = codec.decode('{"version":2}');
+    expect(
+      result,
+      isA<Err<KeychainManifest, KeychainManifestFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<KeychainManifestUnsupportedVersionFailure>(),
+      ),
+    );
+  });
+
+  final malformed = <String, String Function()>{
+    'invalid JSON': () => '{',
+    'non-object root': () => '[]',
+    'missing required field': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      json.remove('generatedAt');
+      return jsonEncode(json);
+    },
+    'wrong field type': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      json['generatedAt'] = '3';
+      return jsonEncode(json);
+    },
+    'out-of-range timestamp': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      json['generatedAt'] = 8640000000001;
+      return jsonEncode(json);
+    },
+    'entry updated before creation': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      entry['createdAt'] = 2;
+      entry['updatedAt'] = 1;
+      return jsonEncode(json);
+    },
+    'materialization updated before creation': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final materialization =
+          (entry['materializations'] as List<dynamic>).single
+              as Map<String, dynamic>;
+      materialization['createdAt'] = 2;
+      materialization['updatedAt'] = 1;
+      return jsonEncode(json);
+    },
+    'derived entry id': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      entry['entryId'] = "73c5da0a:39'/0'/12'/100'";
+      return jsonEncode(json);
+    },
+    'duplicate entry': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entries = json['entries'] as List<dynamic>;
+      entries.add(entries.first);
+      return jsonEncode(json);
+    },
+    'too many materializations': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final item = (entry['materializations'] as List<dynamic>).single;
+      entry['materializations'] = List.filled(9, item);
+      return jsonEncode(json);
+    },
+    'non-canonical path': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      entry['derivationPath'] = "39'/00'/12'/100'";
+      return jsonEncode(json);
+    },
+    'invalid Nostr metadata': () {
+      final json =
+          jsonDecode(codec.encode(manifest(entries: [nostrManifestEntry()])))
+              as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final materialization =
+          (entry['materializations'] as List<dynamic>).single
+              as Map<String, dynamic>;
+      materialization['purpose'] = '\u0000';
+      return jsonEncode(json);
+    },
+    'watch-only wallet provenance': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final materialization =
+          (entry['materializations'] as List<dynamic>).single
+              as Map<String, dynamic>;
+      materialization['provenance'] = 'watchOnly';
+      return jsonEncode(json);
+    },
+    'external-signer wallet provenance': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final materialization =
+          (entry['materializations'] as List<dynamic>).single
+              as Map<String, dynamic>;
+      materialization['provenance'] = 'externalSigner';
+      return jsonEncode(json);
+    },
+    'passphrase wallet without a descriptor': () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      final materialization =
+          (entry['materializations'] as List<dynamic>).single
+              as Map<String, dynamic>;
+      materialization['provenance'] = 'defaultSeedPassphrase';
+      return jsonEncode(json);
+    },
+  };
+  for (final MapEntry(key: name, value: payload) in malformed.entries) {
+    test('rejects $name', () {
+      expect(
+        codec.decode(payload()),
+        isA<Err<KeychainManifest, KeychainManifestFailure>>().having(
+          (value) => value.failure,
+          'failure',
+          isA<KeychainManifestMalformedFileFailure>(),
+        ),
+      );
+    });
+  }
+
+  test('enforces the UTF-8 payload bound', () {
+    expect(
+      codec.decode('x' * (KeychainManifestFileCodec.maxPayloadSizeBytes + 1)),
+      isA<Err<KeychainManifest, KeychainManifestFailure>>(),
+    );
+  });
+
+  group('parse', () {
+    final parse = ParseKeychainManifestFileUsecase(codec.decode);
+
+    test('reuses the validated manifest without copying entry fields', () {
+      final result = parse.execute(
+        canonicalWalletManifest,
+        expectedParentFingerprint: manifestFingerprint,
+      );
+      final parsed =
+          (result as Ok<KeychainManifest, KeychainManifestFailure>).value;
+      expect(parsed.entries.single.bip85DerivationPath, "39'/0'/12'/100'");
+      expect(parsed.wallets.single.walletId, 'wallet-1');
+    });
+
+    test('rejects a different locally verified parent', () {
+      final result = parse.execute(
+        canonicalWalletManifest,
+        expectedParentFingerprint: Fingerprint('00000000'),
+      );
+      expect(
+        result,
+        isA<Err<KeychainManifest, KeychainManifestFailure>>().having(
+          (value) => value.failure,
+          'failure',
+          isA<KeychainManifestParentMismatchFailure>(),
+        ),
+      );
+    });
+
+    test('rejects an unknown derivation path', () {
+      final json = jsonDecode(canonicalWalletManifest) as Map<String, dynamic>;
+      final entry =
+          (json['entries'] as List<dynamic>).single as Map<String, dynamic>;
+      entry['derivationPath'] = "39'/0'/12'/999'";
+      final result = parse.execute(
+        jsonEncode(json),
+        expectedParentFingerprint: manifestFingerprint,
+      );
+      expect(
+        result,
+        isA<Err<KeychainManifest, KeychainManifestFailure>>().having(
+          (value) => value.failure,
+          'failure',
+          isA<KeychainManifestUnknownReservationFailure>(),
+        ),
+      );
+    });
+
+    test('rejects a default wallet derived from another seed', () {
+      final childFingerprint = Fingerprint('fedcba98');
+      const path = "m/84'/0'/0'";
+      final entryId = KeychainManifestEntry.entryIdFor(
+        parentFingerprint: manifestFingerprint,
+        derivationKind: KeychainManifestDerivationKind.bip32,
+        derivationPath: path,
+        seedFingerprint: childFingerprint,
+      );
+      final payload = codec.encode(
+        manifest(
+          entries: [
+            KeychainManifestEntry(
+              parentFingerprint: manifestFingerprint,
+              derivationKind: KeychainManifestDerivationKind.bip32,
+              derivationPath: path,
+              createdAt: 1,
+              updatedAt: 1,
+              materializations: [
+                KeychainManifestWallet(
+                  walletId: 'wrong-default',
+                  entryId: entryId,
+                  childSeedFingerprint: childFingerprint,
+                  network: Network.bitcoinMainnet,
+                  scriptType: ScriptType.bip84,
+                  provenance: WalletProvenance.defaultSeed,
+                  seedPassphraseUsed: false,
+                  createdAt: 1,
+                  updatedAt: 1,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        parse.execute(payload, expectedParentFingerprint: manifestFingerprint),
+        isA<Err<KeychainManifest, KeychainManifestFailure>>().having(
+          (value) => value.failure,
+          'failure',
+          isA<KeychainManifestUnknownReservationFailure>(),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/keychain_manifest/keychain_manifest_facade_test.dart
+++ b/test/features/keychain_manifest/keychain_manifest_facade_test.dart
@@ -1,0 +1,355 @@
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/keychain_manifest_repository_impl.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart' show Err, Fingerprint, Ok, Result;
+
+import 'support/manifest_fixtures.dart';
+
+class _MockSettings extends Mock implements GetSettingsUsecase {}
+
+class _MockDefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+void main() {
+  late SqliteDatabase database;
+  late KeychainManifestRepositoryImpl repository;
+  late KeychainManifestFacade facade;
+
+  setUp(() {
+    database = SqliteDatabase(NativeDatabase.memory());
+    repository = KeychainManifestRepositoryImpl(database);
+    const codec = KeychainManifestFileCodec();
+    final parse = ParseKeychainManifestFileUsecase(codec.decode);
+    facade = KeychainManifestFacade(
+      WatchKeychainManifestChangesUsecase(repository),
+      codec.encode,
+      BuildKeychainManifestFileUsecase(repository),
+      parse,
+      ReplaceSeedWalletInventoryUsecase(repository),
+      RecordPassphraseWalletUsecase(repository),
+      RestoreManifestSnapshotUsecase(repository),
+      RecordKeychainManifestNostrKeyUsecase(repository),
+      RestoreKeychainManifestNostrKeyUsecase(
+        KeychainManifestNostrKeyDeriver(_MockSettings(), _MockDefaultSeed()),
+        RecordKeychainManifestNostrKeyUsecase(repository),
+      ),
+      UpdatePassphraseLabelHintUsecase(repository),
+      RemovePassphraseWalletUsecase(repository),
+    );
+  });
+
+  tearDown(() async {
+    await repository.close();
+    await database.close();
+  });
+
+  test('publishes local commits but not recovered inventory', () async {
+    var changes = 0;
+    final subscription = facade.watchCommittedChanges().listen(
+      (_) => changes++,
+    );
+    addTearDown(subscription.cancel);
+
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: [_inventory('default-bitcoin')],
+      ),
+      isA<Ok<bool, KeychainManifestFailure>>(),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(changes, 1);
+  });
+
+  test('publishes writes made by same-feature use cases', () async {
+    var changes = 0;
+    final subscription = facade.watchCommittedChanges().listen(
+      (_) => changes++,
+    );
+    addTearDown(subscription.cancel);
+    final record = RecordKeychainManifestNostrKeyUsecase(repository);
+    expect(
+      await record.execute(
+        reservationId: 'nostr_user_key',
+        parentFingerprint: manifestFingerprint,
+        derivationPath: "128002'/1'/1'",
+        publicKeyHex: '1' * 64,
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: 'Personal',
+        now: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+      ),
+      isA<Ok<bool, KeychainManifestFailure>>(),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(changes, 1);
+  });
+
+  test('builds and parses through one codec', () async {
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: [_inventory('default-bitcoin')],
+      ),
+      isA<Ok<bool, KeychainManifestFailure>>(),
+    );
+    final built = await _buildPayload(facade, manifestFingerprint);
+    final payload = (built as Ok<String, KeychainManifestFailure>).value;
+    expect(
+      facade.parseManifestFilePayload(
+        payload,
+        expectedParentFingerprint: manifestFingerprint,
+      ),
+      isA<Ok<KeychainManifest, KeychainManifestFailure>>(),
+    );
+  });
+
+  test('records seed-derived wallet facts without descriptors', () async {
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: [
+          KeychainManifestWalletInventoryBinding(
+            walletId: 'default-bitcoin',
+            seedFingerprint: manifestFingerprint,
+            network: Network.bitcoinMainnet,
+            scriptType: ScriptType.bip84,
+            provenance: WalletProvenance.defaultSeed,
+            derivationPath: 'm/84h/0h/0h',
+            seedPassphraseUsed: false,
+          ),
+          KeychainManifestWalletInventoryBinding(
+            walletId: 'imported-bitcoin',
+            seedFingerprint: Fingerprint('fedcba98'),
+            network: Network.bitcoinMainnet,
+            scriptType: ScriptType.bip84,
+            provenance: WalletProvenance.importedMnemonic,
+            derivationPath: "m/84'/0'/0'",
+            seedPassphraseUsed: true,
+          ),
+        ],
+      ),
+      isA<Ok<bool, KeychainManifestFailure>>(),
+    );
+
+    final payload =
+        ((await _buildPayload(facade, manifestFingerprint))
+                as Ok<String, KeychainManifestFailure>)
+            .value;
+    expect(payload, contains('"derivationKind":"bip32"'));
+    expect(payload, contains('"derivationPath":"m/84\'/0\'/0\'"'));
+    expect(payload, contains('"provenance":"defaultSeed"'));
+    expect(payload, contains('"provenance":"importedMnemonic"'));
+    expect(payload, isNot(contains('descriptor')));
+
+    final parsed =
+        (facade.parseManifestFilePayload(
+                  payload,
+                  expectedParentFingerprint: manifestFingerprint,
+                )
+                as Ok<KeychainManifest, KeychainManifestFailure>)
+            .value;
+    expect(parsed.wallets.length, 2);
+    expect(
+      parsed.entries.map((entry) => entry.entryId).toSet().length,
+      2,
+      reason: 'different seed roots may use the same BIP32 account path',
+    );
+    expect(
+      parsed.wallets
+          .singleWhere((wallet) => wallet.walletId == 'imported-bitcoin')
+          .seedPassphraseUsed,
+      isTrue,
+    );
+  });
+
+  test(
+    'refreshes current wallets while retaining recovered mnemonic facts',
+    () async {
+      final defaultWallet = KeychainManifestWalletInventoryBinding(
+        walletId: 'default-bitcoin',
+        seedFingerprint: manifestFingerprint,
+        network: Network.bitcoinMainnet,
+        scriptType: ScriptType.bip84,
+        provenance: WalletProvenance.defaultSeed,
+        derivationPath: "m/84'/0'/0'",
+        seedPassphraseUsed: false,
+      );
+      final importedWallet = KeychainManifestWalletInventoryBinding(
+        walletId: 'imported-bitcoin',
+        seedFingerprint: Fingerprint('fedcba98'),
+        network: Network.bitcoinMainnet,
+        scriptType: ScriptType.bip84,
+        provenance: WalletProvenance.importedMnemonic,
+        derivationPath: "m/84'/0'/0'",
+        seedPassphraseUsed: true,
+      );
+      expect(
+        await facade.replaceSeedWalletInventory(
+          parentFingerprint: manifestFingerprint,
+          wallets: [defaultWallet, importedWallet],
+        ),
+        isA<Ok>(),
+      );
+
+      expect(
+        await facade.replaceSeedWalletInventory(
+          parentFingerprint: manifestFingerprint,
+          wallets: const [],
+        ),
+        isA<Ok>(),
+      );
+
+      final manifest =
+          ((await facade.readManifest(manifestFingerprint))
+                  as Ok<KeychainManifest, KeychainManifestFailure>)
+              .value;
+      final wallets = manifest.entries
+          .expand((entry) => entry.materializations)
+          .whereType<KeychainManifestWallet>()
+          .toList(growable: false);
+      expect(wallets, hasLength(1));
+      expect(wallets.single.walletId, 'imported-bitcoin');
+      expect(wallets.single.provenance, WalletProvenance.importedMnemonic);
+    },
+  );
+
+  test('preserves, updates, and forgets passphrase wallet records', () async {
+    const walletId = 'passphrase-bitcoin';
+    const descriptor = 'wpkh(public-descriptor/<0;1>/*)';
+    final passphraseWallet = KeychainManifestWalletInventoryBinding(
+      walletId: walletId,
+      seedFingerprint: Fingerprint('01234567'),
+      network: Network.bitcoinMainnet,
+      scriptType: ScriptType.bip84,
+      provenance: WalletProvenance.defaultSeedPassphrase,
+      derivationPath: "m/84'/0'/0'",
+      seedPassphraseUsed: true,
+      descriptor: descriptor,
+      label: 'Vault',
+      description: 'Original hint',
+    );
+
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: [passphraseWallet],
+      ),
+      isA<Ok>(),
+    );
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: const [],
+      ),
+      isA<Ok>(),
+    );
+
+    var manifest =
+        ((await facade.readManifest(manifestFingerprint))
+                as Ok<KeychainManifest, KeychainManifestFailure>)
+            .value;
+    expect(manifest.wallets.single.descriptor, descriptor);
+    expect(manifest.wallets.single.label, 'Vault');
+    expect(manifest.entries.single.description, 'Original hint');
+
+    expect(
+      await facade.updatePassphraseLabelHint(
+        parentFingerprint: manifestFingerprint,
+        walletId: walletId,
+        hint: const KeychainManifestEdit('Updated hint'),
+      ),
+      isA<Ok>(),
+    );
+    manifest =
+        ((await facade.readManifest(manifestFingerprint))
+                as Ok<KeychainManifest, KeychainManifestFailure>)
+            .value;
+    expect(manifest.entries.single.description, 'Updated hint');
+
+    expect(
+      await facade.deleteWallet(
+        parentFingerprint: manifestFingerprint,
+        walletId: walletId,
+      ),
+      isA<Ok>(),
+    );
+    manifest =
+        ((await facade.readManifest(manifestFingerprint))
+                as Ok<KeychainManifest, KeychainManifestFailure>)
+            .value;
+    expect(manifest.entries, isEmpty);
+  });
+
+  test('rejects unsupported inventory provenance', () async {
+    expect(
+      await facade.replaceSeedWalletInventory(
+        parentFingerprint: manifestFingerprint,
+        wallets: [
+          KeychainManifestWalletInventoryBinding(
+            walletId: 'watch-only',
+            seedFingerprint: Fingerprint('fedcba98'),
+            network: Network.bitcoinMainnet,
+            scriptType: ScriptType.bip84,
+            provenance: WalletProvenance.watchOnly,
+            derivationPath: "m/84'/0'/0'",
+            seedPassphraseUsed: null,
+          ),
+        ],
+      ),
+      isA<Err<bool, KeychainManifestFailure>>(),
+    );
+  });
+
+  test('rejects an empty inventory unless explicitly allowed', () async {
+    expect(
+      await _buildPayload(facade, manifestFingerprint),
+      isA<Err<String, KeychainManifestFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<KeychainManifestEmptyFailure>(),
+      ),
+    );
+    expect(
+      await _buildPayload(facade, manifestFingerprint, allowEmpty: true),
+      isA<Ok<String, KeychainManifestFailure>>(),
+    );
+  });
+}
+
+KeychainManifestWalletInventoryBinding _inventory(String id) =>
+    KeychainManifestWalletInventoryBinding(
+      walletId: id,
+      seedFingerprint: manifestFingerprint,
+      network: Network.bitcoinMainnet,
+      scriptType: ScriptType.bip84,
+      provenance: WalletProvenance.defaultSeed,
+      derivationPath: "m/84'/0'/0'",
+      seedPassphraseUsed: false,
+    );
+
+Future<Result<String, KeychainManifestFailure>> _buildPayload(
+  KeychainManifestFacade facade,
+  Fingerprint parentFingerprint, {
+  bool allowEmpty = false,
+}) async => (await facade.buildManifest(
+  parentFingerprint,
+  allowEmpty: allowEmpty,
+)).map(facade.encodeManifestFilePayload);

--- a/test/features/keychain_manifest/keychain_manifest_repository_test.dart
+++ b/test/features/keychain_manifest/keychain_manifest_repository_test.dart
@@ -1,0 +1,417 @@
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/keychain_manifest_repository_impl.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+import 'support/manifest_fixtures.dart';
+
+/// Every manifest write is one named intent (spec F11).
+///
+/// What is asserted here is that each intent answers a collision the way its
+/// own caller needs: a local edit, a re-derivation, and a recovery apply are
+/// not the same question, and the generic save they used to share could only
+/// give one answer to all three.
+void main() {
+  late SqliteDatabase database;
+  late KeychainManifestRepositoryImpl repository;
+
+  setUp(() {
+    database = SqliteDatabase(NativeDatabase.memory());
+    repository = KeychainManifestRepositoryImpl(database);
+  });
+
+  tearDown(() async {
+    await repository.close();
+    await database.close();
+  });
+
+  Future<List<KeychainManifestEntry>> stored() async =>
+      (await repository.fetch(manifestFingerprint)
+              as Ok<List<KeychainManifestEntry>, KeychainManifestFailure>)
+          .value;
+
+  Future<KeychainManifestEntry> single() async => (await stored()).single;
+
+  group('upsertPassphraseWallet', () {
+    test('inserts a record that is not there yet', () async {
+      expect(
+        await repository.upsertPassphraseWallet(
+          passphraseWalletEntry(hint: 'Blue notebook'),
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final entry = await single();
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      expect(
+        (wallet.walletId, wallet.descriptor, wallet.label, entry.description),
+        (
+          'passphrase-1',
+          'wpkh(xpubPassphraseOne/<0;1>/*)',
+          'Vault',
+          'Blue notebook',
+        ),
+      );
+    });
+
+    test('writing the same record back changes nothing', () async {
+      await repository.upsertPassphraseWallet(passphraseWalletEntry());
+
+      expect(
+        await repository.upsertPassphraseWallet(passphraseWalletEntry()),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final entry = await single();
+      expect(entry.updatedAt, 2);
+      expect(await stored(), hasLength(1));
+    });
+
+    test('updates the label and hint of the same descriptor', () async {
+      await repository.upsertPassphraseWallet(
+        passphraseWalletEntry(hint: 'Old hint'),
+      );
+
+      expect(
+        await repository.upsertPassphraseWallet(
+          passphraseWalletEntry(label: 'Renamed', hint: 'New hint'),
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final entry = await single();
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      expect((wallet.label, entry.description), ('Renamed', 'New hint'));
+      expect(
+        entry.updatedAt,
+        greaterThan(2),
+        reason: 'an edit must be ordered after what it replaces',
+      );
+    });
+
+    test(
+      'refuses a second descriptor under a colliding seed fingerprint',
+      () async {
+        await repository.upsertPassphraseWallet(passphraseWalletEntry());
+
+        // Same four-byte child fingerprint and path, so the same entry id, but
+        // a different passphrase produced it. The fingerprint is a lookup hint,
+        // never an identity (spec 6.5).
+        expect(
+          await repository.upsertPassphraseWallet(
+            passphraseWalletEntry(
+              walletId: 'passphrase-2',
+              descriptor: 'wpkh(xpubPassphraseTwo/<0;1>/*)',
+              label: 'Other',
+            ),
+          ),
+          isA<Err<void, KeychainManifestFailure>>().having(
+            (result) => result.failure,
+            'failure',
+            isA<KeychainManifestConflictFailure>(),
+          ),
+        );
+
+        final wallet =
+            (await single()).materializations.single as KeychainManifestWallet;
+        expect(
+          (wallet.walletId, wallet.descriptor, wallet.label),
+          ('passphrase-1', 'wpkh(xpubPassphraseOne/<0;1>/*)', 'Vault'),
+          reason: 'the stored wallet must survive the collision untouched',
+        );
+      },
+    );
+  });
+
+  group('updatePassphraseLabelHint', () {
+    setUp(
+      () => repository.upsertPassphraseWallet(
+        passphraseWalletEntry(hint: 'Old hint'),
+      ),
+    );
+
+    test('a newer revision wins', () async {
+      expect(
+        await repository.updatePassphraseLabelHint(
+          parentFingerprint: manifestFingerprint,
+          walletId: 'passphrase-1',
+          label: const KeychainManifestEdit('Renamed'),
+          hint: const KeychainManifestEdit('New hint'),
+          updatedAt: 9,
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final entry = await single();
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      expect(
+        (wallet.label, entry.description, entry.updatedAt),
+        ('Renamed', 'New hint', 9),
+      );
+    });
+
+    test('an equal revision carrying other content is a conflict', () async {
+      expect(
+        await repository.updatePassphraseLabelHint(
+          parentFingerprint: manifestFingerprint,
+          walletId: 'passphrase-1',
+          hint: const KeychainManifestEdit('Rival hint'),
+          updatedAt: 2,
+        ),
+        isA<Err<void, KeychainManifestFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<KeychainManifestConflictFailure>(),
+        ),
+      );
+
+      expect((await single()).description, 'Old hint');
+    });
+
+    test('an absent edit leaves that field alone', () async {
+      await repository.updatePassphraseLabelHint(
+        parentFingerprint: manifestFingerprint,
+        walletId: 'passphrase-1',
+        hint: const KeychainManifestEdit(null),
+        updatedAt: 9,
+      );
+
+      final entry = await single();
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      expect((wallet.label, entry.description), ('Vault', null));
+    });
+
+    test('an unknown wallet is a conflict', () async {
+      expect(
+        await repository.updatePassphraseLabelHint(
+          parentFingerprint: manifestFingerprint,
+          walletId: 'never-existed',
+          hint: const KeychainManifestEdit('New hint'),
+          updatedAt: 9,
+        ),
+        isA<Err<void, KeychainManifestFailure>>(),
+      );
+    });
+  });
+
+  group('restoreSnapshot', () {
+    test('applies a restored hint that is newer than the local one', () async {
+      await repository.upsertPassphraseWallet(
+        passphraseWalletEntry(hint: 'Old hint'),
+      );
+
+      final report = await repository.restoreSnapshot(
+        manifest(
+          entries: [
+            passphraseWalletEntry(
+              label: 'Renamed',
+              hint: 'Restored hint',
+              updatedAt: 7,
+            ),
+          ],
+        ),
+      );
+
+      expect(_report(report).applied, 1);
+      final entry = await single();
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      expect(
+        (wallet.label, entry.description, entry.updatedAt),
+        ('Renamed', 'Restored hint', 7),
+      );
+    });
+
+    test('older restored text does not clobber newer local text', () async {
+      await repository.upsertPassphraseWallet(
+        passphraseWalletEntry(hint: 'Old hint'),
+      );
+      await repository.updatePassphraseLabelHint(
+        parentFingerprint: manifestFingerprint,
+        walletId: 'passphrase-1',
+        hint: const KeychainManifestEdit('Local hint'),
+        updatedAt: 20,
+      );
+
+      final report = await repository.restoreSnapshot(
+        manifest(
+          entries: [passphraseWalletEntry(hint: 'Stale hint', updatedAt: 7)],
+          generatedAt: 21,
+        ),
+      );
+
+      expect((_report(report).applied, _report(report).unchanged), (0, 1));
+      expect((await single()).description, 'Local hint');
+    });
+
+    test('a different descriptor under one entry id is a conflict', () async {
+      await repository.upsertPassphraseWallet(passphraseWalletEntry());
+
+      final report = _report(
+        await repository.restoreSnapshot(
+          manifest(
+            entries: [
+              passphraseWalletEntry(
+                walletId: 'passphrase-2',
+                descriptor: 'wpkh(xpubPassphraseTwo/<0;1>/*)',
+                label: 'Other',
+                updatedAt: 9,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(report.conflicts, hasLength(1));
+      expect(report.restored, 0);
+      final wallet =
+          (await single()).materializations.single as KeychainManifestWallet;
+      expect(wallet.walletId, 'passphrase-1');
+      expect(wallet.descriptor, 'wpkh(xpubPassphraseOne/<0;1>/*)');
+    });
+
+    test('an equal revision carrying other text is a conflict', () async {
+      await repository.upsertPassphraseWallet(
+        passphraseWalletEntry(hint: 'Old hint'),
+      );
+
+      final report = _report(
+        await repository.restoreSnapshot(
+          manifest(entries: [passphraseWalletEntry(hint: 'Rival hint')]),
+        ),
+      );
+
+      expect(report.conflicts, hasLength(1));
+      expect((await single()).description, 'Old hint');
+    });
+
+    test('inserts records the installation has never seen', () async {
+      final report = _report(
+        await repository.restoreSnapshot(
+          manifest(entries: [passphraseWalletEntry(hint: 'Restored hint')]),
+        ),
+      );
+
+      expect(report.applied, 1);
+      expect((await single()).description, 'Restored hint');
+    });
+  });
+
+  group('replaceSeedWalletInventory', () {
+    test('keeps a passphrase record the re-derivation cannot see', () async {
+      await repository.upsertPassphraseWallet(passphraseWalletEntry());
+
+      expect(
+        await repository.replaceSeedWalletInventory(manifestFingerprint, []),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final wallet =
+          (await single()).materializations.single as KeychainManifestWallet;
+      expect(wallet.walletId, 'passphrase-1');
+    });
+  });
+
+  group('removePassphraseWallet', () {
+    test('forgets the record', () async {
+      await repository.upsertPassphraseWallet(passphraseWalletEntry());
+
+      expect(
+        await repository.removePassphraseWallet(
+          parentFingerprint: manifestFingerprint,
+          walletId: 'passphrase-1',
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+      expect(await stored(), isEmpty);
+    });
+
+    test('reports a wallet that was never recorded', () async {
+      expect(
+        await repository.removePassphraseWallet(
+          parentFingerprint: manifestFingerprint,
+          walletId: 'never-existed',
+        ),
+        isA<Err<void, KeychainManifestFailure>>(),
+      );
+    });
+  });
+
+  group('Nostr key materialization', () {
+    test('persists and reconstructs wallet and Nostr entries', () async {
+      await repository.upsertPassphraseWallet(passphraseWalletEntry());
+      expect(
+        await repository.insertNostrKey(nostrManifestEntry()),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final entries = await stored();
+      expect(entries, hasLength(2));
+      expect(
+        entries.expand((entry) => entry.materializations),
+        containsAll([
+          isA<KeychainManifestWallet>(),
+          isA<KeychainManifestNostrKey>(),
+        ]),
+      );
+    });
+
+    test('the same key written back changes nothing', () async {
+      await repository.insertNostrKey(nostrManifestEntry());
+
+      expect(
+        await repository.insertNostrKey(nostrManifestEntry()),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+      expect(await stored(), hasLength(1));
+    });
+
+    test('refuses a different key on a recorded derivation', () async {
+      await repository.insertNostrKey(nostrManifestEntry());
+
+      expect(
+        await repository.insertNostrKey(
+          nostrManifestEntry(publicKeyHex: 'a' * 64),
+        ),
+        isA<Err<void, KeychainManifestFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<KeychainManifestConflictFailure>(),
+        ),
+      );
+    });
+
+    test('updates user metadata atomically and monotonically', () async {
+      final entry = nostrManifestEntry(description: 'old');
+      await repository.insertNostrKey(entry);
+
+      expect(
+        await repository.updateNostrMetadata(
+          parentFingerprint: manifestFingerprint,
+          entryId: entry.entryId,
+          purpose: 'new',
+          description: 'new note',
+          updatedAt: 1,
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+
+      final updatedEntry = await single();
+      final updated =
+          updatedEntry.materializations.single as KeychainManifestNostrKey;
+      expect(
+        (updated.purpose, updatedEntry.description, updated.updatedAt),
+        ('new', 'new note', 3),
+      );
+    });
+  });
+}
+
+KeychainManifestRestoreReport _report(
+  Result<KeychainManifestRestoreReport, KeychainManifestFailure> result,
+) => (result as Ok<KeychainManifestRestoreReport, KeychainManifestFailure>)
+    .value;

--- a/test/features/keychain_manifest/nostr_key_detail_screen_test.dart
+++ b/test/features/keychain_manifest/nostr_key_detail_screen_test.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/screens/nostr_key_detail_screen.dart';
+import 'package:bb_mobile/features/keychain_manifest/ui/widgets/nostr_nsec_reveal_dialog.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:bb_mobile/locator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:primitives/primitives.dart';
+
+import 'support/manifest_fixtures.dart';
+
+const _noScreenshotChannel = MethodChannel(
+  'com.flutterplaza.no_screenshot_methods',
+);
+
+void main() {
+  String? clipboard;
+
+  setUp(() {
+    clipboard = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_noScreenshotChannel, (_) async => true);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboard =
+                (call.arguments as Map<Object?, Object?>)['text'] as String?;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_noScreenshotChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    await locator.reset();
+  });
+
+  testWidgets('user npub is shareable as QR and nsec is warning-gated', (
+    tester,
+  ) async {
+    var revealCalls = 0;
+    locator.registerFactory<NostrNsecRevealPresenter>(
+      () => NostrNsecRevealPresenter.forTesting((_) async {
+        revealCalls++;
+        return Ok(RevealedNostrSecret('nsec1revealedsecret'));
+      }),
+    );
+    await _pump(tester, nostrManifestEntry());
+
+    expect(find.text('Edit'), findsNothing);
+    expect(find.text('Show nsec'), findsOneWidget);
+    await tester.tap(find.textContaining('npub1'));
+    await tester.pumpAndSettle();
+    expect(find.byType(QrDisplayWidget), findsOneWidget);
+    Navigator.of(tester.element(find.byType(QrDisplayWidget))).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Show nsec'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('DO NOT SHARE WITH ANYONE'), findsOneWidget);
+    expect(revealCalls, 0);
+    await tester.tap(find.text('I understand'));
+    await tester.pumpAndSettle();
+    expect(revealCalls, 1);
+    expect(find.text('nsec 1rev eale dsec ret'), findsOneWidget);
+    expect(find.byType(QrDisplayWidget), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('nostr_nsec_copy_action')));
+    await tester.pumpAndSettle();
+    expect(clipboard, 'nsec1revealedsecret');
+    expect(find.textContaining('nsec 1rev'), findsNothing);
+    await tester.pump(const Duration(seconds: 3));
+  });
+
+  testWidgets('system key gates npub and nsec without allowing edits', (
+    tester,
+  ) async {
+    var revealCalls = 0;
+    locator.registerFactory<NostrNsecRevealPresenter>(
+      () => NostrNsecRevealPresenter.forTesting((_) async {
+        revealCalls++;
+        return Ok(RevealedNostrSecret('nsec1systemsecret'));
+      }),
+    );
+    await _pump(tester, _systemEntry());
+
+    expect(find.text('Edit'), findsNothing);
+    expect(find.text('Show nsec'), findsOneWidget);
+    expect(find.text('Show npub'), findsOneWidget);
+    expect(find.byType(QrDisplayWidget), findsNothing);
+    await tester.tap(find.text('Show npub'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('only for troubleshooting'), findsOneWidget);
+    await tester.tap(find.text('I understand'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('npub1'), findsOneWidget);
+    expect(find.byType(QrDisplayWidget), findsNothing);
+    await tester.tap(find.textContaining('npub1'));
+    await tester.pumpAndSettle();
+    expect(find.byType(QrDisplayWidget), findsNothing);
+    Navigator.of(tester.element(find.byType(NostrKeyDetailScreen))).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Show nsec'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('debugging and advanced usage'), findsOneWidget);
+    expect(revealCalls, 0);
+    await tester.tap(find.text('I understand'));
+    await tester.pumpAndSettle();
+    expect(revealCalls, 1);
+    expect(find.textContaining('nsec 1sys tems ecre t'), findsOneWidget);
+  });
+
+  testWidgets('backgrounding while privacy setup is pending never derives', (
+    tester,
+  ) async {
+    final privacy = Completer<Object?>();
+    var revealCalls = 0;
+    var privacyOffCalls = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_noScreenshotChannel, (call) {
+          if (call.method == 'screenshotOff') return privacy.future;
+          if (call.method == 'screenshotOn') privacyOffCalls++;
+          return Future<Object?>.value(true);
+        });
+    locator.registerFactory<NostrNsecRevealPresenter>(
+      () => NostrNsecRevealPresenter.forTesting((_) async {
+        revealCalls++;
+        return Ok(RevealedNostrSecret('nsec1mustneverappear'));
+      }),
+    );
+    await _pump(tester, nostrManifestEntry());
+    await tester.tap(find.text('Show nsec'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('I understand'));
+    await tester.pump();
+    expect(revealCalls, 0);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pumpAndSettle();
+    privacy.complete(true);
+    await tester.pumpAndSettle();
+    expect(revealCalls, 0);
+    expect(privacyOffCalls, 2);
+    expect(find.textContaining('mustneverappear'), findsNothing);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  });
+}
+
+Future<void> _pump(WidgetTester tester, KeychainManifestEntry entry) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, _) => NostrKeyDetailScreen(entry: entry),
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: router,
+      theme: AppTheme.themeData(AppThemeType.light),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+KeychainManifestEntry _systemEntry() {
+  const path = "128002'/100'/1'";
+  final entryId = '${manifestFingerprint.hex}:$path';
+  return KeychainManifestEntry(
+    parentFingerprint: manifestFingerprint,
+    derivationPath: path,
+    createdAt: 1,
+    updatedAt: 1,
+    materializations: [
+      KeychainManifestNostrKey(
+        entryId: entryId,
+        publicKeyHex:
+            '4fb85384f3a52baadbadc3f9bcb7fd59691e323293160b58959dadd6195c7981',
+        keyKind: KeychainManifestNostrKeyKind.reserved,
+        purpose: 'stored value ignored',
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    ],
+  );
+}

--- a/test/features/keychain_manifest/nostr_key_form_validation_test.dart
+++ b/test/features/keychain_manifest/nostr_key_form_validation_test.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/features/keychain_manifest/presentation/nostr_keys_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('assigns invalid name characters only to the name field', () {
+    expect(
+      validateNostrKeyForm('bad\nname', 'valid'),
+      NostrKeyFormError.invalidNameCharacters,
+    );
+  });
+
+  test('assigns invalid description characters only to description', () {
+    expect(
+      validateNostrKeyForm('valid', 'bad\ndescription'),
+      NostrKeyFormError.invalidDescriptionCharacters,
+    );
+  });
+}

--- a/test/features/keychain_manifest/nostr_key_materialization_test.dart
+++ b/test/features/keychain_manifest/nostr_key_materialization_test.dart
@@ -1,0 +1,365 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart' as wallet;
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest_requests.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/revealed_nostr_secret.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/keychain_manifest_failure.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/create_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/reveal_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bip32_keys/bip32_keys.dart' as bip32;
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+class _MockSettings extends Mock implements GetSettingsUsecase {}
+
+class _MockDefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+const _mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+void main() {
+  late Seed seed;
+  late _MockSettings settings;
+  late _MockDefaultSeed defaultSeed;
+  late KeychainManifestNostrKeyDeriver deriver;
+
+  setUpAll(() {
+    final bytes = Uint8List.fromList(
+      bip39.Mnemonic.fromSentence(_mnemonic, bip39.Language.english).seed,
+    );
+    seed = Seed.bytes(
+      bytes: bytes,
+      masterFingerprint: hex.encode(
+        bip32.Bip32Keys.fromSeed(bytes).fingerprint,
+      ),
+    );
+  });
+
+  setUp(() {
+    settings = _MockSettings();
+    defaultSeed = _MockDefaultSeed();
+    when(() => settings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'CRC',
+      ),
+    );
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(seed));
+    deriver = KeychainManifestNostrKeyDeriver(settings, defaultSeed);
+  });
+
+  test('keeps the first user identity derivation byte-stable', () {
+    final publicKey = deriver.derivePublicKey(seed, "128002'/1'/1'");
+    final secret = deriver.revealSecret(seed, "128002'/1'/1'");
+    // These values are permanent user identity material; any change requires
+    // an explicit wire/identity migration decision.
+    expect(
+      publicKey,
+      'c071c9b02afd19a9d9b240ea9eed3f8ba80f89474953b752471f3d006b63a332',
+    );
+    expect(
+      secret.nsec,
+      'nsec17s2p4ad3hpd3xs70ssq2xydj076uz6kw25m7umlf25hzmktlxydsw2t3sg',
+    );
+  });
+
+  test('uses the active environment and maps expected seed failures', () async {
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer(
+      (_) async => const Err<Seed, SeedFailure>(DefaultSeedNotFoundFailure()),
+    );
+    expect(
+      await deriver.source(),
+      isA<Err<KeychainManifestSeedSource, KeychainManifestFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<KeychainManifestSeedFailure>(),
+      ),
+    );
+    verify(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).called(1);
+  });
+
+  test(
+    'allocates after the durable high-water mark and skips app ids',
+    () async {
+      final repository = _MemoryRepository([
+        _userEntry(seed, identity: 99, deriver: deriver),
+      ]);
+      final create = CreateKeychainManifestNostrKeyUsecase(
+        deriver,
+        repository,
+        RecordKeychainManifestNostrKeyUsecase(repository),
+      );
+      final result = await create.execute(
+        purpose: ' personal identity ',
+        description: ' notes ',
+        now: DateTime.fromMillisecondsSinceEpoch(2000, isUtc: true),
+      );
+      final entry =
+          (result as Ok<KeychainManifestEntry, KeychainManifestFailure>).value;
+      final key = entry.materializations.single as KeychainManifestNostrKey;
+      expect(entry.bip85DerivationPath, "128002'/200'/1'");
+      expect((key.purpose, entry.description), ('personal identity', 'notes'));
+    },
+  );
+
+  test(
+    'ignores non-BIP85 manifest entries when allocating an identity',
+    () async {
+      final parent = Fingerprint(seed.masterFingerprint);
+      final child = Fingerprint('12345678');
+      const path = "m/84'/0'/0'";
+      final repository = _MemoryRepository([
+        KeychainManifestEntry(
+          parentFingerprint: parent,
+          derivationKind: KeychainManifestDerivationKind.bip32,
+          derivationPath: path,
+          createdAt: 1,
+          updatedAt: 1,
+          materializations: [
+            KeychainManifestWallet(
+              walletId: 'imported-wallet',
+              entryId: KeychainManifestEntry.entryIdFor(
+                parentFingerprint: parent,
+                derivationKind: KeychainManifestDerivationKind.bip32,
+                derivationPath: path,
+                seedFingerprint: child,
+              ),
+              childSeedFingerprint: child,
+              network: wallet.Network.bitcoinMainnet,
+              scriptType: wallet.ScriptType.bip84,
+              provenance: WalletProvenance.importedMnemonic,
+              seedPassphraseUsed: false,
+              createdAt: 1,
+              updatedAt: 1,
+            ),
+          ],
+        ),
+      ]);
+      final create = CreateKeychainManifestNostrKeyUsecase(
+        deriver,
+        repository,
+        RecordKeychainManifestNostrKeyUsecase(repository),
+      );
+
+      final result = await create.execute(purpose: 'Personal identity');
+
+      expect(result, isA<Ok<KeychainManifestEntry, KeychainManifestFailure>>());
+    },
+  );
+
+  test('reveals only a verified manifest key and redacts toString', () async {
+    final entry = _userEntry(seed, identity: 1, deriver: deriver);
+    final result = await RevealKeychainManifestNostrKeyUsecase(
+      deriver,
+    ).execute(entry);
+    final secret =
+        (result as Ok<RevealedNostrSecret, KeychainManifestFailure>).value;
+    expect(secret.nsec, startsWith('nsec1'));
+    expect(secret.toString(), isNot(contains(secret.nsec)));
+
+    final reserved = _reservedEntry(seed, deriver);
+    expect(
+      await RevealKeychainManifestNostrKeyUsecase(deriver).execute(reserved),
+      isA<Ok<RevealedNostrSecret, KeychainManifestFailure>>(),
+    );
+  });
+
+  test('restores only a key derived from the active seed', () async {
+    final repository = _MemoryRepository();
+    final path = "128002'/1'/1'";
+    final parentFingerprint = Fingerprint(seed.masterFingerprint);
+    final restore = RestoreKeychainManifestNostrKeyUsecase(
+      deriver,
+      RecordKeychainManifestNostrKeyUsecase(repository),
+    );
+
+    expect(
+      await restore.execute(
+        reservationId: 'nostr_user_key',
+        parentFingerprint: parentFingerprint,
+        derivationPath: path,
+        publicKeyHex: deriver.derivePublicKey(seed, path),
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: 'Personal identity',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+      ),
+      isA<Ok<bool, KeychainManifestFailure>>(),
+    );
+    expect(repository.entries, hasLength(1));
+
+    expect(
+      await restore.execute(
+        reservationId: 'nostr_user_key',
+        parentFingerprint: Fingerprint('00000000'),
+        derivationPath: path,
+        publicKeyHex: deriver.derivePublicKey(seed, path),
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: 'Personal identity',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+      ),
+      isA<Err<bool, KeychainManifestFailure>>(),
+    );
+  });
+}
+
+KeychainManifestEntry _userEntry(
+  Seed seed, {
+  required int identity,
+  required KeychainManifestNostrKeyDeriver deriver,
+}) {
+  final path = "128002'/$identity'/1'";
+  final parent = Fingerprint(seed.masterFingerprint);
+  final entryId = '${parent.hex}:$path';
+  final publicKey = deriver.derivePublicKey(seed, path);
+  return KeychainManifestEntry(
+    parentFingerprint: parent,
+    derivationPath: path,
+    description: 'key $identity',
+    createdAt: 1,
+    updatedAt: 1,
+    materializations: [
+      KeychainManifestNostrKey(
+        entryId: entryId,
+        publicKeyHex: publicKey,
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: 'key $identity',
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    ],
+  );
+}
+
+KeychainManifestEntry _reservedEntry(
+  Seed seed,
+  KeychainManifestNostrKeyDeriver deriver,
+) {
+  const path = "128002'/100'/1'";
+  final parent = Fingerprint(seed.masterFingerprint);
+  final entryId = '${parent.hex}:$path';
+  final publicKey = deriver.derivePublicKey(seed, path);
+  return KeychainManifestEntry(
+    parentFingerprint: parent,
+    derivationPath: path,
+    createdAt: 1,
+    updatedAt: 1,
+    materializations: [
+      KeychainManifestNostrKey(
+        entryId: entryId,
+        publicKeyHex: publicKey,
+        keyKind: KeychainManifestNostrKeyKind.reserved,
+        purpose: 'Wallet backup',
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    ],
+  );
+}
+
+final class _MemoryRepository implements KeychainManifestRepository {
+  final List<KeychainManifestEntry> entries;
+
+  _MemoryRepository([List<KeychainManifestEntry>? entries])
+    : entries = [...?entries];
+
+  @override
+  Stream<void> watchLocalChanges() => const Stream.empty();
+
+  @override
+  Future<Result<List<KeychainManifestEntry>, KeychainManifestFailure>> fetch(
+    Fingerprint parentFingerprint,
+  ) async => Ok([
+    for (final entry in entries)
+      if (entry.parentFingerprint == parentFingerprint) entry,
+  ]);
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> insertNostrKey(
+    KeychainManifestEntry record, {
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  }) async {
+    if (entries.any((entry) => entry.entryId == record.entryId)) {
+      return const Err(KeychainManifestConflictFailure());
+    }
+    entries.add(record);
+    return const Ok(null);
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> replaceSeedWalletInventory(
+    Fingerprint parentFingerprint,
+    List<KeychainManifestEntry> replacements,
+  ) async {
+    entries.removeWhere(
+      (entry) =>
+          entry.parentFingerprint == parentFingerprint &&
+          entry.derivationKind == KeychainManifestDerivationKind.bip32,
+    );
+    entries.addAll(replacements);
+    return const Ok(null);
+  }
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> upsertPassphraseWallet(
+    KeychainManifestEntry record,
+  ) async => const Err(KeychainManifestConflictFailure());
+
+  @override
+  Future<Result<KeychainManifestRestoreReport, KeychainManifestFailure>>
+  restoreSnapshot(
+    KeychainManifest manifest, {
+    KeychainManifestRestorePolicy policy =
+        KeychainManifestRestorePolicy.keepNewest,
+  }) async => const Err(KeychainManifestConflictFailure());
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> updatePassphraseLabelHint({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+    KeychainManifestEdit<String?>? label,
+    KeychainManifestEdit<String?>? hint,
+    required int updatedAt,
+  }) async => const Err(KeychainManifestConflictFailure());
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> removePassphraseWallet({
+    required Fingerprint parentFingerprint,
+    required String walletId,
+  }) async => const Err(KeychainManifestConflictFailure());
+
+  @override
+  Future<Result<void, KeychainManifestFailure>> updateNostrMetadata({
+    required Fingerprint parentFingerprint,
+    required String entryId,
+    required String purpose,
+    String? description,
+    required int updatedAt,
+    KeychainManifestWriteOrigin origin = KeychainManifestWriteOrigin.local,
+  }) async => const Err(KeychainManifestConflictFailure());
+
+  @override
+  Future<void> close() async {}
+}

--- a/test/features/keychain_manifest/support/manifest_fixtures.dart
+++ b/test/features/keychain_manifest/support/manifest_fixtures.dart
@@ -1,0 +1,125 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
+
+final manifestFingerprint = Fingerprint('73c5da0a');
+
+KeychainManifestEntry walletManifestEntry({
+  String walletId = 'wallet-1',
+  int updatedAt = 2,
+}) {
+  const path = "39'/0'/12'/100'";
+  final entryId = '${manifestFingerprint.hex}:$path';
+  return KeychainManifestEntry(
+    parentFingerprint: manifestFingerprint,
+    derivationPath: path,
+    createdAt: 1,
+    updatedAt: updatedAt,
+    materializations: [
+      KeychainManifestWallet(
+        walletId: walletId,
+        entryId: entryId,
+        childSeedFingerprint: Fingerprint('fedcba98'),
+        network: Network.bitcoinMainnet,
+        scriptType: ScriptType.bip84,
+        provenance: WalletProvenance.bip85,
+        seedPassphraseUsed: false,
+        createdAt: 1,
+        updatedAt: updatedAt,
+      ),
+    ],
+  );
+}
+
+/// A passphrase wallet as the manifest holds it: BIP32 provenance, the
+/// combined public descriptor that is its identity, and the label and hint the
+/// manifest owns.
+KeychainManifestEntry passphraseWalletEntry({
+  String walletId = 'passphrase-1',
+  String seedFingerprint = '01234567',
+  String descriptor = 'wpkh(xpubPassphraseOne/<0;1>/*)',
+  String? label = 'Vault',
+  String? hint,
+  String path = "m/84'/0'/0'",
+  int createdAt = 1,
+  int updatedAt = 2,
+}) {
+  final child = Fingerprint(seedFingerprint);
+  return KeychainManifestEntry(
+    parentFingerprint: manifestFingerprint,
+    derivationKind: KeychainManifestDerivationKind.bip32,
+    derivationPath: path,
+    description: hint,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+    materializations: [
+      KeychainManifestWallet(
+        walletId: walletId,
+        entryId: KeychainManifestEntry.entryIdFor(
+          parentFingerprint: manifestFingerprint,
+          derivationKind: KeychainManifestDerivationKind.bip32,
+          derivationPath: path,
+          seedFingerprint: child,
+        ),
+        childSeedFingerprint: child,
+        network: Network.bitcoinMainnet,
+        scriptType: ScriptType.bip84,
+        provenance: WalletProvenance.defaultSeedPassphrase,
+        seedPassphraseUsed: true,
+        descriptor: descriptor,
+        label: label,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      ),
+    ],
+  );
+}
+
+KeychainManifestEntry nostrManifestEntry({
+  int identity = 1,
+  String publicKeyHex =
+      '4fb85384f3a52baadbadc3f9bcb7fd59691e323293160b58959dadd6195c7981',
+  String purpose = 'Personal identity',
+  String? description,
+  int updatedAt = 2,
+}) {
+  final path = "128002'/$identity'/1'";
+  final entryId = '${manifestFingerprint.hex}:$path';
+  return KeychainManifestEntry(
+    parentFingerprint: manifestFingerprint,
+    derivationPath: path,
+    description: description,
+    createdAt: 1,
+    updatedAt: updatedAt,
+    materializations: [
+      KeychainManifestNostrKey(
+        entryId: entryId,
+        publicKeyHex: publicKeyHex,
+        keyKind: KeychainManifestNostrKeyKind.userGenerated,
+        purpose: purpose,
+        createdAt: 1,
+        updatedAt: updatedAt,
+      ),
+    ],
+  );
+}
+
+KeychainManifest manifest({
+  List<KeychainManifestEntry>? entries,
+  int generatedAt = 3,
+}) => KeychainManifest(
+  parentFingerprint: manifestFingerprint,
+  generatedAt: generatedAt,
+  entries: entries ?? [walletManifestEntry()],
+);
+
+const canonicalWalletManifest =
+    '{"version":1,"parentFingerprint":"73c5da0a","generatedAt":3,'
+    '"entries":[{'
+    '"derivationKind":"bip85","derivationPath":"39\'/0\'/12\'/100\'",'
+    '"createdAt":1,"updatedAt":2,"materializations":[{"type":"wallet",'
+    '"walletId":"wallet-1","childSeedFingerprint":"fedcba98",'
+    '"network":"bitcoinMainnet","scriptType":"bip84",'
+    '"provenance":"bip85","seedPassphraseUsed":false,"createdAt":1,'
+    '"updatedAt":2}]}]}';


### PR DESCRIPTION
## What this adds

This adds a recovery manifest for seed-derived identities and deterministic wallet bindings.

- Records each recoverable Nostr key with its derivation path, parent fingerprint, description, and timestamps.
- Records deterministic wallet bindings before remote registration or publication.
- Supports named user Nostr identities and the reserved system identities.
- Provides create and edit screens using the shared input controls.
- Allows warning-gated, point-of-use nsec reveal for user and system identities.
- Produces and parses one canonical JSON representation for backup and recovery.

## Approach

The repository is the single write and change-notification boundary. Local writes notify backup consumers; recovered inventory does not immediately republish itself. Parsing, validation, canonical ordering, and merge behavior use the same entity rules so malformed data fails before persistence.

Private keys are re-derived only when the user confirms a reveal. The reveal verifies the active seed fingerprint and stored public key, enables screen-capture protection before derivation, and clears the secret when copied, closed, or backgrounded.

## Verification

Tests pin canonical manifest bytes and frozen Nostr derivation vectors, cover local versus recovery writes, validate additive import behavior, exercise user-key allocation alongside non-BIP85 wallet entries, and verify protected secret reveal for both user and system identities.
