### PR TITLE
feat: add encrypted wallet data backup and recovery

### DIFF
--- a/lib/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart
+++ b/lib/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:drift/drift.dart';
@@ -11,10 +13,13 @@ import 'package:drift/drift.dart';
 /// origin; it attributes a freeze for BIP329 export, never for exclusion.
 class FrozenWalletUtxoDatasource {
   final SqliteDatabase _db;
+  final StreamController<void> _changes = StreamController<void>.broadcast(
+    sync: true,
+  );
 
-  FrozenWalletUtxoDatasource({required SqliteDatabase db})
-    : _db = db; // ignore: prefer_initializing_formals
-  // Named `db` (not `_db`) so callers read `db:`; the field stays private.
+  FrozenWalletUtxoDatasource({required this._db});
+
+  Stream<void> get changes => _changes.stream;
 
   /// Upserts a freeze row per outpoint, attributed to [walletId] (the wallet
   /// origin). All-or-nothing via a single batch.
@@ -36,6 +41,27 @@ class FrozenWalletUtxoDatasource {
         );
       }
     });
+    _changes.add(null);
+  }
+
+  Future<void> restoreFrozenWalletOutpoints(
+    List<({String walletId, String txId, int vout})> outpoints,
+  ) async {
+    if (outpoints.isEmpty) return;
+    await _db.batch((batch) {
+      for (final outpoint in outpoints) {
+        batch.insert(
+          _db.frozenUtxos,
+          FrozenUtxosCompanion.insert(
+            walletId: outpoint.walletId,
+            txId: outpoint.txId,
+            vout: outpoint.vout,
+          ),
+          mode: InsertMode.insertOrReplace,
+        );
+      }
+    });
+    _changes.add(null);
   }
 
   /// Deletes the freeze rows for the given outpoints.
@@ -61,6 +87,7 @@ class FrozenWalletUtxoDatasource {
         );
       }
     });
+    _changes.add(null);
   }
 
   /// Returns the frozen outpoints attributed to a wallet.
@@ -80,6 +107,6 @@ class FrozenWalletUtxoDatasource {
     final rows = await _db.select(_db.frozenUtxos).get();
     return rows
         .map((row) => (walletId: row.walletId, txId: row.txId, vout: row.vout))
-        .toList();
+        .toList(growable: false);
   }
 }

--- a/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart
+++ b/lib/core/wallet/data/datasources/wallet_metadata_datasource.dart
@@ -1,16 +1,79 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 
 class WalletMetadataDatasource {
   final SqliteDatabase _sqlite;
+  final StreamController<void> _preferenceChanges =
+      StreamController<void>.broadcast(sync: true);
+  final StreamController<void> _catalogChanges =
+      StreamController<void>.broadcast(sync: true);
 
   WalletMetadataDatasource({required this._sqlite});
 
+  Stream<void> get preferenceChanges => _preferenceChanges.stream;
+  Stream<void> get catalogChanges => _catalogChanges.stream;
+
   Future<void> store(WalletMetadataModel metadata) async {
+    final previous = await fetch(metadata.id);
+    await _store(metadata);
+    if (_preferencesDiffer(previous, metadata)) {
+      _preferenceChanges.add(null);
+    }
+    if (_definitionsDiffer(previous, metadata)) _catalogChanges.add(null);
+  }
+
+  Future<void> _store(WalletMetadataModel metadata) async {
     final companion = metadata.toSqlite();
     await _sqlite
         .into(_sqlite.walletMetadatas)
         .insertOnConflictUpdate(companion);
+  }
+
+  Future<void> storeAll(List<WalletMetadataModel> metadata) async {
+    if (metadata.isEmpty) return;
+    final previous = {for (final item in await fetchAll()) item.id: item};
+    await _sqlite.transaction(() async {
+      for (final item in metadata) {
+        await _store(item);
+      }
+    });
+    if (metadata.any((item) => _preferencesDiffer(previous[item.id], item))) {
+      _preferenceChanges.add(null);
+    }
+    if (metadata.any((item) => _definitionsDiffer(previous[item.id], item))) {
+      _catalogChanges.add(null);
+    }
+  }
+
+  /// Applies recovered preference fields only while the classified local
+  /// preference projection is still current.
+  Future<Set<String>> storeRecoveredPreferencesConditionally(
+    List<WalletMetadataPreferenceRecoveryUpdate> updates,
+  ) async {
+    if (updates.isEmpty) return const {};
+    final conflicted = <String>{};
+    var changed = false;
+    await _sqlite.transaction(() async {
+      for (final update in updates) {
+        final current = await fetch(update.walletRef);
+        if (current == null || !_matchesExpectedPreferences(current, update)) {
+          conflicted.add(update.walletRef);
+          continue;
+        }
+        final recovered = current.copyWith(
+          label: update.recoveredLabel,
+          hideOnHome: update.recoveredHideOnHome,
+          autoSweepEnabled: update.recoveredAutoSweepEnabled,
+        );
+        if (_preferencesDiffer(current, recovered)) changed = true;
+        await _store(recovered);
+      }
+    });
+    if (changed) _preferenceChanges.add(null);
+    return Set.unmodifiable(conflicted);
   }
 
   Future<WalletMetadataModel?> fetch(String walletId) async {
@@ -28,8 +91,85 @@ class WalletMetadataDatasource {
   }
 
   Future<void> delete(String walletId) async {
-    await _sqlite.managers.walletMetadatas
+    final previous = await fetch(walletId);
+    final deleted = await _sqlite.managers.walletMetadatas
         .filter((e) => e.id(walletId))
         .delete();
+    if (deleted > 0 &&
+        previous != null &&
+        _hasRepresentedPreferences(previous)) {
+      _preferenceChanges.add(null);
+    }
+    if (deleted > 0 && previous != null && _isBackedUpDefinition(previous)) {
+      _catalogChanges.add(null);
+    }
   }
 }
+
+final class WalletMetadataPreferenceRecoveryUpdate {
+  final String walletRef;
+  final String? expectedLabel;
+  final bool? expectedHideOnHome;
+  final bool? expectedAutoSweepEnabled;
+  final String? recoveredLabel;
+  final bool? recoveredHideOnHome;
+  final bool? recoveredAutoSweepEnabled;
+
+  const WalletMetadataPreferenceRecoveryUpdate({
+    required this.walletRef,
+    required this.expectedLabel,
+    required this.expectedHideOnHome,
+    required this.expectedAutoSweepEnabled,
+    required this.recoveredLabel,
+    required this.recoveredHideOnHome,
+    required this.recoveredAutoSweepEnabled,
+  });
+}
+
+bool _matchesExpectedPreferences(
+  WalletMetadataModel current,
+  WalletMetadataPreferenceRecoveryUpdate update,
+) =>
+    current.label == update.expectedLabel &&
+    current.hideOnHome == update.expectedHideOnHome &&
+    current.autoSweepEnabled == update.expectedAutoSweepEnabled;
+
+bool _preferencesDiffer(
+  WalletMetadataModel? previous,
+  WalletMetadataModel current,
+) {
+  if (previous == null) return _hasRepresentedPreferences(current);
+  return previous.label != current.label ||
+      previous.hideOnHome != current.hideOnHome ||
+      previous.autoSweepEnabled != current.autoSweepEnabled;
+}
+
+bool _hasRepresentedPreferences(WalletMetadataModel metadata) {
+  return metadata.label != null ||
+      metadata.hideOnHome != null ||
+      metadata.autoSweepEnabled != null;
+}
+
+bool _definitionsDiffer(
+  WalletMetadataModel? previous,
+  WalletMetadataModel current,
+) {
+  if (previous != null &&
+      _isBackedUpDefinition(previous) != _isBackedUpDefinition(current)) {
+    return true;
+  }
+  if (!_isBackedUpDefinition(current)) return false;
+  return previous == null ||
+      previous.externalPublicDescriptor != current.externalPublicDescriptor ||
+      previous.internalPublicDescriptor != current.internalPublicDescriptor ||
+      previous.masterFingerprint != current.masterFingerprint ||
+      previous.signerDevice != current.signerDevice ||
+      previous.birthday != current.birthday ||
+      previous.provenance != current.provenance ||
+      previous.seedPassphraseUsed != current.seedPassphraseUsed;
+}
+
+bool _isBackedUpDefinition(WalletMetadataModel metadata) =>
+    metadata.isBitcoin &&
+    (metadata.provenance == WalletProvenance.watchOnly ||
+        metadata.provenance == WalletProvenance.externalSigner);

--- a/lib/core/wallet/data/models/wallet_metadata_model.dart
+++ b/lib/core/wallet/data/models/wallet_metadata_model.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/core/wallet/wallet_metadata_service.dart';
 import 'package:drift/drift.dart' show Value;
 
@@ -23,11 +24,15 @@ abstract class WalletMetadataModel with _$WalletMetadataModel {
     required String internalPublicDescriptor,
     required Signer signer,
     required bool isDefault,
+    bool? hideOnHome,
+    bool? autoSweepEnabled,
     @Default(0) int lastReceiveAddressIndex,
     String? label,
     DateTime? syncedAt,
     SignerDevice? signerDevice,
     DateTime? birthday,
+    @Default(WalletProvenance.watchOnly) WalletProvenance provenance,
+    bool? seedPassphraseUsed,
   }) = _WalletMetadataModel;
 
   const WalletMetadataModel._();
@@ -61,10 +66,14 @@ extension WalletMetadataModelMapper on WalletMetadataModel {
     internalPublicDescriptor: Value(internalPublicDescriptor),
     signer: Value(signer.name),
     isDefault: Value(isDefault),
+    hideOnHome: Value(hideOnHome),
+    autoSweepEnabled: Value(autoSweepEnabled),
     label: Value(label),
     syncedAt: Value(syncedAt),
     signerDevice: Value(signerDevice),
     birthday: Value(birthday),
+    provenance: Value(provenance.name),
+    seedPassphraseUsed: Value(seedPassphraseUsed),
   );
 
   static WalletMetadataModel fromSqlite(WalletMetadataRow row) =>
@@ -81,9 +90,19 @@ extension WalletMetadataModelMapper on WalletMetadataModel {
         internalPublicDescriptor: row.internalPublicDescriptor,
         signer: Signer.fromName(row.signer),
         isDefault: row.isDefault,
+        hideOnHome: row.hideOnHome,
+        autoSweepEnabled: row.autoSweepEnabled,
         label: row.label,
         syncedAt: row.syncedAt,
         signerDevice: row.signerDevice,
         birthday: row.birthday,
+        provenance: _parseProvenance(row.provenance),
+        seedPassphraseUsed: row.seedPassphraseUsed,
       );
 }
+
+WalletProvenance _parseProvenance(String value) =>
+    WalletProvenance.values.firstWhere(
+      (candidate) => candidate.name == value,
+      orElse: () => throw FormatException('Unknown wallet provenance'),
+    );

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -17,9 +17,12 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_balances.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/seed_derived_wallet_recovery_fact.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
 import 'package:bb_mobile/core/wallet/wallet_metadata_service.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
 
 class WalletRepository {
   final WalletMetadataDatasource _walletMetadataDatasource;
@@ -332,6 +335,59 @@ class WalletRepository {
         .toList(growable: false);
   }
 
+  Future<bool> containsWallet(String walletId) async =>
+      await _walletMetadataDatasource.fetch(walletId) != null;
+
+  Future<List<SeedDerivedWalletRecoveryFact>>
+  getSeedDerivedWalletRecoveryFacts() async =>
+      (await _walletMetadataDatasource.fetchAll())
+          .where(
+            (metadata) =>
+                metadata.provenance == WalletProvenance.defaultSeed ||
+                metadata.provenance == WalletProvenance.importedMnemonic,
+          )
+          .map(
+            (metadata) => SeedDerivedWalletRecoveryFact(
+              walletId: metadata.id,
+              seedFingerprint: Fingerprint(metadata.masterFingerprint),
+              network: metadata.network,
+              scriptType: metadata.scriptType,
+              provenance: metadata.provenance,
+              derivationPath: _recoveryPath(metadata),
+              seedPassphraseUsed: metadata.seedPassphraseUsed,
+            ),
+          )
+          .toList(growable: false);
+
+  Future<Set<String>> getLocallyKeyedWalletIds() async => {
+    for (final metadata in await _walletMetadataDatasource.fetchAll())
+      if (metadata.provenance.recoverableFromSeed ||
+          metadata.provenance == WalletProvenance.importedMnemonic)
+        metadata.id,
+  };
+
+  Future<bool> matchesSeedDerivedRecoveryIdentity({
+    required String walletId,
+    required String seedFingerprint,
+    required Network network,
+    required ScriptType scriptType,
+    required WalletProvenance provenance,
+    required String derivationPath,
+    required bool? seedPassphraseUsed,
+  }) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+    if (metadata == null) return false;
+    final actualPath = _recoveryPath(metadata);
+    return metadata.masterFingerprint.toLowerCase() ==
+            seedFingerprint.toLowerCase() &&
+        metadata.network == network &&
+        metadata.scriptType == scriptType &&
+        metadata.provenance == provenance &&
+        metadata.seedPassphraseUsed == seedPassphraseUsed &&
+        metadata.isDefault == (provenance == WalletProvenance.defaultSeed) &&
+        actualPath == derivationPath;
+  }
+
   Future<void> updateEncryptedBackupTime({
     required DateTime? time,
     required String walletId,
@@ -581,4 +637,12 @@ class WalletRepository {
       );
     }
   }
+}
+
+String _recoveryPath(WalletMetadataModel metadata) {
+  final origin = metadata.decodeOrigin;
+  final account = origin.account.endsWith('h')
+      ? "${origin.account.substring(0, origin.account.length - 1)}'"
+      : origin.account;
+  return "m/${origin.script.purpose}'/${origin.network.coinType}'/$account";
 }

--- a/lib/core/wallet/data/repositories/wallet_utxo_repository_impl.dart
+++ b/lib/core/wallet/data/repositories/wallet_utxo_repository_impl.dart
@@ -6,6 +6,7 @@ import 'package:bb_mobile/core/wallet/data/mappers/wallet_utxo_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
@@ -25,6 +26,9 @@ class WalletUtxoRepositoryImpl implements WalletUtxoRepository {
     required this._lwkWalletDatasource,
     required this._frozenWalletUtxoDatasource,
   });
+
+  @override
+  Stream<void> get freezeChanges => _frozenWalletUtxoDatasource.changes;
 
   @override
   Future<List<WalletUtxo>> getWalletUtxos({required String walletId}) async {
@@ -129,5 +133,36 @@ class WalletUtxoRepositoryImpl implements WalletUtxoRepository {
   Future<List<Outpoint>> getAllFrozenOutpoints() async {
     final rows = await _frozenWalletUtxoDatasource.getAllFrozen();
     return rows.map((row) => (txId: row.txId, vout: row.vout)).toList();
+  }
+
+  @override
+  Future<List<FrozenWalletOutpoint>> getAllFrozenWalletOutpoints() async {
+    final rows = await _frozenWalletUtxoDatasource.getAllFrozen();
+    return rows
+        .map(
+          (row) => FrozenWalletOutpoint(
+            walletId: row.walletId,
+            txId: row.txId,
+            vout: row.vout,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  @override
+  Future<void> restoreFrozenWalletOutpoints(
+    List<FrozenWalletOutpoint> outpoints,
+  ) {
+    return _frozenWalletUtxoDatasource.restoreFrozenWalletOutpoints(
+      outpoints
+          .map(
+            (outpoint) => (
+              walletId: outpoint.walletId,
+              txId: outpoint.txId,
+              vout: outpoint.vout,
+            ),
+          )
+          .toList(growable: false),
+    );
   }
 }

--- a/lib/core/wallet/data/wallet_preferences_repository_impl.dart
+++ b/lib/core/wallet/data/wallet_preferences_repository_impl.dart
@@ -1,0 +1,98 @@
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_preferences_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_preferences_failure.dart';
+import 'package:meta/meta.dart';
+
+final class WalletPreferencesRepositoryImpl
+    implements WalletPreferencesRepository {
+  final WalletMetadataDatasource _metadata;
+
+  const WalletPreferencesRepositoryImpl(this._metadata);
+
+  @override
+  Stream<void> get changes => _metadata.preferenceChanges;
+
+  @override
+  @useResult
+  Future<Result<List<WalletPreferences>, WalletPreferencesFailure>>
+  fetchAll() async {
+    try {
+      final metadata = await _metadata.fetchAll();
+      if (metadata.any((wallet) => wallet.id.isEmpty)) {
+        return _preferencesStorageFailure('read', StackTrace.current);
+      }
+      return Ok(
+        List.unmodifiable(
+          metadata.map(
+            (wallet) => WalletPreferences(
+              walletRef: wallet.id,
+              label: wallet.label,
+              hideOnHome: wallet.hideOnHome,
+              autoSweepEnabled: wallet.autoSweepEnabled,
+            ),
+          ),
+        ),
+      );
+    } on Exception catch (_, st) {
+      return _preferencesStorageFailure('read', st);
+    }
+  }
+
+  @override
+  @useResult
+  Future<Result<WalletPreferencesRecoveryApplyResult, WalletPreferencesFailure>>
+  applyRecovered(List<WalletPreferencesRecoveryUpdate> updates) async {
+    try {
+      final byWalletRef = <String, WalletPreferencesRecoveryUpdate>{};
+      for (final update in updates) {
+        if (!update.recovered.hasRepresentedValue ||
+            byWalletRef.containsKey(update.recovered.walletRef)) {
+          throw const FormatException(
+            'Recovered wallet preferences are invalid',
+          );
+        }
+        byWalletRef[update.recovered.walletRef] = update;
+      }
+      final conflicts = await _metadata.storeRecoveredPreferencesConditionally(
+        updates
+            .map(
+              (update) => WalletMetadataPreferenceRecoveryUpdate(
+                walletRef: update.recovered.walletRef,
+                expectedLabel: update.expected.label,
+                expectedHideOnHome: update.expected.hideOnHome,
+                expectedAutoSweepEnabled: update.expected.autoSweepEnabled,
+                recoveredLabel: update.recovered.label,
+                recoveredHideOnHome: update.recovered.hideOnHome,
+                recoveredAutoSweepEnabled: update.recovered.autoSweepEnabled,
+              ),
+            )
+            .toList(growable: false),
+      );
+      return Ok(
+        WalletPreferencesRecoveryApplyResult(
+          appliedWalletRefs: byWalletRef.keys.toSet()..removeAll(conflicts),
+          conflictedWalletRefs: conflicts,
+        ),
+      );
+    } on Exception catch (_, st) {
+      return _preferencesStorageFailure('restore', st);
+    }
+  }
+}
+
+Result<T, WalletPreferencesFailure> _preferencesStorageFailure<T>(
+  String operation,
+  StackTrace stack,
+) {
+  // Wallet metadata is private; neither row values nor raw mapper/storage
+  // exceptions are attached to logs.
+  log.severe(
+    message: 'Failed to $operation wallet preferences',
+    error: StateError('Wallet preferences $operation failed'),
+    trace: stack,
+  );
+  return const Err(WalletPreferencesStorageFailure());
+}

--- a/lib/core/wallet/domain/entities/seed_derived_wallet_recovery_fact.dart
+++ b/lib/core/wallet/domain/entities/seed_derived_wallet_recovery_fact.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
+
+final class SeedDerivedWalletRecoveryFact {
+  final String walletId;
+  final Fingerprint seedFingerprint;
+  final Network network;
+  final ScriptType scriptType;
+  final WalletProvenance provenance;
+  final String derivationPath;
+  final bool? seedPassphraseUsed;
+
+  const SeedDerivedWalletRecoveryFact({
+    required this.walletId,
+    required this.seedFingerprint,
+    required this.network,
+    required this.scriptType,
+    required this.provenance,
+    required this.derivationPath,
+    required this.seedPassphraseUsed,
+  });
+}

--- a/lib/core/wallet/domain/repositories/wallet_definition_repository.dart
+++ b/lib/core/wallet/domain/repositories/wallet_definition_repository.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+
+abstract interface class WalletDefinitionRepository {
+  Stream<void> get catalogChanges;
+
+  Future<List<WalletDefinition>> getWalletDefinitions();
+
+  Future<WalletDefinitionRestoreResult> restoreWalletDefinition(
+    WalletDefinition definition,
+  );
+}

--- a/lib/core/wallet/domain/repositories/wallet_preferences_repository.dart
+++ b/lib/core/wallet/domain/repositories/wallet_preferences_repository.dart
@@ -1,0 +1,15 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_preferences_failure.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class WalletPreferencesRepository {
+  Stream<void> get changes;
+
+  @useResult
+  Future<Result<List<WalletPreferences>, WalletPreferencesFailure>> fetchAll();
+
+  @useResult
+  Future<Result<WalletPreferencesRecoveryApplyResult, WalletPreferencesFailure>>
+  applyRecovered(List<WalletPreferencesRecoveryUpdate> updates);
+}

--- a/lib/core/wallet/domain/repositories/wallet_utxo_repository.dart
+++ b/lib/core/wallet/domain/repositories/wallet_utxo_repository.dart
@@ -1,7 +1,10 @@
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 
 abstract interface class WalletUtxoRepository {
+  Stream<void> get freezeChanges;
+
   Future<List<WalletUtxo>> getWalletUtxos({required String walletId});
 
   /// Freezes the given outpoints, attributed to [walletId] (the wallet origin).
@@ -27,4 +30,16 @@ abstract interface class WalletUtxoRepository {
   /// `walletId` (the wallet origin) is kept only for BIP329 export attribution,
   /// never for exclusion.
   Future<List<Outpoint>> getAllFrozenOutpoints();
+
+  /// Returns every persisted freeze with its exact wallet attribution.
+  ///
+  /// Unlike [getAllFrozenOutpoints], this preserves an empty wallet id used by
+  /// imported, unattributed freezes. Backup/export callers must not infer a
+  /// wallet from the outpoint or reduce the id to a BIP329 origin.
+  Future<List<FrozenWalletOutpoint>> getAllFrozenWalletOutpoints();
+
+  /// Atomically upserts exact wallet-attributed freezes during recovery.
+  Future<void> restoreFrozenWalletOutpoints(
+    List<FrozenWalletOutpoint> outpoints,
+  );
 }

--- a/lib/core/wallet/domain/usecases/apply_recovered_wallet_preferences_usecase.dart
+++ b/lib/core/wallet/domain/usecases/apply_recovered_wallet_preferences_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_preferences_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_preferences_failure.dart';
+import 'package:meta/meta.dart';
+
+final class ApplyRecoveredWalletPreferencesUsecase {
+  final WalletPreferencesRepository _repository;
+
+  const ApplyRecoveredWalletPreferencesUsecase(this._repository);
+
+  @useResult
+  Future<Result<WalletPreferencesRecoveryApplyResult, WalletPreferencesFailure>>
+  execute(List<WalletPreferencesRecoveryUpdate> updates) {
+    return _repository.applyRecovered(updates);
+  }
+}

--- a/lib/core/wallet/domain/usecases/get_frozen_wallet_outpoints_usecase.dart
+++ b/lib/core/wallet/domain/usecases/get_frozen_wallet_outpoints_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+
+final class GetFrozenWalletOutpointsUsecase {
+  final WalletUtxoRepository _repository;
+
+  const GetFrozenWalletOutpointsUsecase(this._repository);
+
+  Future<List<FrozenWalletOutpoint>> execute() {
+    return _repository.getAllFrozenWalletOutpoints();
+  }
+}

--- a/lib/core/wallet/domain/usecases/get_wallet_definitions_usecase.dart
+++ b/lib/core/wallet/domain/usecases/get_wallet_definitions_usecase.dart
@@ -1,0 +1,10 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_definition_repository.dart';
+
+final class GetWalletDefinitionsUsecase {
+  final WalletDefinitionRepository _wallet;
+
+  const GetWalletDefinitionsUsecase(this._wallet);
+
+  Future<List<WalletDefinition>> execute() => _wallet.getWalletDefinitions();
+}

--- a/lib/core/wallet/domain/usecases/get_wallet_preferences_usecase.dart
+++ b/lib/core/wallet/domain/usecases/get_wallet_preferences_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_preferences_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_preferences_failure.dart';
+import 'package:meta/meta.dart';
+
+final class GetWalletPreferencesUsecase {
+  final WalletPreferencesRepository _repository;
+
+  const GetWalletPreferencesUsecase(this._repository);
+
+  @useResult
+  Future<Result<List<WalletPreferences>, WalletPreferencesFailure>> execute() {
+    return _repository.fetchAll();
+  }
+}

--- a/lib/core/wallet/domain/usecases/restore_frozen_wallet_outpoints_usecase.dart
+++ b/lib/core/wallet/domain/usecases/restore_frozen_wallet_outpoints_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+
+final class RestoreFrozenWalletOutpointsUsecase {
+  final WalletUtxoRepository _repository;
+
+  const RestoreFrozenWalletOutpointsUsecase(this._repository);
+
+  Future<void> execute(List<FrozenWalletOutpoint> outpoints) {
+    return _repository.restoreFrozenWalletOutpoints(outpoints);
+  }
+}

--- a/lib/core/wallet/domain/usecases/restore_wallet_definition_usecase.dart
+++ b/lib/core/wallet/domain/usecases/restore_wallet_definition_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_definition_repository.dart';
+
+final class RestoreWalletDefinitionUsecase {
+  final WalletDefinitionRepository _wallet;
+
+  const RestoreWalletDefinitionUsecase(this._wallet);
+
+  Future<WalletDefinitionRestoreResult> execute(WalletDefinition definition) =>
+      _wallet.restoreWalletDefinition(definition);
+}

--- a/lib/core/wallet/domain/usecases/watch_wallet_catalog_changes_usecase.dart
+++ b/lib/core/wallet/domain/usecases/watch_wallet_catalog_changes_usecase.dart
@@ -1,0 +1,9 @@
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_definition_repository.dart';
+
+final class WatchWalletCatalogChangesUsecase {
+  final WalletDefinitionRepository _wallet;
+
+  const WatchWalletCatalogChangesUsecase(this._wallet);
+
+  Stream<void> execute() => _wallet.catalogChanges;
+}

--- a/lib/core/wallet/domain/usecases/watch_wallet_preference_changes_usecase.dart
+++ b/lib/core/wallet/domain/usecases/watch_wallet_preference_changes_usecase.dart
@@ -1,0 +1,9 @@
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_preferences_repository.dart';
+
+final class WatchWalletPreferenceChangesUsecase {
+  final WalletPreferencesRepository _repository;
+
+  const WatchWalletPreferenceChangesUsecase(this._repository);
+
+  Stream<void> execute() => _repository.changes;
+}

--- a/lib/core/wallet/domain/usecases/watch_wallet_utxo_freeze_changes_usecase.dart
+++ b/lib/core/wallet/domain/usecases/watch_wallet_utxo_freeze_changes_usecase.dart
@@ -1,0 +1,9 @@
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+
+final class WatchWalletUtxoFreezeChangesUsecase {
+  final WalletUtxoRepository _repository;
+
+  const WatchWalletUtxoFreezeChangesUsecase(this._repository);
+
+  Stream<void> execute() => _repository.freezeChanges;
+}

--- a/lib/features/labels/application/usecases/import_labels_usecase.dart
+++ b/lib/features/labels/application/usecases/import_labels_usecase.dart
@@ -4,16 +4,19 @@ import 'package:bb_mobile/features/labels/application/labels_converter_port.dart
 import 'package:bb_mobile/features/labels/application/labels_repository_port.dart';
 import 'package:bb_mobile/features/labels/application/wallet_freeze_port.dart';
 import 'package:bb_mobile/features/labels/domain/formatted_labels.dart';
+import 'package:bb_mobile/features/labels/label_change_notifier.dart';
 
 class ImportLabelsUsecase {
   final LabelsRepositoryPort _labelRepository;
   final LabelsConverterPort _labelConverter;
   final WalletFreezePort _walletFreeze;
+  final LabelChangeNotifier _changeNotifier;
 
   ImportLabelsUsecase({
     required this._labelRepository,
     required this._labelConverter,
     required this._walletFreeze,
+    required this._changeNotifier,
   });
 
   Future<int> call(FormattedLabels labels, {bool importFreezes = false}) async {
@@ -24,6 +27,7 @@ class ImportLabelsUsecase {
       // `spendable: false` adopted here becomes a durable freeze the user owns;
       // matched by outpoint, so it applies to whichever wallet holds the coin.
       if (importFreezes) await _freezeOwnedOnly(decoded.frozen);
+      if (decoded.labels.isNotEmpty) _changeNotifier.notify();
       return decoded.labels.length;
     } catch (e) {
       log.severe(error: e, trace: StackTrace.current);

--- a/lib/features/labels/label_change_notifier.dart
+++ b/lib/features/labels/label_change_notifier.dart
@@ -1,0 +1,9 @@
+import 'dart:async';
+
+final class LabelChangeNotifier {
+  final _controller = StreamController<void>.broadcast(sync: true);
+
+  Stream<void> get changes => _controller.stream;
+
+  void notify() => _controller.add(null);
+}

--- a/lib/features/labels/labels_facade.dart
+++ b/lib/features/labels/labels_facade.dart
@@ -6,9 +6,12 @@ import 'package:bb_mobile/features/labels/application/usecases/fetch_all_labels_
 import 'package:bb_mobile/features/labels/application/usecases/fetch_label_by_reference_usecase.dart';
 import 'package:bb_mobile/features/labels/application/usecases/store_labels_usecase.dart';
 import 'package:bb_mobile/features/labels/domain/label_failure.dart';
+import 'package:bb_mobile/features/labels/domain/label_entity.dart';
 import 'package:bb_mobile/features/labels/domain/primitive/label_type.dart';
+import 'package:bb_mobile/features/labels/label_change_notifier.dart';
 import 'package:bb_mobile/features/labels/new_label.dart';
 import 'package:bb_mobile/features/labels/label.dart';
+import 'package:meta/meta.dart';
 
 export 'package:bb_mobile/features/labels/label.dart';
 export 'package:bb_mobile/features/labels/new_label.dart';
@@ -35,13 +38,17 @@ class LabelsFacade {
   final FetchAllLabelsUsecase _fetchAllLabelsUsecase;
   final StoreLabelUsecase _storeLabelsUsecase;
   final TrashLabelUsecase _trashLabelUsecase;
+  final LabelChangeNotifier _changeNotifier;
 
   LabelsFacade({
     required this._fetchLabelByReferenceUsecase,
     required this._fetchAllLabelsUsecase,
     required this._storeLabelsUsecase,
     required this._trashLabelUsecase,
+    required this._changeNotifier,
   });
+
+  Stream<void> get changes => _changeNotifier.changes;
 
   Future<List<Label>> fetchByReference(String reference) async {
     final result = await _fetchLabelByReferenceUsecase.execute(reference);
@@ -63,6 +70,31 @@ class LabelsFacade {
           .toList(),
       (_) => const <Label>[],
     );
+  }
+
+  @useResult
+  Future<Result<List<Label>, LabelFailure>> fetchAllStrict() async {
+    final result = await _fetchAllLabelsUsecase.execute();
+    return result.map(
+      (labels) => labels
+          .map(LabelMapper.applicationLabelToLabel)
+          .toList(growable: false),
+    );
+  }
+
+  bool isValid(NewLabel label) {
+    try {
+      LabelEntity(
+        id: 0,
+        type: label.type,
+        label: label.label,
+        reference: label.reference,
+        origin: label.origin,
+      );
+      return true;
+    } on LabelValidationException {
+      return false;
+    }
   }
 
   /// Distinct user-defined label strings used to feed the suggestion chips
@@ -89,9 +121,15 @@ class LabelsFacade {
         origin: label.origin,
       ),
     );
-    return result.map((stored) => LabelMapper.applicationLabelToLabel(stored));
+    return result.map((stored) {
+      _changeNotifier.notify();
+      return LabelMapper.applicationLabelToLabel(stored);
+    });
   }
 
-  Future<Result<Null, LabelFailure>> trash(int id) =>
-      _trashLabelUsecase.execute(id);
+  Future<Result<Null, LabelFailure>> trash(int id) async {
+    final result = await _trashLabelUsecase.execute(id);
+    if (result case Ok()) _changeNotifier.notify();
+    return result;
+  }
 }

--- a/lib/features/labels/locator.dart
+++ b/lib/features/labels/locator.dart
@@ -15,12 +15,14 @@ import 'package:bb_mobile/features/labels/application/usecases/fetch_label_by_re
 import 'package:bb_mobile/features/labels/application/usecases/import_labels_usecase.dart';
 import 'package:bb_mobile/features/labels/domain/label_format.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/labels/label_change_notifier.dart';
 import 'package:bb_mobile/core/storage/storage.dart';
 import 'package:bb_mobile/features/labels/frameworks/bip329_codec.dart';
 import 'package:get_it/get_it.dart';
 
 class LabelsLocator {
   static void registerPorts(GetIt locator) {
+    locator.registerLazySingleton(LabelChangeNotifier.new);
     locator.registerLazySingleton<LabelsRepositoryPort>(
       () => DriftLabelsRepositoryAdapter(database: locator<SqliteDatabase>()),
     );
@@ -62,6 +64,7 @@ class LabelsLocator {
         labelRepository: locator<LabelsRepositoryPort>(),
         labelConverter: locator<LabelsConverterPort>(),
         walletFreeze: locator<WalletFreezePort>(),
+        changeNotifier: locator<LabelChangeNotifier>(),
       ),
     );
 
@@ -89,6 +92,7 @@ class LabelsLocator {
         fetchAllLabelsUsecase: locator<FetchAllLabelsUsecase>(),
         storeLabelsUsecase: locator<StoreLabelUsecase>(),
         trashLabelUsecase: locator<TrashLabelUsecase>(),
+        changeNotifier: locator<LabelChangeNotifier>(),
       ),
     );
   }

--- a/lib/features/wallet_backup/data/drift_wallet_backup_state_repository.dart
+++ b/lib/features/wallet_backup/data/drift_wallet_backup_state_repository.dart
@@ -1,0 +1,339 @@
+import 'package:bb_mobile/core/storage/backup_revision_recorder.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+final class DriftWalletBackupStateRepository
+    implements WalletBackupStateRepository {
+  static const _id = 1;
+
+  final SqliteDatabase _database;
+  final BackupRevisionRecorder _revisions;
+
+  DriftWalletBackupStateRepository(this._database)
+    : _revisions = DriftBackupRevisionRecorder(_database);
+
+  @override
+  @useResult
+  Future<Result<WalletBackupState, WalletBackupFailure>> get() {
+    return _read('load', () async {
+      await _ensureRow();
+      final row = await (_database.select(
+        _database.walletBackupStates,
+      )..where((table) => table.id.equals(_id))).getSingle();
+      return _map(row);
+    });
+  }
+
+  @override
+  @useResult
+  Stream<Result<WalletBackupState, WalletBackupFailure>> watch() async* {
+    try {
+      await _ensureRow();
+      final rows = (_database.select(
+        _database.walletBackupStates,
+      )..where((table) => table.id.equals(_id))).watchSingle();
+      await for (final row in rows) {
+        yield Ok(_map(row));
+      }
+    } on Exception catch (error, trace) {
+      _logStorageFailure('watch', error, trace);
+      yield Err(_storageFailure('watch', error));
+    }
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setEnabled(bool enabled) {
+    return _write('set enabled', () async {
+      await _database.transaction(() async {
+        final current = await _current();
+        if (!enabled || current.enabled) {
+          await _update(WalletBackupStatesCompanion(enabled: Value(enabled)));
+          return;
+        }
+        // Turning automatic backup on is itself a reason to publish, so the
+        // first pass has something to acknowledge.
+        await _update(const WalletBackupStatesCompanion(enabled: Value(true)));
+        await _revisions.recordCommittedMutation();
+      });
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<int, WalletBackupFailure>> recordLocalMutation() {
+    return _read('record local mutation', () async {
+      return _database.transaction(() async {
+        await _ensureRow();
+        await _revisions.recordCommittedMutation();
+        return (await _current()).localRevision;
+      });
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> recordPublication({
+    required int publishedRevision,
+    required int succeededAt,
+    required WalletBackupRemoteCheckpoint checkpoint,
+  }) {
+    if (publishedRevision < 0) {
+      throw ArgumentError.value(
+        publishedRevision,
+        'publishedRevision',
+        'published revision must be non-negative',
+      );
+    }
+    if (succeededAt < 0) {
+      throw ArgumentError.value(
+        succeededAt,
+        'succeededAt',
+        'wallet backup success timestamp must be non-negative',
+      );
+    }
+    return _write('record publication', () async {
+      await _database.transaction(() async {
+        final current = await _current();
+        if (publishedRevision > current.localRevision) {
+          throw StateError(
+            'published wallet backup revision exceeds the local revision',
+          );
+        }
+        await _update(
+          WalletBackupStatesCompanion(
+            uploadedRevision: Value(
+              publishedRevision > current.uploadedRevision
+                  ? publishedRevision
+                  : current.uploadedRevision,
+            ),
+            lastSucceededAt: Value(succeededAt),
+            unsupportedVersion: const Value(null),
+            remoteGeneration: Value(checkpoint.generation),
+            remoteEtag: Value(checkpoint.etag),
+            remoteCiphertextHash: Value(checkpoint.ciphertextSha256),
+          ),
+        );
+      });
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> blockUnsupportedVersion(
+    int version,
+  ) {
+    if (version <= WalletBackupSnapshot.currentVersion) {
+      throw ArgumentError.value(
+        version,
+        'version',
+        'blocked wallet backup version must be newer than this client',
+      );
+    }
+    return _write('block unsupported version', () async {
+      await _ensureRow();
+      await _update(
+        WalletBackupStatesCompanion(unsupportedVersion: Value(version)),
+      );
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setRecoveryState(
+    WalletBackupRecoveryState state,
+  ) {
+    return _write('set recovery state', () async {
+      await _ensureRow();
+      await _update(
+        WalletBackupStatesCompanion(recoveryState: Value(state.name)),
+      );
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> saveRemoteCheckpoint(
+    WalletBackupRemoteCheckpoint? checkpoint,
+  ) {
+    return _write('save remote checkpoint', () async {
+      await _ensureRow();
+      await _update(
+        WalletBackupStatesCompanion(
+          remoteGeneration: Value(checkpoint?.generation),
+          remoteEtag: Value(checkpoint?.etag),
+          remoteCiphertextHash: Value(checkpoint?.ciphertextSha256),
+        ),
+      );
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> clearRemoteCheckpoint() {
+    return _write('clear remote checkpoint', () async {
+      await _ensureRow();
+      await _update(
+        const WalletBackupStatesCompanion(
+          lastSucceededAt: Value(null),
+          lastRecoveryStatus: Value(null),
+          unsupportedVersion: Value(null),
+          recoveryState: Value('idle'),
+          remoteGeneration: Value(null),
+          remoteEtag: Value(null),
+          remoteCiphertextHash: Value(null),
+        ),
+      );
+    });
+  }
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> saveRecoveryOutcome(
+    WalletBackupRecoveryStatus status,
+  ) => _write('save recovery outcome', () async {
+    await _ensureRow();
+    await _update(
+      WalletBackupStatesCompanion(lastRecoveryStatus: Value(status.name)),
+    );
+  });
+
+  @override
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setServerUrl(String? serverUrl) {
+    return _write('set server URL', () async {
+      await _database.transaction(() async {
+        final current = await _current();
+        if (current.serverUrl == serverUrl) return;
+        await _update(
+          WalletBackupStatesCompanion(
+            serverUrl: Value(serverUrl),
+            lastSucceededAt: const Value(null),
+            lastRecoveryStatus: const Value(null),
+            unsupportedVersion: const Value(null),
+            recoveryState: const Value('idle'),
+            remoteGeneration: const Value(null),
+            remoteEtag: const Value(null),
+            remoteCiphertextHash: const Value(null),
+          ),
+        );
+        // Another origin holds nothing this installation has published, so
+        // everything local is unacknowledged again.
+        await _revisions.recordCommittedMutation();
+      });
+    });
+  }
+
+  Future<void> _ensureRow() async {
+    await _database
+        .into(_database.walletBackupStates)
+        .insert(
+          WalletBackupStatesCompanion.insert(id: const Value(_id)),
+          mode: InsertMode.insertOrIgnore,
+        );
+  }
+
+  Future<WalletBackupStateRow> _current() async {
+    await _ensureRow();
+    return (_database.select(
+      _database.walletBackupStates,
+    )..where((row) => row.id.equals(_id))).getSingle();
+  }
+
+  Future<void> _update(WalletBackupStatesCompanion values) => (_database.update(
+    _database.walletBackupStates,
+  )..where((row) => row.id.equals(_id))).write(values);
+
+  WalletBackupState _map(WalletBackupStateRow row) {
+    return WalletBackupState(
+      enabled: row.enabled,
+      localRevision: row.localRevision,
+      uploadedRevision: row.uploadedRevision > row.localRevision
+          ? row.localRevision
+          : row.uploadedRevision,
+      lastSucceededAt: row.lastSucceededAt,
+      unsupportedVersion: row.unsupportedVersion,
+      recoveryState: _recoveryState(row.recoveryState),
+      lastRecoveryStatus: WalletBackupRecoveryStatus.values
+          .where((value) => value.name == row.lastRecoveryStatus)
+          .firstOrNull,
+      customServerUrl: row.serverUrl,
+      remoteCheckpoint: _checkpoint(row),
+    );
+  }
+
+  /// An unreadable fence value is read as needing attention rather than as
+  /// idle, so a corrupt row can never release publication on its own.
+  WalletBackupRecoveryState _recoveryState(String stored) =>
+      WalletBackupRecoveryState.values
+          .where((value) => value.name == stored)
+          .firstOrNull ??
+      WalletBackupRecoveryState.needsAttention;
+
+  /// A checkpoint is trusted only when the generation and ETag agree; a torn
+  /// pair is read as no checkpoint, so publication falls back to a fetch.
+  WalletBackupRemoteCheckpoint? _checkpoint(WalletBackupStateRow row) {
+    final generation = row.remoteGeneration;
+    final etag = row.remoteEtag;
+    if (generation == null || etag == null) return null;
+    try {
+      return WalletBackupRemoteCheckpoint(
+        generation: generation,
+        etag: etag,
+        ciphertextSha256: row.remoteCiphertextHash,
+      );
+    } on ArgumentError catch (error, trace) {
+      log.warning(
+        'Discarding an invalid stored wallet backup checkpoint',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return null;
+    }
+  }
+
+  Future<Result<T, WalletBackupFailure>> _read<T>(
+    String operation,
+    Future<T> Function() action,
+  ) async {
+    try {
+      return Ok(await action());
+    } on Exception catch (error, trace) {
+      _logStorageFailure(operation, error, trace);
+      return Err(_storageFailure(operation, error));
+    }
+  }
+
+  Future<Result<void, WalletBackupFailure>> _write(
+    String operation,
+    Future<void> Function() action,
+  ) async {
+    try {
+      await action();
+      return const Ok(null);
+    } on Exception catch (error, trace) {
+      _logStorageFailure(operation, error, trace);
+      return Err(_storageFailure(operation, error));
+    }
+  }
+}
+
+WalletBackupStorageFailure _storageFailure(String operation, Object error) =>
+    WalletBackupStorageFailure('$operation failed: ${error.runtimeType}');
+
+void _logStorageFailure(String operation, Object error, StackTrace trace) {
+  log.warning(
+    'Wallet backup state storage operation failed: $operation',
+    error: error.runtimeType,
+    trace: trace,
+  );
+}

--- a/lib/features/wallet_backup/data/metadata_backup_http_repository.dart
+++ b/lib/features/wallet_backup/data/metadata_backup_http_repository.dart
@@ -1,0 +1,357 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_server_config.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+
+const walletBackupConnectTimeout = Duration(seconds: 10);
+const walletBackupReceiveTimeout = Duration(seconds: 15);
+
+final class MetadataBackupHttpRepository
+    implements WalletBackupRemoteRepository {
+  final Dio _dio;
+  final WalletBackupOriginProvider _origin;
+  final DateTime Function() _now;
+  DateTime? _notBefore;
+
+  MetadataBackupHttpRepository(
+    this._dio,
+    this._origin, {
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  factory MetadataBackupHttpRepository.defaults({
+    WalletBackupOriginProvider origin = defaultWalletBackupOrigin,
+  }) => MetadataBackupHttpRepository(
+    Dio(
+      BaseOptions(
+        connectTimeout: walletBackupConnectTimeout,
+        receiveTimeout: walletBackupReceiveTimeout,
+      ),
+    ),
+    origin,
+  );
+
+  @override
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> fetch({
+    required WalletBackupAuthentication authentication,
+  }) async {
+    final result = await _request(
+      method: 'POST',
+      path: '/api/v1/wallet-backups/fetch',
+      body: {
+        'version': walletBackupProtocolVersion,
+        'stream': walletBackupStream,
+        ..._authenticationBody(authentication),
+      },
+    );
+    return switch (result) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _decodeHead(value, authentication.publicKeyHex),
+    };
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> store({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint? current,
+    required WalletBackupCiphertext ciphertext,
+    required String ciphertextSha256,
+  }) async {
+    final generation = (current?.generation ?? 0) + 1;
+    final result = await _request(
+      method: 'PUT',
+      path: '/api/v1/wallet-backups',
+      body: {
+        'version': walletBackupProtocolVersion,
+        'stream': walletBackupStream,
+        'generation': generation,
+        'expected_etag': current?.etag,
+        'ciphertext': ciphertext.value,
+        'ciphertext_sha256': ciphertextSha256,
+        'ciphertext_bytes': ciphertext.byteLength,
+        ..._authenticationBody(authentication),
+      },
+    );
+    return switch (result) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _decodeReceipt(
+        value,
+        generation: generation,
+        expectedEtag: computeWalletBackupEtag(
+          publicKeyHex: authentication.publicKeyHex,
+          generation: generation,
+          ciphertextSha256: ciphertextSha256,
+        ),
+        ciphertextSha256: ciphertextSha256,
+      ),
+    };
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> delete({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint current,
+  }) async {
+    final generation = current.generation + 1;
+    final result = await _request(
+      method: 'DELETE',
+      path: '/api/v1/wallet-backups',
+      body: {
+        'version': walletBackupProtocolVersion,
+        'stream': walletBackupStream,
+        'generation': generation,
+        'expected_etag': current.etag,
+        ..._authenticationBody(authentication),
+      },
+    );
+    return switch (result) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _decodeReceipt(
+        value,
+        generation: generation,
+        expectedEtag: computeWalletBackupEtag(
+          publicKeyHex: authentication.publicKeyHex,
+          generation: generation,
+          ciphertextSha256: '',
+        ),
+        ciphertextSha256: null,
+      ),
+    };
+  }
+
+  Future<Result<Map<String, Object?>, WalletBackupFailure>> _request({
+    required String method,
+    required String path,
+    required Map<String, Object?> body,
+  }) async {
+    final notBefore = _notBefore;
+    if (notBefore != null) {
+      final remaining = notBefore.difference(_now().toUtc());
+      if (!remaining.isNegative && remaining != Duration.zero) {
+        return Err(WalletBackupRateLimitedFailure(remaining));
+      }
+    }
+    final Uri origin;
+    try {
+      origin = await _origin();
+    } on Exception {
+      return const Err(WalletBackupInvalidServerOriginFailure());
+    }
+    try {
+      final response = await _dio.requestUri<Object?>(
+        origin.resolve(path),
+        data: body,
+        options: Options(
+          method: method,
+          followRedirects: false,
+          responseType: ResponseType.json,
+          validateStatus: (status) => status != null && status < 600,
+        ),
+      );
+      return _handleResponse(response);
+    } on DioException catch (error, trace) {
+      if (error.response case final response?) {
+        return _handleResponse(response);
+      }
+      log.warning(
+        'Wallet backup network request failed',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(WalletBackupRemoteUnavailableFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Wallet backup request failed unexpectedly',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(WalletBackupUnexpectedFailure());
+    }
+  }
+
+  Result<Map<String, Object?>, WalletBackupFailure> _handleResponse(
+    Response<Object?> response,
+  ) {
+    final json = _object(response.data);
+    if (json == null) return const Err(WalletBackupInvalidRemoteFailure());
+    if (json['status'] == 'ERROR') {
+      return Err(
+        _decodeServerFailure(response.statusCode, response.headers, json),
+      );
+    }
+    final status = response.statusCode;
+    return status != null && status >= 200 && status < 300
+        ? Ok(json)
+        : const Err(WalletBackupInvalidRemoteFailure());
+  }
+
+  WalletBackupFailure _decodeServerFailure(
+    int? status,
+    Headers headers,
+    Map<String, Object?> json,
+  ) {
+    if (!_hasOnly(json, const {'status', 'code', 'reason'}) ||
+        json['code'] is! String ||
+        json['reason'] is! String) {
+      return const WalletBackupInvalidRemoteFailure();
+    }
+    final code = json['code'];
+    return switch ((status, code)) {
+      (400, 'BackupInvalidRequest') =>
+        const WalletBackupRemoteRejectedFailure(),
+      (401, 'BackupAuthError') => const WalletBackupSigningFailure(),
+      (409, 'BackupHeadConflict') => const WalletBackupHeadConflictFailure(),
+      (413, 'BackupBlobTooLarge') => const WalletBackupTooLargeFailure(),
+      (429, 'RateLimited') => _rateLimited(headers),
+      (503, 'BackupCapacityExceeded') =>
+        const WalletBackupRemoteUnavailableFailure(),
+      (500, 'InternalError') => const WalletBackupRemoteUnavailableFailure(),
+      _ => const WalletBackupInvalidRemoteFailure(),
+    };
+  }
+
+  WalletBackupFailure _rateLimited(Headers headers) {
+    final seconds = int.tryParse(headers.value('retry-after') ?? '');
+    if (seconds == null || seconds < 0) {
+      return const WalletBackupInvalidRemoteFailure();
+    }
+    final retryAfter = Duration(seconds: seconds);
+    _notBefore = _now().toUtc().add(retryAfter);
+    return WalletBackupRateLimitedFailure(retryAfter);
+  }
+
+  Result<WalletBackupRemoteHead, WalletBackupFailure> _decodeHead(
+    Map<String, Object?> json,
+    String publicKeyHex,
+  ) {
+    if (!_hasOnly(json, const {
+          'version',
+          'found',
+          'generation',
+          'etag',
+          'ciphertext',
+          'ciphertext_sha256',
+          'ciphertext_bytes',
+          'updated_at',
+        }) ||
+        json['version'] != walletBackupProtocolVersion ||
+        json['found'] is! bool ||
+        json['generation'] is! int ||
+        (json['generation'] as int) < 0 ||
+        (json['etag'] != null && json['etag'] is! String)) {
+      return const Err(WalletBackupInvalidRemoteFailure());
+    }
+    final found = json['found'] as bool;
+    final generation = json['generation'] as int;
+    final etag = json['etag'] as String?;
+    if (!found) {
+      final updatedAt = json['updated_at'];
+      final validTombstone =
+          generation > 0 &&
+          isWalletBackupHash(etag) &&
+          updatedAt is int &&
+          updatedAt >= 0 &&
+          etag ==
+              computeWalletBackupEtag(
+                publicKeyHex: publicKeyHex,
+                generation: generation,
+                ciphertextSha256: '',
+              );
+      final validAbsence = generation == 0 && etag == null && updatedAt == null;
+      if ((!validAbsence && !validTombstone) ||
+          json['ciphertext'] != null ||
+          json['ciphertext_sha256'] != null ||
+          json['ciphertext_bytes'] != null) {
+        return const Err(WalletBackupInvalidRemoteFailure());
+      }
+      return Ok(
+        WalletBackupRemoteHead.absent(generation: generation, etag: etag),
+      );
+    }
+    final ciphertextValue = json['ciphertext'];
+    final hash = json['ciphertext_sha256'];
+    final byteLength = json['ciphertext_bytes'];
+    final updatedAt = json['updated_at'];
+    if (generation <= 0 ||
+        !isWalletBackupHash(etag) ||
+        ciphertextValue is! String ||
+        hash is! String ||
+        !isWalletBackupHash(hash) ||
+        byteLength is! int ||
+        updatedAt is! int ||
+        updatedAt < 0) {
+      return const Err(WalletBackupInvalidRemoteFailure());
+    }
+    final ciphertext = WalletBackupCiphertext.tryParse(ciphertextValue);
+    if (ciphertext == null ||
+        ciphertext.byteLength != byteLength ||
+        sha256.convert(base64.decode(ciphertext.value)).toString() != hash ||
+        etag !=
+            computeWalletBackupEtag(
+              publicKeyHex: publicKeyHex,
+              generation: generation,
+              ciphertextSha256: hash,
+            )) {
+      return const Err(WalletBackupInvalidRemoteFailure());
+    }
+    return Ok(
+      WalletBackupRemoteHead.present(
+        generation: generation,
+        etag: etag!,
+        ciphertext: ciphertext,
+        ciphertextSha256: hash,
+      ),
+    );
+  }
+
+  Result<WalletBackupRemoteCheckpoint, WalletBackupFailure> _decodeReceipt(
+    Map<String, Object?> json, {
+    required int generation,
+    required String? expectedEtag,
+    required String? ciphertextSha256,
+  }) {
+    if (!_hasOnly(json, const {'version', 'generation', 'etag'}) ||
+        json['version'] != walletBackupProtocolVersion ||
+        json['generation'] != generation ||
+        expectedEtag == null ||
+        json['etag'] != expectedEtag) {
+      return const Err(WalletBackupInvalidRemoteFailure());
+    }
+    return Ok(
+      WalletBackupRemoteCheckpoint(
+        generation: generation,
+        etag: expectedEtag,
+        ciphertextSha256: ciphertextSha256,
+      ),
+    );
+  }
+}
+
+Map<String, Object?> _authenticationBody(
+  WalletBackupAuthentication authentication,
+) => {
+  'npub': authentication.publicKeyHex,
+  'timestamp': authentication.timestamp,
+  'signature': authentication.signatureHex,
+};
+
+Map<String, Object?>? _object(Object? value) {
+  if (value is! Map) return null;
+  final result = <String, Object?>{};
+  for (final entry in value.entries) {
+    if (entry.key is! String) return null;
+    result[entry.key as String] = entry.value;
+  }
+  return result;
+}
+
+bool _hasOnly(Map<String, Object?> json, Set<String> allowed) =>
+    json.keys.every(allowed.contains);

--- a/lib/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository.dart
+++ b/lib/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/data/models/wallet_backup_snapshot_model.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:convert/convert.dart';
+import 'package:primitives/primitives.dart' show Fingerprint;
+import 'package:recoverbull/recoverbull.dart';
+
+final class RecoverBullWalletBackupEncryptionRepository
+    implements WalletBackupEncryptionRepository {
+  final WalletBackupSnapshotCodec _codec;
+
+  const RecoverBullWalletBackupEncryptionRepository(this._codec);
+
+  @override
+  Result<Uint8List, WalletBackupFailure> encodeCanonical(
+    WalletBackupSnapshot envelope,
+  ) {
+    try {
+      return Ok(Uint8List.fromList(utf8.encode(_codec.encode(envelope))));
+    } on WalletBackupSnapshotCodecException catch (error, trace) {
+      return Err(_mapCodecFailure(error, trace));
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to encode wallet backup',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return Err(WalletBackupUnexpectedFailure(error.runtimeType.toString()));
+    }
+  }
+
+  @override
+  Result<WalletBackupSnapshot, WalletBackupFailure> decodeCanonical({
+    required Uint8List bytes,
+    required String expectedParentFingerprint,
+  }) => _decode(
+    () => const Utf8Decoder(allowMalformed: false).convert(bytes),
+    expectedParentFingerprint,
+    'decode',
+  );
+
+  @override
+  @useResult
+  Result<WalletBackupCiphertext, WalletBackupFailure> encrypt({
+    required WalletBackupSnapshot envelope,
+    required WalletBackupEncryptionKey key,
+  }) {
+    try {
+      final backup = RecoverBull.createBackup(
+        secret: utf8.encode(_codec.encode(envelope)),
+        backupKey: hex.decode(key.hex),
+      );
+      return Ok(WalletBackupCiphertext(base64.encode(backup.ciphertext)));
+    } on WalletBackupSnapshotCodecException catch (error, trace) {
+      return Err(_mapCodecFailure(error, trace));
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to encrypt wallet backup',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return Err(WalletBackupEncryptionFailure(error.runtimeType.toString()));
+    }
+  }
+
+  @override
+  @useResult
+  Result<WalletBackupSnapshot, WalletBackupFailure> decrypt({
+    required WalletBackupCiphertext ciphertext,
+    required WalletBackupEncryptionKey key,
+    required String expectedParentFingerprint,
+  }) => _decode(
+    () => utf8.decode(
+      RecoverBull.restoreBackup(
+        backup: BullBackup(
+          createdAt: 0,
+          id: const [],
+          ciphertext: base64.decode(ciphertext.value),
+          salt: const [],
+        ),
+        backupKey: hex.decode(key.hex),
+      ),
+    ),
+    expectedParentFingerprint,
+    'decrypt',
+  );
+
+  Result<WalletBackupSnapshot, WalletBackupFailure> _decode(
+    String Function() plaintext,
+    String expectedParentFingerprint,
+    String operation,
+  ) {
+    final fingerprint = Fingerprint.tryParse(expectedParentFingerprint);
+    if (fingerprint == null) {
+      return const Err(WalletBackupParentFingerprintMismatchFailure());
+    }
+    try {
+      return Ok(
+        _codec.decode(plaintext(), expectedParentFingerprint: fingerprint),
+      );
+    } on WalletBackupSnapshotCodecException catch (error, trace) {
+      return Err(_mapCodecFailure(error, trace));
+    } on FormatException catch (error, trace) {
+      log.warning(
+        'Wallet backup file is not UTF-8',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to $operation wallet backup',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return Err(
+        operation == 'decrypt'
+            ? WalletBackupEncryptionFailure(error.runtimeType.toString())
+            : WalletBackupUnexpectedFailure(error.runtimeType.toString()),
+      );
+    }
+  }
+}
+
+WalletBackupFailure _mapCodecFailure(
+  WalletBackupSnapshotCodecException error,
+  StackTrace trace,
+) {
+  log.warning(
+    'Wallet backup envelope validation failed',
+    error: error.reason.name,
+    trace: trace,
+  );
+  return switch (error.reason) {
+    WalletBackupSnapshotCodecFailureReason.unsupportedVersion =>
+      WalletBackupUnsupportedEnvelopeVersionFailure(error.version!),
+    WalletBackupSnapshotCodecFailureReason.parentFingerprintMismatch =>
+      const WalletBackupParentFingerprintMismatchFailure(),
+    WalletBackupSnapshotCodecFailureReason.tooLarge =>
+      const WalletBackupTooLargeFailure(),
+    WalletBackupSnapshotCodecFailureReason.manifestRejected =>
+      WalletBackupManifestFailure(error.detail),
+    WalletBackupSnapshotCodecFailureReason.malformed =>
+      WalletBackupInvalidEnvelopeFailure(error.reason.name),
+  };
+}

--- a/lib/features/wallet_backup/data/wallet_definitions_backup.dart
+++ b/lib/features/wallet_backup/data/wallet_definitions_backup.dart
@@ -1,0 +1,74 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+
+final class WalletDefinitionsBackupImpl implements WalletDefinitionsBackup {
+  final Future<List<WalletDefinition>> Function() _getDefinitions;
+  final Future<WalletDefinitionRestoreResult> Function(WalletDefinition)
+  _restoreDefinition;
+  final Stream<void> Function() _watchChanges;
+  final DateTime Function() _nowUtc;
+
+  const WalletDefinitionsBackupImpl(
+    this._getDefinitions,
+    this._restoreDefinition,
+    this._watchChanges, {
+    this._nowUtc = _systemNowUtc,
+  });
+
+  @override
+  Stream<void> get changes => _watchChanges();
+
+  @override
+  Future<Result<List<WalletDefinition>, WalletBackupFailure>> read() async {
+    try {
+      return Ok(
+        (await _getDefinitions())
+            .where((definition) => definition.network.isBitcoin)
+            .toList(growable: false),
+      );
+    } on Exception catch (error) {
+      return Err(WalletBackupDefinitionsFailure(error.runtimeType.toString()));
+    }
+  }
+
+  @override
+  Future<Result<WalletDefinitionsRecoveryResult, WalletBackupFailure>> recover({
+    required List<WalletDefinition> definitions,
+    DateTime? deadline,
+  }) async {
+    var restored = 0;
+    var failed = 0;
+    final created = <String>[];
+    for (var index = 0; index < definitions.length; index++) {
+      if (deadline != null && !_nowUtc().isBefore(deadline)) {
+        failed += definitions.length - index;
+        break;
+      }
+      try {
+        final result = await _restoreDefinition(definitions[index]);
+        switch (result.status) {
+          case WalletDefinitionRestoreStatus.created:
+            restored++;
+            created.add(result.walletRef);
+          case WalletDefinitionRestoreStatus.alreadyPresent:
+            restored++;
+          case WalletDefinitionRestoreStatus.conflict:
+            failed++;
+        }
+      } on Exception {
+        failed++;
+      }
+    }
+    return Ok(
+      WalletDefinitionsRecoveryResult(
+        restoredCount: restored,
+        failedCount: failed,
+        createdWalletRefs: created,
+      ),
+    );
+  }
+}
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();

--- a/lib/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart
+++ b/lib/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart
@@ -1,0 +1,37 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+/// The encode-then-encrypt and decrypt-then-decode boundary.
+///
+/// Callers hand over and receive typed snapshots; the canonical wire form only
+/// exists inside this repository.
+abstract interface class WalletBackupEncryptionRepository {
+  @useResult
+  Result<Uint8List, WalletBackupFailure> encodeCanonical(
+    WalletBackupSnapshot envelope,
+  );
+
+  @useResult
+  Result<WalletBackupSnapshot, WalletBackupFailure> decodeCanonical({
+    required Uint8List bytes,
+    required String expectedParentFingerprint,
+  });
+
+  @useResult
+  Result<WalletBackupCiphertext, WalletBackupFailure> encrypt({
+    required WalletBackupSnapshot envelope,
+    required WalletBackupEncryptionKey key,
+  });
+
+  @useResult
+  Result<WalletBackupSnapshot, WalletBackupFailure> decrypt({
+    required WalletBackupCiphertext ciphertext,
+    required WalletBackupEncryptionKey key,
+    required String expectedParentFingerprint,
+  });
+}

--- a/lib/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart
+++ b/lib/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart
@@ -1,0 +1,31 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class WalletBackupRemoteRepository {
+  @useResult
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> fetch({
+    required WalletBackupAuthentication authentication,
+  });
+
+  /// Conditionally stores [ciphertext] against [current], returning the head
+  /// the server acknowledged. [current] is null when nothing was ever stored.
+  @useResult
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> store({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint? current,
+    required WalletBackupCiphertext ciphertext,
+    required String ciphertextSha256,
+  });
+
+  /// Conditionally deletes the object at [current], returning the tombstone
+  /// head the server acknowledged.
+  @useResult
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> delete({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint current,
+  });
+}

--- a/lib/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart
+++ b/lib/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart
@@ -1,0 +1,60 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class WalletBackupStateRepository {
+  @useResult
+  Future<Result<WalletBackupState, WalletBackupFailure>> get();
+
+  @useResult
+  Stream<Result<WalletBackupState, WalletBackupFailure>> watch();
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setEnabled(bool enabled);
+
+  /// Records a backup-relevant local mutation whose owner could not record it
+  /// inside its own transaction, and answers the revision it produced.
+  @useResult
+  Future<Result<int, WalletBackupFailure>> recordLocalMutation();
+
+  /// Acknowledges [publishedRevision] as stored remotely. Anything committed
+  /// during the store keeps the backup dirty, because the local revision has
+  /// moved past what the server holds.
+  @useResult
+  Future<Result<void, WalletBackupFailure>> recordPublication({
+    required int publishedRevision,
+    required int succeededAt,
+    required WalletBackupRemoteCheckpoint checkpoint,
+  });
+
+  /// Records the head last fetched and authenticated, without claiming a
+  /// successful publication. Null clears the checkpoint.
+  @useResult
+  Future<Result<void, WalletBackupFailure>> saveRemoteCheckpoint(
+    WalletBackupRemoteCheckpoint? checkpoint,
+  );
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> blockUnsupportedVersion(
+    int version,
+  );
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setRecoveryState(
+    WalletBackupRecoveryState state,
+  );
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> clearRemoteCheckpoint();
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> saveRecoveryOutcome(
+    WalletBackupRecoveryStatus status,
+  );
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setServerUrl(String? serverUrl);
+}

--- a/lib/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart
@@ -1,0 +1,294 @@
+import 'dart:async';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef ValidateWalletBackupRecovery =
+    Future<Result<bool, WalletBackupFailure>> Function();
+typedef ValidateWalletMetadataSnapshot =
+    Result<void, WalletMetadataBackupFailure> Function(
+      WalletMetadataSnapshot snapshot,
+    );
+typedef RestoreWalletMetadataSnapshot =
+    Future<Result<bool, WalletMetadataBackupFailure>> Function({
+      required WalletMetadataSnapshot snapshot,
+      required Set<String> createdWalletRefs,
+      DateTime? deadline,
+    });
+
+/// The one path that writes a backup snapshot into local storage.
+///
+/// Remote recovery and file import both come through here, so there is a
+/// single durable fence rather than one per entry point (spec F21, 19.7).
+/// The fence is [WalletBackupState.recoveryState]: applying before the first
+/// local write, then idle on a complete, revalidated apply, or needs-attention
+/// on anything else. A process that dies mid-apply leaves applying behind,
+/// which reads as needing attention and refuses publication until the user
+/// resolves it.
+///
+/// Serialization is the job runner's business; nothing here takes a lock.
+final class ApplyBackupSnapshotUsecase {
+  static const defaultBudget = Duration(seconds: 60);
+
+  final WalletBackupStateRepository _state;
+  final WalletDefinitionsBackup _definitions;
+  final RestoreWalletBackupManifestUsecase _restoreManifest;
+  final ValidateWalletMetadataSnapshot _validateMetadata;
+  final RestoreWalletMetadataSnapshot _restoreMetadata;
+  final DateTime Function() _nowUtc;
+  final Duration _budget;
+
+  const ApplyBackupSnapshotUsecase(
+    this._state,
+    this._definitions, {
+    required this._restoreManifest,
+    required this._validateMetadata,
+    required this._restoreMetadata,
+    this._nowUtc = _systemNowUtc,
+    this._budget = defaultBudget,
+  });
+
+  /// Applies [snapshot] under the durable fence.
+  ///
+  /// [revalidate] proves the remote object did not change while the apply was
+  /// running. When [callerSettlesFence] is set the caller decides the final
+  /// fence value and records the outcome, because for a file import the apply
+  /// is only half of the operation.
+  Future<WalletBackupRecoveryResult> execute({
+    required Result<WalletBackupSnapshot?, WalletBackupFailure> snapshot,
+    ValidateWalletBackupRecovery? revalidate,
+    Set<String> defaultCreatedWalletIds = const {},
+    bool callerSettlesFence = false,
+    DateTime? deadline,
+  }) async {
+    final budget = deadline ?? _nowUtc().add(_budget);
+    late WalletBackupRecoveryResult result;
+    try {
+      result = switch (snapshot) {
+        Err(:final failure) => WalletBackupRecoveryResult.fromFailure(failure),
+        Ok(:final value) => await _apply(
+          snapshot: value,
+          revalidate: revalidate,
+          defaultCreatedWalletIds: defaultCreatedWalletIds,
+          deadline: budget,
+          settleFence: !callerSettlesFence,
+        ),
+      };
+    } on TimeoutException {
+      result = _result(WalletBackupRecoveryStatus.timedOut);
+    }
+    return callerSettlesFence ? result : _saveOutcome(result);
+  }
+
+  /// Records the outcome of a [callerSettlesFence] apply, and the fence value
+  /// the caller reached once it knew whether the whole operation succeeded.
+  ///
+  /// A null [fence] leaves the fence untouched, which is what a caller that
+  /// gave up before writing anything wants: it must not clear a block another
+  /// operation raised.
+  Future<WalletBackupRecoveryResult> settle(
+    WalletBackupRecoveryResult result, {
+    required WalletBackupRecoveryState? fence,
+  }) async {
+    if (fence != null) {
+      if (await _state.setRecoveryState(fence) case Err()) {
+        return _localFailure(result);
+      }
+    }
+    return _saveOutcome(result);
+  }
+
+  Future<WalletBackupRecoveryResult> _apply({
+    required WalletBackupSnapshot? snapshot,
+    required ValidateWalletBackupRecovery? revalidate,
+    required Set<String> defaultCreatedWalletIds,
+    required DateTime deadline,
+    required bool settleFence,
+  }) async {
+    if (snapshot != null) {
+      if (_validateSections(snapshot) case Err(:final failure)) {
+        return WalletBackupRecoveryResult.fromFailure(failure);
+      }
+    }
+    // Applying a foreign snapshot invalidates whatever this installation
+    // believed the remote head to be, so the next publication fetches it
+    // afresh. Raising the fence first keeps that off the race with a
+    // publication the runner may start the moment this job ends.
+    if (await _state.setRecoveryState(WalletBackupRecoveryState.applying)
+        case Err()) {
+      return _result(WalletBackupRecoveryStatus.localFailure);
+    }
+    if (await _state.saveRemoteCheckpoint(null) case Err()) {
+      return _result(WalletBackupRecoveryStatus.localFailure);
+    }
+    if (snapshot == null) {
+      return settleFence
+          ? _lower(_result(WalletBackupRecoveryStatus.noBackup))
+          : _result(WalletBackupRecoveryStatus.noBackup);
+    }
+    if (_expired(deadline)) {
+      return _result(WalletBackupRecoveryStatus.timedOut);
+    }
+
+    final restored = await _restoreManifest.execute(
+      snapshot.recoveryManifest,
+      deadline: deadline,
+    );
+    if (_expired(deadline)) {
+      return _result(WalletBackupRecoveryStatus.timedOut, restored: restored);
+    }
+
+    WalletDefinitionsRecoveryResult? definitionsRestored;
+    if (snapshot.externalWalletDefinitions.isNotEmpty) {
+      switch (await _definitions.recover(
+        definitions: snapshot.externalWalletDefinitions,
+        deadline: deadline,
+      )) {
+        case Ok(:final value):
+          definitionsRestored = value;
+        case Err():
+          return _result(
+            WalletBackupRecoveryStatus.invalid,
+            restored: restored,
+          );
+      }
+    }
+    if (_expired(deadline)) {
+      return _result(
+        WalletBackupRecoveryStatus.timedOut,
+        restored: restored,
+        definitions: definitionsRestored,
+      );
+    }
+
+    var metadataComplete = true;
+    if (snapshot.metadata case final metadata?) {
+      final metadataResult = await _restoreMetadata(
+        snapshot: metadata,
+        createdWalletRefs: {
+          ...defaultCreatedWalletIds,
+          ...?definitionsRestored?.createdWalletRefs,
+        },
+        deadline: deadline,
+      );
+      metadataComplete = switch (metadataResult) {
+        Ok(:final value) => value,
+        Err() => false,
+      };
+    }
+    if (_expired(deadline)) {
+      return _result(
+        WalletBackupRecoveryStatus.timedOut,
+        restored: restored,
+        definitions: definitionsRestored,
+      );
+    }
+
+    if (revalidate != null) {
+      switch (await revalidate()) {
+        case Ok(value: true):
+          break;
+        case Ok():
+          return _result(
+            WalletBackupRecoveryStatus.conflict,
+            restored: restored,
+            definitions: definitionsRestored,
+          );
+        case Err(:final failure):
+          return _result(
+            WalletBackupRecoveryResult.statusForFailure(failure),
+            restored: restored,
+            definitions: definitionsRestored,
+          );
+      }
+    }
+
+    final complete =
+        restored.failedCount == 0 &&
+        (definitionsRestored?.failedCount ?? 0) == 0 &&
+        metadataComplete;
+    final result = _result(
+      complete
+          ? WalletBackupRecoveryStatus.restored
+          : WalletBackupRecoveryStatus.partiallyRestored,
+      restored: restored,
+      definitions: definitionsRestored,
+    );
+    return complete && settleFence ? _lower(result) : result;
+  }
+
+  /// Lowers the fence after a complete apply. Anything short of complete keeps
+  /// it raised, which [_saveOutcome] then turns into needs-attention.
+  Future<WalletBackupRecoveryResult> _lower(
+    WalletBackupRecoveryResult result,
+  ) async =>
+      switch (await _state.setRecoveryState(WalletBackupRecoveryState.idle)) {
+        Ok() => result,
+        Err() => _localFailure(result),
+      };
+
+  Future<WalletBackupRecoveryResult> _saveOutcome(
+    WalletBackupRecoveryResult result,
+  ) async {
+    // An apply that got as far as raising the fence and then stopped must not
+    // be left in applying: that value means a run is in progress, and no run
+    // is.
+    if (await _state.get() case Ok(
+      value: WalletBackupState(
+        recoveryState: WalletBackupRecoveryState.applying,
+      ),
+    )) {
+      if (await _state.setRecoveryState(
+            WalletBackupRecoveryState.needsAttention,
+          )
+          case Err()) {
+        return _localFailure(result);
+      }
+    }
+    return switch (await _state.saveRecoveryOutcome(result.status)) {
+      Err() => _localFailure(result),
+      Ok() => result,
+    };
+  }
+
+  Result<void, WalletBackupFailure> _validateSections(
+    WalletBackupSnapshot snapshot,
+  ) {
+    if (snapshot.metadata case final metadata?) {
+      if (_validateMetadata(metadata) case Err(:final failure)) {
+        return Err(WalletBackupManifestFailure(failure.runtimeType.toString()));
+      }
+    }
+    return const Ok(null);
+  }
+
+  WalletBackupRecoveryResult _result(
+    WalletBackupRecoveryStatus status, {
+    WalletBackupManifestRestoreResult? restored,
+    WalletDefinitionsRecoveryResult? definitions,
+  }) => WalletBackupRecoveryResult(
+    status: status,
+    restoredCount:
+        (restored?.restoredCount ?? 0) + (definitions?.restoredCount ?? 0),
+    failedCount: (restored?.failedCount ?? 0) + (definitions?.failedCount ?? 0),
+  );
+
+  bool _expired(DateTime deadline) => !_nowUtc().isBefore(deadline);
+}
+
+WalletBackupRecoveryResult _localFailure(WalletBackupRecoveryResult result) =>
+    WalletBackupRecoveryResult(
+      status: WalletBackupRecoveryStatus.localFailure,
+      restoredCount: result.restoredCount,
+      failedCount: result.failedCount,
+    );
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();

--- a/lib/features/wallet_backup/domain/usecases/backup_wallet_now_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/backup_wallet_now_usecase.dart
@@ -1,0 +1,73 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+typedef PublishWalletBackupSnapshot =
+    Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> Function(
+      WalletBackupRemoteCheckpoint? checkpoint,
+    );
+
+/// One publication pass, as the job runner runs it (spec 19.3).
+///
+/// It exits cheaply when there is nothing to send, captures the local revision
+/// it is about to publish, and acknowledges only that revision. A mutation
+/// committed while the store was in flight therefore leaves the backup dirty
+/// and the runner schedules one more pass.
+final class BackupWalletNowUsecase {
+  final WalletBackupStateRepository _state;
+  final PublishWalletBackupSnapshot _publish;
+  final int Function() _nowSecs;
+
+  const BackupWalletNowUsecase({
+    required this._state,
+    required this._publish,
+    required this._nowSecs,
+  });
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> execute() async {
+    final WalletBackupState state;
+    switch (await _state.get()) {
+      case Ok(:final value):
+        state = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    if (!state.enabled) {
+      return const Err(WalletBackupDisabledFailure());
+    }
+    if (state.recoveryBlocked) {
+      return const Err(WalletBackupRecoveryBlockedFailure());
+    }
+    if (state.unsupportedVersion case final version?) {
+      return Err(WalletBackupUnsupportedEnvelopeVersionFailure(version));
+    }
+    if (!state.dirty) {
+      return const Ok(null);
+    }
+
+    final publishedRevision = state.localRevision;
+    final WalletBackupRemoteCheckpoint checkpoint;
+    switch (await _publish(state.remoteCheckpoint)) {
+      case Ok(:final value):
+        checkpoint = value;
+      case Err(:final failure):
+        if (failure is WalletBackupUnsupportedEnvelopeVersionFailure) {
+          final blockResult = await _state.blockUnsupportedVersion(
+            failure.version,
+          );
+          if (blockResult case Err(:final failure)) return Err(failure);
+        }
+        return Err(failure);
+    }
+
+    return _state.recordPublication(
+      publishedRevision: publishedRevision,
+      succeededAt: _nowSecs(),
+      checkpoint: checkpoint,
+    );
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef BuildWalletBackupSnapshot =
+    Future<Result<WalletBackupSnapshot, WalletBackupFailure>> Function({
+      required String parentFingerprint,
+      bool allowEmpty,
+    });
+
+final class BuildWalletBackupExportUsecase {
+  final BuildWalletBackupSnapshot _buildSnapshot;
+  final Future<Result<WalletBackupKey, WalletBackupFailure>> Function()
+  _resolveKey;
+  final WalletBackupEncryptionRepository _encryption;
+  final DateTime Function() _nowUtc;
+
+  const BuildWalletBackupExportUsecase({
+    required this._buildSnapshot,
+    required this._resolveKey,
+    required this._encryption,
+    this._nowUtc = _systemNowUtc,
+  });
+
+  Future<Result<WalletBackupExport, WalletBackupFailure>> execute({
+    required WalletBackupFileProtection protection,
+    required bool confirmedUnencrypted,
+  }) async {
+    if (protection == WalletBackupFileProtection.unencrypted &&
+        !confirmedUnencrypted) {
+      return const Err(WalletBackupConfirmationRequiredFailure());
+    }
+
+    final WalletBackupKey key;
+    switch (await _resolveKey()) {
+      case Ok(:final value):
+        key = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final snapshotResult = await _buildSnapshot(
+      parentFingerprint: key.parentFingerprint,
+      allowEmpty: true,
+    );
+    final WalletBackupSnapshot envelope;
+    switch (snapshotResult) {
+      case Ok(:final value):
+        envelope = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    final List<int> bytes;
+    final String extension;
+    switch (protection) {
+      case WalletBackupFileProtection.unencrypted:
+        switch (_encryption.encodeCanonical(envelope)) {
+          case Ok(:final value):
+            bytes = value;
+          case Err(:final failure):
+            return Err(failure);
+        }
+        extension = 'json';
+      case WalletBackupFileProtection.encrypted:
+        switch (_encryption.encrypt(
+          envelope: envelope,
+          key: key.encryptionKey,
+        )) {
+          case Ok(:final value):
+            bytes = utf8.encode(value.value);
+          case Err(:final failure):
+            return Err(failure);
+        }
+        extension = 'json.enc';
+    }
+
+    return Ok(
+      WalletBackupExport(
+        suggestedFilename:
+            'bull-wallet-data-backup-${_timestamp(_nowUtc())}.$extension',
+        bytes: bytes,
+      ),
+    );
+  }
+}
+
+String _timestamp(DateTime value) {
+  final utc = value.toUtc();
+  String two(int value) => value.toString().padLeft(2, '0');
+  return '${utc.year}${two(utc.month)}${two(utc.day)}-'
+      '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}';
+}
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();

--- a/lib/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart
@@ -1,0 +1,86 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+typedef ReadWalletMetadataSnapshot =
+    Future<Result<WalletMetadataSnapshot, WalletMetadataBackupFailure>>
+    Function();
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();
+
+/// One read-only capture of the manifest, the external wallet definitions and
+/// the protected-data section (spec 16).
+///
+/// Building a snapshot writes nothing: the invariant recovery material a
+/// published document must carry is registered when the feature starts or is
+/// enabled, by [RegisterWalletBackupRecoveryMaterialUsecase] (spec F5). Each
+/// owner is read exactly once per call, so the result is a snapshot that
+/// actually existed (spec F6).
+final class BuildWalletBackupSnapshotUsecase {
+  final KeychainManifestFacade _keychainManifest;
+  final WalletDefinitionsBackup _definitions;
+  final ReadWalletMetadataSnapshot _readMetadata;
+  final DateTime Function() _nowUtc;
+
+  const BuildWalletBackupSnapshotUsecase(
+    this._keychainManifest,
+    this._definitions,
+    this._readMetadata, {
+    this._nowUtc = _systemNowUtc,
+  });
+
+  @useResult
+  Future<Result<WalletBackupSnapshot, WalletBackupFailure>> execute({
+    required String parentFingerprint,
+    bool allowEmpty = false,
+  }) async {
+    final fingerprint = Fingerprint.tryParse(parentFingerprint);
+    if (fingerprint == null) {
+      return const Err(WalletBackupParentFingerprintMismatchFailure());
+    }
+    final now = _nowUtc();
+
+    final KeychainManifest manifest;
+    switch (await _keychainManifest.buildManifest(
+      fingerprint,
+      allowEmpty: allowEmpty,
+    )) {
+      case Ok(:final value):
+        manifest = value;
+      case Err(:final failure):
+        return Err(WalletBackupManifestFailure(failure.runtimeType.toString()));
+    }
+
+    final List<WalletDefinition> definitions;
+    switch (await _definitions.read()) {
+      case Ok(:final value):
+        definitions = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    final WalletMetadataSnapshot metadata;
+    switch (await _readMetadata()) {
+      case Ok(:final value):
+        metadata = value;
+      case Err(:final failure):
+        return Err(WalletBackupManifestFailure(failure.runtimeType.toString()));
+    }
+
+    return Ok(
+      WalletBackupSnapshot(
+        parentFingerprint: fingerprint,
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        recoveryManifest: manifest,
+        externalWalletDefinitions: definitions,
+        metadata: metadata,
+      ),
+    );
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file_comparison.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef CompareWalletBackupSnapshots =
+    Set<WalletBackupDifference> Function(
+      WalletBackupSnapshot left,
+      WalletBackupSnapshot right,
+    );
+typedef DecodeWalletBackupFile =
+    Future<Result<WalletBackupSnapshot, WalletBackupFailure>> Function(
+      Uint8List bytes,
+    );
+
+final class CompareWalletBackupFileUsecase {
+  final DecodeWalletBackupFile _decodeFile;
+  final Future<Result<WalletBackupState, WalletBackupFailure>> Function()
+  _getState;
+  final Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> Function()
+  _fetchRemote;
+  final Future<Result<WalletBackupSnapshot?, WalletBackupFailure>> Function(
+    WalletBackupRemoteHead,
+  )
+  _fetchImport;
+  final CompareWalletBackupSnapshots _differences;
+
+  const CompareWalletBackupFileUsecase(
+    this._decodeFile,
+    this._getState,
+    this._fetchRemote,
+    this._fetchImport,
+    this._differences,
+  );
+
+  Future<Result<WalletBackupImportComparison, WalletBackupFailure>> execute(
+    Uint8List bytes,
+  ) async {
+    final WalletBackupSnapshot file;
+    switch (await _decodeFile(bytes)) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        file = value;
+    }
+
+    final WalletBackupState state;
+    switch (await _getState()) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        state = value;
+    }
+    final noServerSituation = state.enabled
+        ? WalletBackupImportSituation.noServerBackup
+        : WalletBackupImportSituation.automaticBackupDisabled;
+    final WalletBackupRemoteHead head;
+    switch (await _fetchRemote()) {
+      case Err(failure: WalletBackupRemoteUnavailableFailure()):
+        return Ok(
+          _withoutServer(file, WalletBackupImportSituation.serverUnavailable),
+        );
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(value: final value) when !value.found:
+        return Ok(_withoutServer(file, noServerSituation, head: value));
+      case Ok(:final value):
+        head = value;
+    }
+    final WalletBackupSnapshot server;
+    switch (await _fetchImport(head)) {
+      case Err(failure: WalletBackupRemoteUnavailableFailure()):
+        return Ok(
+          _withoutServer(file, WalletBackupImportSituation.serverUnavailable),
+        );
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(value: null):
+        return Ok(_withoutServer(file, noServerSituation, head: head));
+      case Ok(value: final value?):
+        server = value;
+    }
+    final differences = _differences(file, server);
+    return Ok(
+      WalletBackupImportComparison(
+        situation: differences.isEmpty
+            ? WalletBackupImportSituation.same
+            : WalletBackupImportSituation.different,
+        file: _summary(file),
+        server: _summary(server),
+        comparedServerGeneration: head.generation,
+        comparedServerEtag: head.etag,
+        serverCiphertextBytes: Uint8List.fromList(
+          utf8.encode(head.ciphertext!.value),
+        ),
+        differences: differences,
+      ),
+    );
+  }
+
+  WalletBackupImportComparison _withoutServer(
+    WalletBackupSnapshot file,
+    WalletBackupImportSituation situation, {
+    WalletBackupRemoteHead? head,
+  }) => WalletBackupImportComparison(
+    situation: situation,
+    file: _summary(file),
+    server: null,
+    comparedServerGeneration: head?.generation,
+    comparedServerEtag: head?.etag,
+    differences: const {},
+  );
+}
+
+WalletBackupSnapshotSummary _summary(WalletBackupSnapshot snapshot) {
+  final metadata = snapshot.metadata;
+  return WalletBackupSnapshotSummary(
+    createdAt: snapshot.createdAt,
+    walletCount: snapshot.recoveryManifest.wallets.length,
+    nostrIdentityCount: snapshot.recoveryManifest.nostrKeys.length,
+    externalWalletCount: snapshot.externalWalletDefinitions.length,
+    labelCount: metadata?.labels.length ?? 0,
+    frozenOutpointCount: metadata?.frozenOutpoints.length ?? 0,
+    walletPreferenceCount: metadata?.walletPreferences.length ?? 0,
+  );
+}

--- a/lib/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+final class DecodeWalletBackupFileUsecase {
+  static const maximumFileBytes = WalletBackupCiphertext.maximumEncodedLength;
+
+  final Future<Result<WalletBackupKey, WalletBackupFailure>> Function()
+  _resolveKey;
+  final WalletBackupEncryptionRepository _encryption;
+
+  const DecodeWalletBackupFileUsecase(this._resolveKey, this._encryption);
+
+  Future<Result<WalletBackupSnapshot, WalletBackupFailure>> execute(
+    Uint8List bytes,
+  ) async {
+    if (bytes.isEmpty) {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    if (bytes.length > maximumFileBytes) {
+      return const Err(WalletBackupTooLargeFailure());
+    }
+    final WalletBackupKey key;
+    switch (await _resolveKey()) {
+      case Ok(:final value):
+        key = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final String text;
+    try {
+      text = const Utf8Decoder(allowMalformed: false).convert(bytes);
+    } on FormatException {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    if (text.trimLeft().startsWith('{')) {
+      return _encryption.decodeCanonical(
+        bytes: bytes,
+        expectedParentFingerprint: key.parentFingerprint,
+      );
+    }
+    final ciphertext = WalletBackupCiphertext.tryParse(text);
+    if (ciphertext == null) {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    return _encryption.decrypt(
+      ciphertext: ciphertext,
+      key: key.encryptionKey,
+      expectedParentFingerprint: key.parentFingerprint,
+    );
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/delete_wallet_backup_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/delete_wallet_backup_usecase.dart
@@ -1,0 +1,67 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+final class DeleteWalletBackupUsecase {
+  final FetchWalletBackupRemoteUsecase _fetchRemote;
+  final DeleteWalletBackupRemoteUsecase _deleteRemote;
+  final WalletBackupStateRepository _state;
+
+  const DeleteWalletBackupUsecase({
+    required this._fetchRemote,
+    required this._deleteRemote,
+    required this._state,
+  });
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> execute({
+    required bool confirmed,
+  }) async {
+    if (!confirmed) {
+      return const Err(WalletBackupConfirmationRequiredFailure());
+    }
+
+    final WalletBackupRemoteCheckpoint? checkpoint;
+    switch (await _state.get()) {
+      case Ok(:final value):
+        // Decision 9: automatic backup has to be off first. It is also what
+        // stops a publication queued behind this job from recreating the
+        // object this one is about to remove.
+        if (value.enabled) {
+          return const Err(WalletBackupDeleteRequiresDisabledFailure());
+        }
+        checkpoint = value.remoteCheckpoint;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    // A trusted checkpoint deletes without a fetch; without one, or when the
+    // checkpoint turns out to be stale, the current head decides (spec 19.6).
+    if (checkpoint != null) {
+      switch (await _deleteRemote.execute(current: checkpoint)) {
+        case Ok():
+          return _state.clearRemoteCheckpoint();
+        case Err(failure: WalletBackupHeadConflictFailure()):
+          break;
+        case Err(:final failure):
+          return Err(failure);
+      }
+    }
+
+    final WalletBackupRemoteCheckpoint? head;
+    switch (await _fetchRemote.execute()) {
+      case Ok(:final value):
+        head = value.checkpoint;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    if (head == null) return _state.clearRemoteCheckpoint();
+    if (await _deleteRemote.execute(current: head) case Err(:final failure)) {
+      return Err(failure);
+    }
+    return _state.clearRemoteCheckpoint();
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart
@@ -1,0 +1,56 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+class FetchWalletBackupSnapshotUsecase {
+  final ResolveWalletBackupKeyUsecase _resolveKey;
+  final WalletBackupEncryptionRepository _encryption;
+  final WalletBackupStateRepository _state;
+
+  const FetchWalletBackupSnapshotUsecase({
+    required this._resolveKey,
+    required this._encryption,
+    required this._state,
+  });
+
+  @useResult
+  Future<Result<WalletBackupSnapshot?, WalletBackupFailure>> execute(
+    WalletBackupRemoteHead remote,
+  ) async {
+    final keyResult = await _resolveKey.execute();
+    final WalletBackupKey backupKey;
+    switch (keyResult) {
+      case Ok(:final value):
+        backupKey = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final ciphertext = remote.ciphertext;
+    if (ciphertext == null) return const Ok(null);
+
+    final decryptResult = _encryption.decrypt(
+      ciphertext: ciphertext,
+      key: backupKey.encryptionKey,
+      expectedParentFingerprint: backupKey.parentFingerprint,
+    );
+    switch (decryptResult) {
+      case Err(
+        failure: final WalletBackupUnsupportedEnvelopeVersionFailure failure,
+      ):
+        final blockResult = await _state.blockUnsupportedVersion(
+          failure.version,
+        );
+        if (blockResult case Err(:final failure)) return Err(failure);
+        return Err(failure);
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(:final value):
+        return Ok(value);
+    }
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart
@@ -1,0 +1,119 @@
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_contents.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+final class GetWalletBackupContentsUsecase {
+  final Future<Result<KeychainManifest, WalletBackupFailure>> Function()
+  _manifest;
+  final Future<List<WalletDefinition>> Function() _definitions;
+  final Future<Set<String>> Function() _locallyKeyedWalletIds;
+  final Future<Result<WalletMetadataSnapshot, WalletMetadataBackupFailure>>
+  Function()
+  _metadata;
+
+  const GetWalletBackupContentsUsecase(
+    this._manifest,
+    this._definitions,
+    this._locallyKeyedWalletIds,
+    this._metadata,
+  );
+
+  @useResult
+  Future<Result<WalletBackupContents, WalletBackupFailure>> execute() async {
+    try {
+      final KeychainManifest manifest;
+      switch (await _manifest()) {
+        case Ok(:final value):
+          manifest = value;
+        case Err(:final failure):
+          return Err(failure);
+      }
+      final definitions = await _definitions();
+      final locallyKeyedWalletIds = await _locallyKeyedWalletIds();
+      final metadata = await _metadata();
+      switch (metadata) {
+        case Err(:final failure):
+          return Err(
+            WalletBackupManifestFailure(failure.runtimeType.toString()),
+          );
+        case Ok(:final value):
+          final labels = {
+            for (final preference in value.walletPreferences)
+              if (preference.label != null)
+                preference.walletRef: preference.label!,
+          };
+          final wallets = <String, WalletBackupWalletSummary>{};
+          for (final entry in manifest.entries) {
+            for (final wallet
+                in entry.materializations.whereType<KeychainManifestWallet>()) {
+              if (wallets.containsKey(wallet.walletId)) {
+                throw StateError('Duplicate wallet recovery inventory');
+              }
+              wallets[wallet.walletId] = WalletBackupWalletSummary(
+                label: labels[wallet.walletId] ?? wallet.label,
+                network: wallet.network,
+                provenance: wallet.provenance,
+                keysOnDevice: locallyKeyedWalletIds.contains(wallet.walletId),
+                derivationPath: entry.derivationPath,
+                descriptor: wallet.descriptor,
+                seedPassphraseUsed: wallet.seedPassphraseUsed,
+              );
+            }
+          }
+          for (final definition in definitions.where(
+            (definition) => definition.network.isBitcoin,
+          )) {
+            if (wallets.containsKey(definition.walletRef) ||
+                (definition.provenance != WalletProvenance.watchOnly &&
+                    definition.provenance != WalletProvenance.externalSigner)) {
+              throw StateError('Conflicting wallet recovery inventory');
+            }
+            wallets[definition.walletRef] = WalletBackupWalletSummary(
+              label: labels[definition.walletRef],
+              network: definition.network,
+              provenance: definition.provenance,
+              keysOnDevice: false,
+              descriptor: definition.descriptor,
+              signerDevice: definition.signerDevice,
+            );
+          }
+          final summaries = wallets.values.toList(growable: false)
+            ..sort(_compareWallets);
+          return Ok(
+            WalletBackupContents(
+              wallets: summaries,
+              labelCount: value.labels.length,
+              frozenCoinCount: value.frozenOutpoints.length,
+              walletPreferenceCount: value.walletPreferences.length,
+              settings: value.settings,
+            ),
+          );
+      }
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to read wallet backup contents',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return Err(WalletBackupStorageFailure(error.runtimeType.toString()));
+    }
+  }
+}
+
+int _compareWallets(
+  WalletBackupWalletSummary left,
+  WalletBackupWalletSummary right,
+) {
+  final byNetwork = left.network.index.compareTo(right.network.index);
+  if (byNetwork != 0) return byNetwork;
+  final byProvenance = left.provenance.index.compareTo(right.provenance.index);
+  if (byProvenance != 0) return byProvenance;
+  return (left.label ?? '').compareTo(right.label ?? '');
+}

--- a/lib/features/wallet_backup/domain/usecases/get_wallet_recovery_inventory_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/get_wallet_recovery_inventory_usecase.dart
@@ -1,0 +1,46 @@
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+final class GetWalletRecoveryInventoryUsecase {
+  final Future<Result<WalletBackupKey, WalletBackupFailure>> Function()
+  _resolveKey;
+  final Future<Result<void, WalletBackupFailure>> Function(Fingerprint)
+  _refresh;
+  final Future<Result<KeychainManifest, KeychainManifestFailure>> Function(
+    Fingerprint,
+  )
+  _readManifest;
+
+  const GetWalletRecoveryInventoryUsecase(
+    this._resolveKey,
+    this._refresh,
+    this._readManifest,
+  );
+
+  @useResult
+  Future<Result<KeychainManifest, WalletBackupFailure>> execute() async {
+    final String fingerprint;
+    switch (await _resolveKey()) {
+      case Ok(:final value):
+        fingerprint = value.parentFingerprint;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final parent = Fingerprint.tryParse(fingerprint);
+    if (parent == null) {
+      return const Err(WalletBackupParentFingerprintMismatchFailure());
+    }
+    if (await _refresh(parent) case Err(:final failure)) {
+      return Err(failure);
+    }
+    return switch (await _readManifest(parent)) {
+      Ok(:final value) => Ok(value),
+      Err(:final failure) => Err(
+        WalletBackupManifestFailure(failure.runtimeType.toString()),
+      ),
+    };
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/publish_wallet_backup_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/publish_wallet_backup_usecase.dart
@@ -1,0 +1,130 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+/// Publishes the local snapshot as the authoritative remote document.
+///
+/// The published bytes are exactly the local snapshot: nothing is merged with
+/// what the remote holds, so a record removed locally is gone from the next
+/// publication and a recovery cannot resurrect it (decision 1, spec F1/F2).
+///
+/// With a trusted checkpoint the store goes straight out, with no preceding
+/// fetch (spec 19.3, F7). A head conflict means another installation published
+/// in the meantime: the head is fetched and authenticated once, a durable
+/// needs-attention state is recorded, local work stays dirty, and the decision
+/// is left to the user (spec 19.4, decision 3).
+final class PublishWalletBackupUsecase {
+  final BuildWalletBackupSnapshotUsecase _buildSnapshot;
+  final ResolveWalletBackupKeyUsecase _resolveKey;
+  final WalletBackupEncryptionRepository _encryption;
+  final FetchWalletBackupRemoteUsecase _fetchRemote;
+  final StoreWalletBackupRemoteUsecase _storeRemote;
+  final FetchWalletBackupSnapshotUsecase _readRemoteSnapshot;
+  final WalletBackupStateRepository _state;
+
+  const PublishWalletBackupUsecase({
+    required this._buildSnapshot,
+    required this._resolveKey,
+    required this._encryption,
+    required this._fetchRemote,
+    required this._storeRemote,
+    required this._readRemoteSnapshot,
+    required this._state,
+  });
+
+  @useResult
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> execute(
+    WalletBackupRemoteCheckpoint? checkpoint,
+  ) async {
+    final WalletBackupKey backupKey;
+    switch (await _resolveKey.execute()) {
+      case Ok(:final value):
+        backupKey = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    var current = checkpoint;
+    if (current == null) {
+      switch (await _fetchRemote.execute()) {
+        case Ok(:final value):
+          current = value.checkpoint;
+        case Err(:final failure):
+          return Err(failure);
+      }
+    }
+
+    final WalletBackupSnapshot local;
+    switch (await _buildSnapshot.execute(
+      parentFingerprint: backupKey.parentFingerprint,
+      allowEmpty: true,
+    )) {
+      case Ok(:final value):
+        local = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    final WalletBackupCiphertext ciphertext;
+    switch (_encryption.encrypt(
+      envelope: local,
+      key: backupKey.encryptionKey,
+    )) {
+      case Ok(:final value):
+        ciphertext = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    return switch (await _storeRemote.execute(
+      current: current,
+      ciphertext: ciphertext,
+    )) {
+      Ok(:final value) => Ok(value),
+      Err(failure: WalletBackupHeadConflictFailure()) => _recordConflict(),
+      Err(:final failure) => Err(failure),
+    };
+  }
+
+  /// Fetches the head that beat this publication, authenticates it, and leaves
+  /// the feature needing attention. The remote is never overwritten here.
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>>
+  _recordConflict() async {
+    final WalletBackupRemoteHead head;
+    switch (await _fetchRemote.execute()) {
+      case Ok(:final value):
+        head = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    final decoded = await _readRemoteSnapshot.execute(head);
+    if (await _state.saveRemoteCheckpoint(head.checkpoint) case Err(
+      :final failure,
+    )) {
+      return Err(failure);
+    }
+    // An unsupported version is its own durable block, already recorded while
+    // decoding. Adding needs-attention on top would mask it behind the
+    // recovery fence, so the version failure is reported as it stands.
+    if (decoded case Err(:final failure)) return Err(failure);
+
+    // Local work stays dirty on its own: uploadedRevision never advanced, so
+    // the head conflict only has to raise the fence.
+    if (await _state.setRecoveryState(WalletBackupRecoveryState.needsAttention)
+        case Err(:final failure)) {
+      return Err(failure);
+    }
+    return const Err(WalletBackupHeadConflictFailure());
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart
@@ -1,0 +1,227 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file_comparison.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef ApplyWalletBackupFileImport =
+    Future<WalletBackupRecoveryResult> Function({
+      required Result<WalletBackupSnapshot?, WalletBackupFailure> snapshot,
+      DateTime? deadline,
+    });
+typedef SettleWalletBackupFence =
+    Future<WalletBackupRecoveryResult> Function(
+      WalletBackupRecoveryResult result, {
+      required WalletBackupRecoveryState? fence,
+    });
+typedef DecodeWalletBackupFile =
+    Future<Result<WalletBackupSnapshot, WalletBackupFailure>> Function(
+      Uint8List bytes,
+    );
+typedef StoreSelectedWalletBackup =
+    Future<Result<void, WalletBackupFailure>> Function({
+      required WalletBackupSnapshot selected,
+      required WalletBackupRemoteCheckpoint? current,
+    });
+
+/// File import: decode the file into the same typed snapshot remote recovery
+/// produces, check that the comparison the user acted on is still current, and
+/// delegate the apply to the shared fenced path (spec F21, 19.8).
+///
+/// Unlike remote recovery, applying is only half the job: when automatic
+/// backup is on, the selected snapshot also has to replace the remote head.
+/// This use case therefore settles the fence itself once it knows whether both
+/// halves succeeded.
+final class RecoverWalletBackupFileUsecase {
+  final DecodeWalletBackupFile _decode;
+  final ApplyWalletBackupFileImport _apply;
+  final SettleWalletBackupFence _settle;
+  final Future<Result<WalletBackupState, WalletBackupFailure>> Function()
+  _getState;
+  final Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> Function()
+  _fetchRemote;
+  final StoreSelectedWalletBackup _storeSelected;
+  final DateTime Function() _nowUtc;
+
+  const RecoverWalletBackupFileUsecase(
+    this._decode,
+    this._apply,
+    this._settle,
+    this._getState,
+    this._fetchRemote,
+    this._storeSelected, {
+    this._nowUtc = _systemNowUtc,
+  });
+
+  Future<WalletBackupRecoveryResult> execute({
+    required Uint8List fileBytes,
+    required WalletBackupImportComparison comparison,
+    required WalletBackupImportSource source,
+  }) async {
+    final bytes = switch (source) {
+      WalletBackupImportSource.file => fileBytes,
+      WalletBackupImportSource.server => comparison.copyServerCiphertextBytes(),
+    };
+    // Nothing has been touched yet, so a file this client cannot even read is
+    // reported as it stands rather than recorded as a recovery outcome.
+    if (bytes == null) return _status(WalletBackupRecoveryStatus.invalid);
+
+    final WalletBackupSnapshot selected;
+    switch (await _decode(bytes)) {
+      case Ok(:final value):
+        selected = value;
+      case Err(:final failure):
+        return WalletBackupRecoveryResult.fromFailure(failure);
+    }
+
+    return _recover(
+      selected: selected,
+      comparison: comparison,
+      source: source,
+      deadline: _nowUtc().add(ApplyBackupSnapshotUsecase.defaultBudget),
+    );
+  }
+
+  Future<WalletBackupRecoveryResult> _recover({
+    required WalletBackupSnapshot selected,
+    required WalletBackupImportComparison comparison,
+    required WalletBackupImportSource source,
+    required DateTime deadline,
+  }) async {
+    final WalletBackupState state;
+    switch (await _getState()) {
+      case Ok(:final value):
+        state = value;
+      case Err(:final failure):
+        return _settleNeedsNothing(
+          WalletBackupRecoveryResult.fromFailure(failure),
+        );
+    }
+
+    WalletBackupRemoteHead? comparedHead;
+    var recoveringOffline = false;
+    final requiresRemoteFreshness =
+        state.enabled || source == WalletBackupImportSource.server;
+    if (requiresRemoteFreshness) {
+      switch (await _fetchRemote()) {
+        case Ok(:final value):
+          if (comparison.comparedServerGeneration == null ||
+              !_matchesComparison(value, comparison)) {
+            return _settleNeedsNothing(
+              _status(WalletBackupRecoveryStatus.comparisonStale),
+            );
+          }
+          comparedHead = value;
+        case Err(failure: WalletBackupRemoteUnavailableFailure())
+            when source == WalletBackupImportSource.file &&
+                comparison.situation ==
+                    WalletBackupImportSituation.serverUnavailable:
+          recoveringOffline = true;
+        case Err(failure: WalletBackupRemoteUnavailableFailure()):
+          return _settleNeedsNothing(
+            _status(WalletBackupRecoveryStatus.unavailable),
+          );
+        case Err(:final failure):
+          return _settleNeedsNothing(
+            WalletBackupRecoveryResult.fromFailure(failure),
+          );
+      }
+    }
+
+    final applied = await _apply(snapshot: Ok(selected), deadline: deadline);
+    if (applied.status != WalletBackupRecoveryStatus.restored &&
+        applied.status != WalletBackupRecoveryStatus.partiallyRestored) {
+      return _settleAttention(applied);
+    }
+
+    if (applied.status == WalletBackupRecoveryStatus.partiallyRestored) {
+      return state.enabled ? _settleAttention(applied) : _settleIdle(applied);
+    }
+    if (recoveringOffline) return _settleAttention(applied);
+    if (!state.enabled ||
+        comparison.situation ==
+            WalletBackupImportSituation.automaticBackupDisabled) {
+      return _settleIdle(applied);
+    }
+    if (source == WalletBackupImportSource.server) {
+      switch (await _fetchRemote()) {
+        case Ok(:final value) when _matchesComparison(value, comparison):
+          return _settleIdle(applied);
+        case Ok():
+          return _settleAttention(
+            _sameCounts(applied, WalletBackupRecoveryStatus.comparisonStale),
+          );
+        case Err(failure: WalletBackupRemoteUnavailableFailure()):
+          return _settleAttention(applied);
+        case Err(:final failure):
+          return _settleAttention(
+            _sameCounts(
+              applied,
+              WalletBackupRecoveryResult.statusForFailure(failure),
+            ),
+          );
+      }
+    }
+
+    switch (await _storeSelected(
+      selected: selected,
+      current: comparedHead!.checkpoint,
+    )) {
+      case Ok():
+        return _settleIdle(applied);
+      case Err(failure: WalletBackupHeadConflictFailure()):
+        return _settleAttention(
+          _sameCounts(applied, WalletBackupRecoveryStatus.comparisonStale),
+        );
+      case Err(failure: WalletBackupRemoteUnavailableFailure()):
+        return _settleAttention(applied);
+      case Err(:final failure):
+        return _settleAttention(
+          _sameCounts(
+            applied,
+            WalletBackupRecoveryResult.statusForFailure(failure),
+          ),
+        );
+    }
+  }
+
+  bool _matchesComparison(
+    WalletBackupRemoteHead head,
+    WalletBackupImportComparison comparison,
+  ) =>
+      head.generation == comparison.comparedServerGeneration &&
+      head.etag == comparison.comparedServerEtag;
+
+  Future<WalletBackupRecoveryResult> _settleIdle(
+    WalletBackupRecoveryResult result,
+  ) => _settle(result, fence: WalletBackupRecoveryState.idle);
+
+  Future<WalletBackupRecoveryResult> _settleAttention(
+    WalletBackupRecoveryResult result,
+  ) => _settle(result, fence: WalletBackupRecoveryState.needsAttention);
+
+  /// Nothing was applied, so the fence stays where it already was and only the
+  /// outcome is recorded.
+  Future<WalletBackupRecoveryResult> _settleNeedsNothing(
+    WalletBackupRecoveryResult result,
+  ) => _settle(result, fence: null);
+}
+
+WalletBackupRecoveryResult _status(WalletBackupRecoveryStatus status) =>
+    WalletBackupRecoveryResult(status: status);
+
+WalletBackupRecoveryResult _sameCounts(
+  WalletBackupRecoveryResult applied,
+  WalletBackupRecoveryStatus status,
+) => WalletBackupRecoveryResult(
+  status: status,
+  restoredCount: applied.restoredCount,
+  failedCount: applied.failedCount,
+);
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();

--- a/lib/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart
@@ -1,0 +1,67 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+typedef FetchWalletBackupImport =
+    Future<Result<WalletBackupSnapshot?, WalletBackupFailure>> Function(
+      WalletBackupRemoteHead remote,
+    );
+typedef ApplyFetchedWalletBackup =
+    Future<WalletBackupRecoveryResult> Function({
+      required Result<WalletBackupSnapshot?, WalletBackupFailure> snapshot,
+      ValidateWalletBackupRecovery? revalidate,
+      Set<String> defaultCreatedWalletIds,
+      bool callerSettlesFence,
+      DateTime? deadline,
+    });
+
+/// Remote recovery: fetch the head, turn it into the shared typed snapshot,
+/// and hand it to the one fenced apply path (spec F21, 19.7).
+final class RecoverWalletBackupUsecase {
+  final FetchWalletBackupImport _fetchImport;
+  final Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> Function()
+  _fetchRemote;
+  final ApplyFetchedWalletBackup _apply;
+
+  const RecoverWalletBackupUsecase({
+    required this._fetchImport,
+    required this._fetchRemote,
+    required this._apply,
+  });
+
+  Future<WalletBackupRecoveryResult> execute({
+    Set<String> defaultCreatedWalletIds = const {},
+  }) async {
+    final WalletBackupRemoteHead initialHead;
+    switch (await _fetchRemote()) {
+      case Ok(:final value):
+        initialHead = value;
+      case Err(:final failure):
+        return _apply(
+          snapshot: Err(failure),
+          defaultCreatedWalletIds: defaultCreatedWalletIds,
+        );
+    }
+    final snapshot = await _fetchImport(initialHead);
+    return _apply(
+      defaultCreatedWalletIds: defaultCreatedWalletIds,
+      snapshot: snapshot,
+      revalidate: () async => switch (await _fetchRemote()) {
+        Ok(:final value) => Ok(_sameRemoteObject(value, initialHead)),
+        Err(:final failure) => Err(failure),
+      },
+    );
+  }
+}
+
+bool _sameRemoteObject(
+  WalletBackupRemoteHead left,
+  WalletBackupRemoteHead right,
+) => switch ((left.checkpoint, right.checkpoint)) {
+  (null, null) => true,
+  (final a?, final b?) => a.sameObjectAs(b),
+  _ => false,
+};

--- a/lib/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart
@@ -1,0 +1,42 @@
+import 'package:bb_mobile/core/wallet/domain/entities/seed_derived_wallet_recovery_fact.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+final class RefreshWalletRecoveryManifestUsecase {
+  final Future<List<SeedDerivedWalletRecoveryFact>> Function() _getWallets;
+  final KeychainManifestFacade _manifest;
+
+  const RefreshWalletRecoveryManifestUsecase(this._getWallets, this._manifest);
+
+  Future<Result<void, WalletBackupFailure>> execute(
+    Fingerprint parentFingerprint,
+  ) async {
+    try {
+      final facts = await _getWallets();
+      final result = await _manifest.replaceSeedWalletInventory(
+        parentFingerprint: parentFingerprint,
+        wallets: [
+          for (final fact in facts)
+            KeychainManifestWalletInventoryBinding(
+              walletId: fact.walletId,
+              seedFingerprint: fact.seedFingerprint,
+              network: fact.network,
+              scriptType: fact.scriptType,
+              provenance: fact.provenance,
+              derivationPath: fact.derivationPath,
+              seedPassphraseUsed: fact.seedPassphraseUsed,
+            ),
+        ],
+      );
+      return switch (result) {
+        Ok() => const Ok(null),
+        Err(:final failure) => Err(
+          WalletBackupManifestFailure(failure.runtimeType.toString()),
+        ),
+      };
+    } on Exception catch (error) {
+      return Err(WalletBackupStorageFailure(error.runtimeType.toString()));
+    }
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/register_wallet_backup_recovery_material_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/register_wallet_backup_recovery_material_usecase.dart
@@ -1,0 +1,64 @@
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();
+
+/// Records the invariant recovery material every published snapshot carries:
+/// the reserved backup Nostr key, and the seed-derived wallet inventory.
+///
+/// These are the two writes that used to happen inside snapshot construction.
+/// They run when the feature starts and when the user enables backup, so that
+/// taking a snapshot mutates nothing and emits no manifest change (spec F5).
+final class RegisterWalletBackupRecoveryMaterialUsecase {
+  final ResolveWalletBackupKeyUsecase _resolveKey;
+  final NostrIdentityFacade _nostrIdentity;
+  final KeychainManifestFacade _keychainManifest;
+  final RefreshWalletRecoveryManifestUsecase _refreshManifest;
+  final DateTime Function() _nowUtc;
+
+  const RegisterWalletBackupRecoveryMaterialUsecase(
+    this._resolveKey,
+    this._nostrIdentity,
+    this._keychainManifest,
+    this._refreshManifest, {
+    this._nowUtc = _systemNowUtc,
+  });
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> execute() async {
+    final Fingerprint fingerprint;
+    switch (await _resolveKey.execute()) {
+      case Ok(:final value):
+        final parsed = Fingerprint.tryParse(value.parentFingerprint);
+        if (parsed == null) {
+          return const Err(WalletBackupParentFingerprintMismatchFailure());
+        }
+        fingerprint = parsed;
+      case Err(:final failure):
+        return Err(failure);
+    }
+
+    final String publicKey;
+    switch (await _nostrIdentity.walletBackupPublicKey()) {
+      case Ok(:final value):
+        publicKey = value;
+      case Err():
+        return const Err(WalletBackupSigningFailure());
+    }
+
+    if (await _keychainManifest.recordWalletBackupNostrKey(
+          parentFingerprint: fingerprint,
+          publicKeyHex: publicKey,
+          now: _nowUtc(),
+        )
+        case Err(:final failure)) {
+      return Err(WalletBackupManifestFailure(failure.runtimeType.toString()));
+    }
+    return _refreshManifest.execute(fingerprint);
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart
@@ -1,0 +1,54 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/utils/bip32_derivation.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bip85_entropy/bip85_entropy.dart' as bip85;
+import 'package:meta/meta.dart';
+
+typedef WalletBackupKey = ({
+  String parentFingerprint,
+  WalletBackupEncryptionKey encryptionKey,
+});
+
+final class ResolveWalletBackupKeyUsecase {
+  final GetSettingsUsecase _settings;
+  final GetDefaultSeedUsecase _defaultSeed;
+
+  const ResolveWalletBackupKeyUsecase(this._settings, this._defaultSeed);
+
+  @useResult
+  Future<Result<WalletBackupKey, WalletBackupFailure>> execute() async {
+    try {
+      final settings = await _settings.execute();
+      final Seed seed;
+      switch (await _defaultSeed.execute(environment: settings.environment)) {
+        case Ok(:final value):
+          seed = value;
+        case Err():
+          return const Err(WalletBackupWalletUnavailableFailure());
+      }
+      final entropy = bip85.Bip85Entropy.deriveFromHardenedPath(
+        xprvBase58: Bip32Derivation.getCanonicalRootXprvFromSeed(seed.bytes),
+        path: bip85.Bip85HardenedPath(
+          Bip85Reservations.walletBackupEncryptionKey.path,
+        ),
+      );
+      return Ok((
+        parentFingerprint: seed.masterFingerprint.toLowerCase(),
+        encryptionKey: WalletBackupEncryptionKey(entropy.substring(0, 64)),
+      ));
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Wallet backup key derivation failed',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(WalletBackupKeyDerivationFailure());
+    }
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart
@@ -1,0 +1,152 @@
+import 'package:bb_mobile/core/bip85/domain/bip85_reservations.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+
+typedef MatchesSeedDerivedRecoveryIdentity =
+    Future<bool> Function({
+      required String walletId,
+      required String seedFingerprint,
+      required Network network,
+      required ScriptType scriptType,
+      required WalletProvenance provenance,
+      required String derivationPath,
+      required bool? seedPassphraseUsed,
+    });
+
+class RestoreWalletBackupManifestUsecase {
+  final MatchesSeedDerivedRecoveryIdentity _matchesWallet;
+  final KeychainManifestFacade _manifest;
+  final DateTime Function() _nowUtc;
+
+  const RestoreWalletBackupManifestUsecase(
+    this._matchesWallet,
+    this._manifest, {
+    this._nowUtc = _systemNowUtc,
+  });
+
+  Future<WalletBackupManifestRestoreResult> execute(
+    KeychainManifest manifest, {
+    DateTime? deadline,
+  }) async {
+    var restored = 0;
+    var failed = 0;
+    // Wallet records are applied in one pass so the conflict policy sees the
+    // whole snapshot, and so a half-applied inventory cannot be committed.
+    final admitted = <KeychainManifestEntry>[];
+
+    for (final entry in manifest.entries) {
+      if (_expired(deadline)) {
+        failed += entry.materializations.length;
+        continue;
+      }
+      if (entry.derivationKind == KeychainManifestDerivationKind.bip32) {
+        final wallet = entry.materializations.single as KeychainManifestWallet;
+        if (wallet.provenance == WalletProvenance.defaultSeed) {
+          final matchesRoot =
+              wallet.childSeedFingerprint == manifest.parentFingerprint;
+          final matchesWallet =
+              matchesRoot &&
+              await _matchesWallet(
+                walletId: wallet.walletId,
+                seedFingerprint: wallet.childSeedFingerprint.hex,
+                network: wallet.network,
+                scriptType: wallet.scriptType,
+                provenance: wallet.provenance,
+                derivationPath: entry.derivationPath,
+                seedPassphraseUsed: wallet.seedPassphraseUsed,
+              );
+          if (!matchesWallet) {
+            failed++;
+            continue;
+          }
+        } else if (wallet.provenance != WalletProvenance.importedMnemonic &&
+            wallet.provenance != WalletProvenance.defaultSeedPassphrase) {
+          failed++;
+          continue;
+        }
+        admitted.add(entry);
+        continue;
+      }
+
+      // Product-wallet materialization belongs to the product feature that
+      // owns its creation ceremony. Until that feature is present, report the
+      // wallet as unrestored instead of silently claiming complete recovery.
+      failed += entry.materializations
+          .whereType<KeychainManifestWallet>()
+          .length;
+
+      for (final key
+          in entry.materializations.whereType<KeychainManifestNostrKey>()) {
+        if (_expired(deadline)) {
+          failed++;
+          continue;
+        }
+        final reservationId = _reservationId(entry.derivationPath);
+        if (reservationId == null) {
+          failed++;
+          continue;
+        }
+        final result = await _manifest.restoreNostrKey(
+          reservationId: reservationId,
+          parentFingerprint: manifest.parentFingerprint,
+          derivationPath: entry.derivationPath,
+          publicKeyHex: key.publicKeyHex,
+          keyKind: key.keyKind,
+          purpose: key.purpose,
+          description: entry.description,
+          createdAt: DateTime.fromMillisecondsSinceEpoch(
+            key.createdAt * 1000,
+            isUtc: true,
+          ),
+          updatedAt: DateTime.fromMillisecondsSinceEpoch(
+            key.updatedAt * 1000,
+            isUtc: true,
+          ),
+        );
+        if (result case Ok()) {
+          restored++;
+        } else {
+          failed++;
+        }
+      }
+    }
+
+    if (admitted.isNotEmpty) {
+      final applied = await _manifest.restoreSnapshot(
+        KeychainManifest(
+          parentFingerprint: manifest.parentFingerprint,
+          generatedAt: manifest.generatedAt,
+          entries: admitted,
+        ),
+      );
+      switch (applied) {
+        case Err():
+          failed += admitted.length;
+        case Ok(:final value):
+          restored += value.restored;
+          failed += value.conflicts.length;
+      }
+    }
+
+    return WalletBackupManifestRestoreResult(
+      restoredCount: restored,
+      failedCount: failed,
+    );
+  }
+
+  String? _reservationId(String path) {
+    final reserved = Bip85Reservations.reservationByExactPath(path);
+    if (reserved != null) return reserved.id;
+    return Bip85Reservations.isNostrUserKeyPath(path)
+        ? Bip85Reservations.nostrUserKeyReservationId
+        : null;
+  }
+
+  bool _expired(DateTime? deadline) =>
+      deadline != null && !_nowUtc().isBefore(deadline);
+}
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();

--- a/lib/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart
@@ -1,0 +1,60 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+final class SetWalletBackupEnabledUsecase {
+  final WalletBackupStateRepository _repository;
+  final Future<WalletBackupRecoveryResult> Function() _recover;
+  final Future<Result<void, WalletBackupFailure>> Function() _register;
+  final Future<Result<void, WalletBackupFailure>> Function() _publish;
+
+  const SetWalletBackupEnabledUsecase(
+    this._repository,
+    this._recover,
+    this._register,
+    this._publish,
+  );
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> execute(bool enabled) async {
+    if (!enabled) return _repository.setEnabled(false);
+
+    // The recovery material has to be in the manifest before anything reads a
+    // snapshot from it, because reading no longer writes it. Registering ahead
+    // of recovery also keeps it clear of the publication the recovery fence
+    // releases when it finishes.
+    if (await _register() case Err(:final failure)) return Err(failure);
+
+    final recovery = await _recover();
+    final recoveryFailure = _recoveryFailure(recovery.status);
+    if (recoveryFailure != null) return Err(recoveryFailure);
+
+    final enabledResult = await _repository.setEnabled(true);
+    if (enabledResult case Err()) return enabledResult;
+    return _publish();
+  }
+}
+
+WalletBackupFailure? _recoveryFailure(WalletBackupRecoveryStatus status) =>
+    switch (status) {
+      WalletBackupRecoveryStatus.noBackup ||
+      WalletBackupRecoveryStatus.restored => null,
+      WalletBackupRecoveryStatus.unavailable ||
+      WalletBackupRecoveryStatus.timedOut =>
+        const WalletBackupRemoteUnavailableFailure(),
+      WalletBackupRecoveryStatus.newerVersion =>
+        const WalletBackupUnsupportedEnvelopeVersionFailure(
+          WalletBackupSnapshot.currentVersion + 1,
+        ),
+      WalletBackupRecoveryStatus.conflict =>
+        const WalletBackupHeadConflictFailure(),
+      WalletBackupRecoveryStatus.invalid => const WalletBackupManifestFailure(),
+      WalletBackupRecoveryStatus.comparisonStale ||
+      WalletBackupRecoveryStatus.partiallyRestored =>
+        const WalletBackupRecoveryBlockedFailure(),
+      WalletBackupRecoveryStatus.localFailure =>
+        const WalletBackupStorageFailure(),
+    };

--- a/lib/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+/// Points Bull backup at another origin. The job runner serializes it against
+/// publication, so no store can land on the origin that is being replaced.
+final class SetWalletBackupServerUsecase {
+  final WalletBackupStateRepository _state;
+  final Uri? Function(String value) parseOrigin;
+
+  const SetWalletBackupServerUsecase(this._state, {required this.parseOrigin});
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> execute(String value) async {
+    final trimmed = value.trim();
+    final origin = trimmed.isEmpty ? null : parseOrigin(trimmed);
+    if (trimmed.isNotEmpty && origin == null) {
+      return const Err(WalletBackupInvalidServerOriginFailure());
+    }
+    return _state.setServerUrl(origin?.toString());
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/store_selected_wallet_backup_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/store_selected_wallet_backup_usecase.dart
@@ -1,0 +1,64 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:primitives/primitives.dart';
+
+/// Replaces the compared remote snapshot with the backup selected by the user.
+final class StoreSelectedWalletBackupUsecase {
+  final ResolveWalletBackupKeyUsecase _resolveKey;
+  final WalletBackupEncryptionRepository _encryption;
+  final StoreWalletBackupRemoteUsecase _storeRemote;
+  final WalletBackupStateRepository _state;
+  final int Function() _nowSecs;
+
+  const StoreSelectedWalletBackupUsecase(
+    this._resolveKey,
+    this._encryption,
+    this._storeRemote,
+    this._state,
+    this._nowSecs,
+  );
+
+  Future<Result<void, WalletBackupFailure>> execute({
+    required WalletBackupSnapshot selected,
+    required WalletBackupRemoteCheckpoint? current,
+  }) async {
+    final backupKeyResult = await _resolveKey.execute();
+    if (backupKeyResult case Err(:final failure)) return Err(failure);
+    final backupKey = (backupKeyResult as Ok).value;
+    if (backupKey.parentFingerprint != selected.parentFingerprint.hex) {
+      return const Err(WalletBackupParentFingerprintMismatchFailure());
+    }
+    final encrypted = _encryption.encrypt(
+      envelope: selected,
+      key: backupKey.encryptionKey,
+    );
+    if (encrypted case Err(:final failure)) return Err(failure);
+    final ciphertext = (encrypted as Ok).value;
+
+    // The selected snapshot replaces local state as well as the remote one, so
+    // it counts as a local mutation before it counts as a publication.
+    final revision = await _state.recordLocalMutation();
+    if (revision case Err(:final failure)) return Err(failure);
+    final capturedRevision = (revision as Ok<int, WalletBackupFailure>).value;
+    final WalletBackupRemoteCheckpoint checkpoint;
+    switch (await _storeRemote.execute(
+      current: current,
+      ciphertext: ciphertext,
+    )) {
+      case Ok(:final value):
+        checkpoint = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    return _state.recordPublication(
+      publishedRevision: capturedRevision,
+      succeededAt: _nowSecs(),
+      checkpoint: checkpoint,
+    );
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart
+++ b/lib/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:crypto/crypto.dart';
+
+final class FetchWalletBackupRemoteUsecase {
+  final WalletBackupRemoteRepository _repository;
+  final WalletBackupAuthenticator _authenticator;
+
+  const FetchWalletBackupRemoteUsecase(this._repository, this._authenticator);
+
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> execute() async {
+    final authentication = await _authenticator.sign(
+      action: WalletBackupAction.fetch,
+      generation: 0,
+      expectedEtag: '',
+      ciphertextSha256: '',
+      ciphertextBytes: 0,
+    );
+    return switch (authentication) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _repository.fetch(authentication: value),
+    };
+  }
+}
+
+final class StoreWalletBackupRemoteUsecase {
+  final WalletBackupRemoteRepository _repository;
+  final WalletBackupAuthenticator _authenticator;
+
+  const StoreWalletBackupRemoteUsecase(this._repository, this._authenticator);
+
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> execute({
+    required WalletBackupRemoteCheckpoint? current,
+    required WalletBackupCiphertext ciphertext,
+  }) async {
+    final generation = (current?.generation ?? 0) + 1;
+    final hash = sha256.convert(base64.decode(ciphertext.value)).toString();
+    final authentication = await _authenticator.sign(
+      action: WalletBackupAction.store,
+      generation: generation,
+      expectedEtag: current?.etag ?? '',
+      ciphertextSha256: hash,
+      ciphertextBytes: ciphertext.byteLength,
+    );
+    return switch (authentication) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _repository.store(
+        authentication: value,
+        current: current,
+        ciphertext: ciphertext,
+        ciphertextSha256: hash,
+      ),
+    };
+  }
+}
+
+final class DeleteWalletBackupRemoteUsecase {
+  final WalletBackupRemoteRepository _repository;
+  final WalletBackupAuthenticator _authenticator;
+
+  const DeleteWalletBackupRemoteUsecase(this._repository, this._authenticator);
+
+  /// Deletes the remote object, or reports the tombstone [current] already is.
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> execute({
+    required WalletBackupRemoteCheckpoint current,
+  }) async {
+    if (!current.found) return Ok(current);
+    final authentication = await _authenticator.sign(
+      action: WalletBackupAction.delete,
+      generation: current.generation + 1,
+      expectedEtag: current.etag,
+      ciphertextSha256: '',
+      ciphertextBytes: 0,
+    );
+    return switch (authentication) {
+      Err(:final failure) => Err(failure),
+      Ok(:final value) => _repository.delete(
+        authentication: value,
+        current: current,
+      ),
+    };
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/watch_wallet_backup_state_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/watch_wallet_backup_state_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+final class WatchWalletBackupStateUsecase {
+  final WalletBackupStateRepository _repository;
+
+  const WatchWalletBackupStateUsecase(this._repository);
+
+  @useResult
+  Stream<Result<WalletBackupState, WalletBackupFailure>> execute() {
+    return _repository.watch();
+  }
+}

--- a/lib/features/wallet_backup/domain/wallet_backup_job_runner.dart
+++ b/lib/features/wallet_backup/domain/wallet_backup_job_runner.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+typedef PublishWalletBackup =
+    Future<Result<void, WalletBackupFailure>> Function();
+
+/// The single queue every remote Bull backup job runs in.
+///
+/// Publish, recover, import, delete remote, and change server are the only
+/// jobs, and exactly one of them touches the server at a time. There is no
+/// separate lease, deferred completer, or lifecycle tail: a job either owns
+/// the runner or waits for it (spec 18, F8).
+///
+/// Publication is additionally coalesced. Triggers arriving while a
+/// publication runs collapse into one further pass, and the durable revisions
+/// decide whether that pass still has work to do.
+final class WalletBackupJobRunner {
+  final PublishWalletBackup _publish;
+  final DateTime Function() _now;
+
+  Future<void> _queue = Future.value();
+  Completer<Result<void, WalletBackupFailure>>? _publication;
+  bool _publishAgain = false;
+  DateTime? _notBefore;
+  bool _disposed = false;
+
+  WalletBackupJobRunner({required this._publish, DateTime Function()? now})
+    : _now = now ?? DateTime.now;
+
+  /// Runs [job] alone, after everything already queued.
+  ///
+  /// A rate-limited server closes the gate for the interval it asked for, and
+  /// jobs reaching the runner before then fail without a request. The gate is
+  /// deliberately in memory only (decision 8).
+  @useResult
+  Future<Result<T, WalletBackupFailure>> run<T>(
+    Future<Result<T, WalletBackupFailure>> Function() job,
+  ) => _enqueue(() => _gated(job));
+
+  /// Requests a publication, joining one that is already queued or running.
+  ///
+  /// The returned future completes with the result of the last pass, so a
+  /// caller that triggered work during an earlier pass still learns whether
+  /// its own change reached the server.
+  Future<Result<void, WalletBackupFailure>> requestPublish() {
+    if (_disposed) return Future.value(const Err(_disposedFailure));
+    final pending = _publication;
+    _publishAgain = true;
+    if (pending != null) return pending.future;
+
+    final completer = Completer<Result<void, WalletBackupFailure>>();
+    _publication = completer;
+    unawaited(_enqueue(_drainPublications));
+    return completer.future;
+  }
+
+  /// Drains anything already queued, so a caller can observe a settled runner.
+  Future<void> settle() => _enqueue<void>(() async {});
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    try {
+      await _queue;
+    } on Exception {
+      // Every job reports its own failure to its own caller.
+    }
+    final pending = _publication;
+    _publication = null;
+    if (pending != null && !pending.isCompleted) {
+      pending.complete(const Err(_disposedFailure));
+    }
+  }
+
+  Future<T> _enqueue<T>(Future<T> Function() job) {
+    final result = _queue.then((_) => job());
+    _queue = result.then<void>((_) {}, onError: (Object _) {});
+    return result;
+  }
+
+  Future<Result<void, WalletBackupFailure>> _drainPublications() async {
+    final completer = _publication!;
+    Result<void, WalletBackupFailure> result = const Ok(null);
+    try {
+      while (_publishAgain && !_disposed) {
+        _publishAgain = false;
+        result = await _gated(_publish);
+      }
+    } catch (error, trace) {
+      _publication = null;
+      if (!completer.isCompleted) completer.completeError(error, trace);
+      rethrow;
+    }
+    _publication = null;
+    if (!completer.isCompleted) completer.complete(result);
+    return result;
+  }
+
+  Future<Result<T, WalletBackupFailure>> _gated<T>(
+    Future<Result<T, WalletBackupFailure>> Function() job,
+  ) async {
+    if (_disposed) return const Err(_disposedFailure);
+    final notBefore = _notBefore;
+    if (notBefore != null) {
+      final remaining = notBefore.difference(_now().toUtc());
+      if (!remaining.isNegative && remaining != Duration.zero) {
+        return Err(WalletBackupRateLimitedFailure(remaining));
+      }
+      _notBefore = null;
+    }
+    final result = await job();
+    if (result case Err(
+      failure: WalletBackupRateLimitedFailure(:final retryAfter),
+    )) {
+      _notBefore = _now().toUtc().add(retryAfter);
+    }
+    return result;
+  }
+}
+
+const _disposedFailure = WalletBackupUnexpectedFailure(
+  'wallet backup job runner disposed',
+);

--- a/lib/features/wallet_backup/domain/wallet_definitions_section.dart
+++ b/lib/features/wallet_backup/domain/wallet_definitions_section.dart
@@ -1,0 +1,32 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:meta/meta.dart';
+
+final class WalletDefinitionsRecoveryResult {
+  final int restoredCount;
+  final int failedCount;
+  final List<String> createdWalletRefs;
+
+  WalletDefinitionsRecoveryResult({
+    required this.restoredCount,
+    required this.failedCount,
+    required List<String> createdWalletRefs,
+  }) : createdWalletRefs = List.unmodifiable(createdWalletRefs);
+}
+
+abstract interface class WalletDefinitionsBackup {
+  Stream<void> get changes;
+
+  /// The definitions to publish, read from local state alone. An empty list
+  /// leaves the section out of the published snapshot, which is how the last
+  /// external wallet is deleted (spec F1, F2).
+  @useResult
+  Future<Result<List<WalletDefinition>, WalletBackupFailure>> read();
+
+  @useResult
+  Future<Result<WalletDefinitionsRecoveryResult, WalletBackupFailure>> recover({
+    required List<WalletDefinition> definitions,
+    DateTime? deadline,
+  });
+}

--- a/lib/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider.dart
+++ b/lib/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider.dart
@@ -1,0 +1,308 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_preferences_failure.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+
+DateTime _systemNowUtc() => DateTime.now().toUtc();
+
+typedef ReadFrozenOutpoints = Future<List<FrozenWalletOutpoint>> Function();
+typedef RestoreFrozenOutpoints =
+    Future<void> Function(List<FrozenWalletOutpoint> outpoints);
+typedef ReadWalletPreferences =
+    Future<Result<List<WalletPreferences>, WalletPreferencesFailure>>
+    Function();
+typedef ApplyWalletPreferences =
+    Future<
+      Result<WalletPreferencesRecoveryApplyResult, WalletPreferencesFailure>
+    >
+    Function(List<WalletPreferencesRecoveryUpdate> updates);
+typedef ReadPortableSettings = Future<WalletPortableSettings> Function();
+typedef RestorePortableSettings =
+    Future<void> Function(WalletPortableSettings settings);
+
+/// The one owner of the backup's protected-data section: it reads the local
+/// snapshot, restores a recovered one, and reports when its inputs change.
+final class WalletMetadataBackupImpl {
+  final LabelsFacade _labels;
+  final ReadFrozenOutpoints _getFrozenOutpoints;
+  final RestoreFrozenOutpoints _restoreFrozenOutpoints;
+  final ReadWalletPreferences _getPreferences;
+  final ApplyWalletPreferences _applyPreferences;
+  final ReadPortableSettings readPortableSettings;
+  final RestorePortableSettings restorePortableSettings;
+  final DateTime Function() _nowUtc;
+  final StreamController<void> _changes = StreamController<void>.broadcast();
+  final List<StreamSubscription<void>> _subscriptions = [];
+  bool _suppressChanges = false;
+  bool _changedWhileSuppressed = false;
+
+  WalletMetadataBackupImpl({
+    required this._labels,
+    required this._getFrozenOutpoints,
+    required this._restoreFrozenOutpoints,
+    required this._getPreferences,
+    required this._applyPreferences,
+    required this.readPortableSettings,
+    required this.restorePortableSettings,
+    required List<Stream<void>> changeStreams,
+    this._nowUtc = _systemNowUtc,
+  }) {
+    for (final stream in changeStreams) {
+      _subscriptions.add(stream.listen((_) => _notifyChanged()));
+    }
+  }
+
+  Stream<void> get changes => _changes.stream;
+
+  Result<void, WalletMetadataBackupFailure> validate(
+    WalletMetadataSnapshot snapshot,
+  ) => _hasUnusableLabel(snapshot)
+      ? const Err(WalletMetadataBackupEncodingFailure())
+      : const Ok(null);
+
+  bool _hasUnusableLabel(WalletMetadataSnapshot snapshot) =>
+      snapshot.labels.any(
+        (label) => !_labels.isValid(
+          NewLabel(
+            type: label.type,
+            reference: label.reference,
+            label: label.label,
+            origin: label.origin,
+          ),
+        ),
+      );
+
+  Future<Result<WalletMetadataSnapshot, WalletMetadataBackupFailure>>
+  localSnapshot() async {
+    try {
+      final labelsResult = await _labels.fetchAllStrict();
+      final List<Label> labels;
+      switch (labelsResult) {
+        case Ok(:final value):
+          labels = value;
+        case Err():
+          return const Err(WalletMetadataBackupReadFailure());
+      }
+      final preferencesResult = await _getPreferences();
+      final List<WalletPreferences> preferences;
+      switch (preferencesResult) {
+        case Ok(:final value):
+          preferences = value
+              .where((item) => item.hasRepresentedValue)
+              .toList(growable: false);
+        case Err():
+          return const Err(WalletMetadataBackupReadFailure());
+      }
+      final snapshot = WalletMetadataSnapshot(
+        labels: labels
+            .map(
+              (label) => WalletMetadataLabel(
+                type: label.type,
+                reference: label.reference,
+                label: label.label,
+                origin: label.origin,
+              ),
+            )
+            .toList(growable: false),
+        frozenOutpoints: await _getFrozenOutpoints(),
+        walletPreferences: preferences,
+        settings: await readPortableSettings(),
+      );
+      return Ok(snapshot);
+    } on Exception catch (_, trace) {
+      _logFailure('read', trace);
+      return const Err(WalletMetadataBackupReadFailure());
+    }
+  }
+
+  Future<Result<bool, WalletMetadataBackupFailure>> recover({
+    required WalletMetadataSnapshot snapshot,
+    required Set<String> createdWalletRefs,
+    DateTime? deadline,
+  }) async {
+    _suppressChanges = true;
+    try {
+      _checkDeadline(deadline);
+      if (_hasUnusableLabel(snapshot)) {
+        return const Err(WalletMetadataBackupEncodingFailure());
+      }
+      final labelsResult = await _restoreLabels(snapshot.labels);
+      final bool labelsComplete;
+      switch (labelsResult) {
+        case Ok(:final value):
+          labelsComplete = value;
+        case Err(:final failure):
+          return Err(failure);
+      }
+      _checkDeadline(deadline);
+      await _restoreFrozenOutpoints(snapshot.frozenOutpoints);
+      _checkDeadline(deadline);
+      final preferencesResult = await _restorePreferences(
+        snapshot.walletPreferences,
+        createdWalletRefs,
+      );
+      final bool preferencesComplete;
+      switch (preferencesResult) {
+        case Ok(:final value):
+          preferencesComplete = value;
+        case Err(:final failure):
+          return Err(failure);
+      }
+      _checkDeadline(deadline);
+      await restorePortableSettings(snapshot.settings);
+      _checkDeadline(deadline);
+      return Ok(labelsComplete && preferencesComplete);
+    } on TimeoutException {
+      rethrow;
+    } on Exception catch (_, trace) {
+      _logFailure('recover', trace);
+      return const Err(WalletMetadataBackupWriteFailure());
+    } finally {
+      _suppressChanges = false;
+      if (_changedWhileSuppressed) {
+        _changedWhileSuppressed = false;
+        if (!_changes.isClosed) _changes.add(null);
+      }
+    }
+  }
+
+  Future<Result<bool, WalletMetadataBackupFailure>> _restoreLabels(
+    List<WalletMetadataLabel> desired,
+  ) async {
+    final currentResult = await _labels.fetchAllStrict();
+    final List<Label> current;
+    switch (currentResult) {
+      case Ok(:final value):
+        current = value;
+      case Err():
+        return const Err(WalletMetadataBackupReadFailure());
+    }
+    final currentByIdentity = {
+      for (final label in current)
+        _labelIdentity(label.label, label.reference): label,
+    };
+    var complete = true;
+    for (final label in desired) {
+      final existing =
+          currentByIdentity[_labelIdentity(label.label, label.reference)];
+      if (existing != null) {
+        if (existing.type != label.type || existing.origin != label.origin) {
+          complete = false;
+        }
+        continue;
+      }
+      final stored = await _labels.store(
+        NewLabel(
+          type: label.type,
+          reference: label.reference,
+          label: label.label,
+          origin: label.origin,
+        ),
+      );
+      if (stored case Err()) {
+        return const Err(WalletMetadataBackupWriteFailure());
+      }
+    }
+    return Ok(complete);
+  }
+
+  Future<Result<bool, WalletMetadataBackupFailure>> _restorePreferences(
+    List<WalletPreferences> desired,
+    Set<String> createdWalletRefs,
+  ) async {
+    final currentResult = await _getPreferences();
+    final List<WalletPreferences> current;
+    switch (currentResult) {
+      case Ok(:final value):
+        current = value;
+      case Err():
+        return const Err(WalletMetadataBackupReadFailure());
+    }
+    final currentByWallet = {for (final item in current) item.walletRef: item};
+    final updates = <WalletPreferencesRecoveryUpdate>[];
+    var complete = true;
+    for (final recovered in desired) {
+      final existing = currentByWallet[recovered.walletRef];
+      if (existing != null && _samePreferences(existing, recovered)) {
+        updates.add(
+          WalletPreferencesRecoveryUpdate(
+            expected: existing,
+            recovered: recovered,
+          ),
+        );
+        continue;
+      }
+      if (existing != null && createdWalletRefs.contains(recovered.walletRef)) {
+        updates.add(
+          WalletPreferencesRecoveryUpdate(
+            expected: existing,
+            recovered: recovered,
+          ),
+        );
+      } else {
+        complete = false;
+      }
+    }
+    final appliedResult = await _applyPreferences(updates);
+    switch (appliedResult) {
+      case Ok(:final value):
+        final expected = updates
+            .map((item) => item.recovered.walletRef)
+            .toSet();
+        final reported = value.appliedWalletRefs.union(
+          value.conflictedWalletRefs,
+        );
+        if (reported.length != expected.length ||
+            !reported.containsAll(expected)) {
+          throw StateError('Wallet preference restore result is incomplete');
+        }
+        return Ok(complete && value.conflictedWalletRefs.isEmpty);
+      case Err():
+        return const Err(WalletMetadataBackupWriteFailure());
+    }
+  }
+
+  void _notifyChanged() {
+    if (_suppressChanges) {
+      _changedWhileSuppressed = true;
+    } else if (!_changes.isClosed) {
+      _changes.add(null);
+    }
+  }
+
+  void _checkDeadline(DateTime? deadline) {
+    if (deadline != null && !_nowUtc().isBefore(deadline)) {
+      throw TimeoutException('wallet metadata recovery deadline');
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final subscription in _subscriptions) {
+      await subscription.cancel();
+    }
+    await _changes.close();
+  }
+}
+
+String _labelIdentity(String label, String reference) =>
+    '$label\u0000$reference';
+
+bool _samePreferences(WalletPreferences left, WalletPreferences right) =>
+    left.walletRef == right.walletRef &&
+    left.label == right.label &&
+    left.hideOnHome == right.hideOnHome &&
+    left.autoSweepEnabled == right.autoSweepEnabled;
+
+void _logFailure(String operation, StackTrace trace) {
+  log.severe(
+    message: 'Failed to $operation protected wallet data',
+    error: StateError('protected wallet data $operation failed'),
+    trace: trace,
+  );
+}

--- a/lib/features/wallet_backup/public/wallet_backup_facade.dart
+++ b/lib/features/wallet_backup/public/wallet_backup_facade.dart
@@ -1,0 +1,153 @@
+import 'dart:typed_data';
+
+export 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_contents.dart'
+    show WalletBackupContents, WalletBackupWalletSummary;
+export 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file.dart'
+    show WalletBackupExport, WalletBackupFileProtection;
+export 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file_comparison.dart'
+    show
+        WalletBackupDifference,
+        WalletBackupImportComparison,
+        WalletBackupImportSituation,
+        WalletBackupImportSource,
+        WalletBackupSnapshotSummary;
+export 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart'
+    show WalletBackupRecoveryResult, WalletBackupRecoveryStatus;
+export 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart'
+    show WalletBackupRecoveryState, WalletBackupState;
+export 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+export 'package:bb_mobile/features/wallet_backup/public/wallet_backup_server_config.dart';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_contents.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file_comparison.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/delete_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/watch_wallet_backup_state_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_job_runner.dart';
+import 'package:meta/meta.dart';
+
+/// The one entry point into Bull backup.
+///
+/// Every intent that touches the server is handed to the job runner, so the
+/// facade never has to know what else is in flight.
+class WalletBackupFacade {
+  final GetWalletBackupContentsUsecase _getContents;
+  final WatchWalletBackupStateUsecase _watchState;
+  final SetWalletBackupEnabledUsecase _setEnabled;
+  final SetWalletBackupServerUsecase _setServer;
+  final DeleteWalletBackupUsecase _delete;
+  final WalletBackupJobRunner _runner;
+  final WalletBackupStateRepository _state;
+  final RecoverWalletBackupUsecase _recover;
+  final BuildWalletBackupExportUsecase _buildExport;
+  final CompareWalletBackupFileUsecase _compareFile;
+  final RecoverWalletBackupFileUsecase _recoverFile;
+
+  const WalletBackupFacade(
+    this._getContents,
+    this._watchState,
+    this._setEnabled,
+    this._setServer,
+    this._delete,
+    this._runner,
+    this._state,
+    this._recover,
+    this._buildExport,
+    this._compareFile,
+    this._recoverFile,
+  );
+
+  @useResult
+  Future<Result<WalletBackupContents, WalletBackupFailure>> getContents() =>
+      _getContents.execute();
+
+  @useResult
+  Stream<Result<WalletBackupState, WalletBackupFailure>> watchState() =>
+      _watchState.execute();
+
+  /// Enabling recovers the account's backup and publishes once, all inside one
+  /// runner job: the recovery and the first publication must not be separated
+  /// by anything else touching the server (spec 19.1).
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setEnabled(bool enabled) =>
+      _runner.run(() => _setEnabled.execute(enabled));
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> setServer(String value) =>
+      _runner.run(() => _setServer.execute(value));
+
+  /// Publishes a snapshot that includes every change committed before this
+  /// call.
+  ///
+  /// Owners outside this database report their changes asynchronously, so an
+  /// explicit "Backup now" records a revision of its own first rather than
+  /// racing a stream event that has not arrived yet.
+  @useResult
+  Future<Result<void, WalletBackupFailure>> backupNow() async {
+    if (await _state.recordLocalMutation() case Err(:final failure)) {
+      return Err(failure);
+    }
+    return _runner.requestPublish();
+  }
+
+  @useResult
+  Future<Result<void, WalletBackupFailure>> deleteRemoteBackup({
+    required bool confirmed,
+  }) {
+    if (!confirmed) return _delete.execute(confirmed: false);
+    return _runner.run(() => _delete.execute(confirmed: true));
+  }
+
+  Future<WalletBackupRecoveryResult> recover({
+    Set<String> defaultCreatedWalletIds = const {},
+  }) => _runRecovery(
+    () => _recover.execute(defaultCreatedWalletIds: defaultCreatedWalletIds),
+  );
+
+  @useResult
+  Future<Result<WalletBackupExport, WalletBackupFailure>> buildExport({
+    required WalletBackupFileProtection protection,
+    required bool confirmedUnencrypted,
+  }) => _buildExport.execute(
+    protection: protection,
+    confirmedUnencrypted: confirmedUnencrypted,
+  );
+
+  @useResult
+  Future<Result<WalletBackupImportComparison, WalletBackupFailure>> compareFile(
+    Uint8List bytes,
+  ) => _compareFile.execute(bytes);
+
+  Future<WalletBackupRecoveryResult> recoverComparedFile({
+    required Uint8List fileBytes,
+    required WalletBackupImportComparison comparison,
+    required WalletBackupImportSource source,
+  }) => _runRecovery(
+    () => _recoverFile.execute(
+      fileBytes: fileBytes,
+      comparison: comparison,
+      source: source,
+    ),
+  );
+
+  /// Recovery reports its own outcome, so a runner-level refusal — a closed
+  /// rate-limit gate above all — has to be folded into the same shape.
+  Future<WalletBackupRecoveryResult> _runRecovery(
+    Future<WalletBackupRecoveryResult> Function() job,
+  ) async => switch (await _runner.run(() async => Ok(await job()))) {
+    Ok(:final value) => value,
+    Err(:final failure) => WalletBackupRecoveryResult.fromFailure(failure),
+  };
+}

--- a/lib/features/wallet_backup/wallet_backup_locator.dart
+++ b/lib/features/wallet_backup/wallet_backup_locator.dart
@@ -1,0 +1,335 @@
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_server_repository.dart';
+import 'package:bb_mobile/core/electrum/domain/repositories/electrum_settings_repository.dart';
+import 'package:bb_mobile/core/mempool/domain/repositories/mempool_server_repository.dart';
+import 'package:bb_mobile/core/mempool/domain/repositories/mempool_settings_repository.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/swaps/domain/repositories/auto_swap_settings_repository.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/apply_recovered_wallet_preferences_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_frozen_wallet_outpoints_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_definitions_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_preferences_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/restore_wallet_definition_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/restore_frozen_wallet_outpoints_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_catalog_changes_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_preference_changes_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_utxo_freeze_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/data/drift_wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/data/metadata_backup_http_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/data/models/wallet_backup_snapshot_model.dart';
+import 'package:bb_mobile/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/data/wallet_definitions_backup.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/backup_wallet_now_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/delete_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_recovery_inventory_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/store_selected_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/publish_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/register_wallet_backup_recovery_material_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/watch_wallet_backup_state_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_job_runner.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/data/wallet_portable_settings_backup.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/watchers/wallet_backup_triggers.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:get_it/get_it.dart';
+import 'package:bull_payjoin/bull_payjoin.dart';
+
+abstract final class WalletBackupLocator {
+  static void setup(GetIt locator) {
+    locator.registerLazySingleton<_WalletBackupGraph>(
+      () => _WalletBackupGraph.build(locator),
+      dispose: (graph) => graph.dispose(),
+    );
+    locator.registerLazySingleton<WalletBackupFacade>(
+      () => locator<_WalletBackupGraph>().facade,
+    );
+  }
+
+  static void start(GetIt locator) {
+    final graph = locator<_WalletBackupGraph>();
+    // Registration needs the default seed, which does not exist before the
+    // first wallet. Publication registers again when backup is enabled, so a
+    // failure here is only worth logging.
+    unawaited(
+      graph.registerRecoveryMaterial.execute().then((result) {
+        if (result case Err(:final failure)) {
+          log.info(
+            'Wallet backup recovery material not registered at start-up',
+            error: failure.runtimeType,
+          );
+        }
+      }),
+    );
+    graph.triggers.start();
+  }
+}
+
+final class _WalletBackupGraph {
+  final WalletMetadataBackupImpl metadata;
+  final WalletBackupJobRunner runner;
+  final WalletBackupTriggers triggers;
+  final RegisterWalletBackupRecoveryMaterialUsecase registerRecoveryMaterial;
+  final WalletBackupFacade facade;
+
+  const _WalletBackupGraph({
+    required this.metadata,
+    required this.runner,
+    required this.triggers,
+    required this.registerRecoveryMaterial,
+    required this.facade,
+  });
+
+  factory _WalletBackupGraph.build(GetIt locator) {
+    final definitions = WalletDefinitionsBackupImpl(
+      locator<GetWalletDefinitionsUsecase>().execute,
+      locator<RestoreWalletDefinitionUsecase>().execute,
+      locator<WatchWalletCatalogChangesUsecase>().execute,
+    );
+    final labels = locator<LabelsFacade>();
+    final database = locator<SqliteDatabase>();
+    final payjoin = locator<PayjoinPolicyAccess>();
+    final portableSettings = WalletPortableSettingsBackup(
+      settings: locator<SettingsRepository>(),
+      autoswap: locator<AutoSwapSettingsRepository>(),
+      electrumServers: locator<ElectrumServerRepository>(),
+      electrumSettings: locator<ElectrumSettingsRepository>(),
+      mempoolServers: locator<MempoolServerRepository>(),
+      mempoolSettings: locator<MempoolSettingsRepository>(),
+      payjoin: payjoin,
+      walletExists: locator<WalletRepository>().containsWallet,
+    );
+    final metadata = WalletMetadataBackupImpl(
+      labels: labels,
+      getFrozenOutpoints: locator<GetFrozenWalletOutpointsUsecase>().execute,
+      restoreFrozenOutpoints:
+          locator<RestoreFrozenWalletOutpointsUsecase>().execute,
+      getPreferences: locator<GetWalletPreferencesUsecase>().execute,
+      applyPreferences:
+          locator<ApplyRecoveredWalletPreferencesUsecase>().execute,
+      readPortableSettings: portableSettings.read,
+      restorePortableSettings: portableSettings.restore,
+      changeStreams: [
+        labels.changes,
+        locator<WatchWalletUtxoFreezeChangesUsecase>().execute(),
+        locator<WatchWalletPreferenceChangesUsecase>().execute(),
+        database.select(database.settings).watch().skip(1).map((_) {}),
+        database.select(database.autoSwap).watch().skip(1).map((_) {}),
+        database.select(database.electrumServers).watch().skip(1).map((_) {}),
+        database.select(database.electrumSettings).watch().skip(1).map((_) {}),
+        database.select(database.mempoolServers).watch().skip(1).map((_) {}),
+        database.select(database.mempoolSettings).watch().skip(1).map((_) {}),
+        payjoin.watch().skip(1).map((_) {}),
+      ],
+    );
+    final keychainManifest = locator<KeychainManifestFacade>();
+    final codec = WalletBackupSnapshotCodec(
+      encodeManifest: keychainManifest.encodeManifestFilePayload,
+      decodeManifest: keychainManifest.parseManifestFilePayload,
+    );
+    final encryption = RecoverBullWalletBackupEncryptionRepository(codec);
+    final state = DriftWalletBackupStateRepository(database);
+    Future<Uri> originProvider() async {
+      switch (await state.get()) {
+        case Ok(:final value):
+          final origin = parseWalletBackupServerOrigin(
+            value.customServerUrl ?? walletBackupDefaultServerUrl,
+          );
+          if (origin == null) throw const _WalletBackupOriginException();
+          return origin;
+        case Err():
+          throw const _WalletBackupOriginException();
+      }
+    }
+
+    final remote = MetadataBackupHttpRepository.defaults(
+      origin: originProvider,
+    );
+    final nostrIdentity = locator<NostrIdentityFacade>();
+    final authenticator = WalletBackupAuthenticator(nostrIdentity);
+    final fetchRemote = FetchWalletBackupRemoteUsecase(remote, authenticator);
+    final storeRemote = StoreWalletBackupRemoteUsecase(remote, authenticator);
+    final deleteRemote = DeleteWalletBackupRemoteUsecase(remote, authenticator);
+    final resolveKey = ResolveWalletBackupKeyUsecase(
+      locator<GetSettingsUsecase>(),
+      locator<GetDefaultSeedUsecase>(),
+    );
+    final wallets = locator<WalletRepository>();
+    final refreshManifest = RefreshWalletRecoveryManifestUsecase(
+      wallets.getSeedDerivedWalletRecoveryFacts,
+      keychainManifest,
+    );
+    final recoveryInventory = GetWalletRecoveryInventoryUsecase(
+      resolveKey.execute,
+      refreshManifest.execute,
+      keychainManifest.readManifest,
+    );
+    final buildSnapshot = BuildWalletBackupSnapshotUsecase(
+      keychainManifest,
+      definitions,
+      metadata.localSnapshot,
+    );
+    final registerRecoveryMaterial =
+        RegisterWalletBackupRecoveryMaterialUsecase(
+          resolveKey,
+          nostrIdentity,
+          keychainManifest,
+          refreshManifest,
+        );
+    final fetchImport = FetchWalletBackupSnapshotUsecase(
+      resolveKey: resolveKey,
+      encryption: encryption,
+      state: state,
+    );
+    final publish = PublishWalletBackupUsecase(
+      buildSnapshot: buildSnapshot,
+      resolveKey: resolveKey,
+      encryption: encryption,
+      fetchRemote: fetchRemote,
+      storeRemote: storeRemote,
+      readRemoteSnapshot: fetchImport,
+      state: state,
+    );
+    final publication = BackupWalletNowUsecase(
+      state: state,
+      publish: publish.execute,
+      nowSecs: _nowSecs,
+    );
+    final runner = WalletBackupJobRunner(publish: publication.execute);
+    final applySnapshot = ApplyBackupSnapshotUsecase(
+      state,
+      definitions,
+      restoreManifest: RestoreWalletBackupManifestUsecase(
+        wallets.matchesSeedDerivedRecoveryIdentity,
+        keychainManifest,
+      ),
+      validateMetadata: metadata.validate,
+      restoreMetadata: metadata.recover,
+    );
+    final decodeFile = DecodeWalletBackupFileUsecase(
+      resolveKey.execute,
+      encryption,
+    );
+    final recover = RecoverWalletBackupUsecase(
+      fetchImport: fetchImport.execute,
+      fetchRemote: fetchRemote.execute,
+      apply: applySnapshot.execute,
+    );
+    final triggers = WalletBackupTriggers(
+      // The manifest records its own revision inside the transaction that
+      // changes it (decision 7); every other owner commits outside this
+      // database or outside a repository this feature can reach.
+      recordedChanges: keychainManifest.watchCommittedChanges(),
+      unrecordedChanges: _mergeChanges([definitions.changes, metadata.changes]),
+      syncResults: locator<WatchElectrumSyncResultsUsecase>().execute(),
+      runner: runner,
+      recordMutation: state.recordLocalMutation,
+    );
+    final facade = WalletBackupFacade(
+      GetWalletBackupContentsUsecase(
+        recoveryInventory.execute,
+        locator<GetWalletDefinitionsUsecase>().execute,
+        wallets.getLocallyKeyedWalletIds,
+        metadata.localSnapshot,
+      ),
+      WatchWalletBackupStateUsecase(state),
+      SetWalletBackupEnabledUsecase(
+        state,
+        recover.execute,
+        registerRecoveryMaterial.execute,
+        publication.execute,
+      ),
+      SetWalletBackupServerUsecase(
+        state,
+        parseOrigin: parseWalletBackupServerOrigin,
+      ),
+      DeleteWalletBackupUsecase(
+        fetchRemote: fetchRemote,
+        deleteRemote: deleteRemote,
+        state: state,
+      ),
+      runner,
+      state,
+      recover,
+      BuildWalletBackupExportUsecase(
+        buildSnapshot: buildSnapshot.execute,
+        resolveKey: resolveKey.execute,
+        encryption: encryption,
+      ),
+      CompareWalletBackupFileUsecase(
+        decodeFile.execute,
+        state.get,
+        fetchRemote.execute,
+        fetchImport.execute,
+        codec.differences,
+      ),
+      RecoverWalletBackupFileUsecase(
+        decodeFile.execute,
+        ({required snapshot, deadline}) => applySnapshot.execute(
+          snapshot: snapshot,
+          deadline: deadline,
+          callerSettlesFence: true,
+        ),
+        applySnapshot.settle,
+        state.get,
+        fetchRemote.execute,
+        StoreSelectedWalletBackupUsecase(
+          resolveKey,
+          encryption,
+          storeRemote,
+          state,
+          _nowSecs,
+        ).execute,
+      ),
+    );
+    return _WalletBackupGraph(
+      metadata: metadata,
+      runner: runner,
+      triggers: triggers,
+      registerRecoveryMaterial: registerRecoveryMaterial,
+      facade: facade,
+    );
+  }
+
+  Future<void> dispose() async {
+    await triggers.dispose();
+    await runner.dispose();
+    await metadata.dispose();
+  }
+}
+
+int _nowSecs() => DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+
+Stream<void> _mergeChanges(List<Stream<void>> streams) =>
+    StreamGroup.merge(streams);
+
+final class _WalletBackupOriginException implements Exception {
+  const _WalletBackupOriginException();
+}

--- a/lib/features/wallet_backup/watchers/wallet_backup_triggers.dart
+++ b/lib/features/wallet_backup/watchers/wallet_backup_triggers.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_sync_result.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_job_runner.dart';
+import 'package:flutter/widgets.dart';
+
+typedef RecordWalletBackupMutation =
+    Future<Result<int, WalletBackupFailure>> Function();
+
+/// Turns app events into runner requests, and nothing else.
+///
+/// A change stream does exactly two things (spec 18): make sure the mutation
+/// is recorded durably, then ask the runner for a coalesced publication. All
+/// serialization, queueing, and back-off live in the runner.
+final class WalletBackupTriggers with WidgetsBindingObserver {
+  /// Owners that already incremented the local revision inside the same
+  /// database transaction as their write (decision 7). Nothing is recorded
+  /// here; the change only asks for a publication.
+  final Stream<void> recordedChanges;
+
+  /// Owners that cannot record their own revision, because they do not commit
+  /// through this database. Their change is recorded here before publishing.
+  final Stream<void> unrecordedChanges;
+
+  final Stream<ElectrumSyncResult> syncResults;
+  final WalletBackupJobRunner runner;
+  final RecordWalletBackupMutation recordMutation;
+
+  final List<StreamSubscription<void>> _subscriptions = [];
+  Future<void> _recording = Future.value();
+  bool _started = false;
+  bool _disposed = false;
+
+  WalletBackupTriggers({
+    required this.recordedChanges,
+    required this.unrecordedChanges,
+    required this.syncResults,
+    required this.runner,
+    required this.recordMutation,
+  });
+
+  void start() {
+    if (_started || _disposed) return;
+    _started = true;
+    WidgetsBinding.instance.addObserver(this);
+    _subscriptions.addAll([
+      recordedChanges.listen(
+        (_) => _requestPublish(),
+        onError: _logStreamFailure,
+      ),
+      unrecordedChanges.listen(
+        (_) => _recordThenPublish(),
+        onError: _logStreamFailure,
+      ),
+      syncResults
+          .where((result) => result.success)
+          .listen((_) => _requestPublish(), onError: _logStreamFailure),
+    ]);
+    _requestPublish();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _requestPublish();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    if (_started) {
+      WidgetsBinding.instance.removeObserver(this);
+      _started = false;
+    }
+    for (final subscription in _subscriptions) {
+      await subscription.cancel();
+    }
+    _subscriptions.clear();
+    try {
+      await _recording;
+    } on Exception {
+      // Each recording task already logged its own failure.
+    }
+  }
+
+  /// Recordings run one after another so a burst of changes cannot interleave
+  /// read-modify-write increments.
+  void _recordThenPublish() {
+    if (_disposed) return;
+    _recording = _recording.then((_) async {
+      if (_disposed) return;
+      if (await recordMutation() case Err(:final failure)) {
+        log.warning(
+          'Wallet backup could not record a local change',
+          error: failure.runtimeType,
+        );
+        return;
+      }
+      _requestPublish();
+    });
+  }
+
+  void _requestPublish() {
+    if (_disposed) return;
+    unawaited(
+      runner
+          .requestPublish()
+          .then((result) {
+            if (result case Err(
+              :final failure,
+            ) when failure is! WalletBackupDisabledFailure) {
+              log.warning(
+                'Automatic wallet backup did not complete',
+                error: failure.runtimeType,
+              );
+            }
+          })
+          .catchError((Object error, StackTrace trace) {
+            if (error is Error) Error.throwWithStackTrace(error, trace);
+            log.warning(
+              'Automatic wallet backup failed',
+              error: error.runtimeType,
+              trace: trace,
+            );
+          }),
+    );
+  }
+
+  void _logStreamFailure(Object error, StackTrace trace) {
+    if (error is Error) Error.throwWithStackTrace(error, trace);
+    log.warning(
+      'Wallet backup change stream failed',
+      error: error.runtimeType,
+      trace: trace,
+    );
+  }
+}

--- a/test/features/wallet_backup/apply_backup_snapshot_usecase_test.dart
+++ b/test/features/wallet_backup/apply_backup_snapshot_usecase_test.dart
@@ -1,0 +1,283 @@
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/entities/keychain_manifest.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+import 'metadata/support/portable_settings_fixture.dart';
+
+class _RestoreManifest extends Mock
+    implements RestoreWalletBackupManifestUsecase {}
+
+class _State extends Mock implements WalletBackupStateRepository {}
+
+class _Definitions extends Mock implements WalletDefinitionsBackup {}
+
+/// The protected-data section is a pair of plain functions now, so this is the
+/// surface the test mocks and hands to the use case.
+abstract interface class _MetadataSection {
+  Result<void, WalletMetadataBackupFailure> validate(
+    WalletMetadataSnapshot snapshot,
+  );
+
+  Future<Result<bool, WalletMetadataBackupFailure>> recover({
+    required WalletMetadataSnapshot snapshot,
+    required Set<String> createdWalletRefs,
+    DateTime? deadline,
+  });
+}
+
+class _Metadata extends Mock implements _MetadataSection {}
+
+void main() {
+  final manifest = KeychainManifest(
+    parentFingerprint: Fingerprint('73c5da0a'),
+    generatedAt: 1,
+    entries: const [],
+  );
+  final metadataSnapshot = WalletMetadataSnapshot(
+    labels: const [],
+    frozenOutpoints: const [],
+    walletPreferences: const [],
+    settings: portableSettingsFixture(),
+  );
+  final import = WalletBackupSnapshot(
+    parentFingerprint: Fingerprint('73c5da0a'),
+    createdAt: 1,
+    recoveryManifest: manifest,
+    externalWalletDefinitions: [
+      WalletDefinition(
+        walletRef: 'external',
+        network: Network.bitcoinMainnet,
+        descriptor: 'wpkh(external)',
+        provenance: WalletProvenance.watchOnly,
+      ),
+    ],
+    metadata: metadataSnapshot,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(manifest);
+    registerFallbackValue(metadataSnapshot);
+    registerFallbackValue(const <WalletDefinition>[]);
+    registerFallbackValue(WalletBackupRecoveryStatus.noBackup);
+    registerFallbackValue(WalletBackupRecoveryState.idle);
+  });
+
+  late _RestoreManifest restore;
+  late _State state;
+  late _Definitions definitions;
+  late _Metadata metadata;
+  late List<String> calls;
+  late WalletBackupRecoveryState fence;
+  late ApplyBackupSnapshotUsecase usecase;
+
+  setUp(() {
+    restore = _RestoreManifest();
+    state = _State();
+    definitions = _Definitions();
+    metadata = _Metadata();
+    calls = [];
+    fence = WalletBackupRecoveryState.idle;
+
+    when(() => metadata.validate(any())).thenReturn(const Ok(null));
+    when(
+      () => restore.execute(any(), deadline: any(named: 'deadline')),
+    ).thenAnswer((_) async {
+      calls.add('manifest');
+      return const WalletBackupManifestRestoreResult(
+        restoredCount: 1,
+        failedCount: 0,
+      );
+    });
+    when(
+      () => definitions.recover(
+        definitions: any(named: 'definitions'),
+        deadline: any(named: 'deadline'),
+      ),
+    ).thenAnswer((_) async {
+      calls.add('definitions');
+      return Ok(
+        WalletDefinitionsRecoveryResult(
+          restoredCount: 1,
+          failedCount: 0,
+          createdWalletRefs: ['external'],
+        ),
+      );
+    });
+    when(
+      () => metadata.recover(
+        snapshot: any(named: 'snapshot'),
+        createdWalletRefs: any(named: 'createdWalletRefs'),
+        deadline: any(named: 'deadline'),
+      ),
+    ).thenAnswer((_) async {
+      calls.add('metadata');
+      return const Ok(true);
+    });
+    when(
+      () => state.saveRemoteCheckpoint(null),
+    ).thenAnswer((_) async => const Ok(null));
+    when(() => state.setRecoveryState(any())).thenAnswer((invocation) async {
+      fence =
+          invocation.positionalArguments.single as WalletBackupRecoveryState;
+      calls.add(fence.name);
+      return const Ok(null);
+    });
+    when(() => state.get()).thenAnswer(
+      (_) async => Ok(
+        WalletBackupState(
+          enabled: true,
+          localRevision: 1,
+          uploadedRevision: 0,
+          lastSucceededAt: null,
+          unsupportedVersion: null,
+          recoveryState: fence,
+        ),
+      ),
+    );
+    when(() => state.saveRecoveryOutcome(any())).thenAnswer((_) async {
+      calls.add('outcome');
+      return const Ok(null);
+    });
+
+    usecase = ApplyBackupSnapshotUsecase(
+      state,
+      definitions,
+      restoreManifest: restore,
+      validateMetadata: metadata.validate,
+      restoreMetadata: metadata.recover,
+      nowUtc: () => DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+    );
+  });
+
+  test('validates before mutation and restores in dependency order', () async {
+    final result = await usecase.execute(snapshot: Ok(import));
+
+    expect(result.status, WalletBackupRecoveryStatus.restored);
+    expect(result.restoredCount, 2);
+    expect(calls, [
+      'applying',
+      'manifest',
+      'definitions',
+      'metadata',
+      'idle',
+      'outcome',
+    ]);
+    verify(
+      () => metadata.recover(
+        snapshot: metadataSnapshot,
+        createdWalletRefs: {'external'},
+        deadline: any(named: 'deadline'),
+      ),
+    ).called(1);
+  });
+
+  test('rejects an invalid section before fencing or restoring', () async {
+    when(
+      () => metadata.validate(metadataSnapshot),
+    ).thenReturn(const Err(WalletMetadataBackupEncodingFailure()));
+
+    final result = await usecase.execute(snapshot: Ok(import));
+
+    expect(result.status, WalletBackupRecoveryStatus.invalid);
+    expect(calls, ['outcome']);
+    verifyNever(() => restore.execute(any(), deadline: any(named: 'deadline')));
+  });
+
+  test('a partial restore ends at needs-attention', () async {
+    when(
+      () => metadata.recover(
+        snapshot: any(named: 'snapshot'),
+        createdWalletRefs: any(named: 'createdWalletRefs'),
+        deadline: any(named: 'deadline'),
+      ),
+    ).thenAnswer((_) async {
+      calls.add('metadata');
+      return const Ok(false);
+    });
+
+    final result = await usecase.execute(snapshot: Ok(import));
+
+    expect(result.status, WalletBackupRecoveryStatus.partiallyRestored);
+    expect(fence, WalletBackupRecoveryState.needsAttention);
+    expect(calls, isNot(contains('idle')));
+  });
+
+  test('an unreachable remote is recorded without fencing anything', () async {
+    final result = await usecase.execute(
+      snapshot: const Err(WalletBackupRemoteUnavailableFailure()),
+    );
+
+    expect(result.status, WalletBackupRecoveryStatus.unavailable);
+    expect(calls, ['outcome']);
+    verifyNever(() => restore.execute(any(), deadline: any(named: 'deadline')));
+  });
+
+  test('a post-apply conflict ends at needs-attention', () async {
+    final result = await usecase.execute(
+      snapshot: Ok(import),
+      revalidate: () async => const Ok(false),
+    );
+
+    expect(result.status, WalletBackupRecoveryStatus.conflict);
+    expect(fence, WalletBackupRecoveryState.needsAttention);
+    expect(calls, isNot(contains('idle')));
+  });
+
+  test('a budget already spent stops before it restores anything', () async {
+    final result = await usecase.execute(
+      snapshot: Ok(import),
+      deadline: DateTime.fromMillisecondsSinceEpoch(500, isUtc: true),
+    );
+
+    expect(result.status, WalletBackupRecoveryStatus.timedOut);
+    expect(result.restoredCount, 0);
+    // The fence went up and stayed up: a run that gave up part-way is not a
+    // run that finished.
+    expect(fence, WalletBackupRecoveryState.needsAttention);
+    expect(calls, ['applying', 'needsAttention', 'outcome']);
+    verifyNever(() => restore.execute(any(), deadline: any(named: 'deadline')));
+    verifyNever(
+      () => definitions.recover(
+        definitions: any(named: 'definitions'),
+        deadline: any(named: 'deadline'),
+      ),
+    );
+    verifyNever(
+      () => metadata.recover(
+        snapshot: any(named: 'snapshot'),
+        createdWalletRefs: any(named: 'createdWalletRefs'),
+        deadline: any(named: 'deadline'),
+      ),
+    );
+  });
+
+  test('a caller that settles the fence itself is left holding it', () async {
+    final applied = await usecase.execute(
+      snapshot: Ok(import),
+      callerSettlesFence: true,
+    );
+
+    expect(applied.status, WalletBackupRecoveryStatus.restored);
+    expect(fence, WalletBackupRecoveryState.applying);
+    expect(calls, isNot(contains('outcome')));
+
+    await usecase.settle(applied, fence: WalletBackupRecoveryState.idle);
+
+    expect(fence, WalletBackupRecoveryState.idle);
+    expect(calls.last, 'outcome');
+  });
+}

--- a/test/features/wallet_backup/backup_behavior_baseline_test.dart
+++ b/test/features/wallet_backup/backup_behavior_baseline_test.dart
@@ -1,0 +1,380 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart' hide ScriptType;
+import 'package:recoverbull/recoverbull.dart';
+
+import 'support/wallet_backup_behavior_harness.dart';
+
+/// Product-level baseline for Bull backup.
+///
+/// These tests exercise the public backup facade against real state storage,
+/// a real keychain manifest, real codecs and real encryption. Only the backup
+/// server and the two section owners (external wallets, protected data) are
+/// faked, because those are the process boundaries. Nothing here asserts on
+/// how publication, recovery or fencing are wired internally, so the suite
+/// stays meaningful across a refactor of that wiring.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('enabling automatic backup', () {
+    test('publishes a first snapshot when the account has no backup', () async {
+      final device = await _device();
+      expect(device.remote.isEmpty, isTrue);
+
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      final state = await device.readState();
+      expect(state.enabled, isTrue);
+      expect(state.dirty, isFalse);
+      expect(state.lastSucceededAt, isNotNull);
+      expect(device.remote.isEmpty, isFalse);
+      expect(device.remote.storeCount, 1);
+    });
+
+    test('recovers an existing backup for this seed, then publishes', () async {
+      final server = FakeWalletBackupRemote();
+      final firstDevice = await _device(remote: server);
+      await _addWallet(firstDevice, walletId: 'cold-wallet', label: 'Cold');
+      expect(await firstDevice.facade.setEnabled(true), _succeeds);
+      expect(server.isEmpty, isFalse);
+
+      final newDevice = await _device(remote: server);
+      expect(await _wallets(newDevice), isEmpty);
+
+      expect(await newDevice.facade.setEnabled(true), _succeeds);
+
+      expect(
+        (await _wallets(newDevice)).map((wallet) => wallet.label),
+        contains('Cold'),
+      );
+      final state = await newDevice.readState();
+      expect(state.enabled, isTrue);
+      expect(state.dirty, isFalse);
+      expect(state.lastSucceededAt, isNotNull);
+    });
+
+    test(
+      'refuses a backup bound to another seed and leaves it alone',
+      () async {
+        final device = await _device();
+        device.remote.install(await _foreignRootedBackup(device.encryptionKey));
+        final published = device.remote.storedCiphertext;
+
+        final result = await device.facade.setEnabled(true);
+
+        expect(result, isA<Err<void, WalletBackupFailure>>());
+        final state = await device.readState();
+        expect(state.enabled, isFalse);
+        expect(state.lastRecoveryStatus, WalletBackupRecoveryStatus.invalid);
+        expect(device.remote.storedCiphertext, published);
+        expect(device.remote.storeCount, 0);
+      },
+    );
+
+    test('refuses a backup this wallet cannot read at all', () async {
+      final server = FakeWalletBackupRemote();
+      final otherWallet = await _device(
+        remote: server,
+        seed: backupSeed(
+          mnemonic: foreignSeedMnemonic,
+          fingerprint: foreignSeedFingerprint,
+        ),
+      );
+      expect(await otherWallet.facade.setEnabled(true), _succeeds);
+      final published = server.storedCiphertext;
+
+      final device = await _device(remote: server);
+      final result = await device.facade.setEnabled(true);
+
+      expect(result, isA<Err<void, WalletBackupFailure>>());
+      expect((await device.readState()).enabled, isFalse);
+      expect(server.storedCiphertext, published);
+    });
+  });
+
+  group('publishing local changes', () {
+    test('a backup-relevant change republishes the backup', () async {
+      final device = await _device();
+      expect(await device.facade.setEnabled(true), _succeeds);
+      final published = device.remote.storedCiphertext;
+      final storesAfterEnabling = device.remote.storeCount;
+      device.startCoordinator();
+
+      await _addWallet(device, walletId: 'new-wallet', label: 'Savings');
+
+      await settleUntil(
+        () async => device.remote.storedCiphertext != published,
+        description: 'a republished backup',
+      );
+      final state = await device.readState();
+      expect(state.dirty, isFalse);
+      expect(state.lastSucceededAt, isNotNull);
+      expect(device.remote.storeCount, greaterThan(storesAfterEnabling));
+    });
+
+    test('an unavailable server keeps the backup pending until it is '
+        'reachable again', () async {
+      final device = await _device();
+      expect(await device.facade.setEnabled(true), _succeeds);
+      final published = device.remote.storedCiphertext;
+      final publishedAt = (await device.readState()).lastSucceededAt;
+      final storesAfterEnabling = device.remote.storeCount;
+
+      device.remote.storeFailure = const WalletBackupRemoteUnavailableFailure();
+      await _addWallet(device, walletId: 'offline-wallet', label: 'Offline');
+
+      expect(
+        await device.facade.backupNow(),
+        isA<Err<void, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupRemoteUnavailableFailure>(),
+        ),
+      );
+      var state = await device.readState();
+      expect(state.dirty, isTrue);
+      expect(state.lastSucceededAt, publishedAt);
+      expect(device.remote.storedCiphertext, published);
+      expect(device.remote.storeCount, storesAfterEnabling);
+
+      device.remote.storeFailure = null;
+
+      expect(await device.facade.backupNow(), _succeeds);
+      state = await device.readState();
+      expect(state.dirty, isFalse);
+      expect(state.lastSucceededAt, isNotNull);
+      expect(device.remote.storedCiphertext, isNot(published));
+      expect(
+        (await _wallets(device)).map((wallet) => wallet.label),
+        contains('Offline'),
+      );
+    });
+  });
+
+  group('fencing publication', () {
+    test('an interrupted recovery blocks publication until recovery '
+        'completes', () async {
+      final server = FakeWalletBackupRemote();
+      final device = await _device(remote: server);
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      final otherDevice = await _device(remote: server);
+      await _addWallet(otherDevice, walletId: 'elsewhere', label: 'Elsewhere');
+      expect(await otherDevice.facade.setEnabled(true), _succeeds);
+      final published = server.storedCiphertext;
+
+      device.metadata.recoverComplete = false;
+      final interrupted = await device.facade.recover();
+
+      expect(interrupted.status, WalletBackupRecoveryStatus.partiallyRestored);
+      expect((await device.readState()).recoveryBlocked, isTrue);
+      expect(
+        await device.facade.backupNow(),
+        isA<Err<void, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupRecoveryBlockedFailure>(),
+        ),
+      );
+      expect(server.storedCiphertext, published);
+
+      device.metadata.recoverComplete = true;
+      final finished = await device.facade.recover();
+
+      expect(finished.status, WalletBackupRecoveryStatus.restored);
+      expect((await device.readState()).recoveryBlocked, isFalse);
+      expect(await device.facade.backupNow(), _succeeds);
+    });
+
+    test('a newer remote version blocks publication durably and is never '
+        'overwritten', () async {
+      final device = await _device();
+      expect(await device.facade.setEnabled(true), _succeeds);
+      final storesAfterEnabling = device.remote.storeCount;
+
+      device.remote.install(await _backupFromTheFuture(device));
+      final published = device.remote.storedCiphertext;
+      await _addWallet(device, walletId: 'unpublishable', label: 'Pending');
+
+      expect(await device.facade.backupNow(), _unsupportedVersion(2));
+      expect((await device.readState()).unsupportedVersion, 2);
+      expect(device.remote.storedCiphertext, published);
+
+      expect(await device.facade.backupNow(), _unsupportedVersion(2));
+      expect(device.remote.storedCiphertext, published);
+      expect(device.remote.storeCount, storesAfterEnabling);
+    });
+  });
+
+  group('backup files', () {
+    test('an exported file matches the published backup exactly', () async {
+      final device = await _device();
+      await _addWallet(device, walletId: 'exported-wallet', label: 'Exported');
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      for (final protection in WalletBackupFileProtection.values) {
+        final export = _value(
+          await device.facade.buildExport(
+            protection: protection,
+            confirmedUnencrypted: true,
+          ),
+        );
+
+        final comparison = _value(
+          await device.facade.compareFile(export.copyBytes()),
+        );
+
+        expect(
+          comparison.situation,
+          WalletBackupImportSituation.same,
+          reason: '$protection export should match the server',
+        );
+        expect(comparison.differences, isEmpty, reason: '$protection');
+      }
+    });
+
+    test(
+      'a file exported by another seed is rejected as the wrong seed',
+      () async {
+        final device = await _device();
+        expect(await device.facade.setEnabled(true), _succeeds);
+        final otherWallet = await _device(
+          seed: backupSeed(
+            mnemonic: foreignSeedMnemonic,
+            fingerprint: foreignSeedFingerprint,
+          ),
+        );
+        final foreignFile = _value(
+          await otherWallet.facade.buildExport(
+            protection: WalletBackupFileProtection.unencrypted,
+            confirmedUnencrypted: true,
+          ),
+        );
+
+        expect(
+          await device.facade.compareFile(foreignFile.copyBytes()),
+          isA<Err<WalletBackupImportComparison, WalletBackupFailure>>().having(
+            (result) => result.failure,
+            'failure',
+            isA<WalletBackupParentFingerprintMismatchFailure>(),
+          ),
+        );
+      },
+    );
+  });
+}
+
+final Matcher _succeeds = isA<Ok<void, WalletBackupFailure>>();
+
+Future<WalletBackupBehaviorHarness> _device({
+  FakeWalletBackupRemote? remote,
+  Seed? seed,
+}) async {
+  final harness = await WalletBackupBehaviorHarness.create(
+    remote: remote,
+    seed: seed,
+  );
+  addTearDown(harness.dispose);
+  return harness;
+}
+
+/// Records an imported-mnemonic wallet, the cheapest backup-relevant change a
+/// user can make that survives a recovery-inventory refresh.
+Future<void> _addWallet(
+  WalletBackupBehaviorHarness device, {
+  required String walletId,
+  required String label,
+}) async {
+  final result = await device.keychainManifest.recordWallet(
+    parentFingerprint: device.fingerprint,
+    wallet: KeychainManifestWalletInventoryBinding(
+      walletId: walletId,
+      seedFingerprint: Fingerprint(_seedFingerprintFor(walletId)),
+      network: Network.bitcoinMainnet,
+      scriptType: ScriptType.bip84,
+      provenance: WalletProvenance.importedMnemonic,
+      derivationPath: "m/84'/0'/0'",
+      seedPassphraseUsed: false,
+      label: label,
+    ),
+  );
+  expect(result, isA<Ok<bool, KeychainManifestFailure>>());
+}
+
+Future<List<WalletBackupWalletSummary>> _wallets(
+  WalletBackupBehaviorHarness device,
+) async => _value(await device.facade.getContents()).wallets;
+
+/// A backup that decrypts under [key] but declares another root, which is what
+/// the client sees when the stored object does not belong to this wallet.
+Future<WalletBackupCiphertext> _foreignRootedBackup(
+  WalletBackupEncryptionKey key,
+) async {
+  final otherWallet = await _device(
+    seed: backupSeed(
+      mnemonic: foreignSeedMnemonic,
+      fingerprint: foreignSeedFingerprint,
+    ),
+  );
+  final export = _value(
+    await otherWallet.facade.buildExport(
+      protection: WalletBackupFileProtection.unencrypted,
+      confirmedUnencrypted: true,
+    ),
+  );
+  final envelope = _value(
+    otherWallet.encryption.decodeCanonical(
+      bytes: export.copyBytes(),
+      expectedParentFingerprint: foreignSeedFingerprint,
+    ),
+  );
+  return _value(otherWallet.encryption.encrypt(envelope: envelope, key: key));
+}
+
+/// This wallet's own backup, re-stamped with an envelope version no released
+/// client understands, as a future release would leave it.
+Future<WalletBackupCiphertext> _backupFromTheFuture(
+  WalletBackupBehaviorHarness device,
+) async {
+  final export = _value(
+    await device.facade.buildExport(
+      protection: WalletBackupFileProtection.unencrypted,
+      confirmedUnencrypted: true,
+    ),
+  );
+  final plaintext = utf8
+      .decode(export.copyBytes())
+      .replaceFirst('"version":1,', '"version":2,');
+  final backup = RecoverBull.createBackup(
+    secret: utf8.encode(plaintext),
+    backupKey: hex.decode(device.encryptionKey.hex),
+  );
+  return WalletBackupCiphertext(base64.encode(backup.ciphertext));
+}
+
+Matcher _unsupportedVersion(int version) =>
+    isA<Err<void, WalletBackupFailure>>().having(
+      (result) => result.failure,
+      'failure',
+      isA<WalletBackupUnsupportedEnvelopeVersionFailure>().having(
+        (failure) => failure.version,
+        'version',
+        version,
+      ),
+    );
+
+T _value<T, F extends Failure>(Result<T, F> result) => switch (result) {
+  Ok(:final value) => value,
+  Err(:final failure) => fail('expected a value but got $failure'),
+};
+
+String _seedFingerprintFor(String walletId) =>
+    walletId.hashCode.toUnsigned(32).toRadixString(16).padLeft(8, '0');

--- a/test/features/wallet_backup/backup_wallet_now_usecase_test.dart
+++ b/test/features/wallet_backup/backup_wallet_now_usecase_test.dart
@@ -1,0 +1,166 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/backup_wallet_now_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+final class _StateRepository extends Mock
+    implements WalletBackupStateRepository {}
+
+final _checkpoint = WalletBackupRemoteCheckpoint(
+  generation: 3,
+  etag: 'a' * 64,
+  ciphertextSha256: 'b' * 64,
+);
+
+void main() {
+  late _StateRepository state;
+
+  setUpAll(() => registerFallbackValue(_checkpoint));
+
+  setUp(() {
+    state = _StateRepository();
+    when(() => state.get()).thenAnswer((_) async => Ok(_dirtyState()));
+  });
+
+  test('a failed remote attempt never acknowledges the revision', () async {
+    final usecase = BackupWalletNowUsecase(
+      state: state,
+      publish: (_) async => const Err(WalletBackupRemoteUnavailableFailure()),
+      nowSecs: () => 100,
+    );
+
+    expect(
+      await usecase.execute(),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupRemoteUnavailableFailure>(),
+      ),
+    );
+    verifyNever(
+      () => state.recordPublication(
+        publishedRevision: any(named: 'publishedRevision'),
+        succeededAt: any(named: 'succeededAt'),
+        checkpoint: any(named: 'checkpoint'),
+      ),
+    );
+  });
+
+  test('records the acknowledged head only after publication '
+      'succeeds', () async {
+    when(
+      () => state.recordPublication(
+        publishedRevision: 7,
+        succeededAt: 100,
+        checkpoint: _checkpoint,
+      ),
+    ).thenAnswer((_) async => const Ok(null));
+    WalletBackupRemoteCheckpoint? publishedAgainst;
+    final usecase = BackupWalletNowUsecase(
+      state: state,
+      publish: (checkpoint) async {
+        publishedAgainst = checkpoint;
+        return Ok(_checkpoint);
+      },
+      nowSecs: () => 100,
+    );
+
+    expect(await usecase.execute(), const Ok<void, WalletBackupFailure>(null));
+    expect(publishedAgainst, same(_stored));
+    verify(
+      () => state.recordPublication(
+        publishedRevision: 7,
+        succeededAt: 100,
+        checkpoint: _checkpoint,
+      ),
+    ).called(1);
+  });
+
+  test('nothing new to send is not a publication', () async {
+    when(() => state.get()).thenAnswer((_) async => Ok(_cleanState()));
+    var published = false;
+    final usecase = BackupWalletNowUsecase(
+      state: state,
+      publish: (_) async {
+        published = true;
+        return Ok(_checkpoint);
+      },
+      nowSecs: () => 100,
+    );
+
+    expect(await usecase.execute(), const Ok<void, WalletBackupFailure>(null));
+    expect(published, isFalse, reason: 'a clean state stores nothing');
+    verifyNever(
+      () => state.recordPublication(
+        publishedRevision: any(named: 'publishedRevision'),
+        succeededAt: any(named: 'succeededAt'),
+        checkpoint: any(named: 'checkpoint'),
+      ),
+    );
+  });
+
+  test(
+    'a raised recovery fence stops the pass before any remote call',
+    () async {
+      when(() => state.get()).thenAnswer(
+        (_) async => Ok(
+          _dirtyState(recoveryState: WalletBackupRecoveryState.needsAttention),
+        ),
+      );
+      var synchronized = false;
+      final usecase = BackupWalletNowUsecase(
+        state: state,
+        publish: (_) async {
+          synchronized = true;
+          return Ok(_checkpoint);
+        },
+        nowSecs: () => 100,
+      );
+
+      expect(
+        await usecase.execute(),
+        isA<Err<void, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupRecoveryBlockedFailure>(),
+        ),
+      );
+      expect(synchronized, isFalse);
+    },
+  );
+}
+
+WalletBackupState _dirtyState({
+  WalletBackupRecoveryState recoveryState = WalletBackupRecoveryState.idle,
+}) => WalletBackupState(
+  enabled: true,
+  localRevision: 7,
+  uploadedRevision: 6,
+  lastSucceededAt: null,
+  unsupportedVersion: null,
+  recoveryState: recoveryState,
+  customServerUrl: null,
+  remoteCheckpoint: _stored,
+);
+
+/// Everything local is already on the server: the revisions agree.
+WalletBackupState _cleanState() => WalletBackupState(
+  enabled: true,
+  localRevision: 7,
+  uploadedRevision: 7,
+  lastSucceededAt: 90,
+  unsupportedVersion: null,
+  recoveryState: WalletBackupRecoveryState.idle,
+  customServerUrl: null,
+  remoteCheckpoint: _stored,
+);
+
+final _stored = WalletBackupRemoteCheckpoint(
+  generation: 2,
+  etag: 'c' * 64,
+  ciphertextSha256: 'd' * 64,
+);

--- a/test/features/wallet_backup/data/drift_wallet_backup_state_repository_test.dart
+++ b/test/features/wallet_backup/data/drift_wallet_backup_state_repository_test.dart
@@ -1,0 +1,195 @@
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/features/wallet_backup/data/drift_wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+final _checkpoint = WalletBackupRemoteCheckpoint(
+  generation: 4,
+  etag: 'a' * 64,
+  ciphertextSha256: 'b' * 64,
+);
+
+void main() {
+  late SqliteDatabase database;
+  late DriftWalletBackupStateRepository repository;
+
+  setUp(() {
+    database = SqliteDatabase(NativeDatabase.memory());
+    repository = DriftWalletBackupStateRepository(database);
+  });
+
+  tearDown(() => database.close());
+
+  test(
+    'changing server clears its checkpoint and marks backup dirty',
+    () async {
+      expect(
+        await repository.setServerUrl('https://backup.example.com'),
+        isA<Ok>(),
+      );
+
+      final state = (await repository.get() as Ok).value;
+      expect(state.customServerUrl, 'https://backup.example.com');
+      expect(state.dirty, isTrue);
+      expect(state.localRevision, 1);
+    },
+  );
+
+  test('writing the same server is idempotent', () async {
+    expect(
+      await repository.setServerUrl('https://backup.example.com'),
+      isA<Ok>(),
+    );
+    expect(
+      await repository.setServerUrl('https://backup.example.com'),
+      isA<Ok>(),
+    );
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.localRevision, 1);
+  });
+
+  test('the recovery fence is one durable value', () async {
+    expect(
+      await repository.setRecoveryState(
+        WalletBackupRecoveryState.needsAttention,
+      ),
+      isA<Ok>(),
+    );
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.recoveryState, WalletBackupRecoveryState.needsAttention);
+    expect(state.needsAttention, isTrue);
+    expect(state.recoveryBlocked, isTrue);
+    expect(state.canPublish, isFalse);
+  });
+
+  test('publishing the current revision leaves nothing dirty', () async {
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+
+    expect(
+      await repository.recordPublication(
+        publishedRevision: 1,
+        succeededAt: 10,
+        checkpoint: _checkpoint,
+      ),
+      isA<Ok>(),
+    );
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.localRevision, 1);
+    expect(state.uploadedRevision, 1);
+    expect(state.dirty, isFalse);
+  });
+
+  test('a mutation during a store leaves the backup dirty', () async {
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+    // The publication captured revision 1; this one lands while it is in
+    // flight.
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+
+    expect(
+      await repository.recordPublication(
+        publishedRevision: 1,
+        succeededAt: 10,
+        checkpoint: _checkpoint,
+      ),
+      isA<Ok>(),
+    );
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.localRevision, 2);
+    expect(state.uploadedRevision, 1);
+    expect(state.dirty, isTrue);
+  });
+
+  test('an older store never walks the acknowledged revision back', () async {
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+    expect(
+      await repository.recordPublication(
+        publishedRevision: 2,
+        succeededAt: 10,
+        checkpoint: _checkpoint,
+      ),
+      isA<Ok>(),
+    );
+
+    expect(
+      await repository.recordPublication(
+        publishedRevision: 1,
+        succeededAt: 11,
+        checkpoint: _checkpoint,
+      ),
+      isA<Ok>(),
+    );
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.uploadedRevision, 2);
+    expect(state.dirty, isFalse);
+  });
+
+  test('clearing a remote checkpoint lowers the recovery fence', () async {
+    expect(
+      await repository.setRecoveryState(
+        WalletBackupRecoveryState.needsAttention,
+      ),
+      isA<Ok>(),
+    );
+    expect(await repository.saveRemoteCheckpoint(_checkpoint), isA<Ok>());
+    expect(await repository.clearRemoteCheckpoint(), isA<Ok>());
+
+    final state = (await repository.get() as Ok).value;
+    expect(state.recoveryState, WalletBackupRecoveryState.idle);
+    expect(state.recoveryBlocked, isFalse);
+    expect(state.remoteCheckpoint, isNull);
+  });
+
+  test('a successful publication stores the acknowledged head', () async {
+    expect(await repository.recordLocalMutation(), isA<Ok>());
+    expect(
+      await repository.recordPublication(
+        publishedRevision: 1,
+        succeededAt: 10,
+        checkpoint: _checkpoint,
+      ),
+      isA<Ok>(),
+    );
+
+    final checkpoint = (await repository.get() as Ok).value.remoteCheckpoint;
+    expect(checkpoint?.generation, 4);
+    expect(checkpoint?.etag, 'a' * 64);
+    expect(checkpoint?.ciphertextSha256, 'b' * 64);
+  });
+
+  test('a tombstone checkpoint survives without a ciphertext hash', () async {
+    expect(
+      await repository.saveRemoteCheckpoint(
+        WalletBackupRemoteCheckpoint(
+          generation: 7,
+          etag: 'c' * 64,
+          ciphertextSha256: null,
+        ),
+      ),
+      isA<Ok>(),
+    );
+
+    final checkpoint = (await repository.get() as Ok).value.remoteCheckpoint;
+    expect(checkpoint?.generation, 7);
+    expect(checkpoint?.found, isFalse);
+  });
+
+  test('changing the server drops the checkpoint it belonged to', () async {
+    expect(await repository.saveRemoteCheckpoint(_checkpoint), isA<Ok>());
+
+    expect(
+      await repository.setServerUrl('https://backup.example.com'),
+      isA<Ok>(),
+    );
+
+    expect((await repository.get() as Ok).value.remoteCheckpoint, isNull);
+  });
+}

--- a/test/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository_test.dart
+++ b/test/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/canonical_backup_snapshot.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final repository = RecoverBullWalletBackupEncryptionRepository(
+    canonicalCodec(),
+  );
+  final key = WalletBackupEncryptionKey(
+    '1111111111111111111111111111111111111111111111111111111111111111',
+  );
+  final wrongKey = WalletBackupEncryptionKey(
+    '2222222222222222222222222222222222222222222222222222222222222222',
+  );
+
+  test('authenticates and decrypts a wallet backup envelope', () {
+    final encrypted = repository.encrypt(
+      envelope: canonicalMinimalSnapshot(),
+      key: key,
+    );
+    final ciphertext = switch (encrypted) {
+      Ok(:final value) => value,
+      Err(:final failure) => fail('encryption failed: $failure'),
+    };
+
+    final decrypted = repository.decrypt(
+      ciphertext: ciphertext,
+      key: key,
+      expectedParentFingerprint: 'deadbeef',
+    );
+
+    expect(decrypted, isA<Ok<WalletBackupSnapshot, WalletBackupFailure>>());
+    expect(
+      (decrypted as Ok<WalletBackupSnapshot, WalletBackupFailure>)
+          .value
+          .recoveryManifest
+          .wallets
+          .single
+          .label,
+      'Vacation',
+    );
+  });
+
+  test('rejects wrong keys and authenticated-ciphertext tampering', () {
+    final encrypted = repository.encrypt(
+      envelope: canonicalMinimalSnapshot(),
+      key: key,
+    );
+    final ciphertext =
+        (encrypted as Ok<WalletBackupCiphertext, WalletBackupFailure>).value;
+    final bytes = base64.decode(ciphertext.value)..[20] ^= 0xff;
+
+    for (final attempt in [
+      repository.decrypt(
+        ciphertext: ciphertext,
+        key: wrongKey,
+        expectedParentFingerprint: 'deadbeef',
+      ),
+      repository.decrypt(
+        ciphertext: WalletBackupCiphertext(base64.encode(bytes)),
+        key: key,
+        expectedParentFingerprint: 'deadbeef',
+      ),
+    ]) {
+      expect(
+        attempt,
+        isA<Err<WalletBackupSnapshot, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupEncryptionFailure>(),
+        ),
+      );
+    }
+  });
+
+  test('returns a typed mismatch after successful authentication', () {
+    final encrypted = repository.encrypt(
+      envelope: canonicalMinimalSnapshot(),
+      key: key,
+    );
+    final ciphertext =
+        (encrypted as Ok<WalletBackupCiphertext, WalletBackupFailure>).value;
+
+    final result = repository.decrypt(
+      ciphertext: ciphertext,
+      key: key,
+      expectedParentFingerprint: '01234567',
+    );
+
+    expect(
+      result,
+      isA<Err<WalletBackupSnapshot, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupParentFingerprintMismatchFailure>(),
+      ),
+    );
+  });
+
+  test('rejects oversized Base64 before decoding it', () {
+    expect(
+      () => WalletBackupCiphertext(
+        'A' * (WalletBackupCiphertext.maximumEncodedLength + 1),
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/features/wallet_backup/data/wallet_definitions_backup_test.dart
+++ b/test/features/wallet_backup/data/wallet_definitions_backup_test.dart
@@ -1,0 +1,119 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/wallet_backup/data/wallet_definitions_backup.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const descriptor =
+      'wpkh([86241f88/84h/0h/0h]xpub6DJwRncrB8eNrzUq8XxgjwCZsEeWP8FeqBJbJQZ8JfuDwLdAzyjhHiHJieNuar1wjQTyihhMWtaKGE4DUd8uBgtyrNJqF5drwbNVUqb83b7/<0;1>/*)#n8txaeah';
+  late List<WalletDefinition> localDefinitions;
+  late Map<String, WalletDefinitionRestoreResult> restoreResults;
+  late List<WalletDefinition> restoreCalls;
+  late WalletDefinitionsBackupImpl backup;
+
+  final definition = WalletDefinition(
+    walletRef: 'wallet-a',
+    network: Network.bitcoinMainnet,
+    descriptor: descriptor,
+    provenance: WalletProvenance.watchOnly,
+  );
+  setUp(() {
+    localDefinitions = [];
+    restoreResults = {};
+    restoreCalls = [];
+    backup = WalletDefinitionsBackupImpl(() async => localDefinitions, (
+      definition,
+    ) async {
+      restoreCalls.add(definition);
+      return restoreResults[definition.walletRef]!;
+    }, () => const Stream.empty());
+  });
+
+  test('publishes the current local catalogue', () async {
+    localDefinitions = [definition];
+
+    final result = await backup.read();
+
+    expect(_value(result), [definition]);
+  });
+
+  test(
+    'a Liquid wallet does not affect the remote definitions section',
+    () async {
+      localDefinitions = [
+        definition,
+        WalletDefinition(
+          walletRef: 'liquid-wallet',
+          network: Network.liquidMainnet,
+          descriptor: 'ct(liquid)',
+          provenance: WalletProvenance.watchOnly,
+        ),
+      ];
+
+      final result = await backup.read();
+
+      expect(_value(result), [definition]);
+    },
+  );
+
+  test('omits the section when the local catalogue is empty', () async {
+    final result = await backup.read();
+
+    expect(_value(result), isEmpty);
+  });
+
+  test('reports created, existing, and conflicting definitions', () async {
+    final existing = WalletDefinition(
+      walletRef: 'wallet-b',
+      network: Network.bitcoinMainnet,
+      descriptor: descriptor
+          .replaceFirst('86241f88', '76241f88')
+          .split('#')
+          .first,
+      provenance: WalletProvenance.watchOnly,
+    );
+    final conflicting = WalletDefinition(
+      walletRef: 'wallet-c',
+      network: Network.bitcoinMainnet,
+      descriptor: descriptor
+          .replaceFirst('86241f88', '66241f88')
+          .split('#')
+          .first,
+      provenance: WalletProvenance.watchOnly,
+    );
+    restoreResults = {
+      'wallet-a': const WalletDefinitionRestoreResult(
+        walletRef: 'wallet-a',
+        status: WalletDefinitionRestoreStatus.created,
+      ),
+      'wallet-b': const WalletDefinitionRestoreResult(
+        walletRef: 'wallet-b',
+        status: WalletDefinitionRestoreStatus.alreadyPresent,
+      ),
+      'wallet-c': const WalletDefinitionRestoreResult(
+        walletRef: 'wallet-c',
+        status: WalletDefinitionRestoreStatus.conflict,
+      ),
+    };
+
+    final result = await backup.recover(
+      definitions: [definition, existing, conflicting],
+    );
+    final value =
+        (result as Ok<WalletDefinitionsRecoveryResult, WalletBackupFailure>)
+            .value;
+
+    expect(restoreCalls, hasLength(3));
+    expect(value.restoredCount, 2);
+    expect(value.failedCount, 1);
+    expect(value.createdWalletRefs, ['wallet-a']);
+  });
+}
+
+List<WalletDefinition> _value(
+  Result<List<WalletDefinition>, WalletBackupFailure> result,
+) => (result as Ok<List<WalletDefinition>, WalletBackupFailure>).value;

--- a/test/features/wallet_backup/domain/get_wallet_backup_contents_usecase_test.dart
+++ b/test/features/wallet_backup/domain/get_wallet_backup_contents_usecase_test.dart
@@ -1,0 +1,124 @@
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart' show Fingerprint, Ok;
+
+import '../metadata/support/portable_settings_fixture.dart';
+
+void main() {
+  test('returns sanitized metadata counts', () async {
+    final usecase = GetWalletBackupContentsUsecase(
+      () async => Ok(
+        KeychainManifest(
+          parentFingerprint: Fingerprint('aabbccdd'),
+          generatedAt: 1,
+          entries: const [],
+        ),
+      ),
+      () async => const [],
+      () async => const {},
+      () async => Ok(
+        WalletMetadataSnapshot(
+          labels: [
+            for (var index = 0; index < 3; index++)
+              WalletMetadataLabel(
+                type: LabelType.transaction,
+                reference: 'tx-$index',
+                label: 'label-$index',
+              ),
+          ],
+          frozenOutpoints: [
+            FrozenWalletOutpoint(
+              walletId: 'wallet-1',
+              txId: '00' * 32,
+              vout: 0,
+            ),
+          ],
+          walletPreferences: [
+            for (var index = 0; index < 2; index++)
+              WalletPreferences(
+                walletRef: 'wallet-$index',
+                label: 'Wallet $index',
+              ),
+          ],
+          settings: portableSettingsFixture(),
+        ),
+      ),
+    );
+
+    final result = await usecase.execute();
+
+    final contents = (result as Ok).value;
+    expect(contents.labelCount, 3);
+    expect(contents.frozenCoinCount, 1);
+    expect(contents.walletPreferenceCount, 2);
+    expect(contents.settings?.fiatCurrency, 'USD');
+  });
+
+  test('lists seed-derived wallets by path without descriptors', () async {
+    final fingerprint = Fingerprint('aabbccdd');
+    final entryId = KeychainManifestEntry.entryIdFor(
+      parentFingerprint: fingerprint,
+      derivationKind: KeychainManifestDerivationKind.bip32,
+      derivationPath: "m/84'/0'/0'",
+      seedFingerprint: fingerprint,
+    );
+    final manifest = KeychainManifest(
+      parentFingerprint: fingerprint,
+      generatedAt: 1,
+      entries: [
+        KeychainManifestEntry(
+          parentFingerprint: fingerprint,
+          derivationKind: KeychainManifestDerivationKind.bip32,
+          derivationPath: "m/84'/0'/0'",
+          createdAt: 1,
+          updatedAt: 1,
+          materializations: [
+            KeychainManifestWallet(
+              walletId: 'default-bitcoin',
+              entryId: entryId,
+              childSeedFingerprint: fingerprint,
+              network: Network.bitcoinMainnet,
+              scriptType: ScriptType.bip84,
+              provenance: WalletProvenance.defaultSeed,
+              seedPassphraseUsed: false,
+              createdAt: 1,
+              updatedAt: 1,
+            ),
+          ],
+        ),
+      ],
+    );
+    final usecase = GetWalletBackupContentsUsecase(
+      () async => Ok(manifest),
+      () async => const [],
+      () async => {'default-bitcoin'},
+      () async => Ok(
+        WalletMetadataSnapshot(
+          labels: const [],
+          frozenOutpoints: const [],
+          walletPreferences: [
+            WalletPreferences(
+              walletRef: 'default-bitcoin',
+              label: 'Secure Bitcoin',
+            ),
+          ],
+          settings: portableSettingsFixture(),
+        ),
+      ),
+    );
+
+    final result = await usecase.execute();
+    final wallet = (result as Ok).value.wallets.single;
+
+    expect(wallet.derivationPath, "m/84'/0'/0'");
+    expect(wallet.keysOnDevice, isTrue);
+    expect(wallet.descriptor, isNull);
+  });
+}

--- a/test/features/wallet_backup/domain/get_wallet_recovery_inventory_usecase_test.dart
+++ b/test/features/wallet_backup/domain/get_wallet_recovery_inventory_usecase_test.dart
@@ -1,0 +1,66 @@
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_recovery_inventory_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+void main() {
+  final fingerprint = Fingerprint('aabbccdd');
+  final manifest = KeychainManifest(
+    parentFingerprint: fingerprint,
+    generatedAt: 1,
+    entries: const [],
+  );
+
+  test('refreshes seed-derived facts before returning the inventory', () async {
+    final calls = <String>[];
+    final usecase = GetWalletRecoveryInventoryUsecase(
+      () async {
+        calls.add('resolve');
+        return Ok((
+          parentFingerprint: fingerprint.hex,
+          encryptionKey: WalletBackupEncryptionKey('00' * 32),
+        ));
+      },
+      (parent) async {
+        expect(parent, fingerprint);
+        calls.add('refresh');
+        return const Ok(null);
+      },
+      (parent) async {
+        expect(parent, fingerprint);
+        calls.add('read');
+        return Ok(manifest);
+      },
+    );
+
+    expect(
+      await usecase.execute(),
+      isA<Ok<KeychainManifest, WalletBackupFailure>>().having(
+        (result) => result.value,
+        'value',
+        manifest,
+      ),
+    );
+    expect(calls, ['resolve', 'refresh', 'read']);
+  });
+
+  test('does not read stale inventory when refresh fails', () async {
+    var read = false;
+    final usecase = GetWalletRecoveryInventoryUsecase(
+      () async => Ok((
+        parentFingerprint: fingerprint.hex,
+        encryptionKey: WalletBackupEncryptionKey('00' * 32),
+      )),
+      (_) async => const Err(WalletBackupStorageFailure()),
+      (_) async {
+        read = true;
+        return Ok(manifest);
+      },
+    );
+
+    expect(await usecase.execute(), isA<Err>());
+    expect(read, isFalse);
+  });
+}

--- a/test/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider_test.dart
+++ b/test/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider_test.dart
@@ -1,0 +1,237 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/data/wallet_metadata_backup_section_provider.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../support/portable_settings_fixture.dart';
+
+class _Labels extends Mock implements LabelsFacade {}
+
+void main() {
+  late _Labels labels;
+
+  setUpAll(() {
+    registerFallbackValue(
+      NewLabel.addr(address: 'fallback', label: 'fallback'),
+    );
+  });
+
+  setUp(() => labels = _Labels());
+
+  test('rejects a snapshot whose labels the label store would refuse', () {
+    final backup = WalletMetadataBackupImpl(
+      labels: labels,
+      getFrozenOutpoints: () async => const [],
+      restoreFrozenOutpoints: (_) async {},
+      getPreferences: () async => const Ok([]),
+      applyPreferences: (_) async => Ok(
+        WalletPreferencesRecoveryApplyResult(
+          appliedWalletRefs: const {},
+          conflictedWalletRefs: const {},
+        ),
+      ),
+      readPortableSettings: () async => portableSettingsFixture(),
+      restorePortableSettings: (_) async {},
+      changeStreams: const [Stream.empty()],
+    );
+    final snapshot = WalletMetadataSnapshot(
+      labels: const [
+        WalletMetadataLabel(
+          type: LabelType.address,
+          reference: 'bc1qexample',
+          label: 'Savings',
+        ),
+      ],
+      frozenOutpoints: [
+        FrozenWalletOutpoint(walletId: 'wallet-1', txId: 'a' * 64, vout: 0),
+      ],
+      walletPreferences: [
+        WalletPreferences(walletRef: 'wallet-1', label: 'Primary'),
+      ],
+      settings: portableSettingsFixture(),
+    );
+
+    when(() => labels.isValid(any())).thenReturn(true);
+    expect(backup.validate(snapshot), isA<Ok>());
+
+    when(() => labels.isValid(any())).thenReturn(false);
+    expect(backup.validate(snapshot), isA<Err>());
+  });
+
+  test('reads the explicit protected-data categories', () async {
+    when(() => labels.fetchAllStrict()).thenAnswer(
+      (_) async =>
+          Ok([Label.addr(id: 1, address: 'bc1qexample', label: 'Savings')]),
+    );
+    final backup = WalletMetadataBackupImpl(
+      labels: labels,
+      getFrozenOutpoints: () async => [
+        FrozenWalletOutpoint(walletId: 'wallet-1', txId: 'a' * 64, vout: 0),
+      ],
+      restoreFrozenOutpoints: (_) async {},
+      getPreferences: () async =>
+          Ok([WalletPreferences(walletRef: 'wallet-1', label: 'Primary')]),
+      applyPreferences: (_) async => Ok(
+        WalletPreferencesRecoveryApplyResult(
+          appliedWalletRefs: const {},
+          conflictedWalletRefs: const {},
+        ),
+      ),
+      readPortableSettings: () async => portableSettingsFixture(),
+      restorePortableSettings: (_) async {},
+      changeStreams: const [Stream.empty()],
+    );
+
+    final result = await backup.localSnapshot();
+
+    expect(
+      result,
+      isA<Ok<WalletMetadataSnapshot, WalletMetadataBackupFailure>>(),
+    );
+    final snapshot =
+        (result as Ok<WalletMetadataSnapshot, WalletMetadataBackupFailure>)
+            .value;
+    expect(snapshot.labels, hasLength(1));
+    expect(snapshot.frozenOutpoints, hasLength(1));
+    expect(snapshot.walletPreferences, hasLength(1));
+    await backup.dispose();
+  });
+
+  test('restores additively and reports a preserved label conflict', () async {
+    final payload = WalletMetadataSnapshot(
+      labels: const [
+        WalletMetadataLabel(
+          type: LabelType.address,
+          reference: 'bc1qexample',
+          label: 'Savings',
+          origin: 'remote',
+        ),
+      ],
+      frozenOutpoints: [
+        FrozenWalletOutpoint(walletId: 'wallet-1', txId: 'b' * 64, vout: 1),
+      ],
+      walletPreferences: [
+        WalletPreferences(walletRef: 'wallet-1', hideOnHome: true),
+      ],
+      settings: portableSettingsFixture(),
+    );
+    when(() => labels.isValid(any())).thenReturn(true);
+    when(() => labels.fetchAllStrict()).thenAnswer(
+      (_) async => Ok([
+        Label.addr(
+          id: 1,
+          address: 'bc1qexample',
+          label: 'Savings',
+          origin: 'local',
+        ),
+      ]),
+    );
+    var restoredFreezes = false;
+    final backup = WalletMetadataBackupImpl(
+      labels: labels,
+      getFrozenOutpoints: () async => const [],
+      restoreFrozenOutpoints: (_) async => restoredFreezes = true,
+      getPreferences: () async =>
+          Ok([WalletPreferences(walletRef: 'wallet-1')]),
+      applyPreferences: (updates) async => Ok(
+        WalletPreferencesRecoveryApplyResult(
+          appliedWalletRefs: {
+            for (final update in updates) update.recovered.walletRef,
+          },
+          conflictedWalletRefs: const {},
+        ),
+      ),
+      readPortableSettings: () async => portableSettingsFixture(),
+      restorePortableSettings: (_) async {},
+      changeStreams: const [Stream.empty()],
+    );
+
+    final result = await backup.recover(
+      snapshot: payload,
+      createdWalletRefs: {'wallet-1'},
+    );
+
+    expect((result as Ok<bool, dynamic>).value, isFalse);
+    expect(restoredFreezes, isTrue);
+    verifyNever(() => labels.store(any()));
+    await backup.dispose();
+  });
+
+  test(
+    'returns typed failures when label recovery cannot read or write',
+    () async {
+      final emptySnapshot = WalletMetadataSnapshot(
+        labels: const [],
+        frozenOutpoints: const [],
+        walletPreferences: const [],
+        settings: portableSettingsFixture(),
+      );
+      final backup = WalletMetadataBackupImpl(
+        labels: labels,
+        getFrozenOutpoints: () async => const [],
+        restoreFrozenOutpoints: (_) async {},
+        getPreferences: () async => const Ok([]),
+        applyPreferences: (_) async => Ok(
+          WalletPreferencesRecoveryApplyResult(
+            appliedWalletRefs: const {},
+            conflictedWalletRefs: const {},
+          ),
+        ),
+        readPortableSettings: () async => portableSettingsFixture(),
+        restorePortableSettings: (_) async {},
+        changeStreams: const [Stream.empty()],
+      );
+      when(
+        () => labels.fetchAllStrict(),
+      ).thenAnswer((_) async => const Err(LabelUnexpectedFailure()));
+
+      expect(
+        await backup.recover(
+          snapshot: emptySnapshot,
+          createdWalletRefs: const {},
+        ),
+        isA<Err<bool, WalletMetadataBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletMetadataBackupReadFailure>(),
+        ),
+      );
+
+      final labelSnapshot = WalletMetadataSnapshot(
+        labels: const [
+          WalletMetadataLabel(
+            type: LabelType.address,
+            reference: 'bc1qexample',
+            label: 'Savings',
+          ),
+        ],
+        frozenOutpoints: const [],
+        walletPreferences: const [],
+        settings: portableSettingsFixture(),
+      );
+      when(() => labels.isValid(any())).thenReturn(true);
+      when(() => labels.fetchAllStrict()).thenAnswer((_) async => const Ok([]));
+      when(
+        () => labels.store(any()),
+      ).thenAnswer((_) async => const Err(LabelUnexpectedFailure()));
+
+      expect(
+        await backup.recover(
+          snapshot: labelSnapshot,
+          createdWalletRefs: const {},
+        ),
+        isA<Err<bool, WalletMetadataBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletMetadataBackupWriteFailure>(),
+        ),
+      );
+      await backup.dispose();
+    },
+  );
+}

--- a/test/features/wallet_backup/metadata_backup_http_repository_test.dart
+++ b/test/features/wallet_backup/metadata_backup_http_repository_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/features/wallet_backup/data/metadata_backup_http_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+const _publicKey =
+    '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const _signature =
+    '23c0d3cdf2b0592cebb3ba46ed6ed1e91c1c3e06a93641091e588a86d0241129'
+    '892e75738f6dba21739478e4e684d60bb267e5d0af695c0747d4bd084ad77812';
+
+void main() {
+  final authentication = WalletBackupAuthentication(
+    publicKeyHex: _publicKey,
+    signatureHex: _signature,
+    timestamp: 1700000000,
+  );
+
+  test('fetch uses the frozen route and exact request fields', () async {
+    final harness = _Harness({
+      'version': 1,
+      'found': false,
+      'generation': 0,
+      'etag': null,
+    });
+    final result = await harness.repository.fetch(
+      authentication: authentication,
+    );
+    expect(result, isA<Ok<WalletBackupRemoteHead, WalletBackupFailure>>());
+    expect(harness.request.method, 'POST');
+    expect(
+      harness.request.uri.toString(),
+      'https://backup.example/api/v1/wallet-backups/fetch',
+    );
+    expect(harness.request.data, {
+      'version': 1,
+      'stream': 'wallet_backup',
+      'npub': _publicKey,
+      'timestamp': 1700000000,
+      'signature': _signature,
+    });
+    expect(harness.request.followRedirects, isFalse);
+  });
+
+  test('store accepts only the locally expected receipt', () async {
+    final bytes = List<int>.filled(64, 1);
+    final ciphertext = WalletBackupCiphertext(base64.encode(bytes));
+    final hash = sha256.convert(bytes).toString();
+    final expectedEtag = computeWalletBackupEtag(
+      publicKeyHex: _publicKey,
+      generation: 1,
+      ciphertextSha256: hash,
+    )!;
+    final harness = _Harness({
+      'version': 1,
+      'generation': 1,
+      'etag': expectedEtag,
+    });
+    final result = await harness.repository.store(
+      authentication: authentication,
+      current: null,
+      ciphertext: ciphertext,
+      ciphertextSha256: hash,
+    );
+    expect(
+      result,
+      isA<Ok<WalletBackupRemoteCheckpoint, WalletBackupFailure>>().having(
+        (value) => value.value.generation,
+        'acknowledged generation',
+        1,
+      ),
+    );
+    final body = harness.request.data as Map<String, Object?>;
+    expect(body['expected_etag'], isNull);
+    expect(body['ciphertext_bytes'], 64);
+
+    harness.response = {'version': 1, 'generation': 2, 'etag': expectedEtag};
+    expect(
+      await harness.repository.store(
+        authentication: authentication,
+        current: null,
+        ciphertext: ciphertext,
+        ciphertextSha256: hash,
+      ),
+      isA<Err<WalletBackupRemoteCheckpoint, WalletBackupFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<WalletBackupInvalidRemoteFailure>(),
+      ),
+    );
+  });
+
+  test('verifies fetched ciphertext, hash, byte count, and ETag', () async {
+    final bytes = List<int>.generate(64, (index) => index);
+    final encoded = base64.encode(bytes);
+    final hash = sha256.convert(bytes).toString();
+    final etag = computeWalletBackupEtag(
+      publicKeyHex: _publicKey,
+      generation: 3,
+      ciphertextSha256: hash,
+    )!;
+    final harness = _Harness({
+      'version': 1,
+      'found': true,
+      'generation': 3,
+      'etag': etag,
+      'ciphertext': encoded,
+      'ciphertext_sha256': hash,
+      'ciphertext_bytes': 64,
+      'updated_at': 1700000000,
+    });
+    expect(
+      await harness.repository.fetch(authentication: authentication),
+      isA<Ok<WalletBackupRemoteHead, WalletBackupFailure>>(),
+    );
+    harness.response = {
+      ...harness.response as Map<String, Object?>,
+      'ciphertext_bytes': 63,
+    };
+    expect(
+      await harness.repository.fetch(authentication: authentication),
+      isA<Err<WalletBackupRemoteHead, WalletBackupFailure>>(),
+    );
+  });
+
+  test(
+    'honors Retry-After locally without a timer or second request',
+    () async {
+      var now = DateTime.utc(2026);
+      final harness = _Harness(
+        {'status': 'ERROR', 'code': 'RateLimited', 'reason': 'retry'},
+        statusCode: 429,
+        headers: Headers.fromMap({
+          'retry-after': ['10'],
+        }),
+        now: () => now,
+      );
+      expect(
+        await harness.repository.fetch(authentication: authentication),
+        isA<Err<WalletBackupRemoteHead, WalletBackupFailure>>(),
+      );
+      expect(harness.requestCount, 1);
+      expect(
+        await harness.repository.fetch(authentication: authentication),
+        isA<Err<WalletBackupRemoteHead, WalletBackupFailure>>(),
+      );
+      expect(harness.requestCount, 1);
+      now = now.add(const Duration(seconds: 10));
+      await harness.repository.fetch(authentication: authentication);
+      expect(harness.requestCount, 2);
+    },
+  );
+
+  test('maps every frozen server error without exposing reason text', () async {
+    final cases = <(int, String, Type)>[
+      (400, 'BackupInvalidRequest', WalletBackupRemoteRejectedFailure),
+      (401, 'BackupAuthError', WalletBackupSigningFailure),
+      (409, 'BackupHeadConflict', WalletBackupHeadConflictFailure),
+      (413, 'BackupBlobTooLarge', WalletBackupTooLargeFailure),
+      (503, 'BackupCapacityExceeded', WalletBackupRemoteUnavailableFailure),
+      (500, 'InternalError', WalletBackupRemoteUnavailableFailure),
+    ];
+    for (final (status, code, type) in cases) {
+      final harness = _Harness({
+        'status': 'ERROR',
+        'code': code,
+        'reason': 'private backend text',
+      }, statusCode: status);
+      final result = await harness.repository.fetch(
+        authentication: authentication,
+      );
+      expect((result as Err).failure.runtimeType, type, reason: code);
+    }
+  });
+
+  test('maps an invalid configured origin without making a request', () async {
+    final harness = _Harness(
+      const <String, Object?>{},
+      origin: () async => throw const _InvalidOrigin(),
+    );
+
+    expect(
+      await harness.repository.fetch(authentication: authentication),
+      isA<Err<WalletBackupRemoteHead, WalletBackupFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<WalletBackupInvalidServerOriginFailure>(),
+      ),
+    );
+    expect(harness.requestCount, 0);
+  });
+}
+
+final class _Harness {
+  Object? response;
+  final int statusCode;
+  final Headers headers;
+  late RequestOptions request;
+  late final MetadataBackupHttpRepository repository;
+  int requestCount = 0;
+
+  _Harness(
+    this.response, {
+    this.statusCode = 200,
+    Headers? headers,
+    DateTime Function()? now,
+    Future<Uri> Function()? origin,
+  }) : headers = headers ?? Headers() {
+    final dio = Dio()
+      ..interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            requestCount++;
+            request = options;
+            handler.resolve(
+              Response<Object?>(
+                requestOptions: options,
+                statusCode: statusCode,
+                headers: this.headers,
+                data: response,
+              ),
+            );
+          },
+        ),
+      );
+    repository = MetadataBackupHttpRepository(
+      dio,
+      origin ?? () async => Uri.parse('https://backup.example'),
+      now: now,
+    );
+  }
+}
+
+final class _InvalidOrigin implements Exception {
+  const _InvalidOrigin();
+}

--- a/test/features/wallet_backup/recover_wallet_backup_usecase_test.dart
+++ b/test/features/wallet_backup/recover_wallet_backup_usecase_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+void main() {
+  test('passes an initial remote failure to the shared apply owner', () async {
+    Result<WalletBackupSnapshot?, WalletBackupFailure>? applied;
+    final usecase = RecoverWalletBackupUsecase(
+      fetchImport: (_) async => const Ok(null),
+      fetchRemote: () async =>
+          const Err(WalletBackupRemoteUnavailableFailure()),
+      apply:
+          ({
+            required snapshot,
+            revalidate,
+            defaultCreatedWalletIds = const {},
+            callerSettlesFence = false,
+            deadline,
+          }) async {
+            applied = snapshot;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.unavailable,
+            );
+          },
+    );
+
+    final result = await usecase.execute();
+
+    expect(result.status, WalletBackupRecoveryStatus.unavailable);
+    expect(applied, isA<Err>());
+  });
+
+  test('validates the same remote object after applying', () async {
+    var fetches = 0;
+    bool? unchanged;
+    final head = WalletBackupRemoteHead.absent(generation: 0, etag: null);
+    final usecase = RecoverWalletBackupUsecase(
+      fetchImport: (_) async => const Ok(null),
+      fetchRemote: () async {
+        fetches++;
+        return Ok(head);
+      },
+      apply:
+          ({
+            required snapshot,
+            revalidate,
+            defaultCreatedWalletIds = const {},
+            callerSettlesFence = false,
+            deadline,
+          }) async {
+            unchanged = switch (await revalidate!()) {
+              Ok(:final value) => value,
+              Err() => false,
+            };
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.noBackup,
+            );
+          },
+    );
+
+    await usecase.execute();
+
+    expect(fetches, 2);
+    expect(unchanged, isTrue);
+  });
+
+  test('an object that appeared where there was none is a change', () async {
+    var fetches = 0;
+
+    final unchanged = await _revalidated(() {
+      fetches++;
+      return WalletBackupRemoteHead.absent(
+        generation: fetches - 1,
+        etag: fetches == 1 ? null : _etag,
+      );
+    });
+
+    expect(unchanged, isFalse);
+  });
+
+  // The three cases below run on two real checkpoints, which is the only way
+  // sameObjectAs gets to compare a generation or a ciphertext hash at all: an
+  // absent head carries a null one and short-circuits before either.
+  test('the same stored object passes revalidation', () async {
+    final unchanged = await _revalidated(
+      () => _present(generation: 4, ciphertextSha256: _contents),
+    );
+
+    expect(unchanged, isTrue);
+  });
+
+  test('a new generation of the same bytes is a change', () async {
+    var fetches = 0;
+
+    final unchanged = await _revalidated(() {
+      fetches++;
+      return _present(generation: fetches, ciphertextSha256: _contents);
+    });
+
+    expect(unchanged, isFalse);
+  });
+
+  test('new bytes under the same generation are a change', () async {
+    var fetches = 0;
+
+    final unchanged = await _revalidated(() {
+      fetches++;
+      return _present(
+        generation: 4,
+        ciphertextSha256: fetches == 1 ? _contents : _otherContents,
+      );
+    });
+
+    expect(unchanged, isFalse);
+  });
+}
+
+/// Runs one recovery over [head] — called once for the initial fetch and again
+/// for the revalidation — and reports what the apply owner was told.
+Future<bool?> _revalidated(WalletBackupRemoteHead Function() head) async {
+  bool? unchanged;
+  final usecase = RecoverWalletBackupUsecase(
+    fetchImport: (_) async => const Ok(null),
+    fetchRemote: () async => Ok(head()),
+    apply:
+        ({
+          required snapshot,
+          revalidate,
+          defaultCreatedWalletIds = const {},
+          callerSettlesFence = false,
+          deadline,
+        }) async {
+          unchanged = switch (await revalidate!()) {
+            Ok(:final value) => value,
+            Err() => false,
+          };
+          return const WalletBackupRecoveryResult(
+            status: WalletBackupRecoveryStatus.conflict,
+          );
+        },
+  );
+
+  await usecase.execute();
+  return unchanged;
+}
+
+WalletBackupRemoteHead _present({
+  required int generation,
+  required String ciphertextSha256,
+}) => WalletBackupRemoteHead.present(
+  generation: generation,
+  etag: _etag,
+  ciphertext: _ciphertext,
+  ciphertextSha256: ciphertextSha256,
+);
+
+final _ciphertext = WalletBackupCiphertext(base64.encode(List.filled(64, 7)));
+
+const _etag =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _contents =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _otherContents =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';

--- a/test/features/wallet_backup/restore_wallet_backup_manifest_usecase_test.dart
+++ b/test/features/wallet_backup/restore_wallet_backup_manifest_usecase_test.dart
@@ -1,0 +1,287 @@
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart' show Fingerprint, Ok;
+
+class _Wallets extends Mock implements WalletRepository {}
+
+class _Repository extends Mock implements KeychainManifestRepository {}
+
+class _Settings extends Mock implements GetSettingsUsecase {}
+
+class _DefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+void main() {
+  final root = Fingerprint('fedcba98');
+  late _Wallets wallets;
+  late _Repository repository;
+  late RestoreWalletBackupManifestUsecase usecase;
+
+  setUp(() {
+    wallets = _Wallets();
+    repository = _Repository();
+    const codec = KeychainManifestFileCodec();
+    final parse = ParseKeychainManifestFileUsecase(codec.decode);
+    final manifest = KeychainManifestFacade(
+      WatchKeychainManifestChangesUsecase(repository),
+      codec.encode,
+      BuildKeychainManifestFileUsecase(repository),
+      parse,
+      ReplaceSeedWalletInventoryUsecase(repository),
+      RecordPassphraseWalletUsecase(repository),
+      RestoreManifestSnapshotUsecase(repository),
+      RecordKeychainManifestNostrKeyUsecase(repository),
+      RestoreKeychainManifestNostrKeyUsecase(
+        KeychainManifestNostrKeyDeriver(_Settings(), _DefaultSeed()),
+        RecordKeychainManifestNostrKeyUsecase(repository),
+      ),
+      UpdatePassphraseLabelHintUsecase(repository),
+      RemovePassphraseWalletUsecase(repository),
+    );
+    usecase = RestoreWalletBackupManifestUsecase(
+      wallets.matchesSeedDerivedRecoveryIdentity,
+      manifest,
+    );
+    registerFallbackValue(_manifest(const []));
+    registerFallbackValue(KeychainManifestRestorePolicy.keepNewest);
+    when(
+      () => repository.restoreSnapshot(any(), policy: any(named: 'policy')),
+    ).thenAnswer(
+      (invocation) async => Ok(
+        KeychainManifestRestoreReport(
+          applied: (invocation.positionalArguments.single as KeychainManifest)
+              .entries
+              .length,
+        ),
+      ),
+    );
+  });
+
+  test('admits verified default wallets to recovered inventory', () async {
+    final bitcoin = _walletEntry(
+      walletId: 'secure-bitcoin',
+      network: Network.bitcoinMainnet,
+      path: "m/84'/0'/0'",
+      seedFingerprint: root,
+      provenance: WalletProvenance.defaultSeed,
+    );
+    final liquid = _walletEntry(
+      walletId: 'instant-payments',
+      network: Network.liquidMainnet,
+      path: "m/84'/1776'/0'",
+      seedFingerprint: root,
+      provenance: WalletProvenance.defaultSeed,
+    );
+    for (final entry in [bitcoin, liquid]) {
+      final wallet = entry.materializations.single as KeychainManifestWallet;
+      when(
+        () => wallets.matchesSeedDerivedRecoveryIdentity(
+          walletId: wallet.walletId,
+          seedFingerprint: root.hex,
+          network: wallet.network,
+          scriptType: wallet.scriptType,
+          provenance: WalletProvenance.defaultSeed,
+          derivationPath: entry.derivationPath,
+          seedPassphraseUsed: false,
+        ),
+      ).thenAnswer((_) async => true);
+    }
+
+    final result = await usecase.execute(_manifest([bitcoin, liquid]));
+
+    expect(result.restoredCount, 2);
+    expect(result.failedCount, 0);
+    final restored =
+        verify(
+              () => repository.restoreSnapshot(
+                captureAny(),
+                policy: any(named: 'policy'),
+              ),
+            ).captured.single
+            as KeychainManifest;
+    expect(restored.entries, hasLength(2));
+  });
+
+  test('fails a default entry bound to another root before lookup', () async {
+    final result = await usecase.execute(
+      _manifest([
+        _walletEntry(
+          walletId: 'secure-bitcoin',
+          network: Network.bitcoinMainnet,
+          path: "m/84'/0'/0'",
+          seedFingerprint: Fingerprint('00000000'),
+          provenance: WalletProvenance.defaultSeed,
+        ),
+      ]),
+    );
+
+    expect(result.restoredCount, 0);
+    expect(result.failedCount, 1);
+    verifyZeroInteractions(wallets);
+  });
+
+  test('keeps recovery fenced for contradictory default metadata', () async {
+    final entry = _walletEntry(
+      walletId: 'secure-bitcoin',
+      network: Network.bitcoinMainnet,
+      path: "m/84'/0'/0'",
+      seedFingerprint: root,
+      provenance: WalletProvenance.defaultSeed,
+    );
+    when(
+      () => wallets.matchesSeedDerivedRecoveryIdentity(
+        walletId: 'secure-bitcoin',
+        seedFingerprint: root.hex,
+        network: Network.bitcoinMainnet,
+        scriptType: ScriptType.bip84,
+        provenance: WalletProvenance.defaultSeed,
+        derivationPath: "m/84'/0'/0'",
+        seedPassphraseUsed: false,
+      ),
+    ).thenAnswer((_) async => false);
+
+    final result = await usecase.execute(_manifest([entry]));
+
+    expect(result.restoredCount, 0);
+    expect(result.failedCount, 1);
+    verifyNever(
+      () => repository.restoreSnapshot(any(), policy: any(named: 'policy')),
+    );
+  });
+
+  test(
+    'retains imported-mnemonic inventory without creating a wallet',
+    () async {
+      final imported = _walletEntry(
+        walletId: 'imported-wallet',
+        network: Network.bitcoinMainnet,
+        path: "m/84'/0'/0'",
+        seedFingerprint: Fingerprint('12345678'),
+        provenance: WalletProvenance.importedMnemonic,
+        passphraseUsed: null,
+      );
+
+      final result = await usecase.execute(_manifest([imported]));
+
+      expect(result.restoredCount, 1);
+      expect(result.failedCount, 0);
+      verifyZeroInteractions(wallets);
+      final restored =
+          verify(
+                () => repository.restoreSnapshot(
+                  captureAny(),
+                  policy: any(named: 'policy'),
+                ),
+              ).captured.single
+              as KeychainManifest;
+      final saved =
+          restored.entries.single.materializations.single
+              as KeychainManifestWallet;
+      expect(saved.walletId, 'imported-wallet');
+      expect(saved.provenance, WalletProvenance.importedMnemonic);
+      expect(saved.seedPassphraseUsed, isNull);
+    },
+  );
+
+  test('reports product wallets whose owner is not installed', () async {
+    final parent = Fingerprint('fedcba98');
+    const path = "39'/0'/12'/100'";
+    final entryId = KeychainManifestEntry.entryIdFor(
+      parentFingerprint: parent,
+      derivationKind: KeychainManifestDerivationKind.bip85,
+      derivationPath: path,
+    );
+    final result = await usecase.execute(
+      _manifest([
+        KeychainManifestEntry(
+          parentFingerprint: parent,
+          derivationPath: path,
+          createdAt: 1,
+          updatedAt: 1,
+          materializations: [
+            KeychainManifestWallet(
+              walletId: 'btcpay-bitcoin',
+              entryId: entryId,
+              childSeedFingerprint: Fingerprint('12345678'),
+              network: Network.bitcoinMainnet,
+              scriptType: ScriptType.bip84,
+              provenance: WalletProvenance.bip85,
+              seedPassphraseUsed: false,
+              createdAt: 1,
+              updatedAt: 1,
+            ),
+          ],
+        ),
+      ]),
+    );
+
+    expect(result.restoredCount, 0);
+    expect(result.failedCount, 1);
+    verifyNever(
+      () => repository.restoreSnapshot(any(), policy: any(named: 'policy')),
+    );
+  });
+}
+
+KeychainManifest _manifest(List<KeychainManifestEntry> entries) =>
+    KeychainManifest(
+      parentFingerprint: Fingerprint('fedcba98'),
+      generatedAt: 10,
+      entries: entries,
+    );
+
+KeychainManifestEntry _walletEntry({
+  required String walletId,
+  required Network network,
+  required String path,
+  required Fingerprint seedFingerprint,
+  required WalletProvenance provenance,
+  bool? passphraseUsed = false,
+}) {
+  final parent = Fingerprint('fedcba98');
+  final entryId = KeychainManifestEntry.entryIdFor(
+    parentFingerprint: parent,
+    derivationKind: KeychainManifestDerivationKind.bip32,
+    derivationPath: path,
+    seedFingerprint: seedFingerprint,
+  );
+  return KeychainManifestEntry(
+    parentFingerprint: parent,
+    derivationKind: KeychainManifestDerivationKind.bip32,
+    derivationPath: path,
+    createdAt: 1,
+    updatedAt: 2,
+    materializations: [
+      KeychainManifestWallet(
+        walletId: walletId,
+        entryId: entryId,
+        childSeedFingerprint: seedFingerprint,
+        network: network,
+        scriptType: ScriptType.bip84,
+        provenance: provenance,
+        seedPassphraseUsed: passphraseUsed,
+        createdAt: 1,
+        updatedAt: 2,
+      ),
+    ],
+  );
+}

--- a/test/features/wallet_backup/set_wallet_backup_enabled_usecase_test.dart
+++ b/test/features/wallet_backup/set_wallet_backup_enabled_usecase_test.dart
@@ -1,0 +1,138 @@
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+final class _StateRepository extends Mock
+    implements WalletBackupStateRepository {}
+
+void main() {
+  late _StateRepository state;
+  late Future<Result<void, WalletBackupFailure>> Function() register;
+  late List<String> calls;
+
+  setUp(() {
+    state = _StateRepository();
+    calls = [];
+    register = () async {
+      calls.add('register');
+      return const Ok(null);
+    };
+  });
+
+  test('recovers before enabling and publishing', () async {
+    when(() => state.setEnabled(true)).thenAnswer((_) async {
+      calls.add('enable');
+      return const Ok(null);
+    });
+    final usecase = SetWalletBackupEnabledUsecase(
+      state,
+      () async {
+        calls.add('recover');
+        return const WalletBackupRecoveryResult(
+          status: WalletBackupRecoveryStatus.noBackup,
+        );
+      },
+      register,
+      () async {
+        calls.add('publish');
+        return const Ok(null);
+      },
+    );
+
+    expect(
+      await usecase.execute(true),
+      const Ok<void, WalletBackupFailure>(null),
+    );
+    expect(calls, ['register', 'recover', 'enable', 'publish']);
+  });
+
+  test('does not enable or publish when recovery fails', () async {
+    final usecase = SetWalletBackupEnabledUsecase(
+      state,
+      () async {
+        calls.add('recover');
+        return const WalletBackupRecoveryResult(
+          status: WalletBackupRecoveryStatus.invalid,
+        );
+      },
+      register,
+      () async {
+        calls.add('publish');
+        return const Ok(null);
+      },
+    );
+
+    final result = await usecase.execute(true);
+
+    expect(
+      result,
+      isA<Err<void, WalletBackupFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<WalletBackupManifestFailure>(),
+      ),
+    );
+    expect(calls, ['register', 'recover']);
+    verifyNever(() => state.setEnabled(true));
+  });
+
+  test('does not publish when enabling fails', () async {
+    when(
+      () => state.setEnabled(true),
+    ).thenAnswer((_) async => const Err(WalletBackupStorageFailure()));
+    final usecase = SetWalletBackupEnabledUsecase(
+      state,
+      () async => const WalletBackupRecoveryResult(
+        status: WalletBackupRecoveryStatus.restored,
+      ),
+      register,
+      () async {
+        calls.add('publish');
+        return const Ok(null);
+      },
+    );
+
+    expect(
+      await usecase.execute(true),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<WalletBackupStorageFailure>(),
+      ),
+    );
+    expect(calls, ['register']);
+  });
+
+  test('does not recover, enable or publish when registration fails', () async {
+    register = () async => const Err(WalletBackupWalletUnavailableFailure());
+    final usecase = SetWalletBackupEnabledUsecase(
+      state,
+      () async {
+        calls.add('recover');
+        return const WalletBackupRecoveryResult(
+          status: WalletBackupRecoveryStatus.noBackup,
+        );
+      },
+      register,
+      () async {
+        calls.add('publish');
+        return const Ok(null);
+      },
+    );
+
+    expect(
+      await usecase.execute(true),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (value) => value.failure,
+        'failure',
+        isA<WalletBackupWalletUnavailableFailure>(),
+      ),
+    );
+    expect(calls, isEmpty);
+    verifyNever(() => state.setEnabled(true));
+  });
+}

--- a/test/features/wallet_backup/set_wallet_backup_server_usecase_test.dart
+++ b/test/features/wallet_backup/set_wallet_backup_server_usecase_test.dart
@@ -1,0 +1,65 @@
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+final class _StateRepository extends Mock
+    implements WalletBackupStateRepository {}
+
+/// Serialization against publication belongs to the job runner now, so what is
+/// left here is the origin contract itself.
+void main() {
+  late _StateRepository state;
+
+  setUp(() {
+    state = _StateRepository();
+    when(
+      () => state.setServerUrl(any()),
+    ).thenAnswer((_) async => const Ok(null));
+  });
+
+  test('stores a parsed origin', () async {
+    final usecase = SetWalletBackupServerUsecase(
+      state,
+      parseOrigin: Uri.tryParse,
+    );
+
+    expect(
+      await usecase.execute('  https://backup.example.com  '),
+      isA<Ok<void, WalletBackupFailure>>(),
+    );
+
+    verify(() => state.setServerUrl('https://backup.example.com')).called(1);
+  });
+
+  test('an empty value restores the default origin', () async {
+    final usecase = SetWalletBackupServerUsecase(
+      state,
+      parseOrigin: Uri.tryParse,
+    );
+
+    expect(await usecase.execute('   '), isA<Ok<void, WalletBackupFailure>>());
+
+    verify(() => state.setServerUrl(null)).called(1);
+  });
+
+  test('an unparseable origin is never written', () async {
+    final usecase = SetWalletBackupServerUsecase(
+      state,
+      parseOrigin: (_) => null,
+    );
+
+    expect(
+      await usecase.execute('not-an-origin'),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupInvalidServerOriginFailure>(),
+      ),
+    );
+
+    verifyNever(() => state.setServerUrl(any()));
+  });
+}

--- a/test/features/wallet_backup/support/wallet_backup_behavior_harness.dart
+++ b/test/features/wallet_backup/support/wallet_backup_behavior_harness.dart
@@ -1,0 +1,620 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/storage/backup_revision_recorder.dart';
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/seed_derived_wallet_recovery_fact.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/keychain_manifest_repository_impl.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/get_nostr_public_key_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/sign_nostr_hash_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/data/drift_wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/data/recoverbull_wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/apply_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/backup_wallet_now_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/data/models/wallet_backup_snapshot_model.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/delete_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_backup_contents_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/get_wallet_recovery_inventory_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/restore_wallet_backup_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_enabled_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/set_wallet_backup_server_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/store_selected_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/publish_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/register_wallet_backup_recovery_material_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/watch_wallet_backup_state_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_job_runner.dart';
+import 'package:bb_mobile/features/wallet_backup/watchers/wallet_backup_triggers.dart';
+import 'package:async/async.dart' show StreamGroup;
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart' show driftRuntimeOptions;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+import '../metadata/support/portable_settings_fixture.dart';
+
+/// BIP39 test vector whose root is the default wallet in every backup suite.
+const defaultSeedMnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon '
+    'abandon abandon about';
+const defaultSeedFingerprint = '73c5da0a';
+
+/// A second BIP39 test vector, used wherever a backup must belong to another
+/// root than the one the harness is holding.
+const foreignSeedMnemonic =
+    'legal winner thank year wave sausage worth useful legal winner thank '
+    'yellow';
+const foreignSeedFingerprint = 'fedcba98';
+
+WalletMetadataSnapshot emptyMetadataSnapshot() => WalletMetadataSnapshot(
+  labels: const [],
+  frozenOutpoints: const [],
+  walletPreferences: const [],
+  settings: portableSettingsFixture(),
+);
+
+Seed backupSeed({
+  String mnemonic = defaultSeedMnemonic,
+  String fingerprint = defaultSeedFingerprint,
+}) => Seed.bytes(
+  bytes: Uint8List.fromList(
+    bip39.Mnemonic.fromSentence(mnemonic, bip39.Language.english).seed,
+  ),
+  masterFingerprint: fingerprint,
+);
+
+class _Settings extends Mock implements GetSettingsUsecase {}
+
+class _DefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+/// In-memory stand-in for the backup server.
+///
+/// It keeps the parts of the wire contract the product depends on: one object
+/// per account, a monotonic generation, an ETag that changes with the stored
+/// bytes, and compare-and-swap rejection of a stale write.
+final class FakeWalletBackupRemote implements WalletBackupRemoteRepository {
+  WalletBackupCiphertext? _ciphertext;
+  String? _ciphertextSha256;
+  String? _etag;
+  int _generation = 0;
+
+  /// Injected transport faults. Set to simulate a rate-limited or unavailable
+  /// server; clear to let the next attempt through.
+  WalletBackupFailure? fetchFailure;
+  WalletBackupFailure? storeFailure;
+
+  int storeCount = 0;
+  int storeAttempts = 0;
+  int fetchCount = 0;
+
+  /// Runs just before a store is applied, so a test can commit a local change
+  /// while a publication is in flight.
+  Future<void> Function()? beforeStore;
+
+  String? get storedCiphertext => _ciphertext?.value;
+
+  bool get isEmpty => _ciphertext == null;
+
+  /// Publishes [ciphertext] as if another device had written it.
+  void install(WalletBackupCiphertext ciphertext) {
+    _ciphertext = ciphertext;
+    _ciphertextSha256 = sha256
+        .convert(base64.decode(ciphertext.value))
+        .toString();
+    _generation += 1;
+    _etag = sha256
+        .convert(utf8.encode('$_generation:$_ciphertextSha256'))
+        .toString();
+  }
+
+  WalletBackupRemoteHead head() {
+    final ciphertext = _ciphertext;
+    if (ciphertext == null) {
+      return WalletBackupRemoteHead.absent(
+        generation: _generation,
+        etag: _etag,
+      );
+    }
+    return WalletBackupRemoteHead.present(
+      generation: _generation,
+      etag: _etag!,
+      ciphertext: ciphertext,
+      ciphertextSha256: _ciphertextSha256!,
+    );
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> fetch({
+    required WalletBackupAuthentication authentication,
+  }) async {
+    fetchCount += 1;
+    final failure = fetchFailure;
+    return failure == null ? Ok(head()) : Err(failure);
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> store({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint? current,
+    required WalletBackupCiphertext ciphertext,
+    required String ciphertextSha256,
+  }) async {
+    storeAttempts += 1;
+    await beforeStore?.call();
+    final failure = storeFailure;
+    if (failure != null) return Err(failure);
+    if (!_matchesHead(current)) {
+      return const Err(WalletBackupHeadConflictFailure());
+    }
+    storeCount += 1;
+    install(ciphertext);
+    return Ok(head().checkpoint!);
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> delete({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint current,
+  }) async {
+    final failure = storeFailure;
+    if (failure != null) return Err(failure);
+    if (!_matchesHead(current)) {
+      return const Err(WalletBackupHeadConflictFailure());
+    }
+    _ciphertext = null;
+    _ciphertextSha256 = null;
+    _generation += 1;
+    _etag = sha256.convert(utf8.encode('$_generation:deleted')).toString();
+    return Ok(head().checkpoint!);
+  }
+
+  bool _matchesHead(WalletBackupRemoteCheckpoint? current) =>
+      (current?.generation ?? 0) == _generation && current?.etag == _etag;
+}
+
+/// External-wallet section stand-in. The harness leaves the section out of the
+/// envelope unless a test sets [definitions].
+final class FakeWalletDefinitionsSection implements WalletDefinitionsBackup {
+  final StreamController<void> _changes = StreamController<void>.broadcast();
+
+  List<WalletDefinition> definitions = const [];
+
+  @override
+  Stream<void> get changes => _changes.stream;
+
+  void emitChange() => _changes.add(null);
+
+  @override
+  Future<Result<List<WalletDefinition>, WalletBackupFailure>> read() async =>
+      Ok(definitions);
+
+  @override
+  Future<Result<WalletDefinitionsRecoveryResult, WalletBackupFailure>> recover({
+    required List<WalletDefinition> definitions,
+    DateTime? deadline,
+  }) async => Ok(
+    WalletDefinitionsRecoveryResult(
+      restoredCount: 0,
+      failedCount: 0,
+      createdWalletRefs: const [],
+    ),
+  );
+
+  Future<void> dispose() => _changes.close();
+}
+
+/// Protected-data section stand-in.
+///
+/// [snapshot] is the local snapshot the section would publish; changing it and
+/// calling [emitChange] models the user editing labels or freezing a coin.
+/// [recoverComplete] models a restore that could not finish.
+final class FakeWalletMetadataSection {
+  final StreamController<void> _changes = StreamController<void>.broadcast();
+
+  WalletMetadataSnapshot snapshot = emptyMetadataSnapshot();
+  bool recoverComplete = true;
+
+  /// Thrown from [recover] to model a process that dies part-way through an
+  /// apply, leaving the durable fence raised.
+  Object? recoverError;
+  final List<WalletMetadataSnapshot> recoveredSnapshots = [];
+
+  Stream<void> get changes => _changes.stream;
+
+  void emitChange() => _changes.add(null);
+
+  Result<void, WalletMetadataBackupFailure> validate(
+    WalletMetadataSnapshot snapshot,
+  ) => const Ok(null);
+
+  Future<Result<WalletMetadataSnapshot, WalletMetadataBackupFailure>>
+  localSnapshot() async => Ok(snapshot);
+
+  Future<Result<bool, WalletMetadataBackupFailure>> recover({
+    required WalletMetadataSnapshot snapshot,
+    required Set<String> createdWalletRefs,
+    DateTime? deadline,
+  }) async {
+    if (recoverError case final error?) throw error;
+    recoveredSnapshots.add(snapshot);
+    return Ok(recoverComplete);
+  }
+
+  Future<void> dispose() => _changes.close();
+}
+
+/// One device: real state storage, real keychain manifest, real codecs and
+/// real encryption, with the backup server and the two section owners faked.
+///
+/// Several harnesses can share one [FakeWalletBackupRemote] to model two
+/// devices publishing to the same account.
+final class WalletBackupBehaviorHarness {
+  final SqliteDatabase database;
+  final KeychainManifestRepositoryImpl manifestRepository;
+  final KeychainManifestFacade keychainManifest;
+  final WalletBackupJobRunner runner;
+  final WalletBackupTriggers triggers;
+  final WalletBackupFacade facade;
+  final FakeWalletBackupRemote remote;
+  final FakeWalletDefinitionsSection definitions;
+  final FakeWalletMetadataSection metadata;
+  final RecoverBullWalletBackupEncryptionRepository encryption;
+  final String parentFingerprint;
+  final WalletBackupEncryptionKey encryptionKey;
+  final List<SeedDerivedWalletRecoveryFact> seedDerivedWallets;
+
+  bool _started = false;
+  bool _disposed = false;
+
+  WalletBackupBehaviorHarness._({
+    required this.database,
+    required this.manifestRepository,
+    required this.keychainManifest,
+    required this.runner,
+    required this.triggers,
+    required this.facade,
+    required this.remote,
+    required this.definitions,
+    required this.metadata,
+    required this.encryption,
+    required this.parentFingerprint,
+    required this.encryptionKey,
+    required this.seedDerivedWallets,
+  });
+
+  static Future<WalletBackupBehaviorHarness> create({
+    Seed? seed,
+    FakeWalletBackupRemote? remote,
+    List<SeedDerivedWalletRecoveryFact> seedDerivedWallets = const [],
+    SqliteDatabase? database,
+    DateTime Function()? now,
+  }) async {
+    final walletSeed = seed ?? backupSeed();
+    final settings = _Settings();
+    final defaultSeed = _DefaultSeed();
+    when(() => settings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'CAD',
+      ),
+    );
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(walletSeed));
+
+    driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+    final walletDatabase = database ?? SqliteDatabase(NativeDatabase.memory());
+    final manifestRepository = KeychainManifestRepositoryImpl(
+      walletDatabase,
+      backupRevisions: DriftBackupRevisionRecorder(walletDatabase),
+    );
+    final keychainManifest = _manifestFacade(
+      repository: manifestRepository,
+      settings: settings,
+      defaultSeed: defaultSeed,
+    );
+    final codec = WalletBackupSnapshotCodec(
+      encodeManifest: keychainManifest.encodeManifestFilePayload,
+      decodeManifest: keychainManifest.parseManifestFilePayload,
+    );
+    final encryption = RecoverBullWalletBackupEncryptionRepository(codec);
+    final state = DriftWalletBackupStateRepository(walletDatabase);
+    final backupRemote = remote ?? FakeWalletBackupRemote();
+    final definitions = FakeWalletDefinitionsSection();
+    final metadata = FakeWalletMetadataSection();
+
+    final nostrIdentity = _nostrIdentity(settings, defaultSeed);
+    final authenticator = WalletBackupAuthenticator(nostrIdentity);
+    final fetchRemote = FetchWalletBackupRemoteUsecase(
+      backupRemote,
+      authenticator,
+    );
+    final storeRemote = StoreWalletBackupRemoteUsecase(
+      backupRemote,
+      authenticator,
+    );
+    final deleteRemote = DeleteWalletBackupRemoteUsecase(
+      backupRemote,
+      authenticator,
+    );
+    final resolveKey = ResolveWalletBackupKeyUsecase(settings, defaultSeed);
+    final wallets = List<SeedDerivedWalletRecoveryFact>.of(seedDerivedWallets);
+    final refreshManifest = RefreshWalletRecoveryManifestUsecase(
+      () async => wallets,
+      keychainManifest,
+    );
+    final buildSnapshot = BuildWalletBackupSnapshotUsecase(
+      keychainManifest,
+      definitions,
+      metadata.localSnapshot,
+    );
+    final registerRecoveryMaterial =
+        RegisterWalletBackupRecoveryMaterialUsecase(
+          resolveKey,
+          nostrIdentity,
+          keychainManifest,
+          refreshManifest,
+        );
+    final fetchImport = FetchWalletBackupSnapshotUsecase(
+      resolveKey: resolveKey,
+      encryption: encryption,
+      state: state,
+    );
+    final publish = PublishWalletBackupUsecase(
+      buildSnapshot: buildSnapshot,
+      resolveKey: resolveKey,
+      encryption: encryption,
+      fetchRemote: fetchRemote,
+      storeRemote: storeRemote,
+      readRemoteSnapshot: fetchImport,
+      state: state,
+    );
+    final publication = BackupWalletNowUsecase(
+      state: state,
+      publish: publish.execute,
+      nowSecs: () => DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
+    );
+    final runner = WalletBackupJobRunner(
+      publish: publication.execute,
+      now: now,
+    );
+    final triggers = WalletBackupTriggers(
+      recordedChanges: keychainManifest.watchCommittedChanges(),
+      unrecordedChanges: _mergeChanges([definitions.changes, metadata.changes]),
+      syncResults: const Stream.empty(),
+      runner: runner,
+      recordMutation: state.recordLocalMutation,
+    );
+    final applySnapshot = ApplyBackupSnapshotUsecase(
+      state,
+      definitions,
+      restoreManifest: RestoreWalletBackupManifestUsecase(
+        ({
+          required walletId,
+          required seedFingerprint,
+          required network,
+          required scriptType,
+          required provenance,
+          required derivationPath,
+          required seedPassphraseUsed,
+        }) async => true,
+        keychainManifest,
+      ),
+      validateMetadata: metadata.validate,
+      restoreMetadata: metadata.recover,
+    );
+    final decodeFile = DecodeWalletBackupFileUsecase(
+      resolveKey.execute,
+      encryption,
+    );
+    final recover = RecoverWalletBackupUsecase(
+      fetchImport: fetchImport.execute,
+      fetchRemote: fetchRemote.execute,
+      apply: applySnapshot.execute,
+    );
+    final facade = WalletBackupFacade(
+      GetWalletBackupContentsUsecase(
+        GetWalletRecoveryInventoryUsecase(
+          resolveKey.execute,
+          refreshManifest.execute,
+          keychainManifest.readManifest,
+        ).execute,
+        () async => const <WalletDefinition>[],
+        () async => const <String>{},
+        metadata.localSnapshot,
+      ),
+      WatchWalletBackupStateUsecase(state),
+      SetWalletBackupEnabledUsecase(
+        state,
+        recover.execute,
+        registerRecoveryMaterial.execute,
+        publication.execute,
+      ),
+      SetWalletBackupServerUsecase(
+        state,
+        parseOrigin: parseWalletBackupServerOrigin,
+      ),
+      DeleteWalletBackupUsecase(
+        fetchRemote: fetchRemote,
+        deleteRemote: deleteRemote,
+        state: state,
+      ),
+      runner,
+      state,
+      recover,
+      BuildWalletBackupExportUsecase(
+        buildSnapshot: buildSnapshot.execute,
+        resolveKey: resolveKey.execute,
+        encryption: encryption,
+      ),
+      CompareWalletBackupFileUsecase(
+        decodeFile.execute,
+        state.get,
+        fetchRemote.execute,
+        fetchImport.execute,
+        codec.differences,
+      ),
+      RecoverWalletBackupFileUsecase(
+        decodeFile.execute,
+        ({required snapshot, deadline}) => applySnapshot.execute(
+          snapshot: snapshot,
+          deadline: deadline,
+          callerSettlesFence: true,
+        ),
+        applySnapshot.settle,
+        state.get,
+        fetchRemote.execute,
+        StoreSelectedWalletBackupUsecase(
+          resolveKey,
+          encryption,
+          storeRemote,
+          state,
+          () => DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000,
+        ).execute,
+      ),
+    );
+
+    final key = switch (await resolveKey.execute()) {
+      Ok(:final value) => value,
+      Err(:final failure) => fail('backup key derivation failed: $failure'),
+    };
+
+    return WalletBackupBehaviorHarness._(
+      database: walletDatabase,
+      manifestRepository: manifestRepository,
+      keychainManifest: keychainManifest,
+      runner: runner,
+      triggers: triggers,
+      facade: facade,
+      remote: backupRemote,
+      definitions: definitions,
+      metadata: metadata,
+      encryption: encryption,
+      parentFingerprint: key.parentFingerprint,
+      encryptionKey: key.encryptionKey,
+      seedDerivedWallets: wallets,
+    );
+  }
+
+  Fingerprint get fingerprint => Fingerprint(parentFingerprint);
+
+  /// Starts the automatic publication triggers, as app start-up does.
+  void startCoordinator() {
+    if (_started) return;
+    _started = true;
+    triggers.start();
+  }
+
+  Future<WalletBackupState> readState() async =>
+      switch (await facade.watchState().first) {
+        Ok(:final value) => value,
+        Err(:final failure) => fail('backup state unavailable: $failure'),
+      };
+
+  Future<void> dispose({bool closeDatabase = true}) async {
+    if (_disposed) return;
+    _disposed = true;
+    await triggers.dispose();
+    await runner.dispose();
+    await definitions.dispose();
+    await metadata.dispose();
+    await manifestRepository.close();
+    if (closeDatabase) await database.close();
+  }
+}
+
+/// Pumps the event queue until [reached] holds, so tests can wait on work the
+/// coordinator scheduled without reaching into its internals.
+Future<void> settleUntil(
+  Future<bool> Function() reached, {
+  String description = 'expected state',
+  int attempts = 100,
+}) async {
+  for (var attempt = 0; attempt < attempts; attempt++) {
+    if (await reached()) return;
+    await pumpEventQueue();
+  }
+  fail('timed out waiting for $description');
+}
+
+KeychainManifestFacade _manifestFacade({
+  required KeychainManifestRepositoryImpl repository,
+  required GetSettingsUsecase settings,
+  required GetDefaultSeedUsecase defaultSeed,
+}) {
+  const codec = KeychainManifestFileCodec();
+  final parse = ParseKeychainManifestFileUsecase(codec.decode);
+  return KeychainManifestFacade(
+    WatchKeychainManifestChangesUsecase(repository),
+    codec.encode,
+    BuildKeychainManifestFileUsecase(repository),
+    parse,
+    ReplaceSeedWalletInventoryUsecase(repository),
+    RecordPassphraseWalletUsecase(repository),
+    RestoreManifestSnapshotUsecase(repository),
+    RecordKeychainManifestNostrKeyUsecase(repository),
+    RestoreKeychainManifestNostrKeyUsecase(
+      KeychainManifestNostrKeyDeriver(settings, defaultSeed),
+      RecordKeychainManifestNostrKeyUsecase(repository),
+    ),
+    UpdatePassphraseLabelHintUsecase(repository),
+    RemovePassphraseWalletUsecase(repository),
+  );
+}
+
+NostrIdentityFacade _nostrIdentity(
+  GetSettingsUsecase settings,
+  GetDefaultSeedUsecase defaultSeed,
+) {
+  final resolver = NostrIdentityKeyResolver(settings, defaultSeed);
+  return NostrIdentityFacade(
+    GetNostrPublicKeyUsecase(resolver),
+    SignNostrHashUsecase(resolver),
+  );
+}
+
+Stream<void> _mergeChanges(List<Stream<void>> streams) =>
+    StreamGroup.merge(streams);

--- a/test/features/wallet_backup/wallet_backup_durability_test.dart
+++ b/test/features/wallet_backup/wallet_backup_durability_test.dart
@@ -1,0 +1,269 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart' hide ScriptType;
+
+import 'support/wallet_backup_behavior_harness.dart';
+
+/// What survives a crash, a queue, and a rate limit.
+///
+/// Everything Bull backup still owes the server lives in two durable numbers
+/// and one durable fence, so these tests assert against restarts and injected
+/// faults rather than against in-memory bookkeeping.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('a change during a publication leaves one more pass to run', () async {
+    final device = await _device();
+    expect(await device.facade.setEnabled(true), _succeeds);
+    device.startCoordinator();
+    final storesAfterEnabling = device.remote.storeCount;
+
+    // A wallet is recorded while the first store is still in flight. Its
+    // revision lands in the same transaction as the manifest write, so the
+    // publication that is already running cannot acknowledge it.
+    var interrupted = false;
+    device.remote.beforeStore = () async {
+      if (interrupted) return;
+      interrupted = true;
+      await _addWallet(device, walletId: 'mid-flight', label: 'Mid flight');
+      expect((await device.readState()).dirty, isTrue);
+    };
+
+    expect(await device.facade.backupNow(), _succeeds);
+
+    await settleUntil(
+      () async => !(await device.readState()).dirty,
+      description: 'the follow-up publication',
+    );
+    expect(device.remote.storeCount, storesAfterEnabling + 2);
+
+    // Nothing else is owed, so no further pass runs.
+    await device.runner.settle();
+    await pumpEventQueue();
+    expect(device.remote.storeCount, storesAfterEnabling + 2);
+  });
+
+  test(
+    'deletion cannot race an older store, and no store follows it',
+    () async {
+      final device = await _device();
+      expect(await device.facade.setEnabled(true), _succeeds);
+      await _addWallet(device, walletId: 'doomed', label: 'Doomed');
+
+      final storeReached = Completer<void>();
+      final releaseStore = Completer<void>();
+      device.remote.beforeStore = () async {
+        if (!storeReached.isCompleted) storeReached.complete();
+        await releaseStore.future;
+      };
+
+      final publishing = device.facade.backupNow();
+      await storeReached.future;
+
+      // Both queue behind the store that is already running.
+      final disabling = device.facade.setEnabled(false);
+      final deleting = device.facade.deleteRemoteBackup(confirmed: true);
+      await pumpEventQueue();
+      expect(device.remote.isEmpty, isFalse, reason: 'the delete must wait');
+
+      releaseStore.complete();
+      expect(await publishing, _succeeds);
+      expect(await disabling, _succeeds);
+      expect(await deleting, _succeeds);
+
+      expect(device.remote.isEmpty, isTrue);
+      final storesAfterDelete = device.remote.storeCount;
+
+      // A change arriving after the delete cannot recreate the object, because
+      // deletion required automatic backup to be off first (decision 9).
+      device.startCoordinator();
+      await _addWallet(device, walletId: 'after-delete', label: 'After');
+      await device.runner.settle();
+      await pumpEventQueue();
+
+      expect(device.remote.isEmpty, isTrue);
+      expect(device.remote.storeCount, storesAfterDelete);
+    },
+  );
+
+  test(
+    'deleting a remote backup requires automatic backup to be off',
+    () async {
+      final device = await _device();
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      expect(
+        await device.facade.deleteRemoteBackup(confirmed: true),
+        isA<Err<void, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupDeleteRequiresDisabledFailure>(),
+        ),
+      );
+      expect(device.remote.isEmpty, isFalse);
+    },
+  );
+
+  test('an apply that dies part-way refuses publication until it is '
+      'redone', () async {
+    final server = FakeWalletBackupRemote();
+    final device = await _device(remote: server);
+    expect(await device.facade.setEnabled(true), _succeeds);
+
+    final elsewhere = await _device(remote: server);
+    await _addWallet(elsewhere, walletId: 'elsewhere', label: 'Elsewhere');
+    expect(await elsewhere.facade.setEnabled(true), _succeeds);
+    final published = server.storedCiphertext;
+
+    device.metadata.recoverError = StateError('process died mid-apply');
+    await expectLater(device.facade.recover(), throwsStateError);
+
+    // The fence is durable, and applying reads as blocked precisely because a
+    // run that never finished cannot be told apart from one still going.
+    var state = await device.readState();
+    expect(state.recoveryState, WalletBackupRecoveryState.applying);
+    expect(state.recoveryBlocked, isTrue);
+    expect(state.canPublish, isFalse);
+
+    await _addWallet(device, walletId: 'local', label: 'Local');
+    expect(
+      await device.facade.backupNow(),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupRecoveryBlockedFailure>(),
+      ),
+    );
+    expect(server.storedCiphertext, published);
+
+    device.metadata.recoverError = null;
+    expect(
+      (await device.facade.recover()).status,
+      WalletBackupRecoveryStatus.restored,
+    );
+
+    state = await device.readState();
+    expect(state.recoveryState, WalletBackupRecoveryState.idle);
+    expect(state.dirty, isTrue, reason: 'local work survives the fence');
+    expect(await device.facade.backupNow(), _succeeds);
+  });
+
+  test('a rate-limited store stops every remote call until the gate '
+      'lifts', () async {
+    var now = DateTime.utc(2026);
+    final device = await _device(now: () => now);
+    expect(await device.facade.setEnabled(true), _succeeds);
+    await _addWallet(device, walletId: 'limited', label: 'Limited');
+
+    device.remote.storeFailure = const WalletBackupRateLimitedFailure(
+      Duration(seconds: 30),
+    );
+    expect(
+      await device.facade.backupNow(),
+      isA<Err<void, WalletBackupFailure>>(),
+    );
+
+    device.remote.storeFailure = null;
+    final attemptsWhileLimited = device.remote.storeAttempts;
+    final fetchesWhileLimited = device.remote.fetchCount;
+
+    expect(
+      await device.facade.backupNow(),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupRateLimitedFailure>(),
+      ),
+    );
+    expect(device.remote.storeAttempts, attemptsWhileLimited);
+    expect(device.remote.fetchCount, fetchesWhileLimited);
+    expect((await device.readState()).dirty, isTrue);
+
+    now = now.add(const Duration(seconds: 30));
+
+    expect(await device.facade.backupNow(), _succeeds);
+    expect(device.remote.storeAttempts, attemptsWhileLimited + 1);
+    expect((await device.readState()).dirty, isFalse);
+  });
+
+  test('a restarted app still owes the publication it never made', () async {
+    final database = SqliteDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final server = FakeWalletBackupRemote();
+
+    final before = await WalletBackupBehaviorHarness.create(
+      remote: server,
+      database: database,
+    );
+    expect(await before.facade.setEnabled(true), _succeeds);
+    final publishedAtEnabling = server.storedCiphertext;
+    // No triggers are running, so this change is recorded and never sent.
+    await _addWallet(before, walletId: 'unsent', label: 'Unsent');
+    final pending = await before.readState();
+    expect(pending.dirty, isTrue);
+    expect(pending.localRevision, greaterThan(pending.uploadedRevision));
+    await before.dispose(closeDatabase: false);
+
+    final after = await WalletBackupBehaviorHarness.create(
+      remote: server,
+      database: database,
+    );
+    addTearDown(() => after.dispose(closeDatabase: false));
+
+    final resumed = await after.readState();
+    expect(resumed.dirty, isTrue, reason: 'revisions outlive the process');
+    expect(resumed.canPublish, isTrue);
+    expect(server.storedCiphertext, publishedAtEnabling);
+
+    after.startCoordinator();
+    await settleUntil(
+      () async => !(await after.readState()).dirty,
+      description: 'the publication the restart inherited',
+    );
+    expect(server.storedCiphertext, isNot(publishedAtEnabling));
+  });
+}
+
+final Matcher _succeeds = isA<Ok<void, WalletBackupFailure>>();
+
+Future<WalletBackupBehaviorHarness> _device({
+  FakeWalletBackupRemote? remote,
+  DateTime Function()? now,
+}) async {
+  final harness = await WalletBackupBehaviorHarness.create(
+    remote: remote,
+    now: now,
+  );
+  addTearDown(harness.dispose);
+  return harness;
+}
+
+Future<void> _addWallet(
+  WalletBackupBehaviorHarness device, {
+  required String walletId,
+  required String label,
+}) async {
+  final result = await device.keychainManifest.recordWallet(
+    parentFingerprint: device.fingerprint,
+    wallet: KeychainManifestWalletInventoryBinding(
+      walletId: walletId,
+      seedFingerprint: Fingerprint(
+        walletId.hashCode.toUnsigned(32).toRadixString(16).padLeft(8, '0'),
+      ),
+      network: Network.bitcoinMainnet,
+      scriptType: ScriptType.bip84,
+      provenance: WalletProvenance.importedMnemonic,
+      derivationPath: "m/84'/0'/0'",
+      seedPassphraseUsed: false,
+      label: label,
+    ),
+  );
+  expect(result, isA<Ok<bool, KeychainManifestFailure>>());
+}

--- a/test/features/wallet_backup/wallet_backup_file_usecases_test.dart
+++ b/test/features/wallet_backup/wallet_backup_file_usecases_test.dart
@@ -1,0 +1,1026 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file_comparison.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_recovery.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/labels/labels_facade.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+import '../keychain_manifest/support/manifest_fixtures.dart';
+import 'metadata/support/portable_settings_fixture.dart';
+import 'support/canonical_backup_snapshot.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('file validation', () {
+    test('an export cannot contain zero bytes', () {
+      expect(
+        () => WalletBackupExport(suggestedFilename: 'backup.json', bytes: []),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+      'decode rejects empty, oversized, and malformed UTF-8 input',
+      () async {
+        final decoder = DecodeWalletBackupFileUsecase(
+          () async => Ok(_key),
+          _Encryption(),
+        );
+
+        expect(
+          await decoder.execute(Uint8List(0)),
+          isA<Err>().having(
+            (value) => value.failure,
+            'failure',
+            isA<WalletBackupInvalidEnvelopeFailure>(),
+          ),
+        );
+        expect(
+          await decoder.execute(
+            Uint8List(DecodeWalletBackupFileUsecase.maximumFileBytes + 1),
+          ),
+          isA<Err>().having(
+            (value) => value.failure,
+            'failure',
+            isA<WalletBackupTooLargeFailure>(),
+          ),
+        );
+        expect(
+          await decoder.execute(Uint8List.fromList([0xff])),
+          isA<Err>().having(
+            (value) => value.failure,
+            'failure',
+            isA<WalletBackupInvalidEnvelopeFailure>(),
+          ),
+        );
+      },
+    );
+
+    test(
+      'decode accepts conventional whitespace before plaintext JSON',
+      () async {
+        final decoder = DecodeWalletBackupFileUsecase(
+          () async => Ok(_key),
+          const _Encryption(acceptPlaintext: true),
+        );
+
+        expect(
+          await decoder.execute(Uint8List.fromList(utf8.encode(' \n{"v":1}'))),
+          isA<Ok<WalletBackupSnapshot, WalletBackupFailure>>(),
+        );
+      },
+    );
+  });
+
+  group('comparison', () {
+    test(
+      'disabled automatic backup still compares an existing server backup',
+      () async {
+        var fetches = 0;
+        final usecase = _comparison(
+          state: _state(enabled: false),
+          fetchRemote: () async {
+            fetches++;
+            return Ok(_head(_serverCiphertext));
+          },
+          server: _serverSnapshot(),
+        );
+
+        final result = await usecase.execute(Uint8List.fromList([1]));
+
+        expect(result, isA<Ok>());
+        final comparison = (result as Ok).value as WalletBackupImportComparison;
+        expect(comparison.situation, WalletBackupImportSituation.different);
+        expect(comparison.server, isNotNull);
+        expect(fetches, 1);
+      },
+    );
+
+    test(
+      'disabled automatic backup reports no server backup accurately',
+      () async {
+        final usecase = _comparison(
+          state: _state(enabled: false),
+          fetchRemote: () async =>
+              Ok(WalletBackupRemoteHead.absent(generation: 0, etag: null)),
+        );
+
+        final result = await usecase.execute(Uint8List.fromList([1]));
+
+        final comparison = (result as Ok).value as WalletBackupImportComparison;
+        expect(
+          comparison.situation,
+          WalletBackupImportSituation.automaticBackupDisabled,
+        );
+        expect(comparison.server, isNull);
+      },
+    );
+
+    test('reports exact manifest, definition, and metadata counts', () async {
+      final backup = _fileSnapshot(
+        definitions: [
+          _definition('one'),
+          _definition('two', fingerprint: '76241f88'),
+        ],
+        metadata: _metadata(labels: 3, frozenOutpoints: 4, preferences: 5),
+      );
+      final usecase = _comparison(
+        file: backup,
+        state: _state(enabled: true),
+        fetchRemote: () async =>
+            const Err(WalletBackupRemoteUnavailableFailure()),
+      );
+
+      final result = await usecase.execute(Uint8List.fromList([1]));
+      final summary =
+          ((result as Ok).value as WalletBackupImportComparison).file;
+
+      expect(summary.createdAt, 9);
+      expect(summary.walletCount, 1);
+      expect(summary.nostrIdentityCount, 1);
+      expect(summary.externalWalletCount, 2);
+      expect(summary.labelCount, 3);
+      expect(summary.frozenOutpointCount, 4);
+      expect(summary.walletPreferenceCount, 5);
+    });
+
+    test('a rejected file fails comparison instead of estimating', () async {
+      final usecase = CompareWalletBackupFileUsecase(
+        (_) async => const Err(WalletBackupManifestFailure()),
+        () async => Ok(_state(enabled: false)),
+        () async => throw StateError('server must not be called'),
+        (_) async => const Ok(null),
+        _codec.differences,
+      );
+
+      expect(
+        await usecase.execute(Uint8List.fromList([1])),
+        isA<Err>().having(
+          (value) => value.failure,
+          'failure',
+          isA<WalletBackupManifestFailure>(),
+        ),
+      );
+    });
+
+    test('does not disguise authentication failures as offline', () async {
+      final usecase = _comparison(
+        state: _state(enabled: true),
+        fetchRemote: () async => const Err(WalletBackupSigningFailure()),
+      );
+
+      expect(
+        await usecase.execute(Uint8List.fromList([1])),
+        isA<Err>().having(
+          (value) => value.failure,
+          'failure',
+          isA<WalletBackupSigningFailure>(),
+        ),
+      );
+    });
+
+    test('does not disguise an invalid remote response as offline', () async {
+      final usecase = _comparison(
+        state: _state(enabled: true),
+        fetchRemote: () async => const Err(WalletBackupInvalidRemoteFailure()),
+      );
+
+      expect(
+        await usecase.execute(Uint8List.fromList([1])),
+        isA<Err>().having(
+          (value) => value.failure,
+          'failure',
+          isA<WalletBackupInvalidRemoteFailure>(),
+        ),
+      );
+    });
+
+    test(
+      'does not disguise an unsupported server snapshot as offline',
+      () async {
+        final usecase = _comparison(
+          state: _state(enabled: true),
+          fetchRemote: () async => Ok(_head(_serverCiphertext)),
+          fetchImport: (_) async =>
+              const Err(WalletBackupUnsupportedEnvelopeVersionFailure(2)),
+        );
+
+        expect(
+          await usecase.execute(Uint8List.fromList([1])),
+          isA<Err>().having(
+            (value) => value.failure,
+            'failure',
+            isA<WalletBackupUnsupportedEnvelopeVersionFailure>(),
+          ),
+        );
+      },
+    );
+
+    test('captures the exact server ciphertext used for its summary', () async {
+      var remoteFetches = 0;
+      final usecase = _comparison(
+        state: _state(enabled: true),
+        fetchRemote: () async {
+          remoteFetches++;
+          return Ok(_head(_serverCiphertext));
+        },
+        server: _serverSnapshot(),
+      );
+
+      final result = await usecase.execute(Uint8List.fromList([1]));
+      final comparison = (result as Ok).value as WalletBackupImportComparison;
+      final firstCopy = comparison.copyServerCiphertextBytes()!;
+      firstCopy[0] = 0;
+
+      expect(remoteFetches, 1);
+      expect(
+        utf8.decode(comparison.copyServerCiphertextBytes()!),
+        _serverCiphertext.value,
+      );
+    });
+
+    test(
+      'detects canonical manifest changes when identities still match',
+      () async {
+        final usecase = _comparison(
+          state: _state(enabled: true),
+          fetchRemote: () async => Ok(_head(_serverCiphertext)),
+          server: _fileSnapshot(
+            recoveryManifest: manifest(
+              generatedAt: 9,
+              entries: [
+                walletManifestEntry(updatedAt: 7),
+                nostrManifestEntry(purpose: 'Renamed identity'),
+              ],
+            ),
+          ),
+        );
+
+        final result = await usecase.execute(Uint8List.fromList([1]));
+        final comparison = (result as Ok).value as WalletBackupImportComparison;
+
+        expect(comparison.situation, WalletBackupImportSituation.different);
+        expect(
+          comparison.differences,
+          contains(WalletBackupDifference.walletManifest),
+        );
+      },
+    );
+
+    test('ignores the manifest generation time when content matches', () async {
+      final usecase = _comparison(
+        file: _fileSnapshot(
+          recoveryManifest: manifest(generatedAt: 9),
+          definitions: [_definition('one')],
+          metadata: _metadata(labels: 1),
+        ),
+        state: _state(enabled: true),
+        fetchRemote: () async => Ok(_head(_serverCiphertext)),
+        server: _fileSnapshot(
+          recoveryManifest: manifest(generatedAt: 99),
+          definitions: [_definition('one')],
+          metadata: _metadata(labels: 1),
+        ),
+      );
+
+      final result = await usecase.execute(Uint8List.fromList([1]));
+      final comparison = (result as Ok).value as WalletBackupImportComparison;
+
+      expect(comparison.situation, WalletBackupImportSituation.same);
+      expect(comparison.differences, isEmpty);
+    });
+
+    test('still reports same-count protected content changes', () async {
+      final usecase = _comparison(
+        file: _fileSnapshot(metadata: _metadata(labels: 1, labelText: 'first')),
+        state: _state(enabled: true),
+        fetchRemote: () async => Ok(_head(_serverCiphertext)),
+        server: _fileSnapshot(
+          metadata: _metadata(labels: 1, labelText: 'second'),
+        ),
+      );
+
+      final result = await usecase.execute(Uint8List.fromList([1]));
+      final comparison = (result as Ok).value as WalletBackupImportComparison;
+
+      expect(comparison.situation, WalletBackupImportSituation.different);
+      expect(
+        comparison.differences,
+        contains(WalletBackupDifference.protectedData),
+      );
+    });
+  });
+
+  group('compared recovery', () {
+    test('disabled comparison applies locally without publishing', () async {
+      var stores = 0;
+      var pending = 0;
+      final usecase = _recovery(
+        state: _state(enabled: false),
+        storeSelected: ({required selected, required current}) async {
+          stores++;
+          return const Ok(null);
+        },
+        markPending: () async {
+          pending++;
+          return const Ok(null);
+        },
+      );
+
+      final result = await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: _comparisonValue(
+          WalletBackupImportSituation.automaticBackupDisabled,
+        ),
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(result.status, WalletBackupRecoveryStatus.restored);
+      expect(stores, 0);
+      expect(pending, 0);
+    });
+
+    test(
+      'disabled automatic backup applies the file without server access',
+      () async {
+        var applies = 0;
+        var stores = 0;
+        final usecase = _recovery(
+          state: _state(enabled: false),
+          fetchRemote: () async =>
+              throw StateError('server must not be called'),
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          storeSelected: ({required selected, required current}) async {
+            stores++;
+            return const Ok(null);
+          },
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.different,
+            withServer: true,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.restored);
+        expect(applies, 1);
+        expect(stores, 0);
+      },
+    );
+
+    test(
+      'unavailable server applies the file and schedules reconciliation',
+      () async {
+        var decodes = 0;
+        var applies = 0;
+        var stores = 0;
+        var unblocks = 0;
+        var pending = 0;
+        final usecase = _recovery(
+          decode: (_) async {
+            decodes++;
+            return Ok(_fileSnapshot());
+          },
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          fetchRemote: () async =>
+              const Err(WalletBackupRemoteUnavailableFailure()),
+          storeSelected: ({required selected, required current}) async {
+            stores++;
+            return const Ok(null);
+          },
+          setBlocked: (blocked) async {
+            if (!blocked) unblocks++;
+            return const Ok(null);
+          },
+          markPending: () async {
+            pending++;
+            return const Ok(null);
+          },
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.serverUnavailable,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.restored);
+        expect(decodes, 1);
+        expect(applies, 1);
+        expect(stores, 0);
+        expect(unblocks, 0);
+        expect(pending, 1);
+      },
+    );
+
+    test(
+      'new remote after comparison forces a new choice before apply',
+      () async {
+        var applies = 0;
+        final usecase = _recovery(
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          fetchRemote: () async => Ok(_head(_serverCiphertext)),
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.serverUnavailable,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.comparisonStale);
+        expect(applies, 0);
+      },
+    );
+
+    test('store failure persists reconciliation', () async {
+      var pending = 0;
+      final usecase = _recovery(
+        storeSelected: ({required selected, required current}) async =>
+            const Err(WalletBackupRemoteUnavailableFailure()),
+        markPending: () async {
+          pending++;
+          return const Ok(null);
+        },
+      );
+
+      final result = await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: _comparisonValue(
+          WalletBackupImportSituation.noServerBackup,
+        ),
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(result.status, WalletBackupRecoveryStatus.restored);
+      expect(pending, 1);
+    });
+
+    test('pending persistence failure is a local failure', () async {
+      final usecase = _recovery(
+        storeSelected: ({required selected, required current}) async =>
+            const Err(WalletBackupRemoteUnavailableFailure()),
+        markPending: () async => const Err(WalletBackupStorageFailure()),
+      );
+
+      final result = await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: _comparisonValue(
+          WalletBackupImportSituation.noServerBackup,
+        ),
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(result.status, WalletBackupRecoveryStatus.localFailure);
+    });
+
+    test(
+      'server selection decodes captured bytes after freshness checks',
+      () async {
+        Uint8List? decoded;
+        var stores = 0;
+        var pending = 0;
+        final comparison = _comparisonValue(
+          WalletBackupImportSituation.same,
+          withServer: true,
+        );
+        final usecase = _recovery(
+          decode: (bytes) async {
+            decoded = Uint8List.fromList(bytes);
+            return Ok(_serverSnapshot());
+          },
+          storeSelected: ({required selected, required current}) async {
+            stores++;
+            return const Ok(null);
+          },
+          markPending: () async {
+            pending++;
+            return const Ok(null);
+          },
+          fetchRemote: () async => Ok(_head(_serverCiphertext)),
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([9]),
+          comparison: comparison,
+          source: WalletBackupImportSource.server,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.restored);
+        expect(utf8.decode(decoded!), _serverCiphertext.value);
+        expect(stores, 0);
+        expect(pending, 0);
+      },
+    );
+
+    test('changed remote head rejects the file before applying', () async {
+      var applies = 0;
+      var stores = 0;
+      final comparison = WalletBackupImportComparison(
+        situation: WalletBackupImportSituation.noServerBackup,
+        file: _summary,
+        server: null,
+        comparedServerGeneration: 1,
+        comparedServerEtag: _hash,
+        differences: const {},
+      );
+      final usecase = _recovery(
+        apply: ({required snapshot, deadline}) async {
+          applies++;
+          return const WalletBackupRecoveryResult(
+            status: WalletBackupRecoveryStatus.restored,
+          );
+        },
+        fetchRemote: () async =>
+            Ok(WalletBackupRemoteHead.absent(generation: 2, etag: _otherHash)),
+        storeSelected: ({required selected, required current}) async {
+          stores++;
+          return const Ok(null);
+        },
+      );
+
+      final result = await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: comparison,
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(result.status, WalletBackupRecoveryStatus.comparisonStale);
+      expect(applies, 0);
+      expect(stores, 0);
+    });
+
+    test(
+      'changed remote head rejects the server choice before applying',
+      () async {
+        var applies = 0;
+        final usecase = _recovery(
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          fetchRemote: () async => Ok(
+            WalletBackupRemoteHead.absent(generation: 2, etag: _otherHash),
+          ),
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.different,
+            withServer: true,
+          ),
+          source: WalletBackupImportSource.server,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.comparisonStale);
+        expect(applies, 0);
+      },
+    );
+
+    test(
+      'freshness authentication failure is not treated as offline',
+      () async {
+        var applies = 0;
+        final usecase = _recovery(
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          fetchRemote: () async => const Err(WalletBackupSigningFailure()),
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.different,
+            withServer: true,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.localFailure);
+        expect(applies, 0);
+      },
+    );
+
+    test(
+      'unsupported selected file fails before the runner is asked for work',
+      () async {
+        var applies = 0;
+        var outcomes = 0;
+        final usecase = _recovery(
+          decode: (_) async =>
+              const Err(WalletBackupUnsupportedEnvelopeVersionFailure(2)),
+          apply: ({required snapshot, deadline}) async {
+            applies++;
+            return const WalletBackupRecoveryResult(
+              status: WalletBackupRecoveryStatus.restored,
+            );
+          },
+          saveOutcome: (_) async {
+            outcomes++;
+            return const Ok(null);
+          },
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.noServerBackup,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.newerVersion);
+        expect(applies, 0);
+        expect(outcomes, 0);
+      },
+    );
+
+    test('file choice CAS-publishes while recovery remains fenced', () async {
+      WalletBackupSnapshot? stored;
+      var unblockedAfterStore = false;
+      final usecase = _recovery(
+        fetchRemote: () async => Ok(_head(_serverCiphertext)),
+        storeSelected: ({required selected, required current}) async {
+          stored = selected;
+          return const Ok(null);
+        },
+        setBlocked: (blocked) async {
+          if (!blocked) unblockedAfterStore = stored != null;
+          return const Ok(null);
+        },
+      );
+
+      final result = await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: _comparisonValue(
+          WalletBackupImportSituation.different,
+          withServer: true,
+        ),
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(result.status, WalletBackupRecoveryStatus.restored);
+      expect(
+        stored?.recoveryManifest.wallets.map((wallet) => wallet.walletId),
+        ['wallet-1'],
+      );
+      expect(stored?.createdAt, 9);
+      expect(unblockedAfterStore, isTrue);
+    });
+
+    test(
+      'CAS conflict after local apply stays fenced and reports stale',
+      () async {
+        var pending = 0;
+        var unblocks = 0;
+        final savedOutcomes = <WalletBackupRecoveryStatus>[];
+        final usecase = _recovery(
+          fetchRemote: () async => Ok(_head(_serverCiphertext)),
+          storeSelected: ({required selected, required current}) async =>
+              const Err(WalletBackupHeadConflictFailure()),
+          markPending: () async {
+            pending++;
+            return const Ok(null);
+          },
+          setBlocked: (blocked) async {
+            if (!blocked) unblocks++;
+            return const Ok(null);
+          },
+          saveOutcome: (status) async {
+            savedOutcomes.add(status);
+            return const Ok(null);
+          },
+        );
+
+        final result = await usecase.execute(
+          fileBytes: Uint8List.fromList([1]),
+          comparison: _comparisonValue(
+            WalletBackupImportSituation.different,
+            withServer: true,
+          ),
+          source: WalletBackupImportSource.file,
+        );
+
+        expect(result.status, WalletBackupRecoveryStatus.comparisonStale);
+        expect(pending, 1);
+        expect(unblocks, 0);
+        expect(savedOutcomes, [WalletBackupRecoveryStatus.comparisonStale]);
+      },
+    );
+
+    test('a Nostr-only import still schedules publication', () async {
+      var stores = 0;
+      final usecase = _recovery(
+        decode: (_) async => Ok(
+          _fileSnapshot(
+            recoveryManifest: manifest(entries: [nostrManifestEntry()]),
+          ),
+        ),
+        storeSelected: ({required selected, required current}) async {
+          stores++;
+          return const Ok(null);
+        },
+      );
+
+      await usecase.execute(
+        fileBytes: Uint8List.fromList([1]),
+        comparison: _comparisonValue(
+          WalletBackupImportSituation.noServerBackup,
+        ),
+        source: WalletBackupImportSource.file,
+      );
+
+      expect(stores, 1);
+    });
+  });
+}
+
+CompareWalletBackupFileUsecase _comparison({
+  WalletBackupSnapshot? file,
+  required WalletBackupState state,
+  required Future<Result<WalletBackupRemoteHead, WalletBackupFailure>>
+  Function()
+  fetchRemote,
+  WalletBackupSnapshot? server,
+  Future<Result<WalletBackupSnapshot?, WalletBackupFailure>> Function(
+    WalletBackupRemoteHead,
+  )?
+  fetchImport,
+}) => CompareWalletBackupFileUsecase(
+  (_) async => Ok(file ?? _fileSnapshot()),
+  () async => Ok(state),
+  fetchRemote,
+  fetchImport ?? (_) async => Ok(server),
+  _codec.differences,
+);
+
+RecoverWalletBackupFileUsecase _recovery({
+  Future<Result<WalletBackupSnapshot, WalletBackupFailure>> Function(Uint8List)?
+  decode,
+  ApplyWalletBackupFileImport? apply,
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> Function()?
+  fetchRemote,
+  StoreSelectedWalletBackup? storeSelected,
+  Future<Result<void, WalletBackupFailure>> Function(
+    WalletBackupRecoveryStatus,
+  )?
+  saveOutcome,
+  Future<Result<void, WalletBackupFailure>> Function()? markPending,
+  Future<Result<void, WalletBackupFailure>> Function(bool)? setBlocked,
+  WalletBackupState? state,
+}) => RecoverWalletBackupFileUsecase(
+  decode ?? (_) async => Ok(_fileSnapshot()),
+  apply ??
+      ({required snapshot, deadline}) async => const WalletBackupRecoveryResult(
+        status: WalletBackupRecoveryStatus.restored,
+        restoredCount: 1,
+      ),
+  _settle(
+    markPending: markPending ?? () async => const Ok(null),
+    setBlocked: setBlocked ?? (_) async => const Ok(null),
+    saveOutcome: saveOutcome ?? (_) async => const Ok(null),
+  ),
+  () async => Ok(state ?? _state(enabled: true)),
+  fetchRemote ??
+      () async => Ok(WalletBackupRemoteHead.absent(generation: 0, etag: null)),
+  storeSelected ??
+      ({required selected, required current}) async => const Ok(null),
+);
+
+/// The file path used to raise and lower two separate flags; it now hands one
+/// fence value to the shared apply owner. These tests still describe the same
+/// three observable moves, so the fence is translated back into them here.
+SettleWalletBackupFence _settle({
+  required Future<Result<void, WalletBackupFailure>> Function() markPending,
+  required Future<Result<void, WalletBackupFailure>> Function(bool) setBlocked,
+  required Future<Result<void, WalletBackupFailure>> Function(
+    WalletBackupRecoveryStatus,
+  )
+  saveOutcome,
+}) => (result, {required fence}) async {
+  final fenceWrite = switch (fence) {
+    WalletBackupRecoveryState.needsAttention => await markPending(),
+    WalletBackupRecoveryState.idle => await setBlocked(false),
+    _ => const Ok<void, WalletBackupFailure>(null),
+  };
+  if (fenceWrite case Err()) return _localFailure(result);
+  if (await saveOutcome(result.status) case Err()) {
+    return _localFailure(result);
+  }
+  return result;
+};
+
+WalletBackupRecoveryResult _localFailure(WalletBackupRecoveryResult result) =>
+    WalletBackupRecoveryResult(
+      status: WalletBackupRecoveryStatus.localFailure,
+      restoredCount: result.restoredCount,
+      failedCount: result.failedCount,
+    );
+
+WalletBackupImportComparison _comparisonValue(
+  WalletBackupImportSituation situation, {
+  bool withServer = false,
+}) => WalletBackupImportComparison(
+  situation: situation,
+  file: _summary,
+  server: withServer ? _summary : null,
+  comparedServerGeneration: withServer
+      ? 1
+      : situation == WalletBackupImportSituation.noServerBackup
+      ? 0
+      : null,
+  comparedServerEtag: withServer ? _hash : null,
+  serverCiphertextBytes: withServer
+      ? Uint8List.fromList(utf8.encode(_serverCiphertext.value))
+      : null,
+  differences: const {},
+);
+
+final _codec = canonicalCodec();
+
+WalletBackupSnapshot _fileSnapshot({
+  KeychainManifest? recoveryManifest,
+  List<WalletDefinition> definitions = const [],
+  WalletMetadataSnapshot? metadata,
+}) => WalletBackupSnapshot(
+  parentFingerprint: manifestFingerprint,
+  createdAt: 9,
+  recoveryManifest:
+      recoveryManifest ??
+      manifest(
+        generatedAt: 9,
+        entries: [walletManifestEntry(), nostrManifestEntry()],
+      ),
+  externalWalletDefinitions: definitions,
+  metadata: metadata,
+);
+
+WalletBackupSnapshot _serverSnapshot() => WalletBackupSnapshot(
+  parentFingerprint: manifestFingerprint,
+  createdAt: 10,
+  recoveryManifest: manifest(
+    generatedAt: 10,
+    entries: [walletManifestEntry(walletId: 'server-wallet')],
+  ),
+);
+
+WalletDefinition _definition(
+  String walletRef, {
+  String fingerprint = '86241f88',
+}) => WalletDefinition(
+  walletRef: walletRef,
+  network: Network.bitcoinMainnet,
+  descriptor: canonicalExternalDescriptor.replaceFirst('86241f88', fingerprint),
+  provenance: WalletProvenance.watchOnly,
+);
+
+WalletMetadataSnapshot _metadata({
+  int labels = 0,
+  int frozenOutpoints = 0,
+  int preferences = 0,
+  String labelText = 'label',
+}) => WalletMetadataSnapshot(
+  labels: [
+    for (var index = 0; index < labels; index++)
+      WalletMetadataLabel(
+        type: LabelType.address,
+        reference: 'bc1q$index',
+        label: '$labelText-$index',
+      ),
+  ],
+  frozenOutpoints: [
+    for (var index = 0; index < frozenOutpoints; index++)
+      FrozenWalletOutpoint(
+        walletId: 'wallet-1',
+        txId: '$index'.padLeft(64, 'a'),
+        vout: index,
+      ),
+  ],
+  walletPreferences: [
+    for (var index = 0; index < preferences; index++)
+      WalletPreferences(walletRef: 'wallet-$index', hideOnHome: true),
+  ],
+  settings: portableSettingsFixture(),
+);
+
+WalletBackupState _state({required bool enabled}) => WalletBackupState(
+  enabled: enabled,
+  localRevision: 0,
+  uploadedRevision: 0,
+  lastSucceededAt: null,
+  unsupportedVersion: null,
+  customServerUrl: null,
+);
+
+WalletBackupRemoteHead _head(WalletBackupCiphertext ciphertext) =>
+    WalletBackupRemoteHead.present(
+      generation: 1,
+      etag: _hash,
+      ciphertext: ciphertext,
+      ciphertextSha256: _hash,
+    );
+
+final _serverCiphertext = WalletBackupCiphertext(
+  base64.encode(List.filled(64, 7)),
+);
+
+const _summary = WalletBackupSnapshotSummary(
+  createdAt: 1,
+  walletCount: 1,
+  nostrIdentityCount: 0,
+  externalWalletCount: 0,
+  labelCount: 0,
+  frozenOutpointCount: 0,
+  walletPreferenceCount: 0,
+);
+
+final _key = (
+  parentFingerprint: '73c5da0a',
+  encryptionKey: WalletBackupEncryptionKey('11' * 32),
+);
+
+const _hash =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _otherHash =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+final class _Encryption implements WalletBackupEncryptionRepository {
+  final bool acceptPlaintext;
+
+  const _Encryption({this.acceptPlaintext = false});
+
+  @override
+  Result<WalletBackupSnapshot, WalletBackupFailure> decodeCanonical({
+    required Uint8List bytes,
+    required String expectedParentFingerprint,
+  }) => acceptPlaintext
+      ? Ok(_fileSnapshot())
+      : const Err(WalletBackupInvalidEnvelopeFailure());
+
+  @override
+  Result<WalletBackupSnapshot, WalletBackupFailure> decrypt({
+    required WalletBackupCiphertext ciphertext,
+    required WalletBackupEncryptionKey key,
+    required String expectedParentFingerprint,
+  }) => const Err(WalletBackupInvalidEnvelopeFailure());
+
+  @override
+  Result<Uint8List, WalletBackupFailure> encodeCanonical(
+    WalletBackupSnapshot envelope,
+  ) => throw UnimplementedError();
+
+  @override
+  Result<WalletBackupCiphertext, WalletBackupFailure> encrypt({
+    required WalletBackupSnapshot envelope,
+    required WalletBackupEncryptionKey key,
+  }) => throw UnimplementedError();
+}

--- a/test/features/wallet_backup/wallet_backup_job_runner_test.dart
+++ b/test/features/wallet_backup/wallet_backup_job_runner_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_job_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart';
+
+/// The runner is the only thing serializing Bull backup's remote work, so
+/// these tests state its guarantees directly rather than through the feature.
+void main() {
+  test('one job owns the runner at a time', () async {
+    var running = 0;
+    var overlapped = false;
+    final runner = WalletBackupJobRunner(publish: () async => const Ok(null));
+
+    Future<Result<void, WalletBackupFailure>> job() => runner.run(() async {
+      running++;
+      if (running > 1) overlapped = true;
+      await pumpEventQueue();
+      running--;
+      return const Ok(null);
+    });
+
+    await Future.wait([job(), job(), job()]);
+
+    expect(overlapped, isFalse);
+  });
+
+  test('a job queued behind another waits for it to finish', () async {
+    final order = <String>[];
+    final release = Completer<void>();
+    final runner = WalletBackupJobRunner(publish: () async => const Ok(null));
+
+    final first = runner.run(() async {
+      order.add('first started');
+      await release.future;
+      order.add('first finished');
+      return const Ok(null);
+    });
+    final second = runner.run(() async {
+      order.add('second started');
+      return const Ok(null);
+    });
+
+    await pumpEventQueue();
+    expect(order, ['first started']);
+
+    release.complete();
+    await Future.wait([first, second]);
+
+    expect(order, ['first started', 'first finished', 'second started']);
+  });
+
+  test('a failing job does not wedge the queue', () async {
+    final runner = WalletBackupJobRunner(publish: () async => const Ok(null));
+
+    await expectLater(
+      runner.run<void>(() async => throw StateError('boom')),
+      throwsStateError,
+    );
+
+    expect(
+      await runner.run(() async => const Ok(null)),
+      isA<Ok<void, WalletBackupFailure>>(),
+    );
+  });
+
+  test('triggers during a publication collapse into one more pass', () async {
+    var passes = 0;
+    late WalletBackupJobRunner runner;
+    runner = WalletBackupJobRunner(
+      publish: () async {
+        passes++;
+        if (passes == 1) {
+          // Three more triggers while the first pass is in flight.
+          runner.requestPublish();
+          runner.requestPublish();
+          runner.requestPublish();
+        }
+        return const Ok(null);
+      },
+    );
+
+    await runner.requestPublish();
+
+    expect(passes, 2);
+  });
+
+  test('callers joining a running publication share its result', () async {
+    final release = Completer<void>();
+    var passes = 0;
+    final runner = WalletBackupJobRunner(
+      publish: () async {
+        passes++;
+        await release.future;
+        return const Err(WalletBackupRemoteUnavailableFailure());
+      },
+    );
+
+    final first = runner.requestPublish();
+    final second = runner.requestPublish();
+    release.complete();
+
+    expect(await first, isA<Err<void, WalletBackupFailure>>());
+    expect(await second, isA<Err<void, WalletBackupFailure>>());
+    expect(
+      passes,
+      1,
+      reason: 'the second trigger arrived before the first ran',
+    );
+  });
+
+  test('a rate-limited server closes the gate until it lifts', () async {
+    var now = DateTime.utc(2026);
+    var calls = 0;
+    final runner = WalletBackupJobRunner(
+      publish: () async {
+        calls++;
+        return calls == 1
+            ? const Err(WalletBackupRateLimitedFailure(Duration(seconds: 30)))
+            : const Ok(null);
+      },
+      now: () => now,
+    );
+
+    expect(
+      await runner.requestPublish(),
+      isA<Err<void, WalletBackupFailure>>(),
+    );
+    expect(calls, 1);
+
+    // Nothing reaches the server while the gate is closed, publication and
+    // other jobs alike.
+    expect(
+      await runner.requestPublish(),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupRateLimitedFailure>(),
+      ),
+    );
+    expect(
+      await runner.run(() async => const Ok(null)),
+      isA<Err<void, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupRateLimitedFailure>(),
+      ),
+    );
+    expect(calls, 1);
+
+    now = now.add(const Duration(seconds: 30));
+
+    expect(await runner.requestPublish(), isA<Ok<void, WalletBackupFailure>>());
+    expect(calls, 2);
+  });
+
+  test('the gate is not durable: a fresh runner starts open', () async {
+    final now = DateTime.utc(2026);
+    var calls = 0;
+    Future<Result<void, WalletBackupFailure>> publish() async {
+      calls++;
+      return calls == 1
+          ? const Err(WalletBackupRateLimitedFailure(Duration(seconds: 30)))
+          : const Ok(null);
+    }
+
+    final first = WalletBackupJobRunner(publish: publish, now: () => now);
+    await first.requestPublish();
+    await first.dispose();
+
+    final restarted = WalletBackupJobRunner(publish: publish, now: () => now);
+
+    expect(
+      await restarted.requestPublish(),
+      isA<Ok<void, WalletBackupFailure>>(),
+    );
+    expect(calls, 2);
+  });
+}

--- a/test/features/wallet_backup/wallet_backup_publication_pipeline_test.dart
+++ b/test/features/wallet_backup/wallet_backup_publication_pipeline_test.dart
@@ -1,0 +1,466 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/core/seed/domain/seed_failure.dart';
+import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/features/keychain_manifest/data/models/keychain_manifest_file_model.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/nostr_key_deriver.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/repositories/keychain_manifest_repository.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/build_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/remove_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/parse_keychain_manifest_file_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/record_passphrase_wallet_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/replace_seed_wallet_inventory_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_manifest_snapshot_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/restore_keychain_manifest_nostr_key_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/watch_keychain_manifest_changes_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/domain/usecases/update_passphrase_label_hint_usecase.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/get_nostr_public_key_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/nostr_identity_key_resolver.dart';
+import 'package:bb_mobile/features/nostr_identity/domain/sign_nostr_hash_usecase.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_remote.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_state_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/fetch_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_remote_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_snapshot_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/refresh_wallet_recovery_manifest_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/publish_wallet_backup_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/register_wallet_backup_recovery_material_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/wallet_backup_remote_usecases.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_protocol.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_definitions_section.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
+import 'package:bb_mobile/features/wallet_backup/metadata/domain/wallet_metadata_backup_failure.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+import 'metadata/support/portable_settings_fixture.dart';
+
+class _Settings extends Mock implements GetSettingsUsecase {}
+
+class _DefaultSeed extends Mock implements GetDefaultSeedUsecase {}
+
+class _ManifestRepository extends Mock implements KeychainManifestRepository {}
+
+Future<Result<WalletMetadataSnapshot, WalletMetadataBackupFailure>>
+_readMetadata() async => Ok(metadataSnapshot);
+
+final class _DefinitionsBackup implements WalletDefinitionsBackup {
+  @override
+  Stream<void> get changes => const Stream.empty();
+
+  @override
+  Future<Result<List<WalletDefinition>, WalletBackupFailure>> read() async =>
+      const Ok([]);
+
+  @override
+  Future<Result<WalletDefinitionsRecoveryResult, WalletBackupFailure>> recover({
+    required List<WalletDefinition> definitions,
+    DateTime? deadline,
+  }) => throw UnimplementedError();
+}
+
+/// Only the two operations the publication path uses are exercised here.
+final class _StateRepository extends Mock
+    implements WalletBackupStateRepository {}
+
+final class _EncryptionRepository implements WalletBackupEncryptionRepository {
+  final WalletBackupCiphertext ciphertext;
+  WalletBackupSnapshot? encryptedEnvelope;
+  WalletBackupEncryptionKey? encryptionKey;
+
+  _EncryptionRepository(this.ciphertext);
+
+  @override
+  Result<Uint8List, WalletBackupFailure> encodeCanonical(
+    WalletBackupSnapshot envelope,
+  ) => throw UnimplementedError();
+
+  @override
+  Result<WalletBackupSnapshot, WalletBackupFailure> decodeCanonical({
+    required Uint8List bytes,
+    required String expectedParentFingerprint,
+  }) => throw UnimplementedError();
+
+  @override
+  Result<WalletBackupCiphertext, WalletBackupFailure> encrypt({
+    required WalletBackupSnapshot envelope,
+    required WalletBackupEncryptionKey key,
+  }) {
+    encryptedEnvelope = envelope;
+    encryptionKey = key;
+    return Ok(ciphertext);
+  }
+
+  @override
+  Result<WalletBackupSnapshot, WalletBackupFailure> decrypt({
+    required WalletBackupCiphertext ciphertext,
+    required WalletBackupEncryptionKey key,
+    required String expectedParentFingerprint,
+  }) => throw UnimplementedError();
+}
+
+final class _RemoteRepository implements WalletBackupRemoteRepository {
+  final WalletBackupRemoteHead head = WalletBackupRemoteHead.absent(
+    generation: 0,
+    etag: null,
+  );
+  final List<WalletBackupAuthentication> fetchAuthentications = [];
+  WalletBackupAuthentication? storeAuthentication;
+  WalletBackupRemoteCheckpoint? storedAgainst;
+  WalletBackupCiphertext? storedCiphertext;
+  String? storedCiphertextSha256;
+
+  @override
+  Future<Result<WalletBackupRemoteHead, WalletBackupFailure>> fetch({
+    required WalletBackupAuthentication authentication,
+  }) async {
+    fetchAuthentications.add(authentication);
+    return Ok(head);
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> store({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint? current,
+    required WalletBackupCiphertext ciphertext,
+    required String ciphertextSha256,
+  }) async {
+    storeAuthentication = authentication;
+    storedAgainst = current;
+    storedCiphertext = ciphertext;
+    storedCiphertextSha256 = ciphertextSha256;
+    return Ok(
+      WalletBackupRemoteCheckpoint(
+        generation: (current?.generation ?? 0) + 1,
+        etag: 'e' * 64,
+        ciphertextSha256: ciphertextSha256,
+      ),
+    );
+  }
+
+  @override
+  Future<Result<WalletBackupRemoteCheckpoint, WalletBackupFailure>> delete({
+    required WalletBackupAuthentication authentication,
+    required WalletBackupRemoteCheckpoint current,
+  }) => throw UnimplementedError();
+}
+
+const _mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const _fingerprint = '73c5da0a';
+final metadataSnapshot = WalletMetadataSnapshot(
+  labels: const [],
+  frozenOutpoints: const [],
+  walletPreferences: const [],
+  settings: portableSettingsFixture(),
+);
+const _expectedEncryptionKey =
+    '321154f080538350e83f2ebf866595a778ab671e55aacfe0638305ba95a48830';
+
+void main() {
+  late Seed seed;
+  late _Settings settings;
+  late _DefaultSeed defaultSeed;
+  late _ManifestRepository manifestRepository;
+  late List<KeychainManifestEntry> manifestEntries;
+  late KeychainManifestFacade manifest;
+
+  setUpAll(() {
+    registerFallbackValue(Fingerprint('00000000'));
+    registerFallbackValue(KeychainManifestWriteOrigin.local);
+    registerFallbackValue(<KeychainManifestEntry>[]);
+    registerFallbackValue(_fallbackManifestEntry());
+    seed = Seed.bytes(
+      bytes: Uint8List.fromList(
+        bip39.Mnemonic.fromSentence(_mnemonic, bip39.Language.english).seed,
+      ),
+      masterFingerprint: _fingerprint,
+    );
+  });
+
+  setUp(() {
+    settings = _Settings();
+    defaultSeed = _DefaultSeed();
+    manifestRepository = _ManifestRepository();
+    manifestEntries = [];
+    when(() => settings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'CRC',
+      ),
+    );
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer((_) async => Ok<Seed, SeedFailure>(seed));
+    when(
+      () => manifestRepository.fetch(Fingerprint(_fingerprint)),
+    ).thenAnswer((_) async => Ok(List.unmodifiable(manifestEntries)));
+    when(
+      () => manifestRepository.insertNostrKey(
+        any(),
+        origin: any(named: 'origin'),
+      ),
+    ).thenAnswer((invocation) async {
+      manifestEntries = [
+        ...manifestEntries,
+        invocation.positionalArguments.single as KeychainManifestEntry,
+      ];
+      return const Ok(null);
+    });
+    when(
+      () => manifestRepository.replaceSeedWalletInventory(any(), any()),
+    ).thenAnswer((_) async => const Ok(null));
+    manifest = _manifestFacade(
+      repository: manifestRepository,
+      settings: settings,
+      defaultSeed: defaultSeed,
+    );
+  });
+
+  test('derives the frozen backup key from the reserved BIP85 path', () async {
+    final result = await ResolveWalletBackupKeyUsecase(
+      settings,
+      defaultSeed,
+    ).execute();
+
+    expect(result, isA<Ok<WalletBackupKey, WalletBackupFailure>>());
+    final key = (result as Ok<WalletBackupKey, WalletBackupFailure>).value;
+    expect(key.parentFingerprint, _fingerprint);
+    expect(key.encryptionKey.hex, _expectedEncryptionKey);
+  });
+
+  test('reports an unavailable wallet without deriving a key', () async {
+    when(
+      () => defaultSeed.execute(environment: Environment.mainnet),
+    ).thenAnswer((_) async => const Err(DefaultSeedNotFoundFailure()));
+
+    expect(
+      await ResolveWalletBackupKeyUsecase(settings, defaultSeed).execute(),
+      isA<Err<WalletBackupKey, WalletBackupFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<WalletBackupWalletUnavailableFailure>(),
+      ),
+    );
+  });
+
+  test('builds one snapshot from the manifest and metadata sections', () async {
+    final identity = _nostrIdentity(settings, defaultSeed);
+    final definitions = _DefinitionsBackup();
+    expect(
+      await RegisterWalletBackupRecoveryMaterialUsecase(
+        ResolveWalletBackupKeyUsecase(settings, defaultSeed),
+        identity,
+        manifest,
+        RefreshWalletRecoveryManifestUsecase(() async => const [], manifest),
+      ).execute(),
+      isA<Ok<void, WalletBackupFailure>>(),
+    );
+
+    final result = await BuildWalletBackupSnapshotUsecase(
+      manifest,
+      definitions,
+      _readMetadata,
+      nowUtc: () => DateTime.fromMillisecondsSinceEpoch(42000, isUtc: true),
+    ).execute(parentFingerprint: _fingerprint, allowEmpty: true);
+
+    expect(result, isA<Ok<WalletBackupSnapshot, WalletBackupFailure>>());
+    final snapshot =
+        (result as Ok<WalletBackupSnapshot, WalletBackupFailure>).value;
+    expect(snapshot.parentFingerprint.hex, _fingerprint);
+    expect(snapshot.createdAt, 42);
+    expect(snapshot.metadata, same(metadataSnapshot));
+    expect(snapshot.externalWalletDefinitions, isEmpty);
+    expect(snapshot.recoveryManifest.parentFingerprint.hex, _fingerprint);
+    final entries = snapshot.recoveryManifest.entries;
+    expect(entries, hasLength(1));
+    expect(entries.single.derivationPath, "128002'/100'/1'");
+    expect(
+      entries.map((entry) => entry.derivationPath),
+      isNot(contains("128002'/101'/1'")),
+    );
+    expect(
+      entries.map((entry) => entry.derivationPath),
+      isNot(contains("128002'/102'/1'")),
+    );
+    final materialization =
+        entries.single.materializations.single as KeychainManifestNostrKey;
+    expect(materialization.keyKind, KeychainManifestNostrKeyKind.reserved);
+    expect(materialization.purpose, 'Wallet backup');
+  });
+
+  test('stores an authenticated backup when the remote is absent', () async {
+    final harness = _publication(settings, defaultSeed, manifest);
+
+    final result = await harness.publish.execute(null);
+
+    expect(
+      result,
+      isA<Ok<WalletBackupRemoteCheckpoint, WalletBackupFailure>>(),
+    );
+    expect(harness.remote.fetchAuthentications, hasLength(1));
+    expect(harness.remote.fetchAuthentications.single.timestamp, 1234);
+    expect(harness.remote.storeAuthentication?.timestamp, 1234);
+    expect(
+      harness.remote.storeAuthentication?.publicKeyHex,
+      harness.remote.fetchAuthentications.single.publicKeyHex,
+    );
+    expect(harness.remote.storeAuthentication?.signatureHex, isNot(isEmpty));
+    expect(harness.remote.storedAgainst, isNull);
+    expect(harness.remote.storedCiphertext, same(harness.ciphertext));
+    expect(
+      harness.remote.storedCiphertextSha256,
+      sha256.convert(base64.decode(harness.ciphertext.value)).toString(),
+    );
+    expect(
+      harness.encryption.encryptedEnvelope?.metadata,
+      same(metadataSnapshot),
+    );
+    expect(harness.encryption.encryptionKey?.hex, _expectedEncryptionKey);
+  });
+
+  test('a trusted checkpoint publishes without fetching the head', () async {
+    final harness = _publication(settings, defaultSeed, manifest);
+    final checkpoint = WalletBackupRemoteCheckpoint(
+      generation: 5,
+      etag: 'f' * 64,
+      ciphertextSha256: 'a' * 64,
+    );
+
+    final result = await harness.publish.execute(checkpoint);
+
+    expect(
+      result,
+      isA<Ok<WalletBackupRemoteCheckpoint, WalletBackupFailure>>().having(
+        (value) => value.value.generation,
+        'acknowledged generation',
+        6,
+      ),
+    );
+    expect(harness.remote.fetchAuthentications, isEmpty);
+    expect(harness.remote.storedAgainst, same(checkpoint));
+  });
+}
+
+final class _PublicationHarness {
+  final PublishWalletBackupUsecase publish;
+  final _RemoteRepository remote;
+  final _EncryptionRepository encryption;
+  final WalletBackupCiphertext ciphertext;
+
+  const _PublicationHarness({
+    required this.publish,
+    required this.remote,
+    required this.encryption,
+    required this.ciphertext,
+  });
+}
+
+_PublicationHarness _publication(
+  GetSettingsUsecase settings,
+  GetDefaultSeedUsecase defaultSeed,
+  KeychainManifestFacade manifest,
+) {
+  final ciphertext = WalletBackupCiphertext(
+    base64.encode(List<int>.generate(64, (index) => index)),
+  );
+  final encryption = _EncryptionRepository(ciphertext);
+  final remote = _RemoteRepository();
+  final identity = _nostrIdentity(settings, defaultSeed);
+  final authenticator = WalletBackupAuthenticator(identity, () => 1234);
+  final resolveKey = ResolveWalletBackupKeyUsecase(settings, defaultSeed);
+  final state = _StateRepository();
+  return _PublicationHarness(
+    publish: PublishWalletBackupUsecase(
+      buildSnapshot: BuildWalletBackupSnapshotUsecase(
+        manifest,
+        _DefinitionsBackup(),
+        _readMetadata,
+        nowUtc: () => DateTime.fromMillisecondsSinceEpoch(42000, isUtc: true),
+      ),
+      resolveKey: resolveKey,
+      encryption: encryption,
+      fetchRemote: FetchWalletBackupRemoteUsecase(remote, authenticator),
+      storeRemote: StoreWalletBackupRemoteUsecase(remote, authenticator),
+      readRemoteSnapshot: FetchWalletBackupSnapshotUsecase(
+        resolveKey: resolveKey,
+        encryption: encryption,
+        state: state,
+      ),
+      state: state,
+    ),
+    remote: remote,
+    encryption: encryption,
+    ciphertext: ciphertext,
+  );
+}
+
+KeychainManifestFacade _manifestFacade({
+  required KeychainManifestRepository repository,
+  required GetSettingsUsecase settings,
+  required GetDefaultSeedUsecase defaultSeed,
+}) {
+  const codec = KeychainManifestFileCodec();
+  final parse = ParseKeychainManifestFileUsecase(codec.decode);
+  return KeychainManifestFacade(
+    WatchKeychainManifestChangesUsecase(repository),
+    codec.encode,
+    BuildKeychainManifestFileUsecase(repository),
+    parse,
+    ReplaceSeedWalletInventoryUsecase(repository),
+    RecordPassphraseWalletUsecase(repository),
+    RestoreManifestSnapshotUsecase(repository),
+    RecordKeychainManifestNostrKeyUsecase(repository),
+    RestoreKeychainManifestNostrKeyUsecase(
+      KeychainManifestNostrKeyDeriver(settings, defaultSeed),
+      RecordKeychainManifestNostrKeyUsecase(repository),
+    ),
+    UpdatePassphraseLabelHintUsecase(repository),
+    RemovePassphraseWalletUsecase(repository),
+  );
+}
+
+NostrIdentityFacade _nostrIdentity(
+  GetSettingsUsecase settings,
+  GetDefaultSeedUsecase defaultSeed,
+) {
+  final resolver = NostrIdentityKeyResolver(settings, defaultSeed);
+  return NostrIdentityFacade(
+    GetNostrPublicKeyUsecase(resolver),
+    SignNostrHashUsecase(resolver),
+  );
+}
+
+KeychainManifestEntry _fallbackManifestEntry() => KeychainManifestEntry(
+  parentFingerprint: Fingerprint(_fingerprint),
+  derivationPath: "128002'/0'/0'",
+  createdAt: 1,
+  updatedAt: 1,
+  materializations: [
+    KeychainManifestNostrKey(
+      entryId: "$_fingerprint:128002'/0'/0'",
+      publicKeyHex: '1' * 64,
+      keyKind: KeychainManifestNostrKeyKind.userGenerated,
+      purpose: 'Fallback',
+      createdAt: 1,
+      updatedAt: 1,
+    ),
+  ],
+);

--- a/test/features/wallet_backup/wallet_backup_snapshot_semantics_test.dart
+++ b/test/features/wallet_backup/wallet_backup_snapshot_semantics_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/entities/signer_device_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
+import 'package:bb_mobile/features/keychain_manifest/public/keychain_manifest_facade.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:convert/convert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:primitives/primitives.dart' hide ScriptType;
+import 'package:recoverbull/recoverbull.dart';
+
+import 'support/wallet_backup_behavior_harness.dart';
+
+/// Bull backup is an authoritative snapshot: a publication replaces the whole
+/// remote object and nothing is merged into it, so deletion is by omission.
+///
+/// These tests read the bytes the server actually holds, because the point of
+/// snapshot semantics is what a second installation would recover — not what
+/// the publishing device believes it sent.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('deletion by omission', () {
+    test('a forgotten wallet leaves the remote snapshot and never '
+        'comes back', () async {
+      final server = FakeWalletBackupRemote();
+      final device = await _device(remote: server);
+      await _addWallet(device, walletId: 'forgotten', label: 'Forgotten');
+      expect(await device.facade.setEnabled(true), _succeeds);
+      expect(_published(device), contains('forgotten'));
+
+      expect(
+        await device.keychainManifest.deleteWallet(
+          parentFingerprint: device.fingerprint,
+          walletId: 'forgotten',
+        ),
+        isA<Ok<void, KeychainManifestFailure>>(),
+      );
+      expect(await device.facade.backupNow(), _succeeds);
+
+      expect(_published(device), isNot(contains('forgotten')));
+      final replacement = await _device(remote: server);
+      expect(await replacement.facade.setEnabled(true), _succeeds);
+      expect(
+        (await _wallets(replacement)).map((wallet) => wallet.label),
+        isNot(contains('Forgotten')),
+      );
+    });
+
+    test('deleting the last external wallet publishes a document without '
+        'the definitions section', () async {
+      final device = await _device();
+      device.definitions.definitions = [
+        WalletDefinition(
+          walletRef: 'external-wallet',
+          network: Network.bitcoinMainnet,
+          descriptor: _externalDescriptor,
+          signerDevice: SignerDeviceEntity.ledgerNanoX,
+          birthday: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+          provenance: WalletProvenance.externalSigner,
+        ),
+      ];
+      expect(await device.facade.setEnabled(true), _succeeds);
+      expect(_publishedDocument(device), contains('definitions'));
+
+      device.definitions.definitions = const [];
+      expect(await device.facade.backupNow(), _succeeds);
+
+      expect(_publishedDocument(device), isNot(contains('definitions')));
+      expect(_published(device), isNot(contains('86241f88')));
+    });
+  });
+
+  group('head conflict', () {
+    test('a stale installation stops at needs-attention and leaves the '
+        'remote alone', () async {
+      final server = FakeWalletBackupRemote();
+      final device = await _device(remote: server);
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      final elsewhere = await _device(remote: server);
+      await _addWallet(elsewhere, walletId: 'elsewhere', label: 'Elsewhere');
+      expect(await elsewhere.facade.setEnabled(true), _succeeds);
+      final published = server.storedCiphertext;
+      final storesBefore = server.storeCount;
+
+      await _addWallet(device, walletId: 'stale', label: 'Stale');
+      final result = await device.facade.backupNow();
+
+      expect(
+        result,
+        isA<Err<void, WalletBackupFailure>>().having(
+          (value) => value.failure,
+          'failure',
+          isA<WalletBackupHeadConflictFailure>(),
+        ),
+      );
+      expect(server.storedCiphertext, published);
+      expect(server.storeCount, storesBefore);
+      final state = await device.readState();
+      expect(state.needsAttention, isTrue);
+      expect(state.recoveryBlocked, isTrue);
+      expect(state.dirty, isTrue, reason: 'local work must survive a conflict');
+      expect(state.remoteCheckpoint?.generation, storesBefore);
+    });
+
+    test('recovering resolves the conflict and publication resumes', () async {
+      final server = FakeWalletBackupRemote();
+      final device = await _device(remote: server);
+      expect(await device.facade.setEnabled(true), _succeeds);
+
+      final elsewhere = await _device(remote: server);
+      await _addWallet(elsewhere, walletId: 'elsewhere', label: 'Elsewhere');
+      expect(await elsewhere.facade.setEnabled(true), _succeeds);
+
+      await _addWallet(device, walletId: 'stale', label: 'Stale');
+      expect(await device.facade.backupNow(), isA<Err<void, Failure>>());
+
+      expect(
+        (await device.facade.recover()).status,
+        WalletBackupRecoveryStatus.restored,
+      );
+      expect((await device.readState()).recoveryBlocked, isFalse);
+
+      expect(await device.facade.backupNow(), _succeeds);
+      expect(_published(device), contains('elsewhere'));
+      expect(_published(device), contains('stale'));
+    });
+  });
+
+  test('a routine publication stores against its checkpoint without '
+      'fetching', () async {
+    final device = await _device();
+    expect(await device.facade.setEnabled(true), _succeeds);
+    final fetchesAfterEnabling = device.remote.fetchCount;
+    expect((await device.readState()).remoteCheckpoint, isNotNull);
+
+    await _addWallet(device, walletId: 'routine', label: 'Routine');
+    expect(await device.facade.backupNow(), _succeeds);
+
+    expect(device.remote.fetchCount, fetchesAfterEnabling);
+    expect(_published(device), contains('routine'));
+  });
+}
+
+const _externalDescriptor =
+    'wpkh([86241f88/84h/0h/0h]xpub6DJwRncrB8eNrzUq8XxgjwCZsEeWP8FeqBJbJQZ8Jfu'
+    'DwLdAzyjhHiHJieNuar1wjQTyihhMWtaKGE4DUd8uBgtyrNJqF5drwbNVUqb83b7/<0;1>/*)'
+    '#n8txaeah';
+
+final Matcher _succeeds = isA<Ok<void, WalletBackupFailure>>();
+
+Future<WalletBackupBehaviorHarness> _device({
+  FakeWalletBackupRemote? remote,
+}) async {
+  final harness = await WalletBackupBehaviorHarness.create(remote: remote);
+  addTearDown(harness.dispose);
+  return harness;
+}
+
+Future<void> _addWallet(
+  WalletBackupBehaviorHarness device, {
+  required String walletId,
+  required String label,
+}) async {
+  final result = await device.keychainManifest.recordWallet(
+    parentFingerprint: device.fingerprint,
+    wallet: KeychainManifestWalletInventoryBinding(
+      walletId: walletId,
+      seedFingerprint: Fingerprint(
+        walletId.hashCode.toUnsigned(32).toRadixString(16).padLeft(8, '0'),
+      ),
+      network: Network.bitcoinMainnet,
+      scriptType: ScriptType.bip84,
+      provenance: WalletProvenance.importedMnemonic,
+      derivationPath: "m/84'/0'/0'",
+      seedPassphraseUsed: false,
+      label: label,
+    ),
+  );
+  expect(result, isA<Ok<bool, KeychainManifestFailure>>());
+}
+
+Future<List<WalletBackupWalletSummary>> _wallets(
+  WalletBackupBehaviorHarness device,
+) async => switch (await device.facade.getContents()) {
+  Ok(:final value) => value.wallets,
+  Err(:final failure) => fail('backup contents unavailable: $failure'),
+};
+
+/// The plaintext the server is holding right now, decrypted with this device's
+/// backup key exactly as another installation would.
+String _published(WalletBackupBehaviorHarness device) {
+  final ciphertext = device.remote.storedCiphertext;
+  if (ciphertext == null) fail('nothing has been published');
+  return utf8.decode(
+    RecoverBull.restoreBackup(
+      backup: BullBackup(
+        createdAt: 0,
+        id: const [],
+        ciphertext: base64.decode(ciphertext),
+        salt: const [],
+      ),
+      backupKey: hex.decode(device.encryptionKey.hex),
+    ),
+  );
+}
+
+/// The published document's top-level keys, so a test can assert that a whole
+/// section is absent rather than merely empty.
+Set<String> _publishedDocument(WalletBackupBehaviorHarness device) =>
+    (jsonDecode(_published(device)) as Map<String, Object?>).keys.toSet();


### PR DESCRIPTION
## What this adds

This adds automatic encrypted backup and recovery for wallet data.

The backup contains the recovery manifest, labels, frozen-coin state, wallet preferences, and selected portable app settings:

- Bitcoin unit, fiat currency, language, theme, and hidden-amount preference.
- Autoswap policy, excluding its runtime latch and acknowledgement state.
- Ordered custom Electrum servers and connection options for each network.
- Custom Mempool servers and fee-estimation choices for each network.
- Payjoin policy.

It does not contain wallet seeds, passphrases, private keys, credentials, Tor configuration, environment selection, developer settings, crash-reporting consent, or reminder state.

## Approach

One coordinator owns publication and funnels protected-data changes, lifecycle retries, and manual requests through a single-flight queue. Settings are collected and restored through their existing repositories. A missing autoswap recipient restores the policy disabled rather than silently choosing another wallet.

Each HTTP request resolves the configured backup origin once, sends only to that origin, and refuses redirects. Invalid origin configuration returns a typed backup failure.

Recovery is additive and ordered: validate the remote object, restore the manifest, apply protected data through each owning feature, recheck the remote identity as a conflict fence, and only then mark recovery complete. Partial or conflicting recovery remains fenced and retryable.

Encryption uses a dedicated seed-derived backup key. Authentication uses the separate wallet-backup Nostr identity. The default service origin is https://backup.bull-wallet.com.

## Verification

Tests cover exact protocol requests, redirect refusal, invalid origin handling, encryption compatibility, tamper rejection, canonical envelopes, parent-fingerprint validation, publication coalescing, recovery fencing, exact settings round trips, excluded local-only values, missing autoswap recipients, Electrum and Mempool replacement, Payjoin restoration, and change detection after the initial database state.