### PR TITLE
fix: keep focus when tapping the mnemonic keyboard on desktop

### DIFF
--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -764,27 +764,29 @@ class _MnemonicSentenceWidgetState extends State<MnemonicSentenceWidget> {
       builder: (context, _) {
         if (_activeField.value == null) return const SizedBox.shrink();
         final paranoid = _paranoid.value;
-        return ExcludeFocus(
-          child: Material(
-            color: context.appColors.surfaceContainer,
-            child: SafeArea(
-              top: false,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-                    // Suggestions stay visible in paranoid mode; they are only
-                    // shuffled (see _buildHintsList), so an onlooker cannot map
-                    // a chip position to a word either. ExcludeSemantics: the
-                    // chips are plain-text word candidates — an accessibility
-                    // service must not read them any more than the keys.
-                    child: ExcludeSemantics(
-                      child: _buildHintsList(paranoid: paranoid),
+        return TextFieldTapRegion(
+          child: ExcludeFocus(
+            child: Material(
+              color: context.appColors.surfaceContainer,
+              child: SafeArea(
+                top: false,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                      // Suggestions stay visible in paranoid mode; they are only
+                      // shuffled (see _buildHintsList), so an onlooker cannot map
+                      // a chip position to a word either. ExcludeSemantics: the
+                      // chips are plain-text word candidates — an accessibility
+                      // service must not read them any more than the keys.
+                      child: ExcludeSemantics(
+                        child: _buildHintsList(paranoid: paranoid),
+                      ),
                     ),
-                  ),
-                  _buildKeyboard(),
-                ],
+                    _buildKeyboard(),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Fixes: #2749

**What was happening**

On Linux, the in-app keyboard did not work when recovering a seed. Tapping a key closed the keyboard and typed nothing

**Why**

The keyboard only shows while a word field has focus. On desktop, Flutter drops a field's focus on any tap outside the field's tap region. The keys sit outside that region, so each key tap unfocused the field and hid the keyboard before it could type. On mobile, touch taps are exempt, so it worked there

**Fix**

Wrap the keyboard bar in a `TextFieldTapRegion`. This puts the keys in the field's tap group, so a key tap counts as a tap inside the field. The field keeps focus and the keys type

**Testing**

- Linux: keys now type
- Android: tested manually, no regression

**Note**

Switching to another window still hides the keyboard, because the window losing focus drops the field's focus, but that doesn't block us in any way, so ignoring it for now

**Screen Recordings:**

Before:

https://github.com/user-attachments/assets/9b24977a-c317-4be7-9d99-f60a94582bbb

After:

https://github.com/user-attachments/assets/1f3ba44c-8445-4718-87fb-60ad80543787