### PR TITLE
docs: point agents to AGENTS.local.md for host-specific instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ app.*.map.json
 today.md
 
 CLAUDE.md
+AGENTS.local.md
 .zed/
 .claude/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Instructions for AI coding agents working in this repo. Cross-tool standard ([agents.md](https://agents.md/)) — read by most coding agents (Cursor, Codex, Copilot, Claude Code, …). Tools that only read `CLAUDE.md`: create a local, gitignored `CLAUDE.md` containing `See @AGENTS.md`.
+Instructions for AI coding agents working in this repo. Cross-tool standard ([agents.md](https://agents.md/)) — read by most coding agents (Cursor, Codex, Copilot, Claude Code, …). Tools that only read `CLAUDE.md`: create a local, gitignored `CLAUDE.md` containing `See @AGENTS.md`. Also read `AGENTS.local.md` if present — it holds instructions specific to the current host or developer.
 
 ## Project
 


### PR DESCRIPTION
Here is what I have in my `AGENTS.local.md` file, helps store developer/host specific custom instructions for all agents

```
# AGENTS.local.md

Instructions specific to this host/developer. Supplements @AGENTS.md.

- I am using devcontainers, and all the development tooling is installed inside of it. For commands mentioned in AGENTS.md you'll need to do `dc exec bash -lc '<command>'`. For example, to run `make translations`, you'll do `dc exec bash -lc 'make translations'`. The dc command is a wrapper on top of the devcontainer CLI to make my life easier.
- Don't yapp. Keep your responses short. Keep yourself focused on what is being asked. No need for many words when few words work.
- No unnecessary comments in code
```