### PR TITLE
feat: add wallet data backup settings

### DIFF
--- a/lib/features/backup_settings/domain/backup_settings_failure.dart
+++ b/lib/features/backup_settings/domain/backup_settings_failure.dart
@@ -7,3 +7,66 @@ sealed class BackupSettingsFailure extends Failure {
 final class BackupSettingsUnexpectedFailure extends BackupSettingsFailure {
   const BackupSettingsUnexpectedFailure([super.logMessage]);
 }
+
+final class BackupSettingsUnavailableFailure extends BackupSettingsFailure {
+  const BackupSettingsUnavailableFailure();
+}
+
+final class BackupSettingsDisabledFailure extends BackupSettingsFailure {
+  const BackupSettingsDisabledFailure();
+}
+
+final class BackupSettingsUpdateRequiredFailure extends BackupSettingsFailure {
+  const BackupSettingsUpdateRequiredFailure();
+}
+
+final class BackupSettingsInvalidServerFailure extends BackupSettingsFailure {
+  const BackupSettingsInvalidServerFailure();
+}
+
+final class BackupSettingsFileReadFailure extends BackupSettingsFailure {
+  const BackupSettingsFileReadFailure();
+}
+
+final class BackupSettingsFileSaveFailure extends BackupSettingsFailure {
+  const BackupSettingsFileSaveFailure();
+}
+
+final class BackupSettingsFileTooLargeFailure extends BackupSettingsFailure {
+  const BackupSettingsFileTooLargeFailure();
+}
+
+final class BackupSettingsInvalidFileFailure extends BackupSettingsFailure {
+  const BackupSettingsInvalidFileFailure();
+}
+
+/// The backup decoded, but it was sealed to another recovery phrase.
+///
+/// Kept apart from [BackupSettingsInvalidFileFailure] because a readable backup
+/// from the wrong seed is not a damaged one, and telling the user otherwise
+/// sends them looking for a corrupt file (spec F17, 21.2).
+final class BackupSettingsSeedMismatchFailure extends BackupSettingsFailure {
+  const BackupSettingsSeedMismatchFailure();
+}
+
+/// The server refused the credentials, or answered with something this client
+/// cannot authenticate.
+final class BackupSettingsUnverifiedFailure extends BackupSettingsFailure {
+  const BackupSettingsUnverifiedFailure();
+}
+
+/// Another installation moved the remote head.
+final class BackupSettingsHeadConflictFailure extends BackupSettingsFailure {
+  const BackupSettingsHeadConflictFailure();
+}
+
+/// Local storage refused a read or a write. Nothing about the backup is wrong.
+final class BackupSettingsStorageFailure extends BackupSettingsFailure {
+  const BackupSettingsStorageFailure();
+}
+
+/// A recovery stopped part way, so some restored data still needs the user.
+final class BackupSettingsRecoveryNeedsAttentionFailure
+    extends BackupSettingsFailure {
+  const BackupSettingsRecoveryNeedsAttentionFailure();
+}

--- a/lib/features/backup_settings/domain/usecases/backup_wallet_now_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/backup_wallet_now_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+
+final class BackupWalletNowUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const BackupWalletNowUsecase(this._walletBackup);
+
+  Future<Result<void, BackupSettingsFailure>> execute() async =>
+      (await _walletBackup.backupNow()).mapErr(mapWalletBackupFailure);
+}

--- a/lib/features/backup_settings/domain/usecases/delete_wallet_backup_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/delete_wallet_backup_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+
+final class DeleteWalletBackupUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const DeleteWalletBackupUsecase(this._walletBackup);
+
+  Future<Result<void, BackupSettingsFailure>> execute() async {
+    final disabled = await _walletBackup.setEnabled(false);
+    if (disabled case Err(:final failure)) {
+      return Err(mapWalletBackupFailure(failure));
+    }
+    return (await _walletBackup.deleteRemoteBackup(
+      confirmed: true,
+    )).mapErr(mapWalletBackupFailure);
+  }
+}

--- a/lib/features/backup_settings/domain/usecases/get_wallet_backup_contents_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/get_wallet_backup_contents_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:meta/meta.dart';
+
+final class GetWalletBackupContentsUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const GetWalletBackupContentsUsecase(this._walletBackup);
+
+  @useResult
+  Future<Result<WalletBackupContents, BackupSettingsFailure>> execute() async =>
+      switch (await _walletBackup.getContents()) {
+        Ok(:final value) => Ok(value),
+        Err(:final failure) => Err(mapWalletBackupFailure(failure)),
+      };
+}

--- a/lib/features/backup_settings/domain/usecases/retry_wallet_backup_recovery_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/retry_wallet_backup_recovery_usecase.dart
@@ -1,0 +1,9 @@
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+
+final class RetryWalletBackupRecoveryUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const RetryWalletBackupRecoveryUsecase(this._walletBackup);
+
+  Future<WalletBackupRecoveryResult> execute() => _walletBackup.recover();
+}

--- a/lib/features/backup_settings/domain/usecases/set_wallet_backup_enabled_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/set_wallet_backup_enabled_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+
+final class SetWalletBackupEnabledUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const SetWalletBackupEnabledUsecase(this._walletBackup);
+
+  Future<Result<void, BackupSettingsFailure>> execute(bool enabled) async =>
+      (await _walletBackup.setEnabled(enabled)).mapErr(mapWalletBackupFailure);
+}

--- a/lib/features/backup_settings/domain/usecases/set_wallet_backup_server_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/set_wallet_backup_server_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:meta/meta.dart';
+
+final class SetWalletBackupServerUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const SetWalletBackupServerUsecase(this._walletBackup);
+
+  @useResult
+  Future<Result<void, BackupSettingsFailure>> execute(String value) async =>
+      switch (await _walletBackup.setServer(value)) {
+        Ok() => const Ok(null),
+        Err(:final failure) => Err(mapWalletBackupFailure(failure)),
+      };
+}

--- a/lib/features/backup_settings/domain/usecases/watch_wallet_backup_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/watch_wallet_backup_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+
+final class WatchWalletBackupUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const WatchWalletBackupUsecase(this._walletBackup);
+
+  Stream<Result<WalletBackupState, BackupSettingsFailure>> execute() =>
+      _walletBackup.watchState().map(
+        (result) => result.mapErr(mapWalletBackupFailure),
+      );
+}

--- a/lib/features/backup_settings/domain/wallet_backup_failure_mapper.dart
+++ b/lib/features/backup_settings/domain/wallet_backup_failure_mapper.dart
@@ -1,0 +1,68 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+
+/// Translates the backup feature's failures into the states the settings
+/// screen can explain.
+///
+/// The switch is exhaustive on purpose: a new [WalletBackupFailure] has to be
+/// given a user meaning here rather than silently collapsing into
+/// "something went wrong" (spec F17, 21.2).
+BackupSettingsFailure mapWalletBackupFailure(
+  WalletBackupFailure failure,
+) => switch (failure) {
+  // Availability. Local work stays pending; nothing about it is invalid.
+  WalletBackupRemoteUnavailableFailure() ||
+  WalletBackupRateLimitedFailure() => const BackupSettingsUnavailableFailure(),
+  WalletBackupDisabledFailure() => const BackupSettingsDisabledFailure(),
+  WalletBackupInvalidServerOriginFailure() =>
+    const BackupSettingsInvalidServerFailure(),
+  WalletBackupUnsupportedEnvelopeVersionFailure() =>
+    const BackupSettingsUpdateRequiredFailure(),
+  WalletBackupParentFingerprintMismatchFailure() =>
+    const BackupSettingsSeedMismatchFailure(),
+  WalletBackupInvalidEnvelopeFailure() ||
+  WalletBackupEncryptionFailure() ||
+  WalletBackupManifestFailure() ||
+  WalletBackupDefinitionsFailure() => const BackupSettingsInvalidFileFailure(),
+  WalletBackupSigningFailure() ||
+  WalletBackupInvalidRemoteFailure() ||
+  WalletBackupRemoteRejectedFailure() =>
+    const BackupSettingsUnverifiedFailure(),
+  WalletBackupTooLargeFailure() => const BackupSettingsFileTooLargeFailure(),
+  WalletBackupHeadConflictFailure() =>
+    const BackupSettingsHeadConflictFailure(),
+  WalletBackupStorageFailure() => const BackupSettingsStorageFailure(),
+  WalletBackupRecoveryBlockedFailure() =>
+    const BackupSettingsRecoveryNeedsAttentionFailure(),
+  WalletBackupKeyDerivationFailure() ||
+  WalletBackupWalletUnavailableFailure() ||
+  WalletBackupConfirmationRequiredFailure() ||
+  WalletBackupDeleteRequiresDisabledFailure() ||
+  WalletBackupUnexpectedFailure() => BackupSettingsUnexpectedFailure(
+    failure.runtimeType.toString(),
+  ),
+};
+
+/// The user meaning of a finished recovery, or null when it finished cleanly.
+///
+/// A recovery that only got part way is never reported as success (spec 21.1).
+BackupSettingsFailure? mapWalletBackupRecoveryStatus(
+  WalletBackupRecoveryStatus status,
+) => switch (status) {
+  WalletBackupRecoveryStatus.restored ||
+  WalletBackupRecoveryStatus.noBackup => null,
+  WalletBackupRecoveryStatus.partiallyRestored ||
+  WalletBackupRecoveryStatus.comparisonStale =>
+    const BackupSettingsRecoveryNeedsAttentionFailure(),
+  WalletBackupRecoveryStatus.unavailable ||
+  WalletBackupRecoveryStatus.timedOut =>
+    const BackupSettingsUnavailableFailure(),
+  WalletBackupRecoveryStatus.newerVersion =>
+    const BackupSettingsUpdateRequiredFailure(),
+  WalletBackupRecoveryStatus.conflict =>
+    const BackupSettingsHeadConflictFailure(),
+  WalletBackupRecoveryStatus.invalid =>
+    const BackupSettingsInvalidFileFailure(),
+  WalletBackupRecoveryStatus.localFailure =>
+    const BackupSettingsStorageFailure(),
+};

--- a/lib/features/backup_settings/presentation/backup_settings_failure_l10n.dart
+++ b/lib/features/backup_settings/presentation/backup_settings_failure_l10n.dart
@@ -5,5 +5,26 @@ import 'package:flutter/widgets.dart';
 extension BackupSettingsFailureL10n on BackupSettingsFailure {
   String toTranslated(BuildContext context) => switch (this) {
     BackupSettingsUnexpectedFailure() => context.loc.oopsSomethingWentWrong,
+    BackupSettingsUnavailableFailure() =>
+      context.loc.walletBackupSettingsUnavailable,
+    BackupSettingsDisabledFailure() => context.loc.walletBackupSettingsDisabled,
+    BackupSettingsUpdateRequiredFailure() =>
+      context.loc.walletBackupSettingsUpdateRequired,
+    BackupSettingsInvalidServerFailure() =>
+      context.loc.walletBackupSettingsInvalidServer,
+    BackupSettingsFileReadFailure() => context.loc.walletBackupFileReadFailure,
+    BackupSettingsFileSaveFailure() => context.loc.walletBackupFileSaveFailure,
+    BackupSettingsFileTooLargeFailure() => context.loc.walletBackupFileTooLarge,
+    BackupSettingsInvalidFileFailure() => context.loc.walletBackupFileInvalid,
+    BackupSettingsSeedMismatchFailure() =>
+      context.loc.walletBackupSettingsSeedMismatch,
+    BackupSettingsUnverifiedFailure() =>
+      context.loc.walletBackupSettingsUnverified,
+    BackupSettingsHeadConflictFailure() =>
+      context.loc.walletBackupSettingsHeadConflict,
+    BackupSettingsStorageFailure() =>
+      context.loc.walletBackupSettingsStorageFailure,
+    BackupSettingsRecoveryNeedsAttentionFailure() =>
+      context.loc.walletBackupSettingsRecoveryBlocked,
   };
 }

--- a/lib/features/backup_settings/ui/widgets/backup_server_editor_dialog.dart
+++ b/lib/features/backup_settings/ui/widgets/backup_server_editor_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_server_config.dart';
+import 'package:flutter/material.dart';
+
+Future<String?> showBackupServerEditorDialog(
+  BuildContext context, {
+  String? current,
+}) => showDialog<String>(
+  context: context,
+  builder: (_) => BackupServerEditorDialog(
+    initialValue: current ?? walletBackupDefaultServerUrl,
+  ),
+);
+
+class BackupServerEditorDialog extends StatefulWidget {
+  final String initialValue;
+
+  const BackupServerEditorDialog({required this.initialValue, super.key});
+
+  @override
+  State<BackupServerEditorDialog> createState() =>
+      _BackupServerEditorDialogState();
+}
+
+class _BackupServerEditorDialogState extends State<BackupServerEditorDialog> {
+  late String _value = widget.initialValue;
+  String? _error;
+
+  void _changed(String value) {
+    final error = parseWalletBackupServerOrigin(value) == null
+        ? context.loc.walletBackupSettingsServerHelp
+        : null;
+    setState(() {
+      _value = value;
+      _error = error;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    title: Text(context.loc.walletBackupSettingsServer),
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(context.loc.walletBackupSettingsServerChangeWarning),
+        const SizedBox(height: 16),
+        TextFormField(
+          initialValue: widget.initialValue,
+          autocorrect: false,
+          keyboardType: TextInputType.url,
+          onChanged: _changed,
+          decoration: InputDecoration(
+            labelText: context.loc.walletBackupSettingsServerUrl,
+            helperText: _error == null
+                ? context.loc.walletBackupSettingsServerHelp
+                : null,
+            errorText: _error,
+          ),
+        ),
+      ],
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => Navigator.pop(context),
+        child: Text(context.loc.walletBackupSettingsCancel),
+      ),
+      TextButton(
+        onPressed: () => Navigator.pop(context, ''),
+        child: Text(context.loc.walletBackupSettingsServerReset),
+      ),
+      TextButton(
+        onPressed: _error == null
+            ? () => Navigator.pop(context, _value.trim())
+            : null,
+        child: Text(context.loc.walletBackupSettingsServerSave),
+      ),
+    ],
+  );
+}

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14621,5 +14621,58 @@
   "@settingsNostrKeysSystemNsecWarningMessage": {
     "description": "Security warning shown before revealing a system Nostr private key."
   },
+  "walletBackupSettingsCancel": "Cancel",
+  "@walletBackupSettingsCancel": {
+    "description": "Cancel remote Bull backup deletion"
+  },
+  "walletBackupSettingsUnavailable": "Bull backup is temporarily unavailable.",
+  "@walletBackupSettingsUnavailable": {
+    "description": "Error when the Bull backup service cannot be reached"
+  },
+  "walletBackupSettingsDisabled": "Enable automatic Bull backup first.",
+  "@walletBackupSettingsDisabled": {
+    "description": "Error shown when backup now is requested while disabled"
+  },
+  "walletBackupSettingsUpdateRequired": "Update the app before changing this backup.",
+  "@walletBackupSettingsUpdateRequired": {
+    "description": "Error or status for a backup written by a newer app"
+  },
+  "walletBackupSettingsRecoveryBlocked": "Backup recovery needs attention.",
+  "@walletBackupSettingsRecoveryBlocked": {
+    "description": "Shown when remote wallet backup recovery was incomplete"
+  },
+  "walletBackupFileInvalid": "This backup file is invalid or belongs to another wallet",
+  "walletBackupFileReadFailure": "The backup file could not be read",
+  "walletBackupFileSaveFailure": "The backup file could not be saved",
+  "walletBackupFileTooLarge": "The backup file is too large",
+  "walletBackupSettingsServer": "Backup server",
+  "walletBackupSettingsServerUrl": "Server URL",
+  "walletBackupSettingsServerHelp": "Use HTTPS. Reset to use the Bull Bitcoin default.",
+  "walletBackupSettingsServerReset": "Reset",
+  "walletBackupSettingsServerSave": "Save",
+  "walletBackupSettingsInvalidServer": "Enter a valid HTTPS backup server URL.",
+  "@walletBackupSettingsInvalidServer": {
+    "description": "Error shown when a custom backup server URL is invalid."
+  },
+  "walletBackupSettingsServerChangeWarning": "Changing servers does not delete the encrypted backup from the previous server. Delete it first if you do not want to leave a copy there.",
+  "@walletBackupSettingsServerChangeWarning": {
+    "description": "Warning shown before changing the data backup server"
+  },
+  "walletBackupSettingsSeedMismatch": "This backup belongs to a different recovery phrase",
+  "@walletBackupSettingsSeedMismatch": {
+    "description": "Shown when a decoded Bull backup was sealed to another seed, so it cannot be recovered onto this wallet."
+  },
+  "walletBackupSettingsUnverified": "This backup could not be verified",
+  "@walletBackupSettingsUnverified": {
+    "description": "Shown when a Bull backup document fails authentication or decoding, so its contents cannot be trusted."
+  },
+  "walletBackupSettingsHeadConflict": "This backup changed on another installation",
+  "@walletBackupSettingsHeadConflict": {
+    "description": "Shown when the remote backup head moved, so this installation must reconcile before it can publish."
+  },
+  "walletBackupSettingsStorageFailure": "The app could not save recovered data",
+  "@walletBackupSettingsStorageFailure": {
+    "description": "Shown when local storage refused a read or write during a Bull backup operation."
+  },
   "walletBackupManifestPassphraseWallet": "Passphrase Wallet"
 }

--- a/test/features/backup_settings/domain/wallet_backup_failure_mapper_test.dart
+++ b/test/features/backup_settings/domain/wallet_backup_failure_mapper_test.dart
@@ -1,0 +1,187 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mapWalletBackupFailure', () {
+    // Spec 21.2. Each row is a condition the user has to be able to tell
+    // apart; two rows must never land on the same state.
+    final taxonomy = <String, (List<WalletBackupFailure>, Type)>{
+      'temporarily unavailable': (
+        [
+          const WalletBackupRemoteUnavailableFailure(),
+          const WalletBackupRateLimitedFailure(Duration(seconds: 30)),
+        ],
+        BackupSettingsUnavailableFailure,
+      ),
+      'newer version blocked': (
+        [const WalletBackupUnsupportedEnvelopeVersionFailure(99)],
+        BackupSettingsUpdateRequiredFailure,
+      ),
+      'wrong seed': (
+        [const WalletBackupParentFingerprintMismatchFailure()],
+        BackupSettingsSeedMismatchFailure,
+      ),
+      'malformed document': (
+        [
+          const WalletBackupInvalidEnvelopeFailure(),
+          const WalletBackupEncryptionFailure(),
+          const WalletBackupManifestFailure(),
+          const WalletBackupDefinitionsFailure(),
+        ],
+        BackupSettingsInvalidFileFailure,
+      ),
+      'authentication failed': (
+        [
+          const WalletBackupSigningFailure(),
+          const WalletBackupInvalidRemoteFailure(),
+          const WalletBackupRemoteRejectedFailure(),
+        ],
+        BackupSettingsUnverifiedFailure,
+      ),
+      'head conflict': (
+        [const WalletBackupHeadConflictFailure()],
+        BackupSettingsHeadConflictFailure,
+      ),
+      'too large': (
+        [const WalletBackupTooLargeFailure()],
+        BackupSettingsFileTooLargeFailure,
+      ),
+      'local storage failure': (
+        [const WalletBackupStorageFailure()],
+        BackupSettingsStorageFailure,
+      ),
+      'recovery needs attention': (
+        [const WalletBackupRecoveryBlockedFailure()],
+        BackupSettingsRecoveryNeedsAttentionFailure,
+      ),
+      'disabled': (
+        [const WalletBackupDisabledFailure()],
+        BackupSettingsDisabledFailure,
+      ),
+      'invalid server': (
+        [const WalletBackupInvalidServerOriginFailure()],
+        BackupSettingsInvalidServerFailure,
+      ),
+      'unexpected': (
+        [
+          const WalletBackupKeyDerivationFailure(),
+          const WalletBackupWalletUnavailableFailure(),
+          const WalletBackupConfirmationRequiredFailure(),
+          const WalletBackupDeleteRequiresDisabledFailure(),
+          const WalletBackupUnexpectedFailure(),
+        ],
+        BackupSettingsUnexpectedFailure,
+      ),
+    };
+
+    taxonomy.forEach((condition, entry) {
+      final (failures, expected) = entry;
+      test('$condition reaches the user as $expected', () {
+        for (final failure in failures) {
+          expect(
+            mapWalletBackupFailure(failure).runtimeType,
+            expected,
+            reason: '${failure.runtimeType} must read as $condition',
+          );
+        }
+      });
+    });
+
+    test('every condition produces a state no other condition produces', () {
+      final states = <Type, String>{};
+      taxonomy.forEach((condition, entry) {
+        final state = mapWalletBackupFailure(entry.$1.first).runtimeType;
+        expect(
+          states,
+          isNot(contains(state)),
+          reason: '$condition collapses into ${states[state]}',
+        );
+        states[state] = condition;
+      });
+      expect(states, hasLength(taxonomy.length));
+    });
+
+    test('availability is never reported as invalid data', () {
+      expect(
+        mapWalletBackupFailure(
+          const WalletBackupRateLimitedFailure(Duration(minutes: 1)),
+        ),
+        isNot(isA<BackupSettingsInvalidFileFailure>()),
+      );
+    });
+
+    test('a readable backup from another seed is not called invalid', () {
+      expect(
+        mapWalletBackupFailure(
+          const WalletBackupParentFingerprintMismatchFailure(),
+        ),
+        isNot(isA<BackupSettingsInvalidFileFailure>()),
+      );
+    });
+
+    test('the unexpected state keeps the developer detail', () {
+      final failure = mapWalletBackupFailure(
+        const WalletBackupUnexpectedFailure(),
+      );
+      expect(
+        (failure as BackupSettingsUnexpectedFailure).logMessage,
+        'WalletBackupUnexpectedFailure',
+      );
+    });
+  });
+
+  group('mapWalletBackupRecoveryStatus', () {
+    test('a finished recovery has nothing to report', () {
+      for (final status in const [
+        WalletBackupRecoveryStatus.restored,
+        WalletBackupRecoveryStatus.noBackup,
+      ]) {
+        expect(mapWalletBackupRecoveryStatus(status), isNull);
+      }
+    });
+
+    test('a partial recovery is not reported as success', () {
+      expect(
+        mapWalletBackupRecoveryStatus(
+          WalletBackupRecoveryStatus.partiallyRestored,
+        ),
+        isA<BackupSettingsRecoveryNeedsAttentionFailure>(),
+      );
+    });
+
+    test('each unfinished status keeps its own meaning', () {
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.unavailable),
+        isA<BackupSettingsUnavailableFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.timedOut),
+        isA<BackupSettingsUnavailableFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.newerVersion),
+        isA<BackupSettingsUpdateRequiredFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.conflict),
+        isA<BackupSettingsHeadConflictFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.invalid),
+        isA<BackupSettingsInvalidFileFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(WalletBackupRecoveryStatus.localFailure),
+        isA<BackupSettingsStorageFailure>(),
+      );
+      expect(
+        mapWalletBackupRecoveryStatus(
+          WalletBackupRecoveryStatus.comparisonStale,
+        ),
+        isA<BackupSettingsRecoveryNeedsAttentionFailure>(),
+      );
+    });
+  });
+}

--- a/test/features/backup_settings/ui/backup_server_editor_dialog_test.dart
+++ b/test/features/backup_settings/ui/backup_server_editor_dialog_test.dart
@@ -1,0 +1,104 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/backup_settings/ui/widgets/backup_server_editor_dialog.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('edits, validates, and saves without owning a controller', (
+    tester,
+  ) async {
+    String? result;
+    await _pump(
+      tester,
+      onOpen: (context) async {
+        result = await showBackupServerEditorDialog(context);
+      },
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('https://backup.bull-wallet.com'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField), 'http://example.com');
+    await tester.pump();
+    expect(
+      tester
+          .widget<TextButton>(find.widgetWithText(TextButton, 'Save'))
+          .onPressed,
+      isNull,
+    );
+
+    await tester.enterText(
+      find.byType(TextFormField),
+      'https://backup.example.com',
+    );
+    tester.testTextInput.hide();
+    await tester.pump();
+    await tester.tap(find.widgetWithText(TextButton, 'Save'));
+    await tester.pumpAndSettle();
+    expect(result, 'https://backup.example.com');
+  });
+
+  testWidgets('cancel and route pop return no value', (tester) async {
+    String? result = 'unchanged';
+    await _pump(
+      tester,
+      onOpen: (context) async {
+        result = await showBackupServerEditorDialog(context);
+      },
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(result, isNull);
+
+    result = 'unchanged';
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(result, isNull);
+  });
+
+  testWidgets('reset returns the default sentinel', (tester) async {
+    String? result;
+    await _pump(
+      tester,
+      onOpen: (context) async {
+        result = await showBackupServerEditorDialog(
+          context,
+          current: 'https://backup.example.com',
+        );
+      },
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+    await tester.pumpAndSettle();
+    expect(result, '');
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required Future<void> Function(BuildContext context) onOpen,
+}) => tester.pumpWidget(
+  MaterialApp(
+    theme: AppTheme.themeData(AppThemeType.light),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    locale: const Locale('en'),
+    home: Builder(
+      builder: (context) => Scaffold(
+        body: TextButton(
+          onPressed: () => onOpen(context),
+          child: const Text('Open'),
+        ),
+      ),
+    ),
+  ),
+);


### PR DESCRIPTION
## What this adds

This adds the settings and status surface for encrypted wallet data backups.

- Enables or disables automatic Bull Backup.
- Shows whether protected data is current, dirty, unavailable, or recovering.
- Allows an immediate backup.
- Configures the backup server, defaulting to https://backup.bull-wallet.com.
- Deletes the remote backup without deleting local wallet data.
- Shows the recovery manifest and Nostr identity inventory.
- Shows the actual protected labels, frozen-coin state, wallet preferences, app settings, autoswap policy, Electrum configuration, Mempool configuration, and Payjoin policy in a read-only view.

## Approach

The screen reads the existing backup presentation state and sends mutations through the backup facade. The protected-data view receives the same typed settings snapshot used by backup; it introduces no editable controls or second UI model. Destructive actions require confirmation. Server URL validation accepts HTTPS hosts and non-release loopback HTTP for local development.

## Verification

Cubit and widget tests cover state labels, enabling and disabling, immediate backup, server changes, remote deletion, unavailable states, protected-data counts, and representative values from every backed-up settings category.
