### PR TITLE
fix(ci): correct PR readiness metadata handling

### DIFF
--- a/.github/workflows/analyze_and_test.yml
+++ b/.github/workflows/analyze_and_test.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          ref: 78be3ed5f14bb2765e19602b90ca6ad62a6cf9c1
+          ref: 5390416e2d89a521269216a916fc2ac7bc74328e
           persist-credentials: false
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pr-readiness-feedback.yml
+++ b/.github/workflows/pr-readiness-feedback.yml
@@ -27,7 +27,7 @@ jobs:
             const p = context.payload.pull_request;
             let cursor = null, pr, refs = [];
             do {
-              const data = await github.graphql(`query($owner:String!,$name:String!,$number:Int!,$cursor:String){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ author{login} labels(first:100){nodes{name}} closingIssuesReferences(first:100,after:$cursor){nodes{state repository{nameWithOwner} labels(first:100){nodes{name}}} pageInfo{hasNextPage endCursor}}}}}`, { owner: context.repo.owner, name: context.repo.name, number: p.number, cursor });
+              const data = await github.graphql(`query($owner:String!,$name:String!,$number:Int!,$cursor:String){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ author{login} labels(first:100){nodes{name}} closingIssuesReferences(first:100,after:$cursor){nodes{state repository{nameWithOwner} labels(first:100){nodes{name}}} pageInfo{hasNextPage endCursor}}}}}`, { owner: context.repo.owner, name: context.repo.repo, number: p.number, cursor });
               pr = data.repository.pullRequest;
               refs = refs.concat(pr.closingIssuesReferences.nodes);
               cursor = pr.closingIssuesReferences.pageInfo.hasNextPage ? pr.closingIssuesReferences.pageInfo.endCursor : null;

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -35,7 +35,7 @@ jobs:
                 if (!timeline) throw new Error('timeline unavailable');
                 let cursor = null, linked = [];
                 do {
-                  const refs = await github.graphql(`query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){closingIssuesReferences(first:100,after:$cursor){nodes{number repository{nameWithOwner}} pageInfo{hasNextPage endCursor}}}}}`, { owner: context.repo.owner, name: context.repo.name, number: p.number, cursor });
+                  const refs = await github.graphql(`query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){closingIssuesReferences(first:100,after:$cursor){nodes{number repository{nameWithOwner}} pageInfo{hasNextPage endCursor}}}}}`, { owner: context.repo.owner, name: context.repo.repo, number: p.number, cursor });
                   linked = linked.concat(refs.repository.pullRequest.closingIssuesReferences.nodes.filter((i) => i.repository.nameWithOwner === `${context.repo.owner}/${context.repo.repo}`));
                   cursor = refs.repository.pullRequest.closingIssuesReferences.pageInfo.hasNextPage ? refs.repository.pullRequest.closingIssuesReferences.pageInfo.endCursor : null;
                 } while (cursor);

--- a/tools/pr_governance/policy.js
+++ b/tools/pr_governance/policy.js
@@ -3,7 +3,9 @@
 const READY = 'ready';
 
 function labelsOf(pr) {
-  return new Set((pr.labels || []).map((label) => typeof label === 'string' ? label : label.name));
+  const source = pr?.labels;
+  const labels = Array.isArray(source) ? source : Array.isArray(source?.nodes) ? source.nodes : [];
+  return new Set(labels.flatMap((label) => typeof label === 'string' ? [label] : typeof label?.name === 'string' ? [label.name] : []));
 }
 
 function readiness(pr) {

--- a/tools/pr_governance/policy.test.js
+++ b/tools/pr_governance/policy.test.js
@@ -12,6 +12,11 @@ const life = (days, extra = {}) => lifecycle({ now: iso(90), lastActivityAt: iso
 const comment = (marker, days, user = 'github-actions[bot]') => ({ body: marker, created_at: iso(days), user: { login: user, type: 'Bot' } });
 
 test('readiness accepts one local open ready closing issue', () => assert.equal(readiness(base({ closingIssuesReferences: [issue(1)] })).ready, true));
+test('readiness accepts GraphQL label connections', () => {
+  const graphqlIssue = { ...issue(1), labels: { nodes: [{ name: 'ready' }] } };
+  const graphqlPr = base({ labels: { nodes: [] }, closingIssuesReferences: [graphqlIssue] });
+  assert.equal(readiness(graphqlPr).ready, true);
+});
 test('readiness rejects invalid issue references', () => {
   for (const refs of [[], [issue(1, 'OPEN', [])], [issue(1, 'CLOSED')], [issue(1), issue(2, 'CLOSED')]]) assert.equal(readiness(base({ closingIssuesReferences: refs })).ready, false);
   assert.equal(readiness(base({ closingIssuesReferences: [{ ...issue(1), repository: { nameWithOwner: 'other/project' } }] })).ready, false);


### PR DESCRIPTION

`no-issue-needed` exemption: this repairs the repository-governance workflows introduced by #2740.

## Problem

Live fixtures exposed two metadata-shape errors. The readiness policy rejected GraphQL label connections with `TypeError: (pr.labels || []).map is not a function`, and the feedback workflow passed an undefined repository name to GraphQL by reading `context.repo.name` instead of `context.repo.repo`. The same repository-name error was present in the stale workflow.

## Changes

- Accept both label arrays and GraphQL `{ nodes: [...] }` connections in the shared readiness policy.
- Add regression coverage for GraphQL label connections.
- Pass the correct repository name to the feedback and stale GraphQL queries.
- Update the immutable readiness-policy pin used by `Analyze and Test`.

Review the commits in order: policy and regression test, governance query correction, then immutable policy-pin update.

## Non-goals

- No changes to readiness semantics, exemptions, stale timing, or required-check configuration.
- No application-code changes.

## Risk and security

The changes are limited to trusted GitHub metadata workflows and execute no pull-request-head code. Token permissions and action pins are unchanged. There is no impact on user funds, wallet data, privacy, or key material.
