### PR TITLE
v6.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to Bull Bitcoin Mobile will be documented in this file.
 
 ---
 
+## 6.13.1 - 2026-08-27
+
+### Fixed
+
+- Fixed coin control selection, fee changes, and frozen-coin handling.
+- Fixed fee shortfalls in swaps and enabled Payjoin retries.
+- Fixed Passport UR fountain decoding.
+- Fixed Receive QR codes retaining Payjoin after the toggle is turned off.
+- Fixed RBF fee prefill.
+- Fixed Back navigation and transaction details for swaps.
+- Fixed Payjoin and order lookup/listing, including copying the order number.
+- Fixed stale Send payment-request parsing.
+- Kept mnemonics out of state and preserved exact passphrase punctuation.
+
+---
+
 ## [6.13.0] - 2026-08-13
 
 ### New Features

--- a/lib/core/fees/domain/fees_entity.dart
+++ b/lib/core/fees/domain/fees_entity.dart
@@ -109,6 +109,50 @@ extension NetworkFeeRelayPolicy on NetworkFee {
   static const double minRelaySatPerVbyte = 0.1;
   static const int minRelaySatPerKwu = 25;
 
+  /// BIP-125's incremental relay fee: 1 sat/vByte = 250 sat/kwu, exact. A
+  /// replacement must add at least this on top of the rate it replaces.
+  static const int incrementalRelaySatPerKwu = 250;
+
+  /// The lowest rate that can replace a [feeSat] / [vsize] transaction.
+  ///
+  /// BDK derives the rate to beat from the transaction **weight**, while a
+  /// [WalletTransaction] only carries `vsize` — which is `ceil(weight / 4)`.
+  /// `feeSat / vsize` therefore *under-states* the original rate, and a naive
+  /// `+ 1 sat/vByte` on top of it lands under BDK's threshold: the app
+  /// proposes a bump that BDK then rejects as too low, which reads as
+  /// nonsense to the user.
+  ///
+  /// Bound the original rate from above instead, using the lightest weight a
+  /// transaction of this vsize can have (`4 · vsize − 3`), in integer sat/kwu
+  /// so nothing rounds down, then add the incremental relay fee. Overshoots
+  /// the strict minimum by at most 3 sat/kwu (0.012 sat/vByte), when the real
+  /// weight happens to be an exact multiple of 4.
+  static int minimumReplacementSatPerKwu({
+    required int feeSat,
+    required int vsize,
+  }) {
+    assert(vsize > 0, 'vsize must be positive');
+    final lightestWeightWu = 4 * vsize - 3;
+    final originalSatPerKwu =
+        (feeSat * 1000 + lightestWeightWu - 1) ~/ lightestWeightWu;
+    return originalSatPerKwu + incrementalRelaySatPerKwu;
+  }
+
+  /// A safe replacement rate after the custom input displays and reparses it.
+  ///
+  /// The input is expressed to two decimal places in sat/vByte. One displayed
+  /// cent therefore represents 2.5 sat/kwu, so formatting the exact minimum
+  /// to the nearest cent can round back below BDK's threshold. Quantize upward
+  /// to the next displayable cent, then convert it exactly as the input does.
+  static int replacementPrefillSatPerKwu({
+    required int feeSat,
+    required int vsize,
+  }) {
+    final minimum = minimumReplacementSatPerKwu(feeSat: feeSat, vsize: vsize);
+    final centiSatPerVbyte = (minimum * 2 + 4) ~/ 5;
+    return (centiSatPerVbyte * 5 + 1) ~/ 2;
+  }
+
   /// True when this fee is at or above the relay floor. The floor defaults
   /// to the static [minRelaySatPerKwu] (0.1 sat/vByte) but callers SHOULD
   /// pass [floorSatPerKwu] from the live mempool `minimumFee`

--- a/lib/core/urqr/urqr.dart
+++ b/lib/core/urqr/urqr.dart
@@ -138,8 +138,12 @@ class UrQrReader {
 
     final sequenceNumber = int.parse(match.group(1)!);
     final sequenceCount = int.parse(match.group(2)!);
+    // Note: sequenceNumber may legitimately exceed sequenceCount. Animated
+    // URs are fountain-coded (BCR-2020-005): once the pure fragments 1..N
+    // have played, the stream keeps emitting mixed parts N+1, N+2, ... so a
+    // decoder that missed frames can still recover. Rejecting those parts
+    // breaks scanning of any stream the camera joins mid-animation.
     if (sequenceNumber < 1 ||
-        sequenceNumber > sequenceCount ||
         sequenceCount > maxMultipartParts ||
         data.length > maxMultipartMessageSize) {
       throw UrSequenceLimitExceeded();

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -261,12 +261,19 @@ class BdkWalletDatasource {
             ),
           )
           .toList();
-      txBuilder.addUtxos(outpoints: selectableOutPoints);
+      // bdk_dart's TxBuilder is immutable — every method returns a NEW
+      // builder instance rather than mutating in place. Discarding the
+      // return value (as this call did before) silently drops the manual
+      // UTXO selection and leaves BDK to pick inputs automatically.
+      txBuilder = txBuilder.addUtxos(outpoints: selectableOutPoints);
     }
 
     // bdk_dart always has RBF (nSequence = 0xFFFFFFFD) enabled by default,
     // so we set the sequence to 0xFFFFFFFE if replaceByFee is explicitly set to false to disable RBF.
-    if (!replaceByFee) txBuilder.setExactSequence(nsequence: 0xFFFFFFFE);
+    // Same immutable-builder pitfall as addUtxos above — must reassign.
+    if (!replaceByFee) {
+      txBuilder = txBuilder.setExactSequence(nsequence: 0xFFFFFFFE);
+    }
 
     switch (networkFee) {
       case AbsoluteFee(:final sats):

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -15,6 +15,7 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_transaction_model.dart'
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/foundation.dart';
@@ -326,7 +327,17 @@ class BdkWalletDatasource {
     }
 
     // Finish the transaction building process
-    final psbt = txBuilder.finish(wallet: bdkWallet);
+    final bdk.Psbt psbt;
+    try {
+      psbt = txBuilder.finish(wallet: bdkWallet);
+    } on bdk.InsufficientFundsCreateTxException catch (e) {
+      // Mapped here so callers don't depend on a BDK type. Both totals
+      // include the fee, so the difference is what's missing.
+      throw InsufficientFundsException(
+        e.toString(),
+        missingSat: e.needed - e.available,
+      );
+    }
 
     return psbt.serialize();
   }

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -331,12 +331,13 @@ class BdkWalletDatasource {
     try {
       psbt = txBuilder.finish(wallet: bdkWallet);
     } on bdk.InsufficientFundsCreateTxException catch (e) {
-      // Mapped here so callers don't depend on a BDK type. Both totals
-      // include the fee, so the difference is what's missing.
-      throw InsufficientFundsException(
-        e.toString(),
-        missingSat: e.needed - e.available,
-      );
+      // Mapped here so callers don't depend on a BDK type.
+      throw InsufficientFundsException(e.toString());
+    } on bdk.CoinSelectionCreateTxException catch (e) {
+      // The same situation reported through a different variant: BDK raises
+      // this one when the selection can't cover the outputs plus the fee,
+      // which is what hand-picked coins hit.
+      throw InsufficientFundsException(e.errorMessage);
     }
 
     return psbt.serialize();

--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -402,10 +402,7 @@ class LwkWalletDatasource {
     } catch (e) {
       if (e is lwk.LwkError) {
         if (e.msg.contains(_lwkInsufficientFundsMarker)) {
-          throw InsufficientFundsException(
-            e.msg,
-            missingSat: _missingSatsFromLwkError(e.msg),
-          );
+          throw InsufficientFundsException(e.msg);
         }
         // A build failure on a wallet whose confirmed L-BTC UTXO count exceeds
         // the Liquid confidential-tx input limit is almost certainly the
@@ -424,16 +421,10 @@ class LwkWalletDatasource {
   /// longer be built (the true protocol maximum is 256).
   static const int maxLiquidTxInputs = 256;
 
+  /// LWK reports a shortfall as plain text, e.g.
+  /// `InsufficientFunds { missing_sats: 21, asset_id: ..., is_token: false }`.
+  /// Matching the text is all the SDK gives us, so it stays in this file.
   static const String _lwkInsufficientFundsMarker = 'InsufficientFunds';
-
-  static final RegExp _lwkMissingSatsPattern = RegExp(r'missing_sats:\s*(\d+)');
-
-  /// How many sats short, or null if the message doesn't say.
-  static int? _missingSatsFromLwkError(String message) {
-    final match = _lwkMissingSatsPattern.firstMatch(message);
-    if (match == null) return null;
-    return int.tryParse(match.group(1)!);
-  }
 
   /// Number of L-BTC UTXOs in the wallet — the count that matters for the
   /// 256-input limit (asset-filtered, mirroring lwk's `utxoStatus`). Drives

--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -13,6 +13,7 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:flutter/material.dart';
 import 'package:bull_sdk/lwk.dart' as lwk;
 
@@ -400,6 +401,12 @@ class LwkWalletDatasource {
       return pset;
     } catch (e) {
       if (e is lwk.LwkError) {
+        if (e.msg.contains(_lwkInsufficientFundsMarker)) {
+          throw InsufficientFundsException(
+            e.msg,
+            missingSat: _missingSatsFromLwkError(e.msg),
+          );
+        }
         // A build failure on a wallet whose confirmed L-BTC UTXO count exceeds
         // the Liquid confidential-tx input limit is almost certainly the
         // ">256 inputs" case.
@@ -416,6 +423,17 @@ class LwkWalletDatasource {
   /// Number of confidential-tx inputs above which a Liquid transaction can no
   /// longer be built (the true protocol maximum is 256).
   static const int maxLiquidTxInputs = 256;
+
+  static const String _lwkInsufficientFundsMarker = 'InsufficientFunds';
+
+  static final RegExp _lwkMissingSatsPattern = RegExp(r'missing_sats:\s*(\d+)');
+
+  /// How many sats short, or null if the message doesn't say.
+  static int? _missingSatsFromLwkError(String message) {
+    final match = _lwkMissingSatsPattern.firstMatch(message);
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
+  }
 
   /// Number of L-BTC UTXOs in the wallet — the count that matters for the
   /// 256-input limit (asset-filtered, mirroring lwk's `utxoStatus`). Drives

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/mappers/wallet_utxo_mapper.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
@@ -12,18 +13,22 @@ import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_send_port.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 
 class BitcoinWalletRepository implements BitcoinSendPort {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final SeedDatasource _seed;
   final BdkWalletDatasource _bdkWallet;
+  final FrozenWalletUtxoDatasource _frozenUtxos;
 
   BitcoinWalletRepository({
     required this._walletMetadataDatasource,
     required SeedDatasource seedDatasource,
     required BdkWalletDatasource bdkWalletDatasource,
+    required FrozenWalletUtxoDatasource frozenWalletUtxoDatasource,
   }) : _seed = seedDatasource,
-       _bdkWallet = bdkWalletDatasource;
+       _bdkWallet = bdkWalletDatasource,
+       _frozenUtxos = frozenWalletUtxoDatasource;
 
   @override
   Future<String> buildPsbt({
@@ -54,17 +59,63 @@ class BitcoinWalletRepository implements BitcoinSendPort {
               id: metadata.id,
             )
             as PublicBdkWalletModel;
+
+    // D7 defense in depth: a frozen coin must never be spendable. BDK's
+    // documented semantics are the opposite — a manually added utxo
+    // (TxBuilder.addUtxos) overrides the unspendable filter — and the
+    // datasource deliberately preserves those raw semantics. Enforce the
+    // app-level invariant here at the repository boundary, reading the
+    // frozen store LIVE at build time, so it holds for ANY caller and
+    // any staleness of the caller's earlier utxo fetch — not only for
+    // callers going through PrepareBitcoinSendUsecase (which reads the
+    // same store plus the payjoin-derived set; payjoin exclusion stays
+    // at the usecase because it comes from another repository).
+    //
+    // The frozen set read here is:
+    //  * merged into `unspendable`, so BDK's automatic selection can
+    //    never pick a frozen coin even when the caller passed no
+    //    exclusion list at all;
+    //  * used to strip `selected`, so a frozen coin can't be forced in
+    //    as a mandatory input either (the addUtxos override above).
+    final frozenRows = await _frozenUtxos.getAllFrozen();
+    final unspendableKeys = {
+      for (final row in frozenRows) '${row.txId}:${row.vout}',
+      for (final outpoint in unspendable ?? const <({String txId, int vout})>[])
+        '${outpoint.txId}:${outpoint.vout}',
+    };
+    final mergedUnspendable = [
+      for (final outpoint in {
+        for (final row in frozenRows) (txId: row.txId, vout: row.vout),
+        ...?unspendable,
+      })
+        outpoint,
+    ];
+    final spendableSelected = selected
+        ?.where(
+          (utxo) => !unspendableKeys.contains('${utxo.txId}:${utxo.vout}'),
+        )
+        .toList();
+    if (selected != null && selected.isNotEmpty && spendableSelected!.isEmpty) {
+      throw NoSpendableUtxoException('All selected UTXOs are unspendable');
+    }
+
     final psbt = await _bdkWallet.buildPsbt(
       wallet: wallet,
       address: address,
       amountSat: amountSat,
       networkFee: networkFee,
       drain: drain,
-      unspendable: unspendable,
-      selected: selected
+      // An empty merged list is equivalent to null for the datasource
+      // (it gates on isNotEmpty), so always pass the merge.
+      unspendable: mergedUnspendable,
+      selected: spendableSelected
           ?.map((utxo) => WalletUtxoMapper.fromEntity(utxo))
           .toList(),
-      replaceByFee: replaceByFee ?? false,
+      // Default to RBF-enabled, matching both the datasource default and
+      // BDK's own default sequence (0xFFFFFFFD). `?? false` would disable
+      // RBF for any caller omitting the flag — harmless while
+      // setExactSequence's result was discarded, wrong now that it works.
+      replaceByFee: replaceByFee ?? true,
     );
 
     return psbt;

--- a/lib/core/wallet/domain/insufficient_funds_exception.dart
+++ b/lib/core/wallet/domain/insufficient_funds_exception.dart
@@ -5,7 +5,5 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 /// Thrown by both wallet datasources so callers can tell a shortfall apart
 /// from a real build failure.
 class InsufficientFundsException extends BullException {
-  final int? missingSat;
-
-  InsufficientFundsException(super.message, {this.missingSat});
+  InsufficientFundsException(super.message);
 }

--- a/lib/core/wallet/domain/insufficient_funds_exception.dart
+++ b/lib/core/wallet/domain/insufficient_funds_exception.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+
+/// The wallet's spendable coins don't cover the amount plus the network fee.
+///
+/// Thrown by both wallet datasources so callers can tell a shortfall apart
+/// from a real build failure.
+class InsufficientFundsException extends BullException {
+  final int? missingSat;
+
+  InsufficientFundsException(super.message, {this.missingSat});
+}

--- a/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -3,6 +3,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_send_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
@@ -71,6 +72,8 @@ class PrepareBitcoinSendUsecase {
       );
       return (unsignedPsbt: psbt, txSize: size, isToSelf: isToSelf);
     } on NoSpendableUtxoException {
+      rethrow;
+    } on InsufficientFundsException {
       rethrow;
     } catch (e) {
       throw PrepareBitcoinSendException(e.toString());

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -64,6 +64,7 @@ class WalletLocator {
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
         bdkWalletDatasource: locator<BdkWalletDatasource>(),
         seedDatasource: locator<SeedDatasource>(),
+        frozenWalletUtxoDatasource: locator<FrozenWalletUtxoDatasource>(),
       ),
     );
 

--- a/lib/core/widgets/inputs/labeled_text_input.dart
+++ b/lib/core/widgets/inputs/labeled_text_input.dart
@@ -10,6 +10,8 @@ class LabeledTextInput extends StatelessWidget {
   final String hint;
   final Function(String)? onChanged;
   final int? maxLines;
+  final SmartQuotesType? smartQuotesType;
+  final SmartDashesType? smartDashesType;
 
   const LabeledTextInput({
     super.key,
@@ -18,6 +20,8 @@ class LabeledTextInput extends StatelessWidget {
     required this.onChanged,
     this.hint = '',
     this.maxLines,
+    this.smartQuotesType,
+    this.smartDashesType,
   });
 
   @override
@@ -64,6 +68,8 @@ class LabeledTextInput extends StatelessWidget {
             hint: hint,
             hideBorder: true,
             maxLines: maxLines,
+            smartQuotesType: smartQuotesType,
+            smartDashesType: smartDashesType,
           ),
         ),
       ],

--- a/lib/core/widgets/inputs/text_input.dart
+++ b/lib/core/widgets/inputs/text_input.dart
@@ -20,6 +20,8 @@ class BBInputText extends StatefulWidget {
     this.onlyPaste = false,
     this.onlyNumbers = false,
     this.obscure = false,
+    this.smartQuotesType,
+    this.smartDashesType,
     this.style,
     this.hideBorder = false,
     this.maxLines,
@@ -43,6 +45,8 @@ class BBInputText extends StatefulWidget {
   final bool onlyPaste;
   final bool onlyNumbers;
   final bool obscure;
+  final SmartQuotesType? smartQuotesType;
+  final SmartDashesType? smartDashesType;
   final int? maxLines;
   final int? minLines;
   final TextStyle? style;
@@ -117,6 +121,8 @@ class _BBInputTextState extends State<BBInputText> {
       obscureText: widget.obscure,
       obscuringCharacter: widget.onlyNumbers ? 'x' : '*',
       enableIMEPersonalizedLearning: false,
+      smartQuotesType: widget.smartQuotesType,
+      smartDashesType: widget.smartDashesType,
       maxLength: widget.maxLength,
       minLines: widget.minLines ?? 1,
       maxLines: widget.maxLines ?? (widget.obscure ? 1 : null),

--- a/lib/core/widgets/mnemonic_widget.dart
+++ b/lib/core/widgets/mnemonic_widget.dart
@@ -183,6 +183,8 @@ class _MnemonicWidgetState extends State<MnemonicWidget> {
               value: passphrase,
               onChanged: updatePassphrase,
               maxLines: 1,
+              smartQuotesType: SmartQuotesType.disabled,
+              smartDashesType: SmartDashesType.disabled,
             ),
           ],
 

--- a/lib/features/buy/ui/screens/buy_success_screen.dart
+++ b/lib/features/buy/ui/screens/buy_success_screen.dart
@@ -130,18 +130,10 @@ class _BuySuccessScreenState extends State<BuySuccessScreen> {
         BBButton.big(
           label: context.loc.buyViewDetails,
           onPressed: () {
-            final txId = buyOrder.payjoin?.txid;
-            if (txId != null) {
-              context.pushNamed(
-                TransactionsRoute.payjoinTransactionDetailsByTxId.name,
-                pathParameters: {'txId': txId},
-              );
-            } else {
-              context.pushNamed(
-                TransactionsRoute.orderTransactionDetails.name,
-                pathParameters: {'orderId': buyOrder.orderId},
-              );
-            }
+            context.pushNamed(
+              TransactionsRoute.orderTransactionDetails.name,
+              pathParameters: {'orderId': buyOrder.orderId},
+            );
           },
           bgColor: context.appColors.secondary,
           textColor: context.appColors.onSecondary,

--- a/lib/features/receive/presentation/bloc/receive_bloc.dart
+++ b/lib/features/receive/presentation/bloc/receive_bloc.dart
@@ -83,7 +83,16 @@ class ReceiveBloc extends Bloc<ReceiveEvent, ReceiveState> {
     //  explicit re-check inside the handler for defense in depth.
     on<ReceivePayjoinSettingChanged>(
       _onPayjoinSettingChanged,
-      transformer: restartable(),
+      // Persistence and the live watcher can report the same value. Filter
+      // adjacent duplicates before restartable so either arrival order keeps
+      // one handler, while enable -> disable is still preserved.
+      transformer: (events, mapper) =>
+          restartable<ReceivePayjoinSettingChanged>()(
+            events.distinct(
+              (previous, current) => previous.enabled == current.enabled,
+            ),
+            mapper,
+          ),
     );
     on<ReceivePayjoinToggled>(_onPayjoinToggled, transformer: droppable());
     on<ReceivePayjoinMinAmountChanged>(_onPayjoinMinAmountChanged);
@@ -935,12 +944,17 @@ class ReceiveBloc extends Bloc<ReceiveEvent, ReceiveState> {
       event.enabled,
       requestConsent: event.requestConsent,
     );
-    result.fold((_) {}, (failure) {
-      log.warning(
-        'Failed to toggle Payjoin from Receive: ${failure.logMessage}',
-      );
-      emit(state.copyWith(error: failure));
-    });
+    result.fold(
+      (updated) {
+        add(ReceivePayjoinSettingChanged(updated));
+      },
+      (failure) {
+        log.warning(
+          'Failed to toggle Payjoin from Receive: ${failure.logMessage}',
+        );
+        emit(state.copyWith(error: failure));
+      },
+    );
   }
 
   void _onPayjoinMinAmountChanged(
@@ -1004,8 +1018,10 @@ class ReceiveBloc extends Bloc<ReceiveEvent, ReceiveState> {
       );
     } else if (state.payjoin != null &&
         !_isPayjoinEligible(wallet, event.enabled)) {
-      await _payjoinSubscription?.cancel();
+      final payjoinSubscription = _payjoinSubscription;
+      _payjoinSubscription = null;
       emit(state.copyWith(payjoin: null));
+      await payjoinSubscription?.cancel();
     }
   }
 

--- a/lib/features/replace_by_fee/domain/bump_fee_usecase.dart
+++ b/lib/features/replace_by_fee/domain/bump_fee_usecase.dart
@@ -47,7 +47,11 @@ class BumpFeeUsecase {
         isPsbt: true,
       );
       return Ok(broadcastedTxid);
-    } on bdk.FeeRateTooLowCreateTxException {
+    } on bdk.FeeRateTooLowCreateTxException catch (e) {
+      log.warning(
+        'BDK rejected replacement fee rate',
+        error: 'Required rate: ${e.required_}',
+      );
       return const Err(ReplaceByFeeFeeRateTooLowFailure());
     } catch (e, st) {
       log.severe(message: 'Bump fee failed', error: e, trace: st);

--- a/lib/features/replace_by_fee/presentation/cubit.dart
+++ b/lib/features/replace_by_fee/presentation/cubit.dart
@@ -30,8 +30,6 @@ class ReplaceByFeeCubit extends Cubit<ReplaceByFeeState> {
             vsize: originalTransaction.vsize,
           ),
         };
-        final originalSatPerVbyte =
-            originalTransaction.feeSat / originalTransaction.vsize;
         emit(
           state.copyWith(
             fastestFeeRate: FeeEntity(
@@ -40,8 +38,11 @@ class ReplaceByFeeCubit extends Cubit<ReplaceByFeeState> {
             ),
             newFeeRate: FeeEntity(
               type: FeeType.custom,
-              feeRate: NetworkFee.relativeFromSatPerVbyte(
-                originalSatPerVbyte + 1,
+              feeRate: RelativeFee(
+                NetworkFeeRelayPolicy.replacementPrefillSatPerKwu(
+                  feeSat: originalTransaction.feeSat,
+                  vsize: originalTransaction.vsize,
+                ),
               ),
             ),
             minRelay: value.minRelay,

--- a/lib/features/send/domain/send_failure.dart
+++ b/lib/features/send/domain/send_failure.dart
@@ -30,6 +30,11 @@ final class SendInsufficientBalanceFailure extends SendFailure {
   const SendInsufficientBalanceFailure([super.logMessage]);
 }
 
+/// The amount fits the balance, but not once the network fee is added.
+final class SendInsufficientFundsForFeesFailure extends SendFailure {
+  const SendInsufficientFundsForFeesFailure([super.logMessage]);
+}
+
 final class SendAmountOutOfBoundsFailure extends SendFailure {
   final BigInt? minimumSat;
   final BigInt? maximumSat;

--- a/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
@@ -3,6 +3,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 
 class PrepareLiquidSendUsecase {
   final LiquidWalletRepository _liquidWalletRepository;
@@ -32,6 +33,8 @@ class PrepareLiquidSendUsecase {
     } on NoSpendableUtxoException {
       rethrow;
     } on ConsolidationRequiredException {
+      rethrow;
+    } on InsufficientFundsException {
       rethrow;
     } catch (e) {
       throw PrepareLiquidSendException(e.toString());

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -11,6 +11,7 @@ import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
@@ -895,7 +896,8 @@ class SendCubit extends Cubit<SendState>
       );
       return;
     }
-    if (state.failure is! SendTransactionBuildFailure) {
+    // Any failure keeps the user here.
+    if (state.failure == null) {
       emit(
         state.copyWith(
           step: SendStep.confirm,
@@ -1629,6 +1631,17 @@ class SendCubit extends Cubit<SendState>
         );
         return;
       }
+      if (e is InsufficientFundsException) {
+        emit(
+          state.copyWith(
+            failure: state.selectedUtxos.isEmpty
+                ? SendInsufficientFundsForFeesFailure(e.message)
+                : SendInsufficientBalanceFailure(e.message),
+            buildingTransaction: false,
+          ),
+        );
+        return;
+      }
       if (e is PrepareBitcoinSendException) {
         emit(
           state.copyWith(
@@ -1963,8 +1976,9 @@ class SendCubit extends Cubit<SendState>
         if (orderNeedsPayin || sendNeedsSignature) {
           await createTransaction();
         }
-        if (state.failure is SendTransactionBuildFailure ||
-            state.unsignedPsbt == null) {
+        // Stop on any failure, not just a build one — otherwise an
+        // insufficient-balance failure would sign whatever PSBT is left over.
+        if (state.failure != null || state.unsignedPsbt == null) {
           emit(state.copyWith(step: SendStep.confirm));
           return;
         }

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -885,7 +885,7 @@ class SendCubit extends Cubit<SendState>
         state.sendType == SendType.bitcoin) {
       await createTransaction();
     }
-    if (!await hasBalance()) {
+    if (state.failure == null && !await hasBalance()) {
       emit(
         state.copyWith(
           failure: const SendInsufficientBalanceFailure(
@@ -1954,6 +1954,7 @@ class SendCubit extends Cubit<SendState>
   }
 
   Future<void> onConfirmTransactionClicked() async {
+    clearFailure();
     try {
       final orderNeedsPayin =
           state.lightningOrder != null &&

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -885,6 +885,8 @@ class SendCubit extends Cubit<SendState>
         state.sendType == SendType.bitcoin) {
       await createTransaction();
     }
+    // Skipped when the build above already failed: it knows whether the fee or
+    // the coins fell short, and this check would flatten that away.
     if (state.failure == null && !await hasBalance()) {
       emit(
         state.copyWith(
@@ -1632,9 +1634,13 @@ class SendCubit extends Cubit<SendState>
         return;
       }
       if (e is InsufficientFundsException) {
+        // Frozen or hand-picked coins can be the real cause, not the fee. Both
+        // need the generic failure
+        final blamesFees =
+            state.selectedUtxos.isEmpty && state.frozenBalanceSat == 0;
         emit(
           state.copyWith(
-            failure: state.selectedUtxos.isEmpty
+            failure: blamesFees
                 ? SendInsufficientFundsForFeesFailure(e.message)
                 : SendInsufficientBalanceFailure(e.message),
             buildingTransaction: false,
@@ -1954,6 +1960,8 @@ class SendCubit extends Cubit<SendState>
   }
 
   Future<void> onConfirmTransactionClicked() async {
+    // Needed even though createTransaction() also clears: the payjoin-only
+    // path below skips it, and a leftover failure blocks every retry.
     clearFailure();
     try {
       final orderNeedsPayin =

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -104,7 +104,9 @@ class SendCubit extends Cubit<SendState>
     required this._checkLiquidConsolidationUsecase,
     required this._getSendPayjoinEnabledUsecase,
     required this._verifySignedTxUsecase,
-  }) : super(const SendState());
+    Future<PaymentRequest> Function(String)? parsePaymentRequest,
+  }) : _parsePaymentRequest = parsePaymentRequest ?? PaymentRequest.parse,
+       super(const SendState());
 
   /// Distinct user-defined labels for the suggestion chips in the label
   /// bottom sheet. Wraps [LabelsFacade.fetchDistinctLabels] so widgets
@@ -156,6 +158,7 @@ class SendCubit extends Cubit<SendState>
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
   final VerifySignedTxUsecase _verifySignedTxUsecase;
+  final Future<PaymentRequest> Function(String) _parsePaymentRequest;
 
   StreamSubscription<Result<OrderSwapRecord, SendFailure>>?
   _orderSwapSubscription;
@@ -170,6 +173,7 @@ class SendCubit extends Cubit<SendState>
   /// re-populating an emptied cache (which could otherwise stage a PSBT
   /// built for the previous tx shape for broadcast).
   int _bitcoinPreviewEpoch = 0;
+  int _paymentRequestInputGeneration = 0;
 
   @override
   Future<void> close() async {
@@ -216,6 +220,14 @@ class SendCubit extends Cubit<SendState>
 
   void clearFailure() => emit(state.copyWith(failure: null));
 
+  int _startNewPaymentRequestInput() {
+    final generation = ++_paymentRequestInputGeneration;
+    if (state.loadingBestWallet) {
+      emit(state.copyWith(loadingBestWallet: false));
+    }
+    return generation;
+  }
+
   void backClicked() {
     _invalidateSignedTransaction();
     if (state.step == SendStep.address) {
@@ -247,6 +259,7 @@ class SendCubit extends Cubit<SendState>
     String scannedRawPaymentRequest,
     PaymentRequest? paymentRequest,
   ) async {
+    _startNewPaymentRequestInput();
     clearFailure();
     _invalidateSignedTransaction();
     final sanitizedText = scannedRawPaymentRequest.trim().replaceAll(
@@ -274,6 +287,7 @@ class SendCubit extends Cubit<SendState>
 
   /// Called when text is pasted or entered manually
   Future<void> onChangedText(String text) async {
+    final inputGeneration = _startNewPaymentRequestInput();
     try {
       clearFailure();
       _invalidateSignedTransaction();
@@ -284,6 +298,7 @@ class SendCubit extends Cubit<SendState>
       final paymentRequest = await _detectBitcoinStringUsecase.execute(
         data: sanitizedText,
       );
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final recipientChanged = state.paymentRequest != paymentRequest;
       emit(
         state.copyWith(
@@ -296,6 +311,7 @@ class SendCubit extends Cubit<SendState>
       // changed. Skip when paste/typing resolves to the same paymentRequest.
       if (recipientChanged) clearBitcoinFeePreviews();
     } catch (e) {
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final recipientCleared = state.paymentRequest != null;
       emit(
         state.copyWith(
@@ -313,9 +329,11 @@ class SendCubit extends Cubit<SendState>
   }
 
   Future<void> continueOnAddressConfirmed() async {
+    final inputGeneration = _paymentRequestInputGeneration;
     try {
       emit(state.copyWith(loadingBestWallet: true));
-      await unifiedBip21Prioritization();
+      await unifiedBip21Prioritization(inputGeneration: inputGeneration);
+      if (inputGeneration != _paymentRequestInputGeneration) return;
 
       if (!state.hasValidPaymentRequest) {
         emit(
@@ -2219,14 +2237,17 @@ class SendCubit extends Cubit<SendState>
         });
   }
 
-  Future<void> unifiedBip21Prioritization() async {
+  Future<void> unifiedBip21Prioritization({
+    required int inputGeneration,
+  }) async {
     final request = state.paymentRequest;
     if (request == null) return;
     if (request is! Bip21PaymentRequest) return;
     if (request.lightning.isEmpty) return;
 
     try {
-      final lightning = await PaymentRequest.parse(request.lightning);
+      final lightning = await _parsePaymentRequest(request.lightning);
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final wallet = _bestWalletUsecase.execute(
         wallets: state.wallets,
         request: lightning,
@@ -2234,6 +2255,7 @@ class SendCubit extends Cubit<SendState>
       );
       emit(state.copyWith(selectedWallet: wallet, paymentRequest: lightning));
     } catch (_) {
+      if (inputGeneration != _paymentRequestInputGeneration) return;
       final wallet = _bestWalletUsecase.execute(
         wallets: state.wallets,
         request: request,

--- a/lib/features/send/presentation/send_failure_l10n.dart
+++ b/lib/features/send/presentation/send_failure_l10n.dart
@@ -16,6 +16,8 @@ extension SendFailureL10n on SendFailure {
       context.loc.sendErrorHardwareWalletCannotSwap,
     SendInsufficientBalanceFailure() =>
       context.loc.sendErrorInsufficientBalanceForPayment,
+    SendInsufficientFundsForFeesFailure() =>
+      context.loc.sendErrorInsufficientFundsForFees,
     SendAmountOutOfBoundsFailure(:final minimumSat?) =>
       context.loc.sendErrorAmountBelowMinimum(minimumSat.toString()),
     SendAmountOutOfBoundsFailure(:final maximumSat?) =>

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/errors/send_errors.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
@@ -1633,7 +1634,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
 
   bool _isInsufficientFundsException(Object e) {
     return e is InsufficientFundsSwapException ||
-        e.toString().contains('InsufficientFundsException');
+        e is InsufficientFundsException;
   }
 
   Future<void> _onOrderSwapUpdated(

--- a/lib/features/swap/ui/pages/swap_in_progress_page.dart
+++ b/lib/features/swap/ui/pages/swap_in_progress_page.dart
@@ -24,6 +24,7 @@ class SwapInProgressPage extends StatelessWidget {
     );
 
     return PopScope(
+      canPop: false,
       onPopInvokedWithResult: (didPop, result) {
         if (didPop) {
           return;

--- a/lib/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart
+++ b/lib/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart
@@ -1,36 +1,27 @@
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart'
     show MnemonicSeedModel, SeedModel;
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
-import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 
 class VerifyPhysicalBackupUsecase {
-  final WalletRepository _walletRepository;
   final SeedRepository _seedRepository;
-  VerifyPhysicalBackupUsecase({
-    required this._walletRepository,
-    required this._seedRepository,
-  });
 
-  Future<bool> execute(List<String> mnemonic) async {
+  VerifyPhysicalBackupUsecase({required this._seedRepository});
+
+  /// Compares [mnemonic] against the seed stored for [fingerprint].
+  ///
+  /// The stored secret is read at the point of use and never leaves this
+  /// method; only the comparison result is returned.
+  Future<bool> execute({
+    required String fingerprint,
+    required List<String> mnemonic,
+  }) async {
     try {
-      final defaultWallets = await _walletRepository.getWallets(
-        onlyDefaults: true,
-        onlyBitcoin: true,
-        environment: Environment.mainnet,
-      );
-      if (defaultWallets.isEmpty) {
-        throw Exception('No default wallet found');
-      }
-      final defaultWallet = defaultWallets.first;
-      final defaultFingerprint = defaultWallet.masterFingerprint;
-      final defaultSeed = await _seedRepository.get(defaultFingerprint);
-
-      final defaultSeedModel = SeedModel.fromEntity(defaultSeed);
-      final mnemonicWords = switch (defaultSeedModel) {
+      final seed = await _seedRepository.get(fingerprint);
+      final seedModel = SeedModel.fromEntity(seed);
+      final mnemonicWords = switch (seedModel) {
         MnemonicSeedModel(:final mnemonicWords) => mnemonicWords,
-        _ => throw Exception('Default seed is not a mnemonic seed'),
+        _ => throw Exception('Selected seed is not a mnemonic seed'),
       };
 
       return mnemonic.length == mnemonicWords.length &&

--- a/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart
+++ b/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/onboarding/complete_physical_backup_verification_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/get_mnemonic_from_fingerprint_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_wallets_for_network_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -13,96 +14,42 @@ part 'test_wallet_backup_state.dart';
 
 class TestWalletBackupBloc
     extends Bloc<TestWalletBackupEvent, TestWalletBackupState> {
-  TestWalletBackupBloc({
-    required this._completePhysicalBackupVerificationUsecase,
-    required this._loadWalletsForNetworkUsecase,
-    required this._getMnemonicFromFingerprintUsecase,
-  }) : super(const TestWalletBackupState()) {
-    on<OnWordsSelected>(_onWordsSelected);
-    on<VerifyPhysicalBackup>(_verifyPhysicalBackup);
-    on<StartPhysicalBackupVerification>((event, emit) {});
-    on<LoadWallets>(_onLoadWallets);
-    on<LoadMnemonicForWallet>(_onLoadMnemonicForWallet);
-    on<ClearError>((event, emit) => emit(state.copyWith(statusError: '')));
-  }
-
   final CompletePhysicalBackupVerificationUsecase
   _completePhysicalBackupVerificationUsecase;
   final LoadWalletsForNetworkUsecase _loadWalletsForNetworkUsecase;
   final GetMnemonicFromFingerprintUsecase _getMnemonicFromFingerprintUsecase;
+  final VerifyPhysicalBackupUsecase _verifyPhysicalBackupUsecase;
 
-  /// Handles word selection during backup verification
-  /// Validates word order and updates test state
-  Future<void> _onWordsSelected(
-    OnWordsSelected event,
-    Emitter<TestWalletBackupState> emit,
-  ) async {
-    final mnemonic = state.mnemonic;
-    final reorderedMnemonic = List<String>.from(
-      state.reorderedMnemonic + [event.word],
-    );
-
-    final isCorrect = mnemonic
-        .join(' ')
-        .startsWith(reorderedMnemonic.join(' '));
-
-    if (isCorrect) {
-      emit(
+  TestWalletBackupBloc({
+    required this._completePhysicalBackupVerificationUsecase,
+    required this._loadWalletsForNetworkUsecase,
+    required this._getMnemonicFromFingerprintUsecase,
+    required this._verifyPhysicalBackupUsecase,
+  }) : super(const TestWalletBackupState()) {
+    on<LoadWallets>(_onLoadWallets);
+    on<WalletSelected>(_onWalletSelected);
+    on<VerifyPhysicalBackup>(_verifyPhysicalBackup);
+    on<ClearError>(
+      (event, emit) => emit(
         state.copyWith(
-          reorderedMnemonic: [...state.reorderedMnemonic, event.word],
           statusError: '',
-          selectedMnemonicWords: [...state.selectedMnemonicWords, event.index],
+          verificationStatus: BackupVerificationStatus.idle,
         ),
-      );
-    } else {
-      final shuffled = List<String>.from(mnemonic)..shuffle();
-      emit(
-        state.copyWith(
-          shuffledMnemonic: shuffled,
-          reorderedMnemonic: [],
-          selectedMnemonicWords: [],
-          statusError: 'Incorrect word order. Please try again.',
-        ),
-      );
-    }
+      ),
+    );
   }
 
-  Future<void> _verifyPhysicalBackup(
-    VerifyPhysicalBackup event,
-    Emitter<TestWalletBackupState> emit,
-  ) async {
-    try {
-      if (state.mnemonic.isEmpty) {
-        emit(state.copyWith(statusError: 'No mnemonic loaded'));
-        return;
-      }
-
-      if (state.reorderedMnemonic.length != state.mnemonic.length) {
-        emit(state.copyWith(statusError: 'Please select all words'));
-        return;
-      }
-
-      // Compare with original mnemonic
-      final isCorrect =
-          state.mnemonic.join(' ') == state.reorderedMnemonic.join(' ');
-
-      if (isCorrect) {
-        await _completePhysicalBackupVerificationUsecase.execute();
-      } else {
-        // Reset test state when wrong
-        final shuffled = state.mnemonic.toList()..shuffle();
-        emit(
-          state.copyWith(
-            statusError: 'Incorrect word order. Please try again.',
-            shuffledMnemonic: shuffled,
-            reorderedMnemonic: [],
-            selectedMnemonicWords: [],
-          ),
-        );
-      }
-    } catch (e) {
-      emit(state.copyWith(statusError: 'Verification failed: $e'));
+  /// Reads the selected wallet's secret at the point of use.
+  ///
+  /// The mnemonic and passphrase are returned directly to the caller and are
+  /// never held in bloc state: secrets must stay ephemeral and must never
+  /// appear in the freezed `toString()` of the state.
+  Future<(List<String>, String?)> loadSelectedWalletMnemonic() {
+    final wallet = state.selectedWallet;
+    if (wallet == null) {
+      throw Exception('No wallet selected');
     }
+    return _getMnemonicFromFingerprintUsecase.execute(wallet.masterFingerprint);
   }
 
   Future<void> _onLoadWallets(
@@ -110,49 +57,68 @@ class TestWalletBackupBloc
     Emitter<TestWalletBackupState> emit,
   ) async {
     try {
-      emit(state.copyWith(selectedWallet: null));
-
       final wallets = await _loadWalletsForNetworkUsecase.execute();
       if (wallets.isEmpty) throw Exception('No wallets found');
       final Wallet selected = wallets.firstWhere(
         (w) => w.isDefault,
         orElse: () => wallets.first,
       );
-      emit(state.copyWith(wallets: wallets, selectedWallet: selected));
-
-      add(LoadMnemonicForWallet(wallet: selected));
+      emit(
+        state.copyWith(
+          wallets: wallets,
+          selectedWallet: selected,
+          verificationStatus: BackupVerificationStatus.idle,
+        ),
+      );
     } catch (e) {
       emit(state.copyWith(statusError: 'Failed to load wallets: $e'));
     }
   }
 
-  Future<void> _onLoadMnemonicForWallet(
-    LoadMnemonicForWallet event,
+  Future<void> _onWalletSelected(
+    WalletSelected event,
+    Emitter<TestWalletBackupState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        selectedWallet: event.wallet,
+        statusError: '',
+        verificationStatus: BackupVerificationStatus.idle,
+      ),
+    );
+  }
+
+  Future<void> _verifyPhysicalBackup(
+    VerifyPhysicalBackup event,
     Emitter<TestWalletBackupState> emit,
   ) async {
     try {
-      emit(state.copyWith(selectedWallet: null));
+      final wallet = state.selectedWallet;
+      if (wallet == null) {
+        emit(state.copyWith(statusError: 'No wallet selected'));
+        return;
+      }
 
-      final wallet = event.wallet;
-      final (
-        mnemonicWords,
-        passphrase,
-      ) = await _getMnemonicFromFingerprintUsecase.execute(
-        wallet.masterFingerprint,
+      final isCorrect = await _verifyPhysicalBackupUsecase.execute(
+        fingerprint: wallet.masterFingerprint,
+        mnemonic: event.reorderedWords,
       );
 
-      emit(
-        state.copyWith(
-          selectedWallet: wallet,
-          mnemonic: mnemonicWords,
-          passphrase: passphrase ?? '',
-          shuffledMnemonic: mnemonicWords.toList()..shuffle(),
-          reorderedMnemonic: [],
-          selectedMnemonicWords: [],
-        ),
-      );
+      if (isCorrect) {
+        await _completePhysicalBackupVerificationUsecase.execute();
+        emit(
+          state.copyWith(
+            verificationStatus: BackupVerificationStatus.success,
+            statusError: '',
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(verificationStatus: BackupVerificationStatus.failure),
+        );
+      }
     } catch (e) {
-      emit(state.copyWith(statusError: 'Failed to load mnemonic: $e'));
+      emit(state.copyWith(statusError: 'Verification failed: $e'));
     }
   }
 }

--- a/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_event.dart
+++ b/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_event.dart
@@ -4,27 +4,18 @@ sealed class TestWalletBackupEvent {
   const TestWalletBackupEvent();
 }
 
-class OnWordsSelected extends TestWalletBackupEvent {
-  const OnWordsSelected({required this.word, required this.index});
-  final String word;
-  final int index;
-}
-
-class StartPhysicalBackupVerification extends TestWalletBackupEvent {
-  const StartPhysicalBackupVerification();
-}
-
-class VerifyPhysicalBackup extends TestWalletBackupEvent {
-  const VerifyPhysicalBackup();
-}
-
 class LoadWallets extends TestWalletBackupEvent {
   const LoadWallets();
 }
 
-class LoadMnemonicForWallet extends TestWalletBackupEvent {
-  const LoadMnemonicForWallet({required this.wallet});
+class WalletSelected extends TestWalletBackupEvent {
+  const WalletSelected({required this.wallet});
   final Wallet wallet;
+}
+
+class VerifyPhysicalBackup extends TestWalletBackupEvent {
+  const VerifyPhysicalBackup({required this.reorderedWords});
+  final List<String> reorderedWords;
 }
 
 class ClearError extends TestWalletBackupEvent {

--- a/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_state.dart
+++ b/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_state.dart
@@ -1,16 +1,15 @@
 part of 'test_wallet_backup_bloc.dart';
 
+enum BackupVerificationStatus { idle, success, failure }
+
 @freezed
 abstract class TestWalletBackupState with _$TestWalletBackupState {
   const factory TestWalletBackupState({
-    @Default([]) List<String> mnemonic,
-    @Default('') String passphrase,
-    @Default([]) List<String> shuffledMnemonic,
-    @Default([]) List<String> reorderedMnemonic,
-    @Default([]) List<int> selectedMnemonicWords,
     @Default('') String statusError,
     @Default([]) List<Wallet> wallets,
     @Default(null) Wallet? selectedWallet,
+    @Default(BackupVerificationStatus.idle)
+    BackupVerificationStatus verificationStatus,
   }) = _TestWalletBackupState;
   const TestWalletBackupState._();
 }

--- a/lib/features/test_wallet_backup/test_wallet_backup_locator.dart
+++ b/lib/features/test_wallet_backup/test_wallet_backup_locator.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_backup_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/get_mnemonic_from_fingerprint_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_wallets_for_network_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
 import 'package:get_it/get_it.dart';
 
 class TestWalletBackupLocator {
@@ -16,6 +17,11 @@ class TestWalletBackupLocator {
     );
     locator.registerLazySingleton<GetMnemonicFromFingerprintUsecase>(
       () => GetMnemonicFromFingerprintUsecase(
+        seedRepository: locator<SeedRepository>(),
+      ),
+    );
+    locator.registerLazySingleton<VerifyPhysicalBackupUsecase>(
+      () => VerifyPhysicalBackupUsecase(
         seedRepository: locator<SeedRepository>(),
       ),
     );

--- a/lib/features/test_wallet_backup/ui/app_bar_widget.dart
+++ b/lib/features/test_wallet_backup/ui/app_bar_widget.dart
@@ -48,7 +48,7 @@ class AppBarWidget extends StatelessWidget {
               );
 
               if (selectedWalletId != null) {
-                bloc.add(LoadMnemonicForWallet(wallet: selectedWallet!));
+                bloc.add(WalletSelected(wallet: selectedWallet!));
               }
             },
           ),
@@ -119,7 +119,7 @@ Future<String?> _showWalletPicker({
               onPressed: () {
                 final wallet = wallets[controller.selectedItem];
                 context.read<TestWalletBackupBloc>().add(
-                  LoadMnemonicForWallet(wallet: wallet),
+                  WalletSelected(wallet: wallet),
                 );
                 Navigator.of(context).pop();
               },

--- a/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart
@@ -83,151 +83,195 @@ class _ShowMnemonicScreenState extends State<ShowMnemonicScreen>
   }
 }
 
-class _MnemonicDisplay extends StatelessWidget {
+/// Sealed secret display: the mnemonic and passphrase are read internally at
+/// the point of use and are never returned to callers nor stored in bloc
+/// state.
+class _MnemonicDisplay extends StatefulWidget {
   const _MnemonicDisplay();
 
   @override
-  Widget build(BuildContext context) {
-    final mnemonic = context.select(
-      (TestWalletBackupBloc bloc) => bloc.state.mnemonic,
-    );
+  State<_MnemonicDisplay> createState() => _MnemonicDisplayState();
+}
 
+class _MnemonicDisplayState extends State<_MnemonicDisplay> {
+  String? _fingerprint;
+  Future<(List<String>, String?)>? _secretFuture;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final fingerprint = context.select<TestWalletBackupBloc, String?>(
+      (bloc) => bloc.state.selectedWallet?.masterFingerprint,
+    );
+    if (fingerprint != _fingerprint) {
+      _fingerprint = fingerprint;
+      _secretFuture = fingerprint == null
+          ? null
+          : context.read<TestWalletBackupBloc>().loadSelectedWalletMnemonic();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final selectedWallet = context
         .watch<TestWalletBackupBloc>()
         .state
         .selectedWallet;
     final lastPhysicalBackup = selectedWallet?.latestPhysicalBackup;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      child: Column(
-        crossAxisAlignment: .stretch,
-        children: [
-          BBText(
-            context.loc.testBackupWriteDownPhrase,
-            textAlign: .center,
-            style: context.font.headlineLarge?.copyWith(
-              fontWeight: .w600,
-              color: context.appColors.text,
-            ),
-            maxLines: 2,
-          ),
-          const Gap(20),
-          BBText(
-            context.loc.testBackupStoreItSafe,
-            textAlign: .center,
-            style: context.font.labelMedium?.copyWith(
-              fontWeight: .w700,
-              color: context.appColors.textMuted,
-              letterSpacing: 0,
-              fontSize: 12,
-            ),
-          ),
-          if (lastPhysicalBackup != null) ...[
-            BBText(
-              context.loc.testBackupLastBackupTest(
-                lastPhysicalBackup.toString().substring(0, 19),
-              ),
-              textAlign: .center,
-              style: context.font.labelMedium?.copyWith(
-                fontWeight: .w700,
-                color: context.appColors.textMuted,
-                letterSpacing: 0,
-                fontSize: 12,
-              ),
-            ),
-          ],
-          const Gap(32),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              children: [
-                for (var i = 0; i < (mnemonic.length + 1) ~/ 2; i++)
-                  Row(
-                    children: [
-                      _RecoveryPhraseWord(index: i, number: i + 1),
-                      if (i + (mnemonic.length + 1) ~/ 2 < mnemonic.length)
-                        _RecoveryPhraseWord(
-                          index: i + (mnemonic.length + 1) ~/ 2,
-                          number: i + (mnemonic.length + 1) ~/ 2 + 1,
-                        )
-                      else
-                        const Expanded(child: SizedBox()),
-                    ],
-                  ),
+    return FutureBuilder<(List<String>, String?)>(
+      future: _secretFuture,
+      builder: (context, snapshot) {
+        final mnemonic = snapshot.data?.$1 ?? const <String>[];
+        final passphrase = snapshot.data?.$2 ?? '';
 
-                const _PassphraseWidget(),
-              ],
-            ),
-          ),
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(color: context.appColors.border),
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(11),
-                topRight: Radius.circular(11),
-                bottomLeft: Radius.circular(2),
-                bottomRight: Radius.circular(2),
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Column(
+            crossAxisAlignment: .stretch,
+            children: [
+              BBText(
+                context.loc.testBackupWriteDownPhrase,
+                textAlign: .center,
+                style: context.font.headlineLarge?.copyWith(
+                  fontWeight: .w600,
+                  color: context.appColors.text,
+                ),
+                maxLines: 2,
               ),
-            ),
-            child: Column(
-              children: [
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.symmetric(vertical: 10),
-                  decoration: BoxDecoration(
-                    color: context.appColors.secondaryFixedDim,
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(11),
-                      topRight: Radius.circular(11),
-                      bottomLeft: Radius.circular(2),
-                      bottomRight: Radius.circular(2),
-                    ),
-                  ),
-                  child: BBText(
-                    context.loc.testBackupDoNotShare,
-                    textAlign: .center,
-                    style: context.font.headlineMedium?.copyWith(
-                      fontWeight: .w500,
-                      fontSize: 16,
-                      color: context.appColors.secondary,
-                    ),
-                  ),
+              const Gap(20),
+              BBText(
+                context.loc.testBackupStoreItSafe,
+                textAlign: .center,
+                style: context.font.labelMedium?.copyWith(
+                  fontWeight: .w700,
+                  color: context.appColors.textMuted,
+                  letterSpacing: 0,
+                  fontSize: 12,
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 16,
+              ),
+              if (lastPhysicalBackup != null) ...[
+                BBText(
+                  context.loc.testBackupLastBackupTest(
+                    lastPhysicalBackup.toString().substring(0, 19),
                   ),
-                  child: Row(
-                    mainAxisAlignment: .spaceEvenly,
-                    children: [
-                      _buildWarningItem(
-                        icon: CupertinoIcons.check_mark,
-                        text: context.loc.testBackupTranscribe,
-                        iconColor: context.appColors.success,
-                        context: context,
-                      ),
-                      _buildWarningItem(
-                        icon: CupertinoIcons.xmark,
-                        text: context.loc.testBackupDigitalCopy,
-                        iconColor: context.appColors.error,
-                        context: context,
-                      ),
-                      _buildWarningItem(
-                        icon: CupertinoIcons.xmark,
-                        text: context.loc.testBackupScreenshot,
-                        iconColor: context.appColors.error,
-                        context: context,
-                      ),
-                    ],
+                  textAlign: .center,
+                  style: context.font.labelMedium?.copyWith(
+                    fontWeight: .w700,
+                    color: context.appColors.textMuted,
+                    letterSpacing: 0,
+                    fontSize: 12,
                   ),
                 ),
               ],
-            ),
+              const Gap(32),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Column(
+                  children: [
+                    if (snapshot.hasError)
+                      BBText(
+                        context.loc.oopsSomethingWentWrong,
+                        textAlign: .center,
+                        style: context.font.bodyLarge?.copyWith(
+                          color: context.appColors.error,
+                        ),
+                      )
+                    else if (!snapshot.hasData)
+                      const Center(child: CircularProgressIndicator())
+                    else ...[
+                      for (var i = 0; i < (mnemonic.length + 1) ~/ 2; i++)
+                        Row(
+                          children: [
+                            _RecoveryPhraseWord(
+                              number: i + 1,
+                              word: mnemonic[i],
+                            ),
+                            if (i + (mnemonic.length + 1) ~/ 2 <
+                                mnemonic.length)
+                              _RecoveryPhraseWord(
+                                number: i + (mnemonic.length + 1) ~/ 2 + 1,
+                                word: mnemonic[i + (mnemonic.length + 1) ~/ 2],
+                              )
+                            else
+                              const Expanded(child: SizedBox()),
+                          ],
+                        ),
+                      _PassphraseWidget(passphrase: passphrase),
+                    ],
+                  ],
+                ),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: context.appColors.border),
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(11),
+                    topRight: Radius.circular(11),
+                    bottomLeft: Radius.circular(2),
+                    bottomRight: Radius.circular(2),
+                  ),
+                ),
+                child: Column(
+                  children: [
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.symmetric(vertical: 10),
+                      decoration: BoxDecoration(
+                        color: context.appColors.secondaryFixedDim,
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(11),
+                          topRight: Radius.circular(11),
+                          bottomLeft: Radius.circular(2),
+                          bottomRight: Radius.circular(2),
+                        ),
+                      ),
+                      child: BBText(
+                        context.loc.testBackupDoNotShare,
+                        textAlign: .center,
+                        style: context.font.headlineMedium?.copyWith(
+                          fontWeight: .w500,
+                          fontSize: 16,
+                          color: context.appColors.secondary,
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 16,
+                      ),
+                      child: Row(
+                        mainAxisAlignment: .spaceEvenly,
+                        children: [
+                          _buildWarningItem(
+                            icon: CupertinoIcons.check_mark,
+                            text: context.loc.testBackupTranscribe,
+                            iconColor: context.appColors.success,
+                            context: context,
+                          ),
+                          _buildWarningItem(
+                            icon: CupertinoIcons.xmark,
+                            text: context.loc.testBackupDigitalCopy,
+                            iconColor: context.appColors.error,
+                            context: context,
+                          ),
+                          _buildWarningItem(
+                            icon: CupertinoIcons.xmark,
+                            text: context.loc.testBackupScreenshot,
+                            iconColor: context.appColors.error,
+                            context: context,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -255,19 +299,13 @@ class _MnemonicDisplay extends StatelessWidget {
 }
 
 class _RecoveryPhraseWord extends StatelessWidget {
-  const _RecoveryPhraseWord({required this.index, required this.number});
+  const _RecoveryPhraseWord({required this.number, required this.word});
 
-  final int index;
   final int number;
+  final String word;
 
   @override
   Widget build(BuildContext context) {
-    final mnemonic = context.select(
-      (TestWalletBackupBloc bloc) => bloc.state.mnemonic,
-    );
-
-    final word = index < mnemonic.length ? mnemonic[index] : '';
-
     return Expanded(
       child: Container(
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 20),
@@ -335,14 +373,12 @@ class _RecoveryPhraseWord extends StatelessWidget {
 }
 
 class _PassphraseWidget extends StatelessWidget {
-  const _PassphraseWidget();
+  const _PassphraseWidget({required this.passphrase});
+
+  final String passphrase;
 
   @override
   Widget build(BuildContext context) {
-    final passphrase = context.select(
-      (TestWalletBackupBloc bloc) => bloc.state.passphrase,
-    );
-
     if (passphrase.isEmpty) return const SizedBox.shrink();
 
     return Container(

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -21,6 +21,79 @@ class VerifyMnemonicScreen extends StatefulWidget {
 
 class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
     with PrivacyScreen {
+  /// The secret lives only in this ephemeral widget state — never in bloc
+  /// state, so it can never leak through the freezed `toString()` or logs.
+  List<String> _mnemonic = [];
+  List<String> _shuffled = [];
+  List<int> _selectedIndices = [];
+  String? _fingerprint;
+  bool _isLoading = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final fingerprint = context.select<TestWalletBackupBloc, String?>(
+      (bloc) => bloc.state.selectedWallet?.masterFingerprint,
+    );
+    if (fingerprint != _fingerprint) {
+      _fingerprint = fingerprint;
+      unawaited(_loadSecret());
+    }
+  }
+
+  Future<void> _loadSecret() async {
+    setState(() => _isLoading = true);
+    try {
+      final (mnemonic, _) = await context
+          .read<TestWalletBackupBloc>()
+          .loadSelectedWalletMnemonic();
+      if (!mounted) return;
+      setState(() {
+        _mnemonic = mnemonic;
+        _shuffled = [...mnemonic]..shuffle();
+        _selectedIndices = [];
+        _isLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+    }
+  }
+
+  void _resetGame() {
+    setState(() {
+      _shuffled = [..._mnemonic]..shuffle();
+      _selectedIndices = [];
+    });
+  }
+
+  void _onWordTap(int index) {
+    final word = _shuffled[index];
+    final candidate = [for (final i in _selectedIndices) _shuffled[i], word];
+
+    final isCorrectSoFar = List.generate(
+      candidate.length,
+      (i) => candidate[i] == _mnemonic[i],
+    ).every((e) => e);
+
+    if (!isCorrectSoFar) {
+      _resetGame();
+      SnackBarUtils.showSnackBar(
+        context,
+        context.loc.testBackupErrorIncorrectOrder,
+      );
+      return;
+    }
+
+    setState(() => _selectedIndices.add(index));
+
+    if (candidate.length == _mnemonic.length) {
+      context.read<TestWalletBackupBloc>().add(
+        VerifyPhysicalBackup(reorderedWords: candidate),
+      );
+    }
+  }
+
   @override
   void dispose() {
     unawaited(disableScreenPrivacy());
@@ -34,26 +107,31 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
       builder: (context, snapshot) {
         return BlocConsumer<TestWalletBackupBloc, TestWalletBackupState>(
           listenWhen: (previous, current) =>
-              (previous.reorderedMnemonic.length != current.mnemonic.length &&
-                  current.reorderedMnemonic.length ==
-                      current.mnemonic.length) ||
+              previous.verificationStatus != current.verificationStatus ||
               (previous.statusError.isEmpty && current.statusError.isNotEmpty),
           listener: (context, state) {
             if (state.statusError.isNotEmpty) {
               SnackBarUtils.showSnackBar(context, state.statusError);
               context.read<TestWalletBackupBloc>().add(const ClearError());
-            } else if (state.reorderedMnemonic.length ==
-                    state.mnemonic.length &&
-                state.statusError.isEmpty) {
-              // Verify and save backup completion before navigating
-              context.read<TestWalletBackupBloc>().add(
-                const VerifyPhysicalBackup(),
-              );
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const BackupTestSuccessScreen(),
-                ),
-              );
+              return;
+            }
+            switch (state.verificationStatus) {
+              case BackupVerificationStatus.success:
+                context.read<TestWalletBackupBloc>().add(const ClearError());
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const BackupTestSuccessScreen(),
+                  ),
+                );
+              case BackupVerificationStatus.failure:
+                _resetGame();
+                SnackBarUtils.showSnackBar(
+                  context,
+                  context.loc.testBackupErrorIncorrectOrder,
+                );
+                context.read<TestWalletBackupBloc>().add(const ClearError());
+              case BackupVerificationStatus.idle:
+                break;
             }
           },
           builder: (context, state) {
@@ -61,19 +139,10 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
                 ? context.loc.testBackupDefaultWallets
                 : state.selectedWallet?.displayLabel(context) ?? '';
             final title = context.loc.testBackupWalletTitle(walletName);
-            final reorderedMnemonic = context
-                .watch<TestWalletBackupBloc>()
-                .state
-                .reorderedMnemonic;
-            final mnemonic = context
-                .watch<TestWalletBackupBloc>()
-                .state
-                .mnemonic;
 
-            final nextWordNumber = reorderedMnemonic.isEmpty
-                ? 1
-                : reorderedMnemonic.length + 1;
-            final showPrompt = reorderedMnemonic.length < mnemonic.length;
+            final nextWordNumber = _selectedIndices.length + 1;
+            final showPrompt = _selectedIndices.length < _mnemonic.length;
+
             return Scaffold(
               backgroundColor: context.appColors.onSecondary,
               appBar: PreferredSize(
@@ -126,8 +195,14 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
                           ),
                         ),
                       const Gap(16),
-
-                      const _ShuffledMnemonicGrid(),
+                      if (_isLoading)
+                        const Center(child: CircularProgressIndicator())
+                      else
+                        _ShuffledMnemonicGrid(
+                          shuffled: _shuffled,
+                          selectedIndices: _selectedIndices,
+                          onWordTap: _onWordTap,
+                        ),
                     ],
                   ),
                 ),
@@ -141,34 +216,38 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
 }
 
 class _ShuffledMnemonicGrid extends StatelessWidget {
-  const _ShuffledMnemonicGrid();
+  const _ShuffledMnemonicGrid({
+    required this.shuffled,
+    required this.selectedIndices,
+    required this.onWordTap,
+  });
+
+  final List<String> shuffled;
+  final List<int> selectedIndices;
+  final ValueChanged<int> onWordTap;
 
   @override
   Widget build(BuildContext context) {
-    final shuffledMnemonic = context
-        .watch<TestWalletBackupBloc>()
-        .state
-        .shuffledMnemonic;
-
     return Column(
       children: [
-        for (var i = 0; i < (shuffledMnemonic.length + 1) ~/ 2; i++)
+        for (var i = 0; i < (shuffled.length + 1) ~/ 2; i++)
           Row(
             children: [
               Expanded(
                 child: _ShuffledMnemonicWord(
                   index: i,
-                  word: shuffledMnemonic[i],
+                  word: shuffled[i],
+                  selectedIndices: selectedIndices,
+                  onTap: onWordTap,
                 ),
               ),
-              if (i + (shuffledMnemonic.length + 1) ~/ 2 <
-                  shuffledMnemonic.length)
+              if (i + (shuffled.length + 1) ~/ 2 < shuffled.length)
                 Expanded(
                   child: _ShuffledMnemonicWord(
-                    index: i + (shuffledMnemonic.length + 1) ~/ 2,
-                    word:
-                        shuffledMnemonic[i +
-                            (shuffledMnemonic.length + 1) ~/ 2],
+                    index: i + (shuffled.length + 1) ~/ 2,
+                    word: shuffled[i + (shuffled.length + 1) ~/ 2],
+                    selectedIndices: selectedIndices,
+                    onTap: onWordTap,
                   ),
                 )
               else
@@ -181,27 +260,25 @@ class _ShuffledMnemonicGrid extends StatelessWidget {
 }
 
 class _ShuffledMnemonicWord extends StatelessWidget {
-  const _ShuffledMnemonicWord({required this.word, required this.index});
+  const _ShuffledMnemonicWord({
+    required this.word,
+    required this.index,
+    required this.selectedIndices,
+    required this.onTap,
+  });
+
   final int index;
   final String word;
+  final List<int> selectedIndices;
+  final ValueChanged<int> onTap;
 
   @override
   Widget build(BuildContext context) {
-    final selectedMnemonicWords = context
-        .watch<TestWalletBackupBloc>()
-        .state
-        .selectedMnemonicWords;
-    final isSelected = selectedMnemonicWords.contains(index);
-    final selectedWordNumber = selectedMnemonicWords.indexOf(index) + 1;
+    final isSelected = selectedIndices.contains(index);
+    final selectedWordNumber = selectedIndices.indexOf(index) + 1;
 
     return InkWell(
-      onTap: isSelected
-          ? null
-          : () {
-              context.read<TestWalletBackupBloc>().add(
-                OnWordsSelected(word: word, index: index),
-              );
-            },
+      onTap: isSelected ? null : () => onTap(index),
       splashColor: context.appColors.transparent,
       child: Container(
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 20),

--- a/lib/features/test_wallet_backup/ui/test_wallet_backup_router.dart
+++ b/lib/features/test_wallet_backup/ui/test_wallet_backup_router.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/features/onboarding/complete_physical_backup_verification_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/get_mnemonic_from_fingerprint_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_wallets_for_network_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/flow.dart';
 import 'package:bb_mobile/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart';
 import 'package:bb_mobile/locator.dart';
@@ -31,6 +32,7 @@ class TestWalletBackupRouter {
           loadWalletsForNetworkUsecase: locator<LoadWalletsForNetworkUsecase>(),
           getMnemonicFromFingerprintUsecase:
               locator<GetMnemonicFromFingerprintUsecase>(),
+          verifyPhysicalBackupUsecase: locator<VerifyPhysicalBackupUsecase>(),
           completePhysicalBackupVerificationUsecase:
               locator<CompletePhysicalBackupVerificationUsecase>(),
         )..add(const LoadWallets()),

--- a/lib/features/transactions/application/usecases/get_transactions_by_tx_id_usecase.dart
+++ b/lib/features/transactions/application/usecases/get_transactions_by_tx_id_usecase.dart
@@ -99,7 +99,9 @@ class GetTransactionsByTxIdUsecase {
       } else if (orderSwap != null) {
         return [Transaction(orderSwap: orderSwap)];
       } else if (payjoins.isNotEmpty) {
-        return payjoins.map((pj) => Transaction(payjoin: pj)).toList();
+        return payjoins
+            .map((pj) => Transaction(payjoin: pj, order: order))
+            .toList();
       } else if (order != null) {
         return [Transaction(order: order)];
       } else {

--- a/lib/features/transactions/application/usecases/get_transactions_usecase.dart
+++ b/lib/features/transactions/application/usecases/get_transactions_usecase.dart
@@ -140,7 +140,9 @@ class GetTransactionsUsecase {
             Order? order;
             try {
               order = orders.firstWhere((o) {
-                if (o.transactionId != wt.txId) return false;
+                if (![o.transactionId, o.payjoin?.txid].contains(wt.txId)) {
+                  return false;
+                }
                 if (o.toAddress != null && o.toAddress != wt.toAddress) {
                   return false;
                 }

--- a/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
+++ b/lib/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart
@@ -804,7 +804,10 @@ class TransactionDetailsCubit extends Cubit<TransactionDetailsState> {
 
       // Check if a transaction with the same transaction ID can be found
       // and initialize the transaction details with it.
-      final txId = order.transactionId;
+      // The payjoin txid is the fallback: the exchange can know the payjoin it
+      // broadcast before it reports its own payout txid, and without this the
+      // screen would sit on order-only details until that txid lands.
+      final txId = order.transactionId ?? order.payjoin?.txid;
       if (txId != null) {
         try {
           final txs = await _getTransactionsByTxIdUsecase.execute(txId);

--- a/lib/features/transactions/ui/screens/transaction_details_screen.dart
+++ b/lib/features/transactions/ui/screens/transaction_details_screen.dart
@@ -40,6 +40,24 @@ class TransactionDetailsScreen extends StatelessWidget {
     final returnToExchange =
         GoRouterState.of(context).uri.queryParameters['returnToExchange'] ==
         'true';
+
+    void closeScreen() {
+      if (returnToExchange) {
+        context.goNamed(ExchangeRoute.exchangeHome.name);
+      } else if (returnHome) {
+        context.goNamed(WalletRoute.walletHome.name);
+      } else if (context.canPop()) {
+        context.pop();
+      } else {
+        context.goNamed(WalletRoute.walletHome.name);
+      }
+    }
+
+    // A flow that `go`es here leaves this screen alone on the stack, so back
+    // had nothing to pop and closed the app. Veto the pop in that case and let
+    // closeScreen navigate; when there is a route below, back still pops.
+    final canPopBack = context.canPop();
+
     final isLoading = context.select(
       (TransactionDetailsCubit cubit) => cubit.state.isLoading,
     );
@@ -67,195 +85,199 @@ class TransactionDetailsScreen extends StatelessWidget {
     final orderSwap = tx?.orderSwap;
     final isChainSwap = tx?.isChainSwap ?? false;
 
-    return Scaffold(
-      appBar: AppBar(
-        forceMaterialTransparency: true,
-        automaticallyImplyLeading: false,
-        flexibleSpace: TopBar(
-          title: isOngoingSwap == true
-              ? (isChainSwap
-                    ? context.loc.transactionDetailTransferProgress
-                    : context.loc.transactionDetailSwapProgress)
-              : context.loc.transactionDetailTitle,
-          actionIcon: Icons.close,
-          onAction: () {
-            if (returnToExchange) {
-              context.goNamed(ExchangeRoute.exchangeHome.name);
-            } else if (returnHome) {
-              context.goNamed(WalletRoute.walletHome.name);
-            } else if (context.canPop()) {
-              context.pop();
-            } else {
-              context.goNamed(WalletRoute.walletHome.name);
-            }
-          },
-        ),
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(3.0),
-          child: FadingLinearProgress(
-            trigger: isBroadcastingPayjoinOriginalTx,
-            backgroundColor: context.appColors.onPrimary,
-            foregroundColor: context.appColors.primary,
+    return PopScope(
+      canPop: canPopBack,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+
+        closeScreen();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          forceMaterialTransparency: true,
+          automaticallyImplyLeading: false,
+          flexibleSpace: TopBar(
+            title: isOngoingSwap == true
+                ? (isChainSwap
+                      ? context.loc.transactionDetailTransferProgress
+                      : context.loc.transactionDetailSwapProgress)
+                : context.loc.transactionDetailTitle,
+            actionIcon: Icons.close,
+            onAction: closeScreen,
+          ),
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(3.0),
+            child: FadingLinearProgress(
+              trigger: isBroadcastingPayjoinOriginalTx,
+              backgroundColor: context.appColors.onPrimary,
+              foregroundColor: context.appColors.primary,
+            ),
           ),
         ),
-      ),
-      body: SafeArea(
-        child: BBRefreshIndicator(
-          onRefresh: () => context.read<TransactionDetailsCubit>().refresh(),
-          child: CustomScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            slivers: [
-              if (hasLoadError)
-                const SliverFillRemaining(
-                  hasScrollBody: false,
-                  child: _LoadErrorContent(),
-                )
-              else
-                SliverPadding(
-                  padding: const EdgeInsets.all(16),
-                  sliver: SliverToBoxAdapter(
-                    child: Center(
-                      child: Column(
-                        children: [
-                          if (isLoading)
-                            const LoadingBoxContent(height: 72, width: 72)
-                          else
-                            TransactionDirectionBadge(
-                              isIncoming: isIncoming ?? false,
-                              isSwap: isChainSwap,
-                            ),
-                          const Gap(24),
-                          if (isLoading)
-                            const LoadingLineContent(width: 150)
-                          else
-                            const TransactionDetailsStatusLabel(),
-                          if (isOngoingSwap == true && swap != null) ...[
-                            const Gap(8),
-                            SwapProgressIndicator(swap: swap),
-                          ],
-                          if (isLoading)
-                            const LoadingLineContent(
-                              height: 24,
-                              width: 200,
-                              padding: EdgeInsets.zero,
-                            )
-                          else
-                            const TransactionDetailsAmount(),
-                          const Gap(16),
-                          if (isOngoingSwap == true && swap != null) ...[
-                            SwapStatusDescription(swap: swap),
+        body: SafeArea(
+          child: BBRefreshIndicator(
+            onRefresh: () => context.read<TransactionDetailsCubit>().refresh(),
+            child: CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                if (hasLoadError)
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: _LoadErrorContent(),
+                  )
+                else
+                  SliverPadding(
+                    padding: const EdgeInsets.all(16),
+                    sliver: SliverToBoxAdapter(
+                      child: Center(
+                        child: Column(
+                          children: [
+                            if (isLoading)
+                              const LoadingBoxContent(height: 72, width: 72)
+                            else
+                              TransactionDirectionBadge(
+                                isIncoming: isIncoming ?? false,
+                                isSwap: isChainSwap,
+                              ),
+                            const Gap(24),
+                            if (isLoading)
+                              const LoadingLineContent(width: 150)
+                            else
+                              const TransactionDetailsStatusLabel(),
+                            if (isOngoingSwap == true && swap != null) ...[
+                              const Gap(8),
+                              SwapProgressIndicator(swap: swap),
+                            ],
+                            if (isLoading)
+                              const LoadingLineContent(
+                                height: 24,
+                                width: 200,
+                                padding: EdgeInsets.zero,
+                              )
+                            else
+                              const TransactionDetailsAmount(),
                             const Gap(16),
-                          ],
-                          if (isOngoingSwap == true && orderSwap != null) ...[
-                            OrderSwapStatusDescription(orderSwap: orderSwap),
-                            const Gap(16),
-                          ],
-                          if (isOrderType &&
-                              tx?.isBuyOrder == true &&
-                              tx?.order != null &&
-                              (tx!.order! as BuyOrder).bitcoinAddress != null &&
-                              tx.order!.sentAt == null) ...[
-                            AccelerateTransactionListTile(
-                              orderId: tx.order!.orderId,
-                              onTap: () {
-                                context.pushNamed(
-                                  BuyRoute.buyAccelerate.name,
-                                  pathParameters: {
-                                    'orderId': tx.order!.orderId,
-                                  },
-                                );
-                              },
-                            ),
-                            const Gap(16),
-                          ],
-                          if (isLoading)
-                            const LoadingBoxContent(height: 400)
-                          else
-                            const TransactionDetailsTable(),
-                          if (tx?.order is FiatPaymentOrder &&
-                              (tx!.order! as FiatPaymentOrder).payoutMethod ==
-                                  OrderPaymentMethod.sinpe &&
-                              (tx.order! as FiatPaymentOrder).payoutCurrency ==
-                                  'CRC') ...[
-                            const Gap(16),
-                            BBButton.big(
-                              label: context.loc.payViewReceipt,
-                              onPressed: () {
-                                showSinpeReceiptBottomSheet(
-                                  context,
-                                  tx.order! as FiatPaymentOrder,
-                                );
-                              },
-                              bgColor: context.appColors.secondary,
-                              textColor: context.appColors.onSecondary,
-                            ),
-                          ],
-                          const Gap(16),
-                          if (payjoin != null)
-                            BroadcastPayjoinOriginalTxButton(payjoin: payjoin),
-                          if (isLoading)
-                            const LoadingLineContent(height: 40)
-                          else
-                            BBButton.big(
-                              label: context.loc.transactionDetailAddNote,
-                              disabled:
-                                  !(walletTransaction != null &&
-                                      walletTransaction.labels.length < 10),
-                              onPressed: () async {
-                                if (walletTransaction == null ||
-                                    walletTransaction.labels.length >= 10) {
-                                  log.warning(
-                                    'A transaction can have up to 10 labels, current length: ${walletTransaction?.labels.length}',
+                            if (isOngoingSwap == true && swap != null) ...[
+                              SwapStatusDescription(swap: swap),
+                              const Gap(16),
+                            ],
+                            if (isOngoingSwap == true && orderSwap != null) ...[
+                              OrderSwapStatusDescription(orderSwap: orderSwap),
+                              const Gap(16),
+                            ],
+                            if (isOrderType &&
+                                tx?.isBuyOrder == true &&
+                                tx?.order != null &&
+                                (tx!.order! as BuyOrder).bitcoinAddress !=
+                                    null &&
+                                tx.order!.sentAt == null) ...[
+                              AccelerateTransactionListTile(
+                                orderId: tx.order!.orderId,
+                                onTap: () {
+                                  context.pushNamed(
+                                    BuyRoute.buyAccelerate.name,
+                                    pathParameters: {
+                                      'orderId': tx.order!.orderId,
+                                    },
                                   );
-                                  return;
-                                }
-                                final cubit = context
-                                    .read<TransactionDetailsCubit>();
-                                final saved = await LabelEntryBottomSheet.label(
-                                  context,
-                                  title: context.loc.transactionNoteAddTitle,
-                                  suggestionsFuture: cubit
-                                      .fetchDistinctLabels(),
-                                  hint: context.loc.transactionNoteHint,
-                                );
-                                if (saved == null || !context.mounted) return;
-                                cubit.saveTransactionLabel(
-                                  NewLabel.tx(
-                                    transactionId: walletTransaction.txId,
-                                    label: saved,
-                                  ),
-                                );
-                              },
-                              bgColor: context.appColors.transparent,
-                              textColor: context.appColors.onSurface,
-                              outlined: true,
-                              borderColor: context.appColors.onSurface,
-                            ),
-                          const Gap(16),
-                          if (isOutgoing == true &&
-                              walletTransaction?.isConfirmed == false &&
-                              walletTransaction?.isRbf == true &&
-                              walletTransaction?.isBitcoin == true &&
-                              wallet?.signsLocally == true &&
-                              tx?.txId != null &&
-                              tx?.isSwap != true)
-                            BBButton.big(
-                              label: context.loc.transactionDetailAccelerate,
-                              onPressed: () {
-                                context.pushNamed(
-                                  ReplaceByFeeRoute.replaceByFeeFlow.name,
-                                  extra: walletTransaction,
-                                );
-                              },
-                              bgColor: context.appColors.onSurface,
-                              textColor: context.appColors.surface,
-                            ),
-                        ],
+                                },
+                              ),
+                              const Gap(16),
+                            ],
+                            if (isLoading)
+                              const LoadingBoxContent(height: 400)
+                            else
+                              const TransactionDetailsTable(),
+                            if (tx?.order is FiatPaymentOrder &&
+                                (tx!.order! as FiatPaymentOrder).payoutMethod ==
+                                    OrderPaymentMethod.sinpe &&
+                                (tx.order! as FiatPaymentOrder)
+                                        .payoutCurrency ==
+                                    'CRC') ...[
+                              const Gap(16),
+                              BBButton.big(
+                                label: context.loc.payViewReceipt,
+                                onPressed: () {
+                                  showSinpeReceiptBottomSheet(
+                                    context,
+                                    tx.order! as FiatPaymentOrder,
+                                  );
+                                },
+                                bgColor: context.appColors.secondary,
+                                textColor: context.appColors.onSecondary,
+                              ),
+                            ],
+                            const Gap(16),
+                            if (payjoin != null)
+                              BroadcastPayjoinOriginalTxButton(
+                                payjoin: payjoin,
+                              ),
+                            if (isLoading)
+                              const LoadingLineContent(height: 40)
+                            else
+                              BBButton.big(
+                                label: context.loc.transactionDetailAddNote,
+                                disabled:
+                                    !(walletTransaction != null &&
+                                        walletTransaction.labels.length < 10),
+                                onPressed: () async {
+                                  if (walletTransaction == null ||
+                                      walletTransaction.labels.length >= 10) {
+                                    log.warning(
+                                      'A transaction can have up to 10 labels, current length: ${walletTransaction?.labels.length}',
+                                    );
+                                    return;
+                                  }
+                                  final cubit = context
+                                      .read<TransactionDetailsCubit>();
+                                  final saved =
+                                      await LabelEntryBottomSheet.label(
+                                        context,
+                                        title:
+                                            context.loc.transactionNoteAddTitle,
+                                        suggestionsFuture: cubit
+                                            .fetchDistinctLabels(),
+                                        hint: context.loc.transactionNoteHint,
+                                      );
+                                  if (saved == null || !context.mounted) return;
+                                  cubit.saveTransactionLabel(
+                                    NewLabel.tx(
+                                      transactionId: walletTransaction.txId,
+                                      label: saved,
+                                    ),
+                                  );
+                                },
+                                bgColor: context.appColors.transparent,
+                                textColor: context.appColors.onSurface,
+                                outlined: true,
+                                borderColor: context.appColors.onSurface,
+                              ),
+                            const Gap(16),
+                            if (isOutgoing == true &&
+                                walletTransaction?.isConfirmed == false &&
+                                walletTransaction?.isRbf == true &&
+                                walletTransaction?.isBitcoin == true &&
+                                wallet?.signsLocally == true &&
+                                tx?.txId != null &&
+                                tx?.isSwap != true)
+                              BBButton.big(
+                                label: context.loc.transactionDetailAccelerate,
+                                onPressed: () {
+                                  context.pushNamed(
+                                    ReplaceByFeeRoute.replaceByFeeFlow.name,
+                                    extra: walletTransaction,
+                                  );
+                                },
+                                bgColor: context.appColors.onSurface,
+                                textColor: context.appColors.surface,
+                              ),
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/transactions/ui/widgets/transaction_details_table.dart
+++ b/lib/features/transactions/ui/widgets/transaction_details_table.dart
@@ -212,6 +212,7 @@ class TransactionDetailsTable extends StatelessWidget {
             DetailsTableItem(
               label: context.loc.transactionDetailLabelOrderNumber,
               displayValue: orderSwap.order!.orderNumber.toString(),
+              copyValue: orderSwap.order!.orderNumber.toString(),
             ),
           DetailsTableItem(
             label: context.loc.transactionDetailLabelPayinAmount,

--- a/packages/bull_payjoin/test/payjoin_expiry_uri_test.dart
+++ b/packages/bull_payjoin/test/payjoin_expiry_uri_test.dart
@@ -1,0 +1,129 @@
+import 'dart:typed_data';
+
+import 'package:bull_payjoin/src/engine/pdk_payjoin_datasource.dart';
+import 'package:payjoin/payjoin.dart' as pj;
+import 'package:test/test.dart';
+
+final _ohttpKeys = pj.OhttpKeys.decode(
+  bytes: Uint8List.fromList([
+    0x01,
+    0x00,
+    0x16,
+    0x04,
+    0x52,
+    0x73,
+    0xda,
+    0xa8,
+    0xf6,
+    0x4c,
+    0xdf,
+    0x80,
+    0x8f,
+    0x1e,
+    0x94,
+    0x03,
+    0x98,
+    0x09,
+    0xf6,
+    0x47,
+    0xfc,
+    0x21,
+    0xca,
+    0x68,
+    0xb2,
+    0xbd,
+    0x31,
+    0xe7,
+    0x30,
+    0xa9,
+    0xc5,
+    0x7d,
+    0xf3,
+    0x68,
+    0x84,
+    0xb2,
+    0xe7,
+    0x82,
+    0x6e,
+    0x2f,
+    0xa1,
+    0xad,
+    0x2b,
+    0x9f,
+    0x23,
+    0x88,
+    0x15,
+    0x76,
+    0x5a,
+    0xa6,
+    0x7b,
+    0x1f,
+    0x56,
+    0xcc,
+    0x72,
+    0xc6,
+    0x69,
+    0x83,
+    0x40,
+    0x69,
+    0x89,
+    0x86,
+    0x87,
+    0x80,
+    0xee,
+    0x59,
+    0x9b,
+    0x1f,
+    0x00,
+    0x04,
+    0x00,
+    0x01,
+    0x00,
+    0x03,
+  ]),
+);
+
+const _expiredBip21 =
+    'bitcoin:2N47mmrWXsNBvQR6k78hWJoTji57zXwNcU7?pjos=0&pj=HTTPS://PAYJO.IN/TXJCGKTKXLUUZ%23EX1WKV8CEC-OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV';
+
+// ORIGINAL_PSBT from payjoin-test-utils, used instead of the unavailable
+// test-only FFI originalPsbt() export in the locally cached native library.
+const _originalPsbt =
+    'cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=';
+
+void main() {
+  test('receiver expiration is encoded in the BIP77 endpoint fragment', () {
+    final persister = InMemoryJsonReceiverSessionPersister();
+    final receiver = pj.ReceiverBuilder(
+      address: 'tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4',
+      directory: 'https://directory.example',
+      ohttpKeys: _ohttpKeys,
+    ).withExpiration(expirationSecs: 3600).build().save(persister: persister);
+
+    final bip21 = Uri.parse(receiver.pjUri().asString());
+    final endpoint = Uri.parse(bip21.queryParameters['pj']!);
+
+    expect(endpoint.fragment, contains('EX1'));
+    expect(endpoint.fragment, contains('OH1'));
+    expect(endpoint.fragment, contains('RK1'));
+    expect(bip21.toString(), contains('%23EX1'));
+  });
+
+  test('sender rejects the official expired BIP77 vector locally', () {
+    final payjoin = pj.Uri.parse(uri: _expiredBip21).checkPjSupported();
+    final sender = pj.SenderBuilder(psbt: _originalPsbt, uri: payjoin)
+        .buildRecommended(minFeeRateSatPerKwu: 1000)
+        .save(persister: InMemoryJsonSenderSessionPersister());
+
+    expect(
+      () => sender.createV2PostRequest(ohttpRelay: 'https://relay.example'),
+      throwsA(
+        isA<pj.CreateRequestException>().having(
+          (exception) => exception.isExpired(),
+          'isExpired',
+          isTrue,
+        ),
+      ),
+    );
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bb_mobile
 description: Bull Bitcoin Mobile Wallet
 publish_to: "none"
-version: 6.13.0+214
+version: 6.13.1+215
 
 environment:
   sdk: "3.12.2"

--- a/test/core_test/urqr/ur_qr_reader_test.dart
+++ b/test/core_test/urqr/ur_qr_reader_test.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/urqr/urqr.dart';
+import 'package:cbor/cbor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ur/ur.dart';
+import 'package:ur/ur_encoder.dart';
+
+void main() {
+  group('UrQrReader', () {
+    // Animated URs are fountain-coded (BCR-2020-005): once the pure
+    // fragments 1..N have played, the stream keeps emitting mixed parts
+    // N+1, N+2, ... The reader must accept them, or any scan that joins
+    // the animation mid-stream fails immediately.
+    test('decodes a stream the camera joins mid-animation', () {
+      final payload = cbor.encode(CborBytes(utf8.encode('x' * 100)));
+      final encoder = UREncoder(UR('bytes', Uint8List.fromList(payload)), 20);
+      final pureParts = <String>[];
+      while (!encoder.isComplete) {
+        pureParts.add(encoder.nextPart());
+      }
+      final mixedPart = encoder.nextPart(); // seqNum N+1 of N
+
+      final reader = UrQrReader();
+      reader.receive(mixedPart); // first captured frame is a mixed part
+      for (final part in pureParts) {
+        reader.receive(part);
+      }
+
+      expect(reader.isComplete, isTrue);
+    });
+  });
+}

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -199,14 +199,23 @@ void main() {
       final datasource = BdkWalletDatasource();
 
       // The LARGE utxo (200k) is marked unspendable — i.e. excluded from
-      // BDK's own automatic coin-selection pool, exactly like a
-      // user-frozen coin (see the D7 guarantee in
-      // PrepareBitcoinSendUsecase). It is ALSO the one manually `selected`
-      // here, which per BDK's coin-control semantics is supposed to force
-      // it into the transaction as a mandatory input regardless of the
-      // unspendable flag (mirroring real coin control: a coin the user
-      // explicitly picks must be spendable even if it's otherwise
-      // frozen-by-default for automatic selection).
+      // BDK's own automatic coin-selection pool. It is ALSO the one
+      // manually `selected` here, which per BDK's documented semantics
+      // forces it into the transaction as a mandatory input REGARDLESS of
+      // the unspendable flag.
+      //
+      // NOTE: this selected-overrides-unspendable behavior is raw BDK
+      // semantics that this datasource deliberately preserves as a thin
+      // wrapper — it is the INVERSE of the app-level D7 invariant ("a
+      // frozen coin must never be spendable"). D7 is enforced one layer
+      // up: BitcoinWalletRepository.buildPsbt strips selected ∩
+      // unspendable before calling down (see
+      // bitcoin_wallet_repository_test.dart), and
+      // PrepareBitcoinSendUsecase additionally strips frozen coins from
+      // the selection. The combination is exploited here ONLY because it
+      // is a deterministic discriminator for the addUtxos-reassignment
+      // regression, with no dependency on BDK's coin-selection
+      // heuristics.
       //
       // The only utxo left in the automatic pool is the SMALL one (30k),
       // which alone cannot cover the 150k send. This makes the two code

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -35,6 +35,7 @@ import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -373,6 +374,59 @@ void main() {
       );
 
       expect(selectedInput.sequence, 0xFFFFFFFD);
+    },
+  );
+
+  // BDK signals a shortfall through two exception types and the docs don't say
+  // which applies when, so these pin it against the real builder: whichever it
+  // picks must arrive as InsufficientFundsException, or the send screen falls
+  // back to a generic "Build Failed".
+  test(
+    'buildPsbt reports more than the whole balance as insufficient funds',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      await expectLater(
+        datasource.buildPsbt(
+          wallet: walletModel,
+          address: _externalTestnetAddress,
+          amountSat: utxoLargeAmountSat + utxoSmallAmountSat + 10000,
+          networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        ),
+        throwsA(isA<InsufficientFundsException>()),
+      );
+    },
+  );
+
+  // The case the send screen carves out: the amount fits the picked coin, but
+  // not once the fee is added. `addUtxos` only makes a coin *required*, so the
+  // large one has to be marked unspendable or BDK tops the transaction up from
+  // it and the shortfall never happens.
+  test(
+    'buildPsbt reports a fee-only shortfall as insufficient funds',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      await expectLater(
+        datasource.buildPsbt(
+          wallet: walletModel,
+          address: _externalTestnetAddress,
+          amountSat: utxoSmallAmountSat,
+          networkFee: const NetworkFee.relativeSatPerKwu(1000),
+          selected: [
+            WalletUtxoModel.bitcoin(
+              txId: utxoLargeTxId,
+              vout: 1,
+              amountSat: BigInt.from(utxoSmallAmountSat),
+              scriptPubkey: Uint8List(0),
+              address: '',
+              isExternalKeyChain: true,
+            ),
+          ],
+          unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
+        ),
+        throwsA(isA<InsufficientFundsException>()),
+      );
     },
   );
 }

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -1,0 +1,369 @@
+// Regression test for a bug where `BdkWalletDatasource.buildPsbt` silently
+// dropped manual UTXO selection and the RBF-off sequence flag.
+//
+// bdk_dart's `TxBuilder` is an IMMUTABLE builder: every method (`addUtxos`,
+// `setExactSequence`, `feeAbsolute`, `unspendable`, ...) returns a brand new
+// `TxBuilder` instance rather than mutating the receiver in place. Two call
+// sites in `buildPsbt` called `txBuilder.addUtxos(...)` and
+// `txBuilder.setExactSequence(...)` without reassigning the result, so both
+// calls were silent no-ops: BDK picked inputs on its own regardless of the
+// user's manual coin selection, and the RBF-off toggle never took effect.
+//
+// This test exercises the real production method end-to-end against a real
+// (offline, in-process) BDK wallet — no network, no mocked repository — so
+// it proves the actual `TxBuilder` wiring, not just that a mock was called
+// with the right arguments.
+//
+// Setup, fully deterministic and offline:
+//   1. A fixed BIP84 testnet wallet (the canonical
+//      "abandon ... abandon about" test mnemonic) is used to derive a
+//      public (watch-only) descriptor pair — exactly what
+//      `BitcoinWalletRepository.buildPsbt` passes down in production.
+//   2. The wallet is "funded" by hand-crafting a raw funding transaction
+//      with two outputs (to two of the wallet's own addresses) and applying
+//      it as an unconfirmed transaction via `Wallet.applyUnconfirmedTxs`.
+//      This is the standard offline way to seed known, deterministic UTXOs
+//      into a BDK wallet without hitting a real Electrum server.
+//   3. `path_provider`'s method channel is mocked to a temp directory so
+//      `BdkFacade`'s sqlite-file persister (production code, untouched)
+//      works under `flutter test`.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The canonical BIP39 test mnemonic ("abandon" x11 + "about"). Public
+// knowledge, no funds, safe to hardcode.
+const _testMnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon '
+    'abandon abandon abandon about';
+
+// A well-known BIP173 test-vector P2WPKH testnet address, used only as an
+// external send destination (not owned by the test wallet).
+const _externalTestnetAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+
+Uint8List _leUint32(int value) {
+  final bytes = ByteData(4)..setUint32(0, value, Endian.little);
+  return bytes.buffer.asUint8List();
+}
+
+Uint8List _leUint64(int value) {
+  final bytes = ByteData(8)..setUint64(0, value, Endian.little);
+  return bytes.buffer.asUint8List();
+}
+
+Uint8List _varInt(int value) {
+  if (value < 0xfd) return Uint8List.fromList([value]);
+  if (value <= 0xffff) {
+    final bytes = ByteData(3)
+      ..setUint8(0, 0xfd)
+      ..setUint16(1, value, Endian.little);
+    return bytes.buffer.asUint8List();
+  }
+  throw UnimplementedError('varint > 0xffff not needed for this test');
+}
+
+/// Hand-crafts a minimal, legacy-serialized (non-segwit) raw transaction
+/// with one throwaway input (never meant to be valid/spendable — BDK's
+/// `apply_unconfirmed_txs` doesn't validate it) and one output per entry in
+/// [outputs]. Used to seed deterministic, known UTXOs into an otherwise
+/// empty offline wallet.
+Uint8List _buildFundingTx(List<({bdk.Script script, int amountSat})> outputs) {
+  final bytes = BytesBuilder();
+  bytes.add(_leUint32(2)); // version
+  bytes.add(_varInt(1)); // 1 (fake) input
+  bytes.add(Uint8List(32)); // prev txid (all-zero, never spent for real)
+  bytes.add(_leUint32(0)); // prev vout
+  bytes.add(_varInt(0)); // empty scriptSig
+  bytes.add(_leUint32(0xFFFFFFFF)); // sequence
+  bytes.add(_varInt(outputs.length));
+  for (final output in outputs) {
+    bytes.add(_leUint64(output.amountSat));
+    final script = output.script.toBytes();
+    bytes.add(_varInt(script.length));
+    bytes.add(script);
+  }
+  bytes.add(_leUint32(0)); // locktime
+  return bytes.toBytes();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late PublicBdkWalletModel walletModel;
+  late String utxoLargeTxId;
+  late int utxoLargeVout;
+
+  const utxoLargeAmountSat = 200000;
+  const utxoSmallAmountSat = 30000;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('bdk_wallet_datasource_');
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'getApplicationDocumentsDirectory') {
+            return tempDir.path;
+          }
+          return null;
+        });
+
+    final mnemonic = bdk.Mnemonic.fromString(mnemonic: _testMnemonic);
+    final secretKey = bdk.DescriptorSecretKey(
+      networkKind: bdk.NetworkKind.test,
+      mnemonic: mnemonic,
+      password: null,
+    );
+    final external = bdk.Descriptor.newBip84(
+      secretKey: secretKey,
+      keychainKind: bdk.KeychainKind.external_,
+      networkKind: bdk.NetworkKind.test,
+    );
+    final internal = bdk.Descriptor.newBip84(
+      secretKey: secretKey,
+      keychainKind: bdk.KeychainKind.internal,
+      networkKind: bdk.NetworkKind.test,
+    );
+
+    walletModel =
+        WalletModel.publicBdk(
+              id: 'bdk-wallet-datasource-test',
+              externalDescriptor: external.toString(),
+              internalDescriptor: internal.toString(),
+              isTestnet: true,
+            )
+            as PublicBdkWalletModel;
+
+    // Build the wallet once here to fund it, then persist so the
+    // datasource's own (separate) `BdkFacade.createWallet` call sees the
+    // exact same UTXOs when the test invokes `buildPsbt`.
+    final wallet = await BdkFacade.createWallet(walletModel);
+
+    final addr0 = wallet.revealNextAddress(
+      keychain: bdk.KeychainKind.external_,
+    );
+    final addr1 = wallet.revealNextAddress(
+      keychain: bdk.KeychainKind.external_,
+    );
+
+    final fundingTxBytes = _buildFundingTx([
+      (script: addr0.address.scriptPubkey(), amountSat: utxoLargeAmountSat),
+      (script: addr1.address.scriptPubkey(), amountSat: utxoSmallAmountSat),
+    ]);
+    final fundingTx = bdk.Transaction(transactionBytes: fundingTxBytes);
+    final fundingTxid = fundingTx.computeTxid().toString();
+
+    wallet.applyUnconfirmedTxs(
+      unconfirmedTxs: [
+        bdk.UnconfirmedTx(
+          tx: fundingTx,
+          lastSeen: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      ],
+    );
+
+    // Sanity-check the funding actually landed before persisting, so a
+    // failure here points clearly at the test's own setup rather than at
+    // `buildPsbt`.
+    final utxos = wallet.listUnspent();
+    expect(
+      utxos.length,
+      2,
+      reason: 'test setup: expected exactly 2 synthetic UTXOs after funding',
+    );
+
+    utxoLargeTxId = fundingTxid;
+    utxoLargeVout = 0;
+
+    await BdkFacade.saveWallet(wallet, walletModel.hexId);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'buildPsbt honors manual UTXO selection: a manually selected UTXO must '
+    'be spendable even when every other UTXO is frozen/unspendable',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      // The LARGE utxo (200k) is marked unspendable — i.e. excluded from
+      // BDK's own automatic coin-selection pool, exactly like a
+      // user-frozen coin (see the D7 guarantee in
+      // PrepareBitcoinSendUsecase). It is ALSO the one manually `selected`
+      // here, which per BDK's coin-control semantics is supposed to force
+      // it into the transaction as a mandatory input regardless of the
+      // unspendable flag (mirroring real coin control: a coin the user
+      // explicitly picks must be spendable even if it's otherwise
+      // frozen-by-default for automatic selection).
+      //
+      // The only utxo left in the automatic pool is the SMALL one (30k),
+      // which alone cannot cover the 150k send. This makes the two code
+      // paths unambiguous, with no dependency on BDK's coin-selection
+      // tie-breaking heuristics:
+      //   * Fixed code: `addUtxos` really runs, forcing the large utxo in
+      //     -> the build succeeds and spends it.
+      //   * Buggy code (return value of `addUtxos` discarded): no utxo is
+      //     forced in; BDK's automatic selection is left with only the
+      //     30k utxo, which can't cover 150k -> the build throws.
+      const sendAmountSat = 150000; // only the large (200k) utxo covers this
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: sendAmountSat,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000), // 4 sat/vB
+        unspendable: [(txId: utxoLargeTxId, vout: utxoLargeVout)],
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final spendsLargeUtxo = tx.input().any(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(
+        spendsLargeUtxo,
+        isTrue,
+        reason:
+            'the manually selected UTXO must be forced into the built '
+            'transaction even though it is also marked unspendable for '
+            "BDK's own automatic selection",
+      );
+    },
+  );
+
+  test(
+    'buildPsbt sets a non-RBF sequence when replaceByFee is false',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: 25000,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: false,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final selectedInput = tx.input().firstWhere(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(selectedInput.sequence, 0xFFFFFFFE);
+    },
+  );
+
+  test(
+    'buildPsbt keeps the selected UTXO after rebuilding with a changed fee',
+    () async {
+      final datasource = BdkWalletDatasource();
+      final selected = [
+        WalletUtxoModel.bitcoin(
+          txId: utxoLargeTxId,
+          vout: utxoLargeVout,
+          amountSat: BigInt.from(utxoLargeAmountSat),
+          scriptPubkey: Uint8List(0),
+          address: '',
+          isExternalKeyChain: true,
+        ),
+      ];
+
+      Future<bool> buildsWithSelectedUtxo(NetworkFee fee) async {
+        final psbt = await datasource.buildPsbt(
+          wallet: walletModel,
+          address: _externalTestnetAddress,
+          amountSat: 150000,
+          networkFee: fee,
+          selected: selected,
+          replaceByFee: true,
+        );
+
+        final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+        return tx.input().any(
+          (input) =>
+              input.previousOutput.txid.toString() == utxoLargeTxId &&
+              input.previousOutput.vout == utxoLargeVout,
+        );
+      }
+
+      expect(
+        await buildsWithSelectedUtxo(const NetworkFee.relativeSatPerKwu(1000)),
+        isTrue,
+      );
+      expect(
+        await buildsWithSelectedUtxo(const NetworkFee.relativeSatPerKwu(5000)),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'buildPsbt keeps the default RBF sequence when replaceByFee is true',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        amountSat: 25000,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoLargeVout,
+            amountSat: BigInt.from(utxoLargeAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final selectedInput = tx.input().firstWhere(
+        (input) =>
+            input.previousOutput.txid.toString() == utxoLargeTxId &&
+            input.previousOutput.vout == utxoLargeVout,
+      );
+
+      expect(selectedInput.sequence, 0xFFFFFFFD);
+    },
+  );
+}

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -105,6 +105,8 @@ void main() {
 
   const utxoLargeAmountSat = 200000;
   const utxoSmallAmountSat = 30000;
+  // Both UTXOs share utxoLargeTxId (same funding tx); only vout differs.
+  const utxoSmallVout = 1;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('bdk_wallet_datasource_');
@@ -377,10 +379,9 @@ void main() {
     },
   );
 
-  // BDK signals a shortfall through two exception types and the docs don't say
-  // which applies when, so these pin it against the real builder: whichever it
-  // picks must arrive as InsufficientFundsException, or the send screen falls
-  // back to a generic "Build Failed".
+  // BDK has two exception types for a shortfall and doesn't say which it uses
+  // when, so these pin it against the real builder: either must arrive as
+  // InsufficientFundsException.
   test(
     'buildPsbt reports more than the whole balance as insufficient funds',
     () async {
@@ -398,10 +399,9 @@ void main() {
     },
   );
 
-  // The case the send screen carves out: the amount fits the picked coin, but
-  // not once the fee is added. `addUtxos` only makes a coin *required*, so the
-  // large one has to be marked unspendable or BDK tops the transaction up from
-  // it and the shortfall never happens.
+  // The amount fits the picked coin but not the fee. The large coin must be
+  // unspendable too: `addUtxos` only makes a coin required, so BDK would
+  // otherwise top the transaction up from it and never fall short.
   test(
     'buildPsbt reports a fee-only shortfall as insufficient funds',
     () async {
@@ -416,7 +416,7 @@ void main() {
           selected: [
             WalletUtxoModel.bitcoin(
               txId: utxoLargeTxId,
-              vout: 1,
+              vout: utxoSmallVout,
               amountSat: BigInt.from(utxoSmallAmountSat),
               scriptPubkey: Uint8List(0),
               address: '',

--- a/test/core_test/wallet/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/bitcoin_wallet_repository_test.dart
@@ -1,0 +1,333 @@
+// Unit tests for the repository-boundary guarantees of
+// `BitcoinWalletRepository.buildPsbt`:
+//
+//  1. D7 defense in depth — "a frozen coin must never be spendable".
+//     BDK's documented semantics are the opposite: a manually added utxo
+//     (`TxBuilder.addUtxos`) overrides the `unspendable` filter, and
+//     `BdkWalletDatasource` deliberately preserves those raw semantics
+//     (see bdk_wallet_datasource_test.dart, which asserts them). The
+//     repository therefore reads the frozen store LIVE at build time and
+//     enforces the invariant itself — merging the frozen set into the
+//     `unspendable` list (automatic selection can't pick a frozen coin)
+//     and stripping it from `selected` (a frozen coin can't be forced in
+//     as a mandatory input) — so it holds for ANY caller, with any
+//     staleness of the caller's earlier utxo fetch, not only for callers
+//     going through PrepareBitcoinSendUsecase's own frozen-set handling.
+//     (Payjoin-derived exclusions remain at the usecase: they come from
+//     another repository, which this repository must not depend on.)
+//
+//  2. RBF defaults to ENABLED when the caller omits the flag. The
+//     previous `replaceByFee ?? false` was harmless while the datasource's
+//     `setExactSequence` call discarded its result (a silent no-op), but
+//     became wrong once that call was fixed: a null flag would have
+//     started disabling RBF by default, diverging from both the
+//     datasource's own default and BDK's default sequence (0xFFFFFFFD).
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockWalletMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+class _MockBdkWalletDatasource extends Mock implements BdkWalletDatasource {}
+
+class _MockFrozenWalletUtxoDatasource extends Mock
+    implements FrozenWalletUtxoDatasource {}
+
+// Encodes as a bitcoin testnet BIP84 origin so
+// WalletMetadataModelExtension.isBitcoin decodes to true.
+const _walletId = 'wpkh([73c5da0a/84h/1h/0h])';
+
+WalletUtxo _utxo({required String txId, required int vout}) =>
+    WalletUtxo.bitcoin(
+      walletId: _walletId,
+      txId: txId,
+      vout: vout,
+      scriptPubkey: Uint8List(0),
+      amountSat: BigInt.from(100000),
+      address: 'tb1-test-address',
+    );
+
+void main() {
+  late _MockWalletMetadataDatasource metadataDatasource;
+  late _MockBdkWalletDatasource bdkDatasource;
+  late _MockFrozenWalletUtxoDatasource frozenDatasource;
+  late BitcoinWalletRepository repository;
+
+  const metadata = WalletMetadataModel(
+    id: _walletId,
+    masterFingerprint: '73c5da0a',
+    xpubFingerprint: 'deadbeef',
+    isEncryptedVaultTested: false,
+    isPhysicalBackupTested: false,
+    xpub: 'tpub-test',
+    externalPublicDescriptor: 'wpkh(external)',
+    internalPublicDescriptor: 'wpkh(internal)',
+    signer: Signer.local,
+    isDefault: true,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(
+      const WalletModel.publicBdk(
+        id: _walletId,
+        externalDescriptor: 'wpkh(external)',
+        internalDescriptor: 'wpkh(internal)',
+        isTestnet: true,
+      ),
+    );
+    registerFallbackValue(const NetworkFee.relativeSatPerKwu(1000));
+  });
+
+  setUp(() {
+    metadataDatasource = _MockWalletMetadataDatasource();
+    bdkDatasource = _MockBdkWalletDatasource();
+    frozenDatasource = _MockFrozenWalletUtxoDatasource();
+    repository = BitcoinWalletRepository(
+      walletMetadataDatasource: metadataDatasource,
+      seedDatasource: _MockSeedDatasource(),
+      bdkWalletDatasource: bdkDatasource,
+      frozenWalletUtxoDatasource: frozenDatasource,
+    );
+
+    when(
+      () => metadataDatasource.fetch(_walletId),
+    ).thenAnswer((_) async => metadata);
+    // Frozen store is empty by default; individual tests override it.
+    when(() => frozenDatasource.getAllFrozen()).thenAnswer((_) async => []);
+    when(
+      () => bdkDatasource.buildPsbt(
+        wallet: any(named: 'wallet'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    ).thenAnswer((_) async => 'psbt');
+  });
+
+  List<WalletUtxoModel>? capturedSelected() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: any(named: 'unspendable'),
+              selected: captureAny(named: 'selected'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as List<WalletUtxoModel>?;
+
+  List<({String txId, int vout})>? capturedUnspendable() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: captureAny(named: 'unspendable'),
+              selected: any(named: 'selected'),
+              replaceByFee: any(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as List<({String txId, int vout})>?;
+
+  bool capturedReplaceByFee() =>
+      verify(
+            () => bdkDatasource.buildPsbt(
+              wallet: any(named: 'wallet'),
+              address: any(named: 'address'),
+              amountSat: any(named: 'amountSat'),
+              networkFee: any(named: 'networkFee'),
+              drain: any(named: 'drain'),
+              unspendable: any(named: 'unspendable'),
+              selected: any(named: 'selected'),
+              replaceByFee: captureAny(named: 'replaceByFee'),
+            ),
+          ).captured.single
+          as bool;
+
+  Future<void> buildPsbt({
+    List<({String txId, int vout})>? unspendable,
+    List<WalletUtxo>? selected,
+    bool? replaceByFee,
+  }) => repository.buildPsbt(
+    walletId: _walletId,
+    address: 'tb1-destination',
+    amountSat: 25000,
+    networkFee: const NetworkFee.relativeSatPerKwu(1000),
+    unspendable: unspendable,
+    selected: selected,
+    replaceByFee: replaceByFee,
+  );
+
+  group('D7 — frozen store is read live at build time', () {
+    test('a coin frozen in the store is stripped from the selection even when '
+        'the caller passes NO unspendable list', () async {
+      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+      );
+
+      await buildPsbt(
+        selected: [
+          _utxo(txId: 'tx-frozen', vout: 0), // frozen in DB -> stripped
+          _utxo(txId: 'tx-free', vout: 1), // passes through
+        ],
+      );
+
+      final selected = capturedSelected();
+      expect(selected, hasLength(1));
+      expect(selected!.single.txId, 'tx-free');
+    });
+
+    test('frozen outpoints are merged into the unspendable list passed down, '
+        'so automatic selection cannot pick them either', () async {
+      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+      );
+
+      await buildPsbt(unspendable: const [(txId: 'tx-caller', vout: 3)]);
+
+      final unspendable = capturedUnspendable();
+      expect(
+        unspendable,
+        containsAll(<({String txId, int vout})>[
+          (txId: 'tx-frozen', vout: 0),
+          (txId: 'tx-caller', vout: 3),
+        ]),
+      );
+      expect(unspendable, hasLength(2));
+    });
+
+    test(
+      'duplicate outpoints (frozen AND caller-supplied) are deduped',
+      () async {
+        when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+          (_) async => [(walletId: _walletId, txId: 'tx-both', vout: 0)],
+        );
+
+        await buildPsbt(unspendable: const [(txId: 'tx-both', vout: 0)]);
+
+        expect(capturedUnspendable(), hasLength(1));
+      },
+    );
+  });
+
+  group('D7 — selected ∩ unspendable (caller-supplied) is stripped', () {
+    test(
+      'throws when an explicit selection is entirely frozen instead of falling back',
+      () async {
+        when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+          (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+        );
+
+        await expectLater(
+          buildPsbt(selected: [_utxo(txId: 'tx-frozen', vout: 0)]),
+          throwsA(isA<NoSpendableUtxoException>()),
+        );
+        verifyNever(
+          () => bdkDatasource.buildPsbt(
+            wallet: any(named: 'wallet'),
+            address: any(named: 'address'),
+            amountSat: any(named: 'amountSat'),
+            networkFee: any(named: 'networkFee'),
+            drain: any(named: 'drain'),
+            unspendable: any(named: 'unspendable'),
+            selected: any(named: 'selected'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'a selected coin that is also unspendable never reaches the datasource',
+      () async {
+        await buildPsbt(
+          unspendable: const [(txId: 'tx-frozen', vout: 0)],
+          selected: [
+            _utxo(txId: 'tx-frozen', vout: 0), // must be stripped
+            _utxo(txId: 'tx-free', vout: 1), // must pass through
+          ],
+        );
+
+        final selected = capturedSelected();
+        expect(selected, hasLength(1));
+        expect(selected!.single.txId, 'tx-free');
+        expect(selected.single.vout, 1);
+      },
+    );
+
+    test('same txId but different vout is NOT stripped', () async {
+      await buildPsbt(
+        unspendable: const [(txId: 'tx-shared', vout: 0)],
+        selected: [_utxo(txId: 'tx-shared', vout: 1)],
+      );
+
+      final selected = capturedSelected();
+      expect(selected, hasLength(1));
+      expect(selected!.single.vout, 1);
+    });
+
+    test(
+      'empty frozen store and no unspendable leaves the selection untouched',
+      () async {
+        await buildPsbt(
+          selected: [
+            _utxo(txId: 'tx-a', vout: 0),
+            _utxo(txId: 'tx-b', vout: 1),
+          ],
+        );
+
+        expect(capturedSelected(), hasLength(2));
+      },
+    );
+
+    test(
+      'null or empty selection keeps automatic selection available',
+      () async {
+        await buildPsbt();
+        expect(capturedSelected(), isNull);
+
+        await buildPsbt(selected: []);
+        expect(capturedSelected(), isEmpty);
+      },
+    );
+  });
+
+  group('replaceByFee default', () {
+    test('omitted flag defaults to RBF ENABLED (true)', () async {
+      await buildPsbt();
+
+      expect(capturedReplaceByFee(), isTrue);
+    });
+
+    test('explicit false is forwarded unchanged', () async {
+      await buildPsbt(replaceByFee: false);
+
+      expect(capturedReplaceByFee(), isFalse);
+    });
+  });
+}

--- a/test/core_test/widgets/mnemonic_widget_test.dart
+++ b/test/core_test/widgets/mnemonic_widget_test.dart
@@ -25,6 +25,8 @@ Future<void> pumpWidget(
   bip39.MnemonicLength length = bip39.MnemonicLength.words12,
   bool allowAutoFillWords = false,
   bool allowMultipleMnemonicLength = true,
+  bool allowPassphrase = false,
+  bool allowLabel = false,
   String? externalError,
   required void Function(Mnemonic) onSubmit,
 }) async {
@@ -39,8 +41,8 @@ Future<void> pumpWidget(
             onSubmit: onSubmit,
             allowAutoFillWords: allowAutoFillWords,
             allowMultipleMnemonicLength: allowMultipleMnemonicLength,
-            allowLabel: false,
-            allowPassphrase: false,
+            allowLabel: allowLabel,
+            allowPassphrase: allowPassphrase,
             externalError: externalError,
           ),
         ),
@@ -50,6 +52,13 @@ Future<void> pumpWidget(
 }
 
 Finder wordField(int index) => find.byType(TextField).at(index);
+
+TextField fieldByHint(WidgetTester tester, String hint) =>
+    tester.widget<TextField>(
+      find.byWidgetPredicate(
+        (widget) => widget is TextField && widget.decoration?.hintText == hint,
+      ),
+    );
 
 Future<void> fillAll(WidgetTester tester, List<String> words) async {
   for (var i = 0; i < words.length; i++) {
@@ -630,6 +639,22 @@ void main() {
         tester.widget<TextField>(wordField(11)).controller!.text,
         equals('senior'),
       );
+    });
+  });
+
+  group('MnemonicWidget labelled inputs', () {
+    testWidgets('disables smart punctuation for passphrases', (tester) async {
+      await pumpWidget(tester, allowPassphrase: true, onSubmit: (_) {});
+      final field = fieldByHint(tester, 'Optional Passphrase');
+      expect(field.smartQuotesType, SmartQuotesType.disabled);
+      expect(field.smartDashesType, SmartDashesType.disabled);
+    });
+
+    testWidgets('keeps smart punctuation enabled for labels', (tester) async {
+      await pumpWidget(tester, allowLabel: true, onSubmit: (_) {});
+      final field = fieldByHint(tester, 'Required');
+      expect(field.smartQuotesType, SmartQuotesType.enabled);
+      expect(field.smartDashesType, SmartDashesType.enabled);
     });
   });
 }

--- a/test/features/buy/ui/screens/buy_success_screen_test.dart
+++ b/test/features/buy/ui/screens/buy_success_screen_test.dart
@@ -1,0 +1,91 @@
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/buy/presentation/buy_bloc.dart';
+import 'package:bb_mobile/features/buy/ui/screens/buy_success_screen.dart';
+import 'package:bb_mobile/features/buy/ui/buy_router.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockBuyBloc extends Mock implements BuyBloc {}
+
+class _MockSettingsCubit extends Mock implements SettingsCubit {}
+
+class _MockBuyOrder extends Mock implements BuyOrder {}
+
+void main() {
+  testWidgets('view details opens the transaction order details route', (
+    tester,
+  ) async {
+    final buyBloc = _MockBuyBloc();
+    final settingsCubit = _MockSettingsCubit();
+    final order = _MockBuyOrder();
+    when(() => buyBloc.state).thenReturn(BuyState(buyOrder: order));
+    when(
+      () => buyBloc.stream,
+    ).thenAnswer((_) => const Stream<BuyState>.empty());
+    when(() => settingsCubit.state).thenReturn(
+      const SettingsState(
+        storedSettings: SettingsEntity(
+          environment: Environment.mainnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+        ),
+      ),
+    );
+    when(
+      () => settingsCubit.stream,
+    ).thenAnswer((_) => const Stream<SettingsState>.empty());
+    when(() => order.orderId).thenReturn('order-42');
+    when(() => order.payoutAmount).thenReturn(0.001);
+    when(() => order.payinAmount).thenReturn(100.0);
+    when(() => order.payinCurrency).thenReturn('CAD');
+    when(() => order.bitcoinAddress).thenReturn(null);
+    when(() => order.transactionId).thenReturn(null);
+    when(() => order.scheduledPayoutTime).thenReturn(null);
+    when(() => order.payjoinOutcome).thenReturn(OrderPayjoinOutcome.none);
+
+    final router = GoRouter(
+      initialLocation: '/buy/success',
+      routes: [
+        GoRoute(
+          path: '/buy/success',
+          name: BuyRoute.buySuccess.name,
+          builder: (context, state) => MultiBlocProvider(
+            providers: [
+              BlocProvider<BuyBloc>.value(value: buyBloc),
+              BlocProvider<SettingsCubit>.value(value: settingsCubit),
+            ],
+            child: const BuySuccessScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/transaction/order/:orderId',
+          name: TransactionsRoute.orderTransactionDetails.name,
+          builder: (context, state) => Text(state.pathParameters['orderId']!),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('View details'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('order-42'), findsOneWidget);
+  });
+}

--- a/test/features/receive/presentation/bloc/receive_bloc_test.dart
+++ b/test/features/receive/presentation/bloc/receive_bloc_test.dart
@@ -100,8 +100,13 @@ class _LateOrderSwapStream
 }
 
 class _NoopSubscription<T> implements StreamSubscription<T> {
+  _NoopSubscription({Future<void>? cancelFuture})
+    : _cancelFuture = cancelFuture ?? Future<void>.value();
+
+  final Future<void> _cancelFuture;
+
   @override
-  Future<void> cancel() async {}
+  Future<void> cancel() => _cancelFuture;
 
   @override
   void onData(void Function(T data)? handleData) {}
@@ -123,6 +128,20 @@ class _NoopSubscription<T> implements StreamSubscription<T> {
 
   @override
   Future<E> asFuture<E>([E? futureValue]) async => futureValue as E;
+}
+
+class _ControlledCancelPayjoinStream extends Stream<PayjoinSession> {
+  _ControlledCancelPayjoinStream(this.cancelFuture);
+
+  final Future<void> cancelFuture;
+
+  @override
+  StreamSubscription<PayjoinSession> listen(
+    void Function(PayjoinSession event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => _NoopSubscription(cancelFuture: cancelFuture);
 }
 
 // Defaults to a confirmed balance: most tests in this file are about the
@@ -549,6 +568,78 @@ void main() {
   });
 
   group('payjoin reacts live to the global setting changing', () {
+    test(
+      'does not create duplicate sessions when persistence and watcher both emit enable',
+      () async {
+        when(
+          () => getPayjoinPolicy.execute(),
+        ).thenAnswer((_) async => (enabled: false, minimumAmountSat: 10000));
+        final creations = <Completer<PayjoinReceiverSession>>[];
+        when(
+          () => receiveWithPayjoin.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+          ),
+        ).thenAnswer((_) {
+          final creation = Completer<PayjoinReceiverSession>();
+          creations.add(creation);
+          return creation.future;
+        });
+
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const ReceiveBitcoinStarted(null));
+        await pumpEventQueue();
+        expect(bloc.state.payjoin, isNull);
+
+        bloc.add(ReceivePayjoinToggled(true, () async => true));
+        await Future<void>.delayed(Duration.zero);
+        payjoinEnabledChangeController.add(true);
+        await pumpEventQueue();
+
+        expect(creations, hasLength(1));
+        creations.single.complete(_receiver());
+        await pumpEventQueue();
+
+        verify(() => watchPayjoin.execute(ids: any(named: 'ids'))).called(1);
+      },
+    );
+
+    test(
+      'does not create duplicate sessions when watcher emits before persistence',
+      () async {
+        when(
+          () => getPayjoinPolicy.execute(),
+        ).thenAnswer((_) async => (enabled: false, minimumAmountSat: 10000));
+        final creations = <Completer<PayjoinReceiverSession>>[];
+        when(
+          () => receiveWithPayjoin.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+          ),
+        ).thenAnswer((_) {
+          final creation = Completer<PayjoinReceiverSession>();
+          creations.add(creation);
+          return creation.future;
+        });
+
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const ReceiveBitcoinStarted(null));
+        await pumpEventQueue();
+        payjoinEnabledChangeController.add(true);
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(ReceivePayjoinToggled(true, () async => true));
+        await pumpEventQueue();
+
+        expect(creations, hasLength(1));
+        creations.single.complete(_receiver());
+        await pumpEventQueue();
+      },
+    );
+
     test('creates a payjoin receiver session as soon as the setting is '
         'flipped on, without needing to leave and re-enter the receive '
         'screen', () async {
@@ -854,6 +945,45 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'updates the QR immediately when disabling payjoin without a watcher event',
+      () async {
+        when(
+          () => setPayjoinEnabled.execute(
+            false,
+            requestConsent: any(named: 'requestConsent'),
+          ),
+        ).thenAnswer((_) async => const Ok<bool, SettingsFailure>(false));
+
+        final cancel = Completer<void>();
+        addTearDown(() {
+          if (!cancel.isCompleted) cancel.complete();
+        });
+        when(
+          () => watchPayjoin.execute(ids: any(named: 'ids')),
+        ).thenAnswer((_) => _ControlledCancelPayjoinStream(cancel.future));
+
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const ReceiveBitcoinStarted(null));
+        await pumpEventQueue();
+        expect(bloc.state.qrData, contains('pj='));
+
+        bloc.add(ReceivePayjoinToggled(false, () async => true));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.payjoinGloballyEnabled, isFalse);
+        expect(bloc.state.payjoin, isNull);
+        expect(
+          Uri.parse(bloc.state.qrData).queryParameters,
+          isNot(contains('pj')),
+        );
+
+        cancel.complete();
+      },
+    );
 
     test(
       'drops repeated toggles while consent and persistence are in flight',

--- a/test/features/receive/presentation/bloc/receive_state_test.dart
+++ b/test/features/receive/presentation/bloc/receive_state_test.dart
@@ -107,12 +107,13 @@ void main() {
     required PayjoinStatus status,
     int? amountSat,
     bool hasRequest = false,
+    String? payjoinUri,
   }) => PayjoinReceiverSession(
     status: status,
     id: 'pj1',
     network: BitcoinNetwork.testnet,
     walletId: 'w1',
-    payjoinUri: 'bitcoin:tb1qtest?pj=https://payjo.in',
+    payjoinUri: payjoinUri ?? 'bitcoin:tb1qtest?pj=https://payjo.in',
     createdAt: DateTime(2026),
     expiresAt: DateTime(2026).add(const Duration(minutes: 1)),
     amount: amountSat == null ? null : Sats.fromInt(amountSat),
@@ -167,6 +168,29 @@ void main() {
       expect(uri.queryParameters['amount'], '0.0005');
       expect(uri.queryParameters['message'], 'pj note');
       expect(uri.queryParameters['pj'], 'https://payjo.in');
+    });
+
+    test('bitcoin: preserves the encoded BIP77 endpoint fragment', () {
+      const payjoinUri =
+          'bitcoin:tb1qtest?pj=HTTPS://PAYJO.IN/TXJCGKTKXLUUZ%23EX1WKV8CEC-OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV';
+      final state = buildState(
+        payjoinGloballyEnabled: true,
+        payjoin: payjoinWith(
+          status: PayjoinStatus.started,
+          payjoinUri: payjoinUri,
+        ),
+      ).copyWith(confirmedAmountSat: 50000, note: 'pj note');
+
+      final output = state.paymentRequest;
+      final outputUri = Uri.parse(output);
+
+      expect(
+        outputUri.queryParameters['pj'],
+        Uri.parse(payjoinUri).queryParameters['pj'],
+      );
+      expect(output, contains('%23EX1'));
+      expect(outputUri.queryParameters['amount'], '0.0005');
+      expect(outputUri.queryParameters['message'], 'pj note');
     });
 
     test('liquid: amount is in BTC (L-BTC) units and the note becomes '

--- a/test/features/replace_by_fee/replace_by_fee_cubit_test.dart
+++ b/test/features/replace_by_fee/replace_by_fee_cubit_test.dart
@@ -54,6 +54,56 @@ void main() {
     bumpFee = _MockBumpFeeUsecase();
   });
 
+  group('ReplaceByFeeCubit — prefilled bump rate', () {
+    test('clears the BDK threshold when fee/vsize is fractional', () async {
+      final cubit = await buildCubit();
+
+      // The fixture pays 200 sat over a 140-vbyte transaction. `vsize` is
+      // BDK's `Transaction::vsize()` — ceil(weight/4) — so a 140-vbyte tx
+      // weighs between 557 and 560 wu, and BDK derives the rate it must beat
+      // from that weight, not from vsize. The strictest case is the lightest
+      // weight: 200 sat over 557 wu = 359.06 sat/kwu, which BDK floors to 359.
+      // A valid replacement must clear that plus the 250 sat/kwu (1 sat/vByte)
+      // incremental relay fee, so the prefilled rate has to be >= 609.
+      //
+      // Computing the original rate as `feeSat / vsize` instead gives
+      // 357.14 sat/kwu, and rounding `357.14 + 250` to the nearest sat/kwu
+      // rounds *down* to 607 — two steps under the threshold. The user then
+      // sees a rate the app itself proposed being rejected as too low.
+      const lightestWeightWu = 4 * 140 - 3;
+      const strictestOriginalSatPerKwu = 200 * 1000 ~/ lightestWeightWu;
+      const incrementalRelaySatPerKwu = 250;
+
+      expect(
+        cubit.state.newFeeRate!.feeRate.satPerKwu,
+        greaterThanOrEqualTo(
+          strictestOriginalSatPerKwu + incrementalRelaySatPerKwu,
+        ),
+      );
+    });
+
+    test('stays valid after the two-decimal input round-trip', () {
+      const feeSat = 201;
+      const vsize = 140;
+      final minimum = NetworkFeeRelayPolicy.minimumReplacementSatPerKwu(
+        feeSat: feeSat,
+        vsize: vsize,
+      );
+      final prefill = NetworkFeeRelayPolicy.replacementPrefillSatPerKwu(
+        feeSat: feeSat,
+        vsize: vsize,
+      );
+      final displayed = (prefill / 250).toStringAsFixed(2);
+      final reparsed = NetworkFee.relativeFromSatPerVbyte(
+        double.parse(displayed),
+      ).satPerKwu;
+
+      expect(minimum, 611);
+      expect(displayed, '2.45');
+      expect(reparsed, greaterThanOrEqualTo(minimum));
+    });
+  });
+
   group('ReplaceByFeeCubit — below-floor selection gate', () {
     test('broadcast refuses while the custom field is below floor', () async {
       final cubit = await buildCubit();

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -252,13 +252,18 @@ Wallet _bitcoinWallet({required int balanceSat}) => Wallet(
   balanceSat: BigInt.from(balanceSat),
 );
 
-WalletUtxo _utxo({required int amountSat}) => WalletUtxo.bitcoin(
+WalletUtxo _utxo({
+  required int amountSat,
+  int vout = 0,
+  bool isFrozen = false,
+}) => WalletUtxo.bitcoin(
   walletId: 'w-bitcoin',
   txId: 'a' * 64,
-  vout: 0,
+  vout: vout,
   scriptPubkey: Uint8List(0),
   amountSat: BigInt.from(amountSat),
   address: 'bc1-utxo',
+  isFrozen: isFrozen,
 );
 
 FeeOptions _feeOptions() => const FeeOptions(
@@ -550,9 +555,7 @@ void main() {
     );
 
     // The payjoin-only path skips createTransaction(), so nothing else clears
-    // the failure a previous attempt left behind. Without a clear at the top
-    // of onConfirmTransactionClicked, the gate that refuses to sign while a
-    // failure is set traps every retry on this screen.
+    // a failure left by the previous attempt and every retry gets trapped.
     test(
       'a failed payjoin start can be retried from the confirm screen',
       () async {
@@ -990,6 +993,52 @@ void main() {
 
       await cubit.onAmountConfirmed();
 
+      expect(cubit.state.failure, isA<SendInsufficientBalanceFailure>());
+      expect(
+        cubit.state.failure,
+        isNot(isA<SendInsufficientFundsForFeesFailure>()),
+      );
+    });
+
+    // #2337: frozen coins cause a shortfall too, and only the generic failure
+    // reaches the "manage coins" hint that tells the user what to do.
+    test('with frozen coins the message stays generic', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      when(
+        () => prepareBitcoinSendUsecase.execute(
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          networkFee: any(named: 'networkFee'),
+          amountSat: any(named: 'amountSat'),
+          drain: any(named: 'drain'),
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: any(named: 'replaceByFee'),
+        ),
+      ).thenThrow(InsufficientFundsException('needed 10000, available 5000'));
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [_utxo(amountSat: 15000, isFrozen: true)]);
+      cubit.setStateForTest(
+        SendState(
+          step: SendStep.amount,
+          sendType: SendType.bitcoin,
+          selectedWallet: _bitcoinWallet(balanceSat: 20000),
+          paymentRequest: const PaymentRequest.bitcoin(
+            address: 'bc1-address',
+            isTestnet: false,
+          ),
+          // Fits the 20000 balance, but 15000 of it is frozen.
+          amount: '10000',
+          inputAmountCurrencyCode: 'sats',
+          liquidFeesList: _feeOptions(),
+          bitcoinFeesList: _feeOptions(),
+        ),
+      );
+
+      await cubit.onAmountConfirmed();
+
+      expect(cubit.state.frozenBalanceSat, 15000);
       expect(cubit.state.failure, isA<SendInsufficientBalanceFailure>());
       expect(
         cubit.state.failure,

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
@@ -10,6 +11,8 @@ import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
@@ -223,6 +226,48 @@ Wallet _bitcoinLocalWallet() => Wallet(
   balanceSat: BigInt.from(1000000),
 );
 
+Wallet _liquidWallet({required int balanceSat}) => Wallet(
+  origin: 'w-liquid',
+  network: Network.liquidMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.from(balanceSat),
+);
+
+Wallet _bitcoinWallet({required int balanceSat}) => Wallet(
+  origin: 'w-bitcoin',
+  network: Network.bitcoinMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.from(balanceSat),
+);
+
+WalletUtxo _utxo({required int amountSat}) => WalletUtxo.bitcoin(
+  walletId: 'w-bitcoin',
+  txId: 'a' * 64,
+  vout: 0,
+  scriptPubkey: Uint8List(0),
+  amountSat: BigInt.from(amountSat),
+  address: 'bc1-utxo',
+);
+
+FeeOptions _feeOptions() => const FeeOptions(
+  fastest: RelativeFee(25),
+  economic: RelativeFee(25),
+  slow: RelativeFee(25),
+  minRelay: RelativeFee(25),
+);
+
 Bip21PaymentRequest _payjoinBip21() =>
     const PaymentRequest.bip21(
           network: Network.bitcoinMainnet,
@@ -357,6 +402,8 @@ void main() {
     registerFallbackValue(_FakeNewLabel());
     registerFallbackValue(_bitcoinLocalWallet());
     registerFallbackValue(BigInt.zero);
+    // For any(named: 'feeRate') on the prepare-send stubs.
+    registerFallbackValue(NetworkFee.relativeFromSatPerVbyte(1));
   });
 
   setUp(() {
@@ -808,6 +855,105 @@ void main() {
               as NewLabel;
       expect(stored.reference, 'broadcast-txid');
       expect(stored.label, 'coffee');
+    });
+  });
+
+  // A shortfall used to show "Build Failed", the same message as a dead
+  // Electrum server or a bad address.
+  group('SendCubit.createTransaction shortfalls', () {
+    test(
+      'a shortfall at build time is an insufficient-balance failure',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        when(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            feeRate: any(named: 'feeRate'),
+            amountSat: any(named: 'amountSat'),
+            drain: any(named: 'drain'),
+          ),
+        ).thenThrow(
+          InsufficientFundsException(
+            'InsufficientFunds { missing_sats: 2, is_token: false }',
+            missingSat: 2,
+          ),
+        );
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => <WalletUtxo>[]);
+        cubit.setStateForTest(
+          SendState(
+            step: SendStep.amount,
+            sendType: SendType.liquid,
+            selectedWallet: _liquidWallet(balanceSat: 20000),
+            paymentRequest: const PaymentRequest.liquid(
+              address: 'lq1-address',
+              isTestnet: false,
+            ),
+            amount: '19998',
+            inputAmountCurrencyCode: 'sats',
+            liquidFeesList: _feeOptions(),
+            bitcoinFeesList: _feeOptions(),
+          ),
+        );
+
+        await cubit.onAmountConfirmed();
+
+        expect(cubit.state.failure, isA<SendInsufficientFundsForFeesFailure>());
+        expect(cubit.state.failure, isNot(isA<SendTransactionBuildFailure>()));
+        // and it must not move on to confirm with no transaction built
+        expect(cubit.state.step, SendStep.amount);
+      },
+    );
+
+    // With hand-picked coins the amount was only checked against the whole
+    // balance, so the shortfall may be the selection rather than the fee.
+    test('with hand-picked coins the message stays generic', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      when(
+        () => prepareBitcoinSendUsecase.execute(
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          networkFee: any(named: 'networkFee'),
+          amountSat: any(named: 'amountSat'),
+          drain: any(named: 'drain'),
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: any(named: 'replaceByFee'),
+        ),
+      ).thenThrow(InsufficientFundsException('needed 5000, available 1000'));
+      final selected = _utxo(amountSat: 1000);
+      // loadUtxos() filters the selection against the wallet's current UTXOs,
+      // so the picked coin has to be in the list or the selection is dropped.
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [selected]);
+      cubit.setStateForTest(
+        SendState(
+          step: SendStep.amount,
+          sendType: SendType.bitcoin,
+          selectedWallet: _bitcoinWallet(balanceSat: 20000),
+          paymentRequest: const PaymentRequest.bitcoin(
+            address: 'bc1-address',
+            isTestnet: false,
+          ),
+          amount: '5000',
+          inputAmountCurrencyCode: 'sats',
+          liquidFeesList: _feeOptions(),
+          bitcoinFeesList: _feeOptions(),
+          selectedUtxos: [selected],
+        ),
+      );
+
+      await cubit.onAmountConfirmed();
+
+      expect(cubit.state.failure, isA<SendInsufficientBalanceFailure>());
+      expect(
+        cubit.state.failure,
+        isNot(isA<SendInsufficientFundsForFeesFailure>()),
+      );
     });
   });
 }

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -549,6 +549,48 @@ void main() {
       },
     );
 
+    // The payjoin-only path skips createTransaction(), so nothing else clears
+    // the failure a previous attempt left behind. Without a clear at the top
+    // of onConfirmTransactionClicked, the gate that refuses to sign while a
+    // failure is set traps every retry on this screen.
+    test(
+      'a failed payjoin start can be retried from the confirm screen',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        var attempts = 0;
+        when(
+          () => sendWithPayjoinUsecase.execute(
+            walletId: any(named: 'walletId'),
+            isTestnet: any(named: 'isTestnet'),
+            bip21: any(named: 'bip21'),
+            unsignedOriginalPsbt: any(named: 'unsignedOriginalPsbt'),
+            amountSat: any(named: 'amountSat'),
+            networkFeesSatPerVb: any(named: 'networkFeesSatPerVb'),
+          ),
+        ).thenAnswer((_) async {
+          attempts++;
+          if (attempts == 1) throw Exception('payjoin directory unreachable');
+          return _sender(status: PayjoinStatus.requested);
+        });
+        cubit.setStateForTest(
+          payjoinReadyState().copyWith(
+            signedBitcoinPsbt: 'signed-regular-psbt',
+          ),
+        );
+
+        await cubit.onConfirmTransactionClicked();
+        expect(cubit.state.step, SendStep.confirm);
+        expect(cubit.state.failure, isA<SendTransactionConfirmationFailure>());
+
+        await cubit.onConfirmTransactionClicked();
+
+        expect(attempts, 2);
+        expect(cubit.state.step, SendStep.sending);
+        expect(cubit.state.payjoinSender?.status, PayjoinStatus.requested);
+      },
+    );
+
     test('a completed PayjoinSender (real payjoin, txId set) resolves the flow '
         'to success with the payjoin txid, syncs the wallet and stores the '
         'user label on that final txid', () async {
@@ -877,7 +919,6 @@ void main() {
         ).thenThrow(
           InsufficientFundsException(
             'InsufficientFunds { missing_sats: 2, is_token: false }',
-            missingSat: 2,
           ),
         );
         when(

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -208,6 +208,7 @@ class _TestableSendCubit extends SendCubit {
     required super.checkLiquidConsolidationUsecase,
     required super.getSendPayjoinEnabledUsecase,
     required super.verifySignedTxUsecase,
+    super.parsePaymentRequest,
   });
 
   void setStateForTest(SendState state) => emit(state);
@@ -343,7 +344,9 @@ void main() {
 
   late StreamController<PayjoinSession> payjoinEvents;
 
-  _TestableSendCubit buildCubit() => _TestableSendCubit(
+  _TestableSendCubit buildCubit({
+    Future<PaymentRequest> Function(String)? parsePaymentRequest,
+  }) => _TestableSendCubit(
     labelsFacade: labelsFacade,
     bestWalletUsecase: bestWalletUsecase,
     detectBitcoinStringUsecase: detectBitcoinStringUsecase,
@@ -382,6 +385,7 @@ void main() {
     checkLiquidConsolidationUsecase: checkLiquidConsolidationUsecase,
     getSendPayjoinEnabledUsecase: _MockGetSendPayjoinEnabledUsecase(),
     verifySignedTxUsecase: verifySignedTxUsecase,
+    parsePaymentRequest: parsePaymentRequest,
   );
 
   /// Precondition state that makes [SendState.willAttemptPayjoin] true and
@@ -407,6 +411,9 @@ void main() {
     registerFallbackValue(_FakeNewLabel());
     registerFallbackValue(_bitcoinLocalWallet());
     registerFallbackValue(BigInt.zero);
+    registerFallbackValue(
+      const PaymentRequest.bitcoin(address: 'fallback', isTestnet: true),
+    );
     // For any(named: 'feeRate') on the prepare-send stubs.
     registerFallbackValue(NetworkFee.relativeFromSatPerVbyte(1));
   });
@@ -901,6 +908,137 @@ void main() {
       expect(stored.reference, 'broadcast-txid');
       expect(stored.label, 'coffee');
     });
+  });
+
+  group('SendCubit.onChangedText stale detection results', () {
+    const oldText = 'old payment request';
+    const newText = 'new payment request';
+    const oldPaymentRequest = PaymentRequest.bitcoin(
+      address: 'old-address',
+      isTestnet: true,
+    );
+    const newPaymentRequest = PaymentRequest.bitcoin(
+      address: 'new-address',
+      isTestnet: true,
+    );
+
+    test('ignores an old success that resolves after a new success', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      final newResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: any(named: 'data')),
+      ).thenAnswer((invocation) {
+        final data = invocation.namedArguments[#data] as String;
+        return data == oldText ? oldResult.future : newResult.future;
+      });
+
+      final oldInput = cubit.onChangedText(oldText);
+      final newInput = cubit.onChangedText(newText);
+      newResult.complete(newPaymentRequest);
+      await newInput;
+      oldResult.complete(oldPaymentRequest);
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, newText);
+      expect(cubit.state.paymentRequest, newPaymentRequest);
+      expect(cubit.state.failure, isNull);
+    });
+
+    test('ignores an old error that resolves after a new success', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      final newResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: any(named: 'data')),
+      ).thenAnswer((invocation) {
+        final data = invocation.namedArguments[#data] as String;
+        return data == oldText ? oldResult.future : newResult.future;
+      });
+
+      final oldInput = cubit.onChangedText(oldText);
+      final newInput = cubit.onChangedText(newText);
+      newResult.complete(newPaymentRequest);
+      await newInput;
+      oldResult.completeError(StateError('old parse failed'));
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, newText);
+      expect(cubit.state.paymentRequest, newPaymentRequest);
+      expect(cubit.state.failure, isNull);
+    });
+
+    test('ignores an old success that resolves after a scan', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldResult = Completer<PaymentRequest>();
+      when(
+        () => detectBitcoinStringUsecase.execute(data: oldText),
+      ).thenAnswer((_) => oldResult.future);
+
+      final oldInput = cubit.onChangedText(oldText);
+      await cubit.onScannedPaymentRequest('scanned payment request', null);
+      oldResult.complete(oldPaymentRequest);
+      await oldInput;
+
+      expect(cubit.state.copiedRawPaymentRequest, 'scanned payment request');
+      expect(cubit.state.paymentRequest, isNull);
+    });
+
+    test(
+      'ignores a stale scan after a newer paste during Lightning parsing',
+      () async {
+        final parsing = Completer<PaymentRequest>();
+        final cubit = buildCubit(parsePaymentRequest: (_) => parsing.future);
+        addTearDown(cubit.close);
+        when(
+          () => detectBitcoinStringUsecase.execute(data: 'new payment request'),
+        ).thenAnswer(
+          (_) async => const PaymentRequest.bitcoin(
+            address: 'new-address',
+            isTestnet: true,
+          ),
+        );
+        when(
+          () => bestWalletUsecase.execute(
+            wallets: any(named: 'wallets'),
+            request: any(named: 'request'),
+            amountSat: any(named: 'amountSat'),
+          ),
+        ).thenReturn(_bitcoinLocalWallet());
+        const bip21 = PaymentRequest.bip21(
+          network: Network.bitcoinMainnet,
+          uri: 'bitcoin:old-address?lightning=old-invoice',
+          address: 'old-address',
+          lightning: 'old-invoice',
+        );
+
+        final oldScan = cubit.onScannedPaymentRequest('old scan', bip21);
+        await Future<void>.delayed(Duration.zero);
+        await cubit.onChangedText('new payment request');
+        parsing.complete(
+          PaymentRequest.bolt11(
+            invoice: 'stale-invoice',
+            amountSat: 1000,
+            paymentHash: 'stale-hash',
+            expiresAt: DateTime(2030).millisecondsSinceEpoch ~/ 1000,
+            isTestnet: true,
+          ),
+        );
+        await oldScan;
+
+        expect(cubit.state.copiedRawPaymentRequest, 'new payment request');
+        expect(
+          cubit.state.paymentRequest,
+          const PaymentRequest.bitcoin(address: 'new-address', isTestnet: true),
+        );
+        expect(cubit.state.selectedWallet, isNull);
+        expect(cubit.state.step, SendStep.address);
+        expect(cubit.state.loadingBestWallet, isFalse);
+      },
+    );
   });
 
   // A shortfall used to show "Build Failed", the same message as a dead

--- a/test/features/swap/presentation/transfer_bloc_test.dart
+++ b/test/features/swap/presentation/transfer_bloc_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
+import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
@@ -13,6 +14,7 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
@@ -116,6 +118,10 @@ class _MockCheckConsolidation extends Mock
     implements CheckLiquidConsolidationUsecase {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(const RelativeFee(250));
+  });
+
   late _MockMarkUnknown markUnknown;
   late _MockMarkBroadcast markBroadcast;
   late _MockBroadcastBitcoin broadcastBitcoin;
@@ -127,6 +133,7 @@ void main() {
   late _MockConvertSats convertSats;
   late _MockWatchOrder watchOrder;
   late _MockGetWallet getWallet;
+  late _MockPrepareBitcoin prepareBitcoin;
   late OrderSwapRecord prepared;
   late TransferBloc bloc;
 
@@ -142,6 +149,7 @@ void main() {
     convertSats = _MockConvertSats();
     watchOrder = _MockWatchOrder();
     getWallet = _MockGetWallet();
+    prepareBitcoin = _MockPrepareBitcoin();
     prepared = _prepared();
     when(
       () => getWallet.execute('wallet-1', sync: true),
@@ -151,7 +159,7 @@ void main() {
       getSettingsUsecase: getSettings,
       getWalletsUsecase: getWallets,
       getNetworkFeesUsecase: getNetworkFees,
-      prepareBitcoinSendUsecase: _MockPrepareBitcoin(),
+      prepareBitcoinSendUsecase: prepareBitcoin,
       prepareLiquidSendUsecase: _MockPrepareLiquid(),
       calculateBitcoinAbsoluteFeesUsecase: _MockCalculateBitcoin(),
       calculateLiquidAbsoluteFeesUsecase: _MockCalculateLiquid(),
@@ -181,6 +189,42 @@ void main() {
   });
 
   tearDown(() => bloc.close());
+
+  test(
+    'exposes insufficient funds when same-chain creation raises a shortfall',
+    () async {
+      final source = _wallet(balanceSat: BigInt.from(2000));
+      final destination = _destinationWallet();
+      when(
+        () => prepareBitcoin.execute(
+          walletId: source.id,
+          address: any(named: 'address'),
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: true,
+        ),
+      ).thenThrow(InsufficientFundsException('shortfall'));
+      bloc.emit(
+        TransferState(
+          fromWallet: source,
+          toWallet: destination,
+          receiveAddress: 'tb1qdestination',
+          bitcoinUnit: BitcoinUnit.sats,
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.swapCreated('1000'));
+      await bloc.stream.firstWhere((state) => !state.isCreatingSwap);
+
+      expect(
+        bloc.state.swapCreationException,
+        isA<InsufficientFundsSwapException>(),
+      );
+    },
+  );
 
   test(
     'broadcasts a prepared order swap and emits its transaction id',
@@ -589,7 +633,7 @@ ChainSwap _swap() =>
         )
         as ChainSwap;
 
-Wallet _wallet() => Wallet(
+Wallet _wallet({BigInt? balanceSat}) => Wallet(
   origin: 'wallet-1',
   network: Network.bitcoinTestnet,
   xpubFingerprint: 'fingerprint',
@@ -599,7 +643,7 @@ Wallet _wallet() => Wallet(
   internalPublicDescriptor: 'internal',
   signer: SignerEntity.local,
   signerDevice: null,
-  balanceSat: BigInt.zero,
+  balanceSat: balanceSat ?? BigInt.zero,
 );
 
 Wallet _liquidWallet({String id = 'wallet-1', bool isDefault = false}) =>

--- a/test/features/swap/ui/swap_in_progress_back_test.dart
+++ b/test/features/swap/ui/swap_in_progress_back_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
+import 'package:bb_mobile/features/swap/ui/pages/swap_in_progress_page.dart';
+import 'package:bb_mobile/features/swap/ui/swap_router.dart';
+import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTransferBloc extends Mock implements TransferBloc {}
+
+void main() {
+  testWidgets('system back on the transfer in progress page goes home', (
+    tester,
+  ) async {
+    final bloc = _MockTransferBloc();
+    when(() => bloc.state).thenReturn(const TransferState());
+    when(
+      () => bloc.stream,
+    ).thenAnswer((_) => StreamController<TransferState>.broadcast().stream);
+
+    // The real flow reaches this page with a `go`, which leaves the stack as
+    // [/swap, /swap/in-progress] — the wallet home is gone from under it, so
+    // popping lands on an orphan transfer page whose next back closes the app.
+    // The transfer page itself is stubbed here; only the stack shape matters.
+    final router = GoRouter(
+      initialLocation: SwapRoute.swap.path,
+      routes: [
+        GoRoute(
+          name: WalletRoute.walletHome.name,
+          path: WalletRoute.walletHome.path,
+          builder: (context, state) => const Scaffold(body: Text('home')),
+        ),
+        GoRoute(
+          name: SwapRoute.swap.name,
+          path: SwapRoute.swap.path,
+          builder: (context, state) => const Scaffold(body: Text('transfer')),
+          routes: [
+            GoRoute(
+              name: SwapRoute.inProgressSwap.name,
+              path: SwapRoute.inProgressSwap.path,
+              builder: (context, state) => BlocProvider<TransferBloc>.value(
+                value: bloc,
+                child: const SwapInProgressPage(),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Exactly what the router does once the transfer is broadcast.
+    router.goNamed(SwapRoute.inProgressSwap.name);
+    await tester.pumpAndSettle();
+    expect(find.byType(SwapInProgressPage), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(handled, isTrue);
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      WalletRoute.walletHome.path,
+    );
+    expect(find.text('transfer'), findsNothing);
+    expect(find.text('home'), findsOneWidget);
+  });
+}

--- a/test/features/test_wallet_backup/domain/verify_physical_backup_usecase_test.dart
+++ b/test/features/test_wallet_backup/domain/verify_physical_backup_usecase_test.dart
@@ -1,0 +1,114 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSeedRepository extends Mock implements SeedRepository {}
+
+const _fingerprint = 'abcd1234';
+const _mnemonicWords = [
+  'legal',
+  'winner',
+  'thank',
+  'year',
+  'wave',
+  'sausage',
+  'worth',
+  'useful',
+  'legal',
+  'winner',
+  'thank',
+  'yes',
+];
+
+void main() {
+  late _MockSeedRepository seedRepository;
+  late VerifyPhysicalBackupUsecase usecase;
+
+  setUp(() {
+    seedRepository = _MockSeedRepository();
+    usecase = VerifyPhysicalBackupUsecase(seedRepository: seedRepository);
+  });
+
+  group('VerifyPhysicalBackupUsecase', () {
+    test('returns true when the words match the stored seed', () async {
+      when(() => seedRepository.get(_fingerprint)).thenAnswer(
+        (_) async => MnemonicSeed(
+          mnemonicWords: _mnemonicWords,
+          bytes: Uint8List.fromList([1, 2, 3]),
+          masterFingerprint: _fingerprint,
+        ),
+      );
+
+      final result = await usecase.execute(
+        fingerprint: _fingerprint,
+        mnemonic: _mnemonicWords,
+      );
+
+      expect(result, isTrue);
+    });
+
+    test('returns false when the word order differs', () async {
+      when(() => seedRepository.get(_fingerprint)).thenAnswer(
+        (_) async => MnemonicSeed(
+          mnemonicWords: _mnemonicWords,
+          bytes: Uint8List.fromList([1, 2, 3]),
+          masterFingerprint: _fingerprint,
+        ),
+      );
+
+      final shuffled = [..._mnemonicWords]..swap(0, 1);
+      final result = await usecase.execute(
+        fingerprint: _fingerprint,
+        mnemonic: shuffled,
+      );
+
+      expect(result, isFalse);
+    });
+
+    test('returns false when the word count differs', () async {
+      when(() => seedRepository.get(_fingerprint)).thenAnswer(
+        (_) async => MnemonicSeed(
+          mnemonicWords: _mnemonicWords,
+          bytes: Uint8List.fromList([1, 2, 3]),
+          masterFingerprint: _fingerprint,
+        ),
+      );
+
+      final result = await usecase.execute(
+        fingerprint: _fingerprint,
+        mnemonic: _mnemonicWords.sublist(0, 11),
+      );
+
+      expect(result, isFalse);
+    });
+
+    test('throws when the stored seed is not a mnemonic seed', () async {
+      when(() => seedRepository.get(_fingerprint)).thenAnswer(
+        (_) async => BytesSeed(
+          bytes: Uint8List.fromList([1, 2, 3]),
+          masterFingerprint: _fingerprint,
+        ),
+      );
+
+      expect(
+        () => usecase.execute(
+          fingerprint: _fingerprint,
+          mnemonic: _mnemonicWords,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}
+
+extension on List<String> {
+  void swap(int a, int b) {
+    final tmp = this[a];
+    this[a] = this[b];
+    this[b] = tmp;
+  }
+}

--- a/test/features/test_wallet_backup/presentation/test_wallet_backup_bloc_test.dart
+++ b/test/features/test_wallet_backup/presentation/test_wallet_backup_bloc_test.dart
@@ -1,0 +1,201 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/features/onboarding/complete_physical_backup_verification_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/get_mnemonic_from_fingerprint_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_wallets_for_network_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockCompletePhysicalBackupVerificationUsecase extends Mock
+    implements CompletePhysicalBackupVerificationUsecase {}
+
+class _MockLoadWalletsForNetworkUsecase extends Mock
+    implements LoadWalletsForNetworkUsecase {}
+
+class _MockGetMnemonicFromFingerprintUsecase extends Mock
+    implements GetMnemonicFromFingerprintUsecase {}
+
+class _MockVerifyPhysicalBackupUsecase extends Mock
+    implements VerifyPhysicalBackupUsecase {}
+
+class _SeedableTestWalletBackupBloc extends TestWalletBackupBloc {
+  _SeedableTestWalletBackupBloc({
+    required super.completePhysicalBackupVerificationUsecase,
+    required super.loadWalletsForNetworkUsecase,
+    required super.getMnemonicFromFingerprintUsecase,
+    required super.verifyPhysicalBackupUsecase,
+  });
+
+  void seed(TestWalletBackupState state) => emit(state);
+}
+
+const _fingerprint = 'abcd1234';
+const _mnemonicWords = [
+  'legal',
+  'winner',
+  'thank',
+  'year',
+  'wave',
+  'sausage',
+  'worth',
+  'useful',
+  'legal',
+  'winner',
+  'thank',
+  'yes',
+];
+
+Wallet _wallet({required bool isDefault, required String origin}) => Wallet(
+  origin: origin,
+  label: 'Test',
+  network: Network.bitcoinMainnet,
+  isDefault: isDefault,
+  masterFingerprint: _fingerprint,
+  xpubFingerprint: _fingerprint,
+  scriptType: ScriptType.bip84,
+  xpub: 'xpub',
+  externalPublicDescriptor: 'desc',
+  internalPublicDescriptor: 'desc',
+  signer: SignerEntity.local,
+  signerDevice: null,
+  balanceSat: BigInt.zero,
+);
+
+void main() {
+  late _MockCompletePhysicalBackupVerificationUsecase completeUsecase;
+  late _MockLoadWalletsForNetworkUsecase loadWalletsUsecase;
+  late _MockGetMnemonicFromFingerprintUsecase getMnemonicUsecase;
+  late _MockVerifyPhysicalBackupUsecase verifyUsecase;
+
+  setUp(() {
+    completeUsecase = _MockCompletePhysicalBackupVerificationUsecase();
+    loadWalletsUsecase = _MockLoadWalletsForNetworkUsecase();
+    getMnemonicUsecase = _MockGetMnemonicFromFingerprintUsecase();
+    verifyUsecase = _MockVerifyPhysicalBackupUsecase();
+  });
+
+  _SeedableTestWalletBackupBloc buildBloc() => _SeedableTestWalletBackupBloc(
+    completePhysicalBackupVerificationUsecase: completeUsecase,
+    loadWalletsForNetworkUsecase: loadWalletsUsecase,
+    getMnemonicFromFingerprintUsecase: getMnemonicUsecase,
+    verifyPhysicalBackupUsecase: verifyUsecase,
+  );
+
+  group('TestWalletBackupBloc', () {
+    test('loads wallets and selects the default one', () async {
+      final nonDefault = _wallet(isDefault: false, origin: 'a');
+      final defaultWallet = _wallet(isDefault: true, origin: 'b');
+      when(
+        () => loadWalletsUsecase.execute(),
+      ).thenAnswer((_) async => [nonDefault, defaultWallet]);
+      final bloc = buildBloc();
+
+      final expectation = expectLater(
+        bloc.stream,
+        emits(
+          predicate<TestWalletBackupState>(
+            (s) => s.wallets.length == 2 && s.selectedWallet == defaultWallet,
+          ),
+        ),
+      );
+      bloc.add(const LoadWallets());
+      await expectation;
+      await bloc.close();
+    });
+
+    test(
+      'emits success and completes the backup when words are correct',
+      () async {
+        when(
+          () => verifyUsecase.execute(
+            fingerprint: _fingerprint,
+            mnemonic: _mnemonicWords,
+          ),
+        ).thenAnswer((_) async => true);
+        when(() => completeUsecase.execute()).thenAnswer((_) async {});
+        final bloc = buildBloc();
+        bloc.seed(
+          TestWalletBackupState(
+            selectedWallet: _wallet(isDefault: true, origin: 'a'),
+          ),
+        );
+
+        final expectation = expectLater(
+          bloc.stream,
+          emits(
+            predicate<TestWalletBackupState>(
+              (s) => s.verificationStatus == BackupVerificationStatus.success,
+            ),
+          ),
+        );
+        bloc.add(const VerifyPhysicalBackup(reorderedWords: _mnemonicWords));
+        await expectation;
+
+        verify(
+          () => verifyUsecase.execute(
+            fingerprint: _fingerprint,
+            mnemonic: _mnemonicWords,
+          ),
+        ).called(1);
+        verify(() => completeUsecase.execute()).called(1);
+        await bloc.close();
+      },
+    );
+
+    test(
+      'emits failure and does not complete the backup when words are wrong',
+      () async {
+        when(
+          () => verifyUsecase.execute(
+            fingerprint: any(named: 'fingerprint'),
+            mnemonic: any(named: 'mnemonic'),
+          ),
+        ).thenAnswer((_) async => false);
+        final bloc = buildBloc();
+        bloc.seed(
+          TestWalletBackupState(
+            selectedWallet: _wallet(isDefault: true, origin: 'a'),
+          ),
+        );
+
+        final expectation = expectLater(
+          bloc.stream,
+          emits(
+            predicate<TestWalletBackupState>(
+              (s) => s.verificationStatus == BackupVerificationStatus.failure,
+            ),
+          ),
+        );
+        bloc.add(const VerifyPhysicalBackup(reorderedWords: _mnemonicWords));
+        await expectation;
+
+        verifyNever(() => completeUsecase.execute());
+        await bloc.close();
+      },
+    );
+
+    test('never exposes the secret through state or toString', () async {
+      when(
+        () => getMnemonicUsecase.execute(_fingerprint),
+      ).thenAnswer((_) async => (_mnemonicWords, 'secret-passphrase'));
+      final bloc = buildBloc();
+      bloc.seed(
+        TestWalletBackupState(
+          selectedWallet: _wallet(isDefault: true, origin: 'a'),
+        ),
+      );
+
+      final (words, passphrase) = await bloc.loadSelectedWalletMnemonic();
+
+      expect(words, _mnemonicWords);
+      expect(passphrase, 'secret-passphrase');
+      for (final word in _mnemonicWords) {
+        expect(bloc.state.toString(), isNot(contains(word)));
+      }
+      expect(bloc.state.toString(), isNot(contains('secret-passphrase')));
+      await bloc.close();
+    });
+  });
+}

--- a/test/features/transactions/application/usecases/get_transactions_by_tx_id_usecase_test.dart
+++ b/test/features/transactions/application/usecases/get_transactions_by_tx_id_usecase_test.dart
@@ -1,0 +1,147 @@
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
+import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
+import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/swaps/domain/repositories/swap_history_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
+import 'package:bb_mobile/features/transactions/application/usecases/get_transaction_order_swaps_usecase.dart';
+import 'package:bb_mobile/features/transactions/application/usecases/get_transactions_by_tx_id_usecase.dart';
+import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+class _MockWalletTransactionRepository extends Mock
+    implements WalletTransactionRepository {}
+
+class _MockSwapHistoryRepository extends Mock
+    implements SwapHistoryRepository {}
+
+class _MockPayjoinSessions extends Mock implements PayjoinSessions {}
+
+class _MockExchangeOrderRepository extends Mock
+    implements ExchangeOrderRepository {}
+
+class _MockGetTransactionOrderSwapsUsecase extends Mock
+    implements GetTransactionOrderSwapsUsecase {}
+
+const _txId = 'tx-1';
+
+void main() {
+  late _MockSettingsRepository settingsRepository;
+  late _MockWalletTransactionRepository walletTransactionRepository;
+  late _MockSwapHistoryRepository swapHistoryRepository;
+  late _MockPayjoinSessions payjoinSessions;
+  late _MockExchangeOrderRepository mainnetOrderRepository;
+  late _MockExchangeOrderRepository testnetOrderRepository;
+  late _MockGetTransactionOrderSwapsUsecase getTransactionOrderSwapsUsecase;
+  late GetTransactionsByTxIdUsecase usecase;
+
+  setUp(() {
+    settingsRepository = _MockSettingsRepository();
+    walletTransactionRepository = _MockWalletTransactionRepository();
+    swapHistoryRepository = _MockSwapHistoryRepository();
+    payjoinSessions = _MockPayjoinSessions();
+    mainnetOrderRepository = _MockExchangeOrderRepository();
+    testnetOrderRepository = _MockExchangeOrderRepository();
+    getTransactionOrderSwapsUsecase = _MockGetTransactionOrderSwapsUsecase();
+    usecase = GetTransactionsByTxIdUsecase(
+      settingsRepository: settingsRepository,
+      walletTransactionRepository: walletTransactionRepository,
+      boltzSwapRepository: swapHistoryRepository,
+      payjoinSessions: payjoinSessions,
+      mainnetExchangeOrderRepository: mainnetOrderRepository,
+      testnetExchangeOrderRepository: testnetOrderRepository,
+      getTransactionOrderSwapsUsecase: getTransactionOrderSwapsUsecase,
+    );
+
+    when(() => settingsRepository.fetch()).thenAnswer((_) async => _settings());
+    when(
+      () => walletTransactionRepository.getWalletTransactions(
+        txId: any(named: 'txId'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(
+      () => swapHistoryRepository.getSwapByTxId(any()),
+    ).thenAnswer((_) async => null);
+    when(
+      () => getTransactionOrderSwapsUsecase.execute(),
+    ).thenAnswer((_) async => []);
+  });
+
+  test(
+    'keeps the order when only a payjoin session is found for the txid',
+    () async {
+      final payjoin = _payjoinSession();
+      final order = _buyOrder();
+      when(
+        () => payjoinSessions.byTransactionId(_txId),
+      ).thenAnswer((_) async => Ok([payjoin]));
+      when(
+        () => mainnetOrderRepository.getOrderByTxId(_txId),
+      ).thenAnswer((_) async => order);
+
+      final transactions = await usecase.execute(_txId);
+
+      expect(transactions, hasLength(1));
+      expect(transactions.single.payjoin, payjoin);
+      // Without this the order-anchored details screen renders as a payjoin
+      // session until the wallet indexes the broadcast.
+      expect(transactions.single.order, order);
+    },
+  );
+
+  test('still returns the payjoin when no order matches the txid', () async {
+    final payjoin = _payjoinSession();
+    when(
+      () => payjoinSessions.byTransactionId(_txId),
+    ).thenAnswer((_) async => Ok([payjoin]));
+    when(
+      () => mainnetOrderRepository.getOrderByTxId(_txId),
+    ).thenAnswer((_) async => null);
+
+    final transactions = await usecase.execute(_txId);
+
+    expect(transactions, hasLength(1));
+    expect(transactions.single.payjoin, payjoin);
+    expect(transactions.single.order, isNull);
+  });
+}
+
+SettingsEntity _settings() => const SettingsEntity(
+  environment: Environment.mainnet,
+  bitcoinUnit: BitcoinUnit.btc,
+  currencyCode: 'CAD',
+);
+
+PayjoinSession _payjoinSession() => PayjoinReceiverSession(
+  status: PayjoinStatus.completed,
+  id: 'payjoin-1',
+  network: BitcoinNetwork.mainnet,
+  walletId: 'wallet-1',
+  createdAt: DateTime.utc(2026, 8, 19),
+  expiresAt: DateTime.utc(2026, 8, 20),
+  payjoinUri: 'bitcoin:address?pj=https://payjoin.example',
+  transactionId: _txId,
+);
+
+Order _buyOrder() => Order.buy(
+  orderId: 'order-1',
+  orderType: OrderType.buy,
+  message: OrderMessage(code: '', message: ''),
+  orderNumber: 1,
+  payinAmount: 100,
+  payinCurrency: 'CAD',
+  payoutAmount: 0.001,
+  payoutCurrency: 'BTC',
+  payinMethod: OrderPaymentMethod.eTransfer,
+  payoutMethod: OrderPaymentMethod.bitcoin,
+  orderStatus: OrderStatus.inProgress,
+  payinStatus: OrderPayinStatus.completed,
+  payoutStatus: OrderPayoutStatus.completed,
+  createdAt: DateTime.utc(2026, 8, 19),
+  payjoinDetails: OrderPayjoinDetails(txid: _txId),
+  isTestnet: false,
+);

--- a/test/features/transactions/application/usecases/get_transactions_usecase_test.dart
+++ b/test/features/transactions/application/usecases/get_transactions_usecase_test.dart
@@ -1,8 +1,10 @@
+import 'dart:typed_data';
 import 'package:bb_mobile/core/exchange/domain/repositories/exchange_order_repository.dart';
 import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/transaction_output.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
@@ -181,6 +183,50 @@ void main() {
     expect(transactions.single.orderSwap?.localId, 'receive-order');
   });
 
+  test('binds a buy the exchange still knows only by its payjoin txid', () async {
+    // The exchange broadcasts the payjoin before it reports that transaction as
+    // the order's payout, so the order carries no payout txid yet while the
+    // wallet already sees the transaction. Both describe the same event and the
+    // amounts agree; the list must show one row, not "Bitcoin" plus "Buy
+    // Bitcoin".
+    final payout = _walletTransaction(
+      txId: 'payjoin-txid',
+      walletId: 'w1',
+      isIncoming: true,
+      amountSat: 175906,
+      address: 'bc1qmine',
+    );
+    when(
+      () => walletTransactionRepository.getWalletTransactions(
+        walletId: any(named: 'walletId'),
+        sync: any(named: 'sync'),
+        environment: any(named: 'environment'),
+      ),
+    ).thenAnswer((_) async => [payout]);
+    when(
+      () => payjoinSessions.list(any()),
+    ).thenAnswer((_) async => const Ok([]));
+    orders.add(
+      _buyOrder(
+        txId: null,
+        address: 'bc1qmine',
+        payoutAmountBtc: 0.00175906,
+        payjoinTxid: 'payjoin-txid',
+        orderStatus: OrderStatus.inProgress,
+      ),
+    );
+
+    final transactions = await usecase.execute();
+
+    expect(
+      transactions,
+      hasLength(1),
+      reason: 'the order must not be listed again beside its own payjoin',
+    );
+    expect(transactions.single.order?.orderId, 'buy-order');
+    expect(transactions.single.walletTransaction?.txId, 'payjoin-txid');
+  });
+
   test('keeps one canonical row for an internal chain swap', () async {
     final payin = _walletTransaction(
       txId: 'payin-tx',
@@ -218,6 +264,8 @@ WalletTransaction _walletTransaction({
   required String txId,
   required String walletId,
   required bool isIncoming,
+  int amountSat = 1000,
+  String? address,
 }) {
   return WalletTransaction(
     walletId: walletId,
@@ -227,14 +275,52 @@ WalletTransaction _walletTransaction({
         : WalletTransactionDirection.outgoing,
     status: WalletTransactionStatus.confirmed,
     txId: txId,
-    amountSat: 1000,
+    amountSat: amountSat,
     feeSat: 1,
     vsize: 100,
     inputs: const [],
-    outputs: const [],
+    outputs: [
+      if (address != null)
+        TransactionOutput.bitcoin(
+          txId: txId,
+          vout: 0,
+          isOwn: isIncoming,
+          scriptPubkey: Uint8List(0),
+          address: address,
+        ),
+    ],
     isRbf: false,
   );
 }
+
+Order _buyOrder({
+  required String? txId,
+  required String address,
+  required double payoutAmountBtc,
+  String? payjoinTxid,
+  OrderStatus orderStatus = OrderStatus.completed,
+}) => Order.buy(
+  orderId: 'buy-order',
+  orderType: OrderType.buy,
+  message: OrderMessage(code: '', message: ''),
+  orderNumber: 1,
+  payinAmount: 100,
+  payinCurrency: 'CAD',
+  payoutAmount: payoutAmountBtc,
+  payoutCurrency: 'BTC',
+  payinMethod: OrderPaymentMethod.cadBalance,
+  payoutMethod: OrderPaymentMethod.bitcoin,
+  orderStatus: orderStatus,
+  payinStatus: OrderPayinStatus.completed,
+  payoutStatus: OrderPayoutStatus.completed,
+  createdAt: DateTime.utc(2026),
+  bitcoinAddress: address,
+  bitcoinTransactionId: txId,
+  payjoinDetails: payjoinTxid == null
+      ? null
+      : OrderPayjoinDetails(txid: payjoinTxid),
+  isTestnet: false,
+);
 
 OrderSwapRecord _receiveOrderSwap() => OrderSwapRecord(
   localId: 'receive-order',

--- a/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
+++ b/test/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:bb_mobile/core/entities/signer_entity.dart' show SignerEntity;
+import 'package:bb_mobile/core/exchange/domain/entity/order.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/get_order_usercase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/get_swap_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/watch_swap_usecase.dart';
@@ -145,6 +146,7 @@ void main() {
   late _MockBroadcastOriginalTransactionUsecase broadcastOriginalTransaction;
   late _MockGetTransactionOrderSwapUsecase getTransactionOrderSwap;
   late _MockWatchTransactionOrderSwapUsecase watchTransactionOrderSwap;
+  late _MockGetOrderUsecase getOrder;
 
   TransactionDetailsCubit buildCubit() => TransactionDetailsCubit(
     getWalletUsecase: getWallet,
@@ -155,7 +157,7 @@ void main() {
     getSwapUsecase: _MockGetSwapUsecase(),
     getPayjoinByIdUsecase: getPayjoinById,
     getPayjoinByTxIdUsecase: getPayjoinByTxId,
-    getOrderUsecase: _MockGetOrderUsecase(),
+    getOrderUsecase: getOrder,
     watchSwapUsecase: _MockWatchSwapUsecase(),
     watchPayjoinUsecase: watchPayjoin,
     watchTransactionOrderSwapUsecase: watchTransactionOrderSwap,
@@ -178,6 +180,7 @@ void main() {
     broadcastOriginalTransaction = _MockBroadcastOriginalTransactionUsecase();
     getTransactionOrderSwap = _MockGetTransactionOrderSwapUsecase();
     watchTransactionOrderSwap = _MockWatchTransactionOrderSwapUsecase();
+    getOrder = _MockGetOrderUsecase();
 
     when(() => broadcastOriginalTransaction.canExecute(any())).thenAnswer((
       invocation,
@@ -1313,7 +1316,96 @@ void main() {
       },
     );
   });
+
+  group('TransactionDetailsCubit.initByOrderId transaction resolution', () {
+    // _loadDetailsByOrderId looks the txid up, then hands it to
+    // initByWalletTxId, which looks it up again — so the usecase is called
+    // more than once per init. What matters is which txid was asked for, not
+    // how often, hence capture over a call count.
+    void expectResolvedTxIds(String txId) {
+      final resolved = verify(
+        () => getTransactionsByTxId.execute(captureAny()),
+      ).captured;
+      expect(resolved, isNotEmpty);
+      expect(resolved, everyElement(txId));
+    }
+
+    test('resolves the payjoin txid when the order has no txid yet', () async {
+      // The exchange can know the payjoin it broadcast before it reports its
+      // own payout txid. Without the fallback the screen stays on order-only
+      // details, with no payjoin shown and no watcher armed.
+      final order = _buyOrder(payjoinTxId: 'payjoin-txid');
+      when(
+        () => getOrder.execute(orderId: 'order-1'),
+      ).thenAnswer((_) async => order);
+      when(() => getTransactionsByTxId.execute(any())).thenAnswer(
+        (_) async => [Transaction(payjoin: _receiver(), order: order)],
+      );
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByOrderId('order-1');
+
+      expectResolvedTxIds('payjoin-txid');
+    });
+
+    test('prefers the order txid when both are known', () async {
+      final order = _buyOrder(
+        bitcoinTransactionId: 'payout-txid',
+        payjoinTxId: 'payjoin-txid',
+      );
+      when(
+        () => getOrder.execute(orderId: 'order-1'),
+      ).thenAnswer((_) async => order);
+      when(() => getTransactionsByTxId.execute(any())).thenAnswer(
+        (_) async => [Transaction(payjoin: _receiver(), order: order)],
+      );
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByOrderId('order-1');
+
+      expectResolvedTxIds('payout-txid');
+    });
+
+    test('falls back to order-only details when no txid is known', () async {
+      final order = _buyOrder();
+      when(
+        () => getOrder.execute(orderId: 'order-1'),
+      ).thenAnswer((_) async => order);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.initByOrderId('order-1');
+
+      verifyNever(() => getTransactionsByTxId.execute(any()));
+      expect(cubit.state.transaction?.order, order);
+    });
+  });
 }
+
+Order _buyOrder({String? bitcoinTransactionId, String? payjoinTxId}) =>
+    Order.buy(
+      orderId: 'order-1',
+      orderType: OrderType.buy,
+      message: OrderMessage(code: '', message: ''),
+      orderNumber: 1,
+      payinAmount: 100,
+      payinCurrency: 'CAD',
+      payoutAmount: 0.001,
+      payoutCurrency: 'BTC',
+      payinMethod: OrderPaymentMethod.eTransfer,
+      payoutMethod: OrderPaymentMethod.bitcoin,
+      orderStatus: OrderStatus.inProgress,
+      payinStatus: OrderPayinStatus.completed,
+      payoutStatus: OrderPayoutStatus.completed,
+      createdAt: DateTime.utc(2026, 8, 19),
+      bitcoinTransactionId: bitcoinTransactionId,
+      payjoinDetails: payjoinTxId == null
+          ? null
+          : OrderPayjoinDetails(txid: payjoinTxId),
+      isTestnet: false,
+    );
 
 OrderSwapRecord _receiveOrderSwap() {
   final createdAt = DateTime.utc(2026, 8, 10);

--- a/test/features/transactions/ui/transaction_details_back_test.dart
+++ b/test/features/transactions/ui/transaction_details_back_test.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
+import 'package:bb_mobile/features/transactions/ui/screens/transaction_details_screen.dart';
+import 'package:bb_mobile/features/transactions/ui/transactions_router.dart';
+import 'package:bb_mobile/features/wallet/ui/wallet_router.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTransactionDetailsCubit extends Mock
+    implements TransactionDetailsCubit {}
+
+/// Shaped like the real router for the routes that matter here: the details
+/// screen is a top-level route, so a flow that `go`es to it on completion
+/// leaves it alone on the stack with nothing to pop.
+GoRouter _router({required String initialLocation}) {
+  final cubit = _MockTransactionDetailsCubit();
+  when(() => cubit.state).thenReturn(const TransactionDetailsState());
+  when(() => cubit.stream).thenAnswer(
+    (_) => StreamController<TransactionDetailsState>.broadcast().stream,
+  );
+
+  return GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        name: WalletRoute.walletHome.name,
+        path: WalletRoute.walletHome.path,
+        builder: (context, state) => const Scaffold(body: Text('home')),
+      ),
+      GoRoute(
+        name: TransactionsRoute.orderSwapTransactionDetails.name,
+        path: TransactionsRoute.orderSwapTransactionDetails.path,
+        builder: (context, state) =>
+            BlocProvider<TransactionDetailsCubit>.value(
+              value: cubit,
+              child: const TransactionDetailsScreen(),
+            ),
+      ),
+    ],
+  );
+}
+
+/// The loading skeletons animate forever, so pumpAndSettle would time out —
+/// pump enough frames to run a route transition instead.
+Future<void> _frames(WidgetTester tester) async {
+  for (var i = 0; i < 4; i++) {
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+}
+
+Future<void> _pump(WidgetTester tester, GoRouter router) async {
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: router,
+      theme: AppTheme.themeData(AppThemeType.light),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
+  );
+  await _frames(tester);
+}
+
+void main() {
+  testWidgets('system back on a returnHome details screen goes home, not out', (
+    tester,
+  ) async {
+    final router = _router(
+      initialLocation: '/transaction/order-swap/local-1?returnHome=true',
+    );
+    await _pump(tester, router);
+    expect(find.byType(TransactionDetailsScreen), findsOneWidget);
+
+    // false means nothing handled the back and the framework falls through to
+    // SystemNavigator.pop() — the app closing, which is issue #2511.
+    final handled = await tester.binding.handlePopRoute();
+    await _frames(tester);
+
+    expect(handled, isTrue);
+    expect(
+      router.routerDelegate.currentConfiguration.uri.path,
+      WalletRoute.walletHome.path,
+    );
+  });
+
+  testWidgets('system back still pops when the screen was pushed', (
+    tester,
+  ) async {
+    final router = _router(initialLocation: WalletRoute.walletHome.path);
+    await _pump(tester, router);
+
+    router.pushNamed(
+      TransactionsRoute.orderSwapTransactionDetails.name,
+      pathParameters: {'localId': 'local-1'},
+    );
+    await _frames(tester);
+    expect(find.byType(TransactionDetailsScreen), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await _frames(tester);
+
+    expect(handled, isTrue);
+    expect(find.byType(TransactionDetailsScreen), findsNothing);
+    expect(find.text('home'), findsOneWidget);
+  });
+
+  testWidgets('a pushed returnHome screen still pops one step, not home', (
+    tester,
+  ) async {
+    final router = _router(initialLocation: WalletRoute.walletHome.path);
+    await _pump(tester, router);
+
+    // Reached the way the send and exchange flows do it: pushed on top of a
+    // screen the user should come back to. returnHome only redirects the ✕.
+    router.pushNamed(
+      TransactionsRoute.orderSwapTransactionDetails.name,
+      pathParameters: {'localId': 'local-1'},
+      queryParameters: {'returnHome': 'true'},
+    );
+    await _frames(tester);
+    expect(find.byType(TransactionDetailsScreen), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await _frames(tester);
+
+    expect(handled, isTrue);
+    expect(find.byType(TransactionDetailsScreen), findsNothing);
+  });
+}

--- a/test/features/transactions/ui/widgets/transaction_details_table_test.dart
+++ b/test/features/transactions/ui/widgets/transaction_details_table_test.dart
@@ -1,0 +1,131 @@
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/core/widgets/tables/details_table_item.dart';
+import 'package:bb_mobile/features/settings/presentation/bloc/settings_cubit.dart';
+import 'package:bb_mobile/features/swap/domain/entities/order_swap.dart';
+import 'package:bb_mobile/features/swap/domain/entities/order_swap_network.dart';
+import 'package:bb_mobile/features/swap/domain/entities/order_swap_record.dart';
+import 'package:bb_mobile/features/transactions/domain/entities/transaction.dart';
+import 'package:bb_mobile/features/transactions/presentation/blocs/transaction_details/transaction_details_cubit.dart';
+import 'package:bb_mobile/features/transactions/ui/widgets/transaction_details_table.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTransactionDetailsCubit extends Mock
+    implements TransactionDetailsCubit {}
+
+class _MockSettingsCubit extends Mock implements SettingsCubit {}
+
+void main() {
+  testWidgets('copies the exact order swap order number', (tester) async {
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copiedText =
+              (call.arguments as Map<Object?, Object?>)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    final detailsCubit = _MockTransactionDetailsCubit();
+    final settingsCubit = _MockSettingsCubit();
+    when(() => detailsCubit.state).thenReturn(
+      TransactionDetailsState(
+        transaction: Transaction(orderSwap: _orderSwap()),
+      ),
+    );
+    when(
+      () => detailsCubit.stream,
+    ).thenAnswer((_) => const Stream<TransactionDetailsState>.empty());
+    when(() => settingsCubit.state).thenReturn(
+      const SettingsState(
+        storedSettings: SettingsEntity(
+          environment: Environment.mainnet,
+          bitcoinUnit: BitcoinUnit.sats,
+          currencyCode: 'USD',
+        ),
+      ),
+    );
+    when(
+      () => settingsCubit.stream,
+    ).thenAnswer((_) => const Stream<SettingsState>.empty());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TransactionDetailsCubit>.value(value: detailsCubit),
+            BlocProvider<SettingsCubit>.value(value: settingsCubit),
+          ],
+          child: const Scaffold(body: TransactionDetailsTable()),
+        ),
+      ),
+    );
+
+    final orderNumberItem = find.ancestor(
+      of: find.text('123456'),
+      matching: find.byType(DetailsTableItem),
+    );
+    await tester.tap(
+      find.descendant(
+        of: orderNumberItem,
+        matching: find.byIcon(Icons.copy_outlined),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(copiedText, '123456');
+  });
+}
+
+OrderSwapRecord _orderSwap() => OrderSwapRecord(
+  localId: 'local-1',
+  purpose: OrderSwapPurpose.receiveLightning,
+  environment: OrderSwapEnvironment.testnet,
+  inNetwork: OrderSwapNetwork.lightning,
+  outNetwork: OrderSwapNetwork.liquid,
+  isInAmountFixed: true,
+  requestedAmountSat: BigInt.from(1000),
+  destinationWalletId: 'wallet-1',
+  destination: 'tlq1destination',
+  fallback: 'tlq1destination',
+  order: OrderSwap(
+    orderId: 'order-1',
+    orderNumber: 123456,
+    inNetwork: OrderSwapNetwork.lightning,
+    outNetwork: OrderSwapNetwork.liquid,
+    payinAmountSat: BigInt.from(1000),
+    payoutAmountSat: BigInt.from(900),
+    payinCurrency: 'BTCLN',
+    payoutCurrency: 'LBTC',
+    payinMethod: 'Lightning',
+    payoutMethod: 'Liquid',
+    orderType: 'Swap',
+    orderStatus: 'In_pending',
+    payinStatus: 'Awaiting payment',
+    payoutStatus: 'Not started',
+    messageCode: 'PAYMENT_NOT_DETECTED',
+    lightningInvoice: 'invoice',
+    liquidAddress: 'tlq1destination',
+    createdAt: DateTime.utc(2026),
+    confirmationDeadline: DateTime.utc(2026, 1, 1, 0, 5),
+  ),
+  createdAt: DateTime.utc(2026),
+  localStatus: OrderSwapLocalStatus.awaitingUserConfirmation,
+);


### PR DESCRIPTION
Ships the `6.13.1` patch with targeted wallet, Payjoin, swap, transaction, QR, navigation, and backup reliability fixes backported onto `main`.

## Changes

- Fix coin control selection, RBF sequence handling, frozen-coin invariants, and replacement fee prefill.
- Map Bitcoin, Liquid, and swap insufficient-funds failures consistently and preserve actionable shortfall information.
- Allow failed Payjoin sends to be retried and refresh the Receive QR immediately when toggling Payjoin.
- Fix Passport animated UR decoding.
- Prevent stale payment-request parsing from overwriting newer Send input.
- Keep mnemonics out of BLoC state and preserve exact passphrase punctuation.
- Fix system Back navigation from swap and transaction details screens.
- Open order details from Buy Success.
- Resolve and list Payjoin-linked orders without duplicate transaction rows.
- Add swap order-number copying.
- Verify BIP77 `EX` generation, QR preservation, and sender expiry handling.
- Bump the app to `6.13.1+215` and add the release changelog.

## Scope

Included: #2473, #2562, #2694, #2695, #2696, #2700, #2702, #2729, #2730, #2736, #2741, and the Payjoin Receive toggle fix.

Intentionally excluded: #2689, the Tor/#2719 chain, and unrelated non-critical UX changes.

## Validation

- [x] Full unit-test suite
- [x] 17 hotfix-focused test files — 156 tests
- [x] BIP77 expiry tests
- [x] Flutter analysis with fatal warnings and infos
- [x] `dart fix --dry-run`
- [x] Format check
- [x] `bull_ui` import-boundary check
- [x] Android arm64 debug build for `6.13.1+215`
- [x] Installed and launched on Pixel 6a
- [ ] Manual hotfix QA on Pixel 6a
- [ ] Pull-request CI

## Suggested review order

1. Wallet coin selection, fees, QR decoding, and typed shortfalls.
2. Send, swap, navigation, and backup behavior.
3. Buy, transaction, and Payjoin order association.
4. Receive QR refresh, BIP77 expiry tests, version bump, and changelog.