### PR TITLE
feat: preserve wallet scan birthdays

### DIFF
--- a/integration_test/coins_test.dart
+++ b/integration_test/coins_test.dart
@@ -8,6 +8,7 @@ import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
@@ -160,6 +161,8 @@ Future<void> main({bool isInitialized = false}) async {
           seed: seed,
           network: Network.bitcoinTestnet,
           scriptType: ScriptType.bip84,
+          birthday: null,
+          provenance: WalletProvenance.importedMnemonic,
         );
         await walletRepository.getWallets(sync: true);
       });

--- a/integration_test/payjoin_test.dart
+++ b/integration_test/payjoin_test.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.dart';
@@ -181,11 +182,15 @@ Future<void> main({bool isInitialized = false}) async {
         seed: receiverSeed,
         network: Network.bitcoinTestnet,
         scriptType: ScriptType.bip84,
+        birthday: null,
+        provenance: WalletProvenance.importedMnemonic,
       );
       senderWallet = await walletRepository.createWallet(
         seed: senderSeed,
         network: Network.bitcoinTestnet,
         scriptType: ScriptType.bip84,
+        birthday: null,
+        provenance: WalletProvenance.importedMnemonic,
       );
     });
 

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -66,10 +66,15 @@ class WalletRepository {
     required Seed seed,
     required Network network,
     required ScriptType scriptType,
+
+    /// Earliest time before which this wallet provably cannot have funds.
+    /// Use null when the creation or import history cannot establish that bound.
+    required DateTime? birthday,
+    required WalletProvenance provenance,
+    bool? seedPassphraseUsed,
     String? label,
     bool isDefault = false,
     bool sync = false,
-    DateTime? birthday,
   }) async {
     // Derive and store the wallet metadata
     final walletLabel =
@@ -89,6 +94,8 @@ class WalletRepository {
       scriptType: scriptType,
       label: walletLabel,
       isDefault: isDefault,
+      provenance: provenance,
+      seedPassphraseUsed: seedPassphraseUsed,
       birthday: birthday,
     );
 

--- a/lib/core/wallet/domain/usecases/create_default_wallets_usecase.dart
+++ b/lib/core/wallet/domain/usecases/create_default_wallets_usecase.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 
 class CreateDefaultWalletsUsecase {
   final SeedRepository _seedRepository;
@@ -59,6 +60,7 @@ class CreateDefaultWalletsUsecase {
               seed: seed,
               network: bitcoinNetwork,
               scriptType: scriptType,
+              provenance: WalletProvenance.defaultSeed,
               isDefault: true,
               birthday: birthday,
             ),
@@ -70,6 +72,7 @@ class CreateDefaultWalletsUsecase {
               seed: seed,
               network: liquidNetwork,
               scriptType: scriptType,
+              provenance: WalletProvenance.defaultSeed,
               isDefault: true,
               birthday: birthday,
             ),

--- a/lib/core/wallet/wallet_metadata_service.dart
+++ b/lib/core/wallet/wallet_metadata_service.dart
@@ -1,10 +1,12 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
 import 'package:bb_mobile/core/utils/descriptor_derivation.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
 
 class WalletMetadataService {
@@ -106,6 +108,8 @@ class WalletMetadataService {
     required ScriptType scriptType,
     String? label,
     required bool isDefault,
+    required WalletProvenance provenance,
+    bool? seedPassphraseUsed,
     DateTime? birthday,
   }) async {
     final xpub = await Bip32Derivation.getAccountXpub(
@@ -165,6 +169,10 @@ class WalletMetadataService {
       isPhysicalBackupTested: false,
       isEncryptedVaultTested: false,
       birthday: birthday,
+      provenance: provenance,
+      seedPassphraseUsed:
+          seedPassphraseUsed ??
+          (seed is MnemonicSeed ? seed.passphrase?.isNotEmpty ?? false : null),
     );
   }
 
@@ -217,12 +225,15 @@ class WalletMetadataService {
       isEncryptedVaultTested: false,
       isPhysicalBackupTested: false,
       isDefault: false,
+      provenance: WalletProvenance.watchOnly,
     );
   }
 
   static Future<WalletMetadataModel> fromDescriptor(
-    WatchOnlyDescriptorEntity entity,
-  ) async {
+    WatchOnlyDescriptorEntity entity, {
+    DateTime? birthday,
+    WalletProvenance? provenance,
+  }) async {
     return WalletMetadataModel(
       id: WalletMetadataService.encodeOrigin(
         fingerprint: entity.masterFingerprint,
@@ -242,6 +253,12 @@ class WalletMetadataService {
       isEncryptedVaultTested: false,
       isPhysicalBackupTested: false,
       label: entity.label,
+      birthday: birthday,
+      provenance:
+          provenance ??
+          (entity.signer == SignerEntity.remote
+              ? WalletProvenance.externalSigner
+              : WalletProvenance.watchOnly),
     );
   }
 }

--- a/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
+++ b/lib/features/app_startup/domain/usecases/check_for_existing_default_wallets_usecase.dart
@@ -3,6 +3,7 @@ import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 
 class CheckForExistingDefaultWalletsUsecase {
   final SettingsRepository _settingsRepository;
@@ -69,7 +70,9 @@ class CheckForExistingDefaultWalletsUsecase {
           seed: seed,
           network: network,
           scriptType: ScriptType.bip84,
+          provenance: WalletProvenance.defaultSeed,
           isDefault: true,
+          birthday: null,
         );
         defaultWallets = await _walletRepository.getWallets(
           onlyDefaults: true,

--- a/lib/features/import_mnemonic/domain/import_wallet_usecase.dart
+++ b/lib/features/import_mnemonic/domain/import_wallet_usecase.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/check_duplicate_mnemonic_usecase.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/import_mnemonic_failure.dart';
 import 'package:meta/meta.dart';
@@ -67,9 +68,11 @@ class ImportWalletUsecase {
         seed: seed,
         network: bitcoinNetwork,
         scriptType: scriptType,
+        provenance: WalletProvenance.importedMnemonic,
         isDefault: false,
         sync: false,
         label: label,
+        birthday: null,
       );
 
       log.fine('Wallet imported');

--- a/test/features/import_mnemonic/domain/import_wallet_usecase_test.dart
+++ b/test/features/import_mnemonic/domain/import_wallet_usecase_test.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/check_duplicate_mnemonic_usecase.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/import_mnemonic_failure.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/import_wallet_usecase.dart';
@@ -119,9 +120,11 @@ void main() {
           seed: any(named: 'seed'),
           network: any(named: 'network'),
           scriptType: any(named: 'scriptType'),
+          provenance: WalletProvenance.importedMnemonic,
           isDefault: any(named: 'isDefault'),
           sync: any(named: 'sync'),
           label: any(named: 'label'),
+          birthday: null,
         ),
       ).thenAnswer((_) async => fakeWallet);
 

--- a/test/security_audit/behavior/import_wallet_seed_cleanup_test.dart
+++ b/test/security_audit/behavior/import_wallet_seed_cleanup_test.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/check_duplicate_mnemonic_usecase.dart';
 import 'package:bb_mobile/features/import_mnemonic/domain/import_mnemonic_failure.dart';
@@ -140,9 +141,11 @@ void main() {
           seed: any(named: 'seed'),
           network: any(named: 'network'),
           scriptType: any(named: 'scriptType'),
+          provenance: WalletProvenance.importedMnemonic,
           isDefault: any(named: 'isDefault'),
           sync: any(named: 'sync'),
           label: any(named: 'label'),
+          birthday: null,
         ),
       ).thenThrow(const WalletAlreadyExistsException('existing-wallet-id'));
 
@@ -166,9 +169,11 @@ void main() {
           seed: any(named: 'seed'),
           network: any(named: 'network'),
           scriptType: any(named: 'scriptType'),
+          provenance: WalletProvenance.importedMnemonic,
           isDefault: any(named: 'isDefault'),
           sync: any(named: 'sync'),
           label: any(named: 'label'),
+          birthday: null,
         ),
       ).thenThrow(Exception('electrum unreachable'));
 


### PR DESCRIPTION
## What this adds

This records the earliest known wallet birthday so restored wallets can avoid scanning blocks from before they could have received funds.

- Newly generated default wallets use their creation time.
- Restored or imported wallets use no birthday when no safe lower bound is known.
- Deterministic child wallets inherit the birthday of their verified parent wallet.
- Future wallet creation call sites must make the birthday decision explicitly.

## Approach

The existing wallet creation funnel receives a required nullable birthday. Imports continue to pass null deliberately, while deterministic wallet preparation performs a balance-free parent metadata lookup and reuses its birthday only when the parent fingerprint and network are unambiguous.

## Verification

Tests cover generated, restored, imported, reused, ambiguous-parent, and deterministic-child behavior.