### PR TITLE
feat: export and recover wallet data backup files

### DIFF
--- a/lib/features/backup_settings/data/file_picker_wallet_backup_file_repository.dart
+++ b/lib/features/backup_settings/data/file_picker_wallet_backup_file_repository.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/repositories/wallet_backup_file_repository.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:primitives/primitives.dart';
+
+final class FilePickerWalletBackupFileRepository
+    implements WalletBackupFileRepository {
+  final FilePicker _picker;
+
+  FilePickerWalletBackupFileRepository([FilePicker? picker])
+    : _picker = picker ?? FilePicker.platform;
+
+  @override
+  Future<Result<bool, BackupSettingsFailure>> save(
+    WalletBackupExport export,
+  ) async {
+    try {
+      final bytes = export.copyBytes();
+      final savedPath = await _picker.saveFile(
+        bytes: bytes,
+        fileName: export.suggestedFilename,
+      );
+      return Ok(savedPath != null);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Could not save wallet backup file',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(BackupSettingsFileSaveFailure());
+    }
+  }
+
+  @override
+  Future<Result<Uint8List?, BackupSettingsFailure>> pick({
+    required int maximumBytes,
+  }) async {
+    try {
+      final result = await _picker.pickFiles(type: FileType.any);
+      if (result == null) return const Ok(null);
+      final file = result.files.single;
+      if (file.size <= 0) {
+        return const Err(BackupSettingsFileReadFailure());
+      }
+      if (file.size > maximumBytes) {
+        return const Err(BackupSettingsFileTooLargeFailure());
+      }
+      final Uint8List bytes;
+      if (file.bytes case final inMemory?) {
+        bytes = inMemory;
+      } else if (file.path case final filePath?) {
+        final builder = BytesBuilder(copy: false);
+        await for (final chunk in File(
+          filePath,
+        ).openRead(0, maximumBytes + 1)) {
+          builder.add(chunk);
+        }
+        bytes = builder.takeBytes();
+      } else {
+        return const Err(BackupSettingsFileReadFailure());
+      }
+      if (bytes.length > maximumBytes) {
+        return const Err(BackupSettingsFileTooLargeFailure());
+      }
+      if (bytes.isEmpty || bytes.length != file.size) {
+        return const Err(BackupSettingsFileReadFailure());
+      }
+      return Ok(bytes);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Could not read wallet backup file',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(BackupSettingsFileReadFailure());
+    }
+  }
+}

--- a/lib/features/backup_settings/domain/repositories/wallet_backup_file_repository.dart
+++ b/lib/features/backup_settings/domain/repositories/wallet_backup_file_repository.dart
@@ -1,0 +1,16 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class WalletBackupFileRepository {
+  @useResult
+  Future<Result<bool, BackupSettingsFailure>> save(WalletBackupExport export);
+
+  @useResult
+  Future<Result<Uint8List?, BackupSettingsFailure>> pick({
+    required int maximumBytes,
+  });
+}

--- a/lib/features/backup_settings/domain/usecases/export_wallet_backup_file_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/export_wallet_backup_file_usecase.dart
@@ -1,0 +1,26 @@
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/repositories/wallet_backup_file_repository.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:primitives/primitives.dart';
+
+final class ExportWalletBackupFileUsecase {
+  final WalletBackupFacade _walletBackup;
+  final WalletBackupFileRepository _files;
+
+  const ExportWalletBackupFileUsecase(this._walletBackup, this._files);
+
+  Future<Result<bool, BackupSettingsFailure>> execute({
+    required WalletBackupFileProtection protection,
+    required bool confirmedUnencrypted,
+  }) async {
+    final export = await _walletBackup.buildExport(
+      protection: protection,
+      confirmedUnencrypted: confirmedUnencrypted,
+    );
+    return switch (export) {
+      Err(:final failure) => Err(mapWalletBackupFailure(failure)),
+      Ok(:final value) => _files.save(value),
+    };
+  }
+}

--- a/lib/features/backup_settings/domain/usecases/import_wallet_backup_file_usecase.dart
+++ b/lib/features/backup_settings/domain/usecases/import_wallet_backup_file_usecase.dart
@@ -1,0 +1,122 @@
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/backup_settings/domain/repositories/wallet_backup_file_repository.dart';
+import 'package:bb_mobile/features/backup_settings/domain/wallet_backup_failure_mapper.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:meta/meta.dart';
+import 'package:primitives/primitives.dart';
+
+sealed class SelectedWalletBackupFileOutcome {
+  const SelectedWalletBackupFileOutcome();
+}
+
+final class WalletBackupFileRecovered extends SelectedWalletBackupFileOutcome {
+  final WalletBackupRecoveryResult result;
+
+  const WalletBackupFileRecovered(this.result);
+}
+
+final class WalletBackupFileReselection
+    extends SelectedWalletBackupFileOutcome {
+  final Uint8List bytes;
+  final WalletBackupImportComparison comparison;
+
+  const WalletBackupFileReselection(this.bytes, this.comparison);
+}
+
+final class ImportWalletBackupFileUsecase {
+  final WalletBackupFacade _walletBackup;
+  final WalletBackupFileRepository _files;
+
+  const ImportWalletBackupFileUsecase(this._walletBackup, this._files);
+
+  @useResult
+  Future<
+    Result<
+      ({Uint8List bytes, WalletBackupImportComparison comparison})?,
+      BackupSettingsFailure
+    >
+  >
+  execute() async {
+    switch (await _files.pick(
+      maximumBytes: WalletBackupExport.maximumFileBytes,
+    )) {
+      case Err(:final failure):
+        return Err(failure);
+      case Ok(value: null):
+        return const Ok(null);
+      case Ok(value: final bytes?):
+        return _compare(_walletBackup, bytes);
+    }
+  }
+}
+
+final class ResumeWalletBackupFileImportUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const ResumeWalletBackupFileImportUsecase(this._walletBackup);
+
+  @useResult
+  Future<
+    Result<
+      ({Uint8List bytes, WalletBackupImportComparison comparison}),
+      BackupSettingsFailure
+    >
+  >
+  execute() async {
+    final export = await _walletBackup.buildExport(
+      protection: WalletBackupFileProtection.unencrypted,
+      confirmedUnencrypted: true,
+    );
+    final Uint8List bytes;
+    switch (export) {
+      case Err(:final failure):
+        return Err(mapWalletBackupFailure(failure));
+      case Ok(:final value):
+        bytes = value.copyBytes();
+    }
+    return _compare(_walletBackup, bytes);
+  }
+}
+
+final class RecoverSelectedWalletBackupFileUsecase {
+  final WalletBackupFacade _walletBackup;
+
+  const RecoverSelectedWalletBackupFileUsecase(this._walletBackup);
+
+  @useResult
+  Future<Result<SelectedWalletBackupFileOutcome, BackupSettingsFailure>>
+  execute({
+    required Uint8List bytes,
+    required WalletBackupImportComparison comparison,
+    required WalletBackupImportSource source,
+  }) async {
+    final result = await _walletBackup.recoverComparedFile(
+      fileBytes: bytes,
+      comparison: comparison,
+      source: source,
+    );
+    if (result.status != WalletBackupRecoveryStatus.comparisonStale) {
+      return Ok(WalletBackupFileRecovered(result));
+    }
+    return switch (await _compare(_walletBackup, bytes)) {
+      Ok(:final value) => Ok(
+        WalletBackupFileReselection(value.bytes, value.comparison),
+      ),
+      Err(:final failure) => Err(failure),
+    };
+  }
+}
+
+Future<
+  Result<
+    ({Uint8List bytes, WalletBackupImportComparison comparison}),
+    BackupSettingsFailure
+  >
+>
+_compare(WalletBackupFacade walletBackup, Uint8List bytes) async =>
+    switch (await walletBackup.compareFile(bytes)) {
+      Ok(:final value) => Ok((bytes: bytes, comparison: value)),
+      Err(:final failure) => Err(mapWalletBackupFailure(failure)),
+    };

--- a/lib/features/backup_settings/ui/widgets/wallet_backup_file_actions.dart
+++ b/lib/features/backup_settings/ui/widgets/wallet_backup_file_actions.dart
@@ -1,0 +1,92 @@
+import 'package:bb_mobile/core/utils/build_context_x.dart';
+import 'package:bb_mobile/core/widgets/settings_entry_item.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:flutter/material.dart';
+
+final class WalletBackupFileActions extends StatelessWidget {
+  final bool busy;
+  final Future<void> Function(
+    WalletBackupFileProtection protection,
+    bool confirmedUnencrypted,
+  )
+  onExport;
+  final Future<void> Function() onImport;
+
+  const WalletBackupFileActions({
+    super.key,
+    required this.busy,
+    required this.onExport,
+    required this.onImport,
+  });
+
+  @override
+  Widget build(BuildContext context) => Column(
+    children: [
+      SettingsEntryItem(
+        icon: Icons.lock_outline,
+        title: context.loc.walletBackupFileExportEncrypted,
+        onTap: busy
+            ? null
+            : () => onExport(WalletBackupFileProtection.encrypted, false),
+      ),
+      SettingsEntryItem(
+        icon: Icons.no_encryption_outlined,
+        title: context.loc.walletBackupFileExportUnencrypted,
+        onTap: busy ? null : () => _exportUnencrypted(context),
+      ),
+      SettingsEntryItem(
+        icon: Icons.file_download_outlined,
+        title: context.loc.walletBackupFileImportAction,
+        onTap: busy ? null : () => _import(context),
+      ),
+    ],
+  );
+
+  Future<void> _exportUnencrypted(BuildContext context) async {
+    final confirmed =
+        await showDialog<bool>(
+          context: context,
+          builder: (dialogContext) => AlertDialog(
+            title: Text(dialogContext.loc.walletBackupFileUnencryptedWarning),
+            content: Text(
+              dialogContext.loc.walletBackupFileUnencryptedConfirmation,
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: Text(dialogContext.loc.walletBackupSettingsCancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: Text(dialogContext.loc.walletBackupFileContinue),
+              ),
+            ],
+          ),
+        ) ==
+        true;
+    if (confirmed && context.mounted) {
+      await onExport(WalletBackupFileProtection.unencrypted, true);
+    }
+  }
+
+  Future<void> _import(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(dialogContext.loc.walletBackupFileImportTitle),
+        content: Text(dialogContext.loc.walletBackupFileImportExplanation),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: Text(dialogContext.loc.walletBackupSettingsCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: Text(dialogContext.loc.walletBackupFileChoose),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && context.mounted) await onImport();
+  }
+}

--- a/lib/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart
@@ -2,9 +2,12 @@ import 'dart:convert';
 
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_file.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_file_signature.dart';
+import 'package:convert/convert.dart';
 import 'package:primitives/primitives.dart';
 
 typedef BuildWalletBackupSnapshot =
@@ -18,12 +21,14 @@ final class BuildWalletBackupExportUsecase {
   final Future<Result<WalletBackupKey, WalletBackupFailure>> Function()
   _resolveKey;
   final WalletBackupEncryptionRepository _encryption;
+  final NostrIdentityFacade _identity;
   final DateTime Function() _nowUtc;
 
   const BuildWalletBackupExportUsecase({
     required this._buildSnapshot,
     required this._resolveKey,
     required this._encryption,
+    required this._identity,
     this._nowUtc = _systemNowUtc,
   });
 
@@ -60,8 +65,23 @@ final class BuildWalletBackupExportUsecase {
     switch (protection) {
       case WalletBackupFileProtection.unencrypted:
         switch (_encryption.encodeCanonical(envelope)) {
-          case Ok(:final value):
-            bytes = value;
+          case Ok(value: final canonicalBytes):
+            final digest = WalletBackupFileSignature.digest(canonicalBytes);
+            switch (await _identity.signWalletBackupHash(hex.encode(digest))) {
+              case Err():
+                return const Err(WalletBackupSigningFailure());
+              case Ok(value: final signature)
+                  when WalletBackupFileSignature.isValidSignature(signature):
+                final root = jsonDecode(utf8.decode(canonicalBytes));
+                if (root is! Map<String, dynamic>) {
+                  return const Err(WalletBackupInvalidEnvelopeFailure());
+                }
+                bytes = utf8.encode(
+                  jsonEncode({...root, 'signature': signature}),
+                );
+              case Ok():
+                return const Err(WalletBackupSigningFailure());
+            }
           case Err(:final failure):
             return Err(failure);
         }

--- a/lib/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart
+++ b/lib/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart
@@ -3,9 +3,11 @@ import 'dart:typed_data';
 
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_snapshot.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/usecases/resolve_wallet_backup_key_usecase.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_file_signature.dart';
 import 'package:primitives/primitives.dart';
 
 final class DecodeWalletBackupFileUsecase {
@@ -14,8 +16,13 @@ final class DecodeWalletBackupFileUsecase {
   final Future<Result<WalletBackupKey, WalletBackupFailure>> Function()
   _resolveKey;
   final WalletBackupEncryptionRepository _encryption;
+  final NostrIdentityFacade _identity;
 
-  const DecodeWalletBackupFileUsecase(this._resolveKey, this._encryption);
+  const DecodeWalletBackupFileUsecase(
+    this._resolveKey,
+    this._encryption,
+    this._identity,
+  );
 
   Future<Result<WalletBackupSnapshot, WalletBackupFailure>> execute(
     Uint8List bytes,
@@ -40,10 +47,7 @@ final class DecodeWalletBackupFileUsecase {
       return const Err(WalletBackupInvalidEnvelopeFailure());
     }
     if (text.trimLeft().startsWith('{')) {
-      return _encryption.decodeCanonical(
-        bytes: bytes,
-        expectedParentFingerprint: key.parentFingerprint,
-      );
+      return _decodeReadable(text, key.parentFingerprint);
     }
     final ciphertext = WalletBackupCiphertext.tryParse(text);
     if (ciphertext == null) {
@@ -54,5 +58,61 @@ final class DecodeWalletBackupFileUsecase {
       key: key.encryptionKey,
       expectedParentFingerprint: key.parentFingerprint,
     );
+  }
+
+  Future<Result<WalletBackupSnapshot, WalletBackupFailure>> _decodeReadable(
+    String text,
+    String expectedParentFingerprint,
+  ) async {
+    final Map<String, dynamic> root;
+    try {
+      final decoded = jsonDecode(text);
+      if (decoded is! Map<String, dynamic>) {
+        return const Err(WalletBackupInvalidEnvelopeFailure());
+      }
+      root = decoded;
+    } on FormatException {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    final signature = root.remove('signature');
+    if (signature is! String ||
+        !WalletBackupFileSignature.isValidSignature(signature)) {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    final unsignedBytes = Uint8List.fromList(utf8.encode(jsonEncode(root)));
+    final WalletBackupSnapshot snapshot;
+    switch (_encryption.decodeCanonical(
+      bytes: unsignedBytes,
+      expectedParentFingerprint: expectedParentFingerprint,
+    )) {
+      case Ok(:final value):
+        snapshot = value;
+      case Err(failure: WalletBackupParentFingerprintMismatchFailure()):
+        return const Err(WalletBackupInvalidEnvelopeFailure());
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final Uint8List canonicalBytes;
+    switch (_encryption.encodeCanonical(snapshot)) {
+      case Ok(:final value):
+        canonicalBytes = value;
+      case Err(:final failure):
+        return Err(failure);
+    }
+    final String publicKey;
+    switch (await _identity.walletBackupPublicKey()) {
+      case Ok(:final value):
+        publicKey = value;
+      case Err():
+        return const Err(WalletBackupSigningFailure());
+    }
+    if (!WalletBackupFileSignature.verify(
+      canonicalUnsignedJson: canonicalBytes,
+      publicKeyHex: publicKey,
+      signatureHex: signature,
+    )) {
+      return const Err(WalletBackupInvalidEnvelopeFailure());
+    }
+    return Ok(snapshot);
   }
 }

--- a/lib/features/wallet_backup/domain/wallet_backup_file_signature.dart
+++ b/lib/features/wallet_backup/domain/wallet_backup_file_signature.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+
+abstract final class WalletBackupFileSignature {
+  static const domain = 'bullbitcoin-wallet-backup-file-v1';
+  static final _publicKeyPattern = RegExp(r'^[0-9a-f]{64}$');
+  static final _signaturePattern = RegExp(r'^[0-9a-f]{128}$');
+
+  static Uint8List digest(Uint8List canonicalUnsignedJson) =>
+      Uint8List.fromList(
+        sha256.convert([
+          ...utf8.encode(domain),
+          0,
+          ...canonicalUnsignedJson,
+        ]).bytes,
+      );
+
+  static bool isValidSignature(String value) =>
+      _signaturePattern.hasMatch(value);
+
+  static bool verify({
+    required Uint8List canonicalUnsignedJson,
+    required String publicKeyHex,
+    required String signatureHex,
+  }) {
+    if (!_publicKeyPattern.hasMatch(publicKeyHex) ||
+        !_signaturePattern.hasMatch(signatureHex)) {
+      return false;
+    }
+    try {
+      return ECPublic.fromHex('02$publicKeyHex').verifyBip340Signature(
+        digest: digest(canonicalUnsignedJson),
+        signature: hex.decode(signatureHex),
+        tweak: false,
+      );
+    } on Exception {
+      return false;
+    }
+  }
+}

--- a/lib/features/wallet_backup/wallet_backup_locator.dart
+++ b/lib/features/wallet_backup/wallet_backup_locator.dart
@@ -236,6 +236,7 @@ final class _WalletBackupGraph {
     final decodeFile = DecodeWalletBackupFileUsecase(
       resolveKey.execute,
       encryption,
+      nostrIdentity,
     );
     final recover = RecoverWalletBackupUsecase(
       fetchImport: fetchImport.execute,
@@ -282,6 +283,7 @@ final class _WalletBackupGraph {
         buildSnapshot: buildSnapshot.execute,
         resolveKey: resolveKey.execute,
         encryption: encryption,
+        identity: nostrIdentity,
       ),
       CompareWalletBackupFileUsecase(
         decodeFile.execute,

--- a/lib/features/wizard/data/datasource/wizard_local_datasource.dart
+++ b/lib/features/wizard/data/datasource/wizard_local_datasource.dart
@@ -1,5 +1,13 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+typedef WizardPreferencesLoader = Future<SharedPreferences> Function();
+
+final class WizardPersistenceException implements Exception {
+  final String operation;
+
+  const WizardPersistenceException(this.operation);
+}
+
 /// Typed accessors over the wizard's slice of [SharedPreferences]. The
 /// only file in the feature that knows about pref key names — repository
 /// and usecases call domain-named methods rather than raw `getString` on
@@ -23,96 +31,136 @@ abstract class WizardLocalDatasource {
   Future<bool?> readPendingErrorReporting();
   Future<void> writePendingErrorReporting(bool enabled);
 
+  Future<bool?> readPendingMetadataBackup();
+  Future<void> writePendingMetadataBackup(bool enabled);
+
   Future<void> clearAllPending();
 }
 
 class WizardLocalDatasourceImpl implements WizardLocalDatasource {
+  final WizardPreferencesLoader _loadPreferences;
+
+  WizardLocalDatasourceImpl({WizardPreferencesLoader? loadPreferences})
+    : _loadPreferences =
+          loadPreferences ?? (() => SharedPreferences.getInstance());
+
   static const _versionKey = 'wizard_completed_version';
   static const _pendingVersionKey = 'wizard_pending_version';
   static const _pendingLanguageKey = 'wizard_pending_language';
   static const _pendingThemeKey = 'wizard_pending_theme_mode';
   static const _pendingCurrencyKey = 'wizard_pending_currency';
   static const _pendingErrorReportingKey = 'wizard_pending_error_reporting';
+  static const _pendingMetadataBackupKey = 'wizard_pending_metadata_backup';
 
   @override
   Future<int?> readCompletedVersion() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getInt(_versionKey);
   }
 
   @override
   Future<void> writeCompletedVersion(int version) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_versionKey, version);
+    final prefs = await _loadPreferences();
+    _require(await prefs.setInt(_versionKey, version), 'completed version');
   }
 
   @override
   Future<int?> readPendingVersion() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getInt(_pendingVersionKey);
   }
 
   @override
   Future<void> writePendingVersion(int version) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_pendingVersionKey, version);
+    final prefs = await _loadPreferences();
+    _require(
+      await prefs.setInt(_pendingVersionKey, version),
+      'pending version',
+    );
   }
 
   @override
   Future<String?> readPendingLanguage() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getString(_pendingLanguageKey);
   }
 
   @override
   Future<void> writePendingLanguage(String name) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_pendingLanguageKey, name);
+    final prefs = await _loadPreferences();
+    _require(await prefs.setString(_pendingLanguageKey, name), 'language');
   }
 
   @override
   Future<String?> readPendingThemeMode() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getString(_pendingThemeKey);
   }
 
   @override
   Future<void> writePendingThemeMode(String name) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_pendingThemeKey, name);
+    final prefs = await _loadPreferences();
+    _require(await prefs.setString(_pendingThemeKey, name), 'theme');
   }
 
   @override
   Future<String?> readPendingCurrency() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getString(_pendingCurrencyKey);
   }
 
   @override
   Future<void> writePendingCurrency(String code) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_pendingCurrencyKey, code);
+    final prefs = await _loadPreferences();
+    _require(await prefs.setString(_pendingCurrencyKey, code), 'currency');
   }
 
   @override
   Future<bool?> readPendingErrorReporting() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _loadPreferences();
     return prefs.getBool(_pendingErrorReportingKey);
   }
 
   @override
   Future<void> writePendingErrorReporting(bool enabled) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_pendingErrorReportingKey, enabled);
+    final prefs = await _loadPreferences();
+    _require(
+      await prefs.setBool(_pendingErrorReportingKey, enabled),
+      'error reporting choice',
+    );
+  }
+
+  @override
+  Future<bool?> readPendingMetadataBackup() async {
+    final prefs = await _loadPreferences();
+    return prefs.getBool(_pendingMetadataBackupKey);
+  }
+
+  @override
+  Future<void> writePendingMetadataBackup(bool enabled) async {
+    final prefs = await _loadPreferences();
+    _require(
+      await prefs.setBool(_pendingMetadataBackupKey, enabled),
+      'metadata backup choice',
+    );
   }
 
   @override
   Future<void> clearAllPending() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_pendingVersionKey);
-    await prefs.remove(_pendingLanguageKey);
-    await prefs.remove(_pendingThemeKey);
-    await prefs.remove(_pendingCurrencyKey);
-    await prefs.remove(_pendingErrorReportingKey);
+    final prefs = await _loadPreferences();
+    for (final key in const [
+      _pendingVersionKey,
+      _pendingLanguageKey,
+      _pendingThemeKey,
+      _pendingCurrencyKey,
+      _pendingErrorReportingKey,
+      _pendingMetadataBackupKey,
+    ]) {
+      _require(await prefs.remove(key), 'remove $key');
+    }
+  }
+
+  void _require(bool persisted, String operation) {
+    if (!persisted) throw WizardPersistenceException(operation);
   }
 }

--- a/lib/features/wizard/data/repository/wizard_repository_impl.dart
+++ b/lib/features/wizard/data/repository/wizard_repository_impl.dart
@@ -2,6 +2,9 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/features/wizard/data/datasource/wizard_local_datasource.dart';
 import 'package:bb_mobile/features/wizard/domain/entity/wizard_choices.dart';
 import 'package:bb_mobile/features/wizard/domain/repository/wizard_repository.dart';
+import 'package:bb_mobile/features/wizard/domain/wizard_failure.dart';
+import 'package:bb_mobile/core/utils/logger.dart';
+import 'package:primitives/primitives.dart';
 
 /// Bump this integer whenever the wizard gains new mandatory questions.
 /// Users whose stored version is lower will see the wizard again on
@@ -46,10 +49,33 @@ class WizardRepositoryImpl implements WizardRepository {
     if (choices.touched.contains(WizardField.defaultCurrency)) {
       await _datasource.writePendingCurrency(choices.defaultCurrency);
     }
+    final metadataBackupEnabled = choices.metadataBackupEnabled;
+    if (choices.touched.contains(WizardField.metadataBackupEnabled) &&
+        metadataBackupEnabled != null) {
+      await _datasource.writePendingMetadataBackup(metadataBackupEnabled);
+    }
     final consent = choices.reportingConsent;
     if (choices.touched.contains(WizardField.reportingConsent) &&
         consent != null) {
       await _datasource.writePendingErrorReporting(consent);
+    }
+  }
+
+  @override
+  Future<Result<void, WizardFailure>> saveMetadataBackupChoice(
+    bool enabled,
+  ) async {
+    try {
+      await _datasource.writePendingVersion(kCurrentWizardVersion);
+      await _datasource.writePendingMetadataBackup(enabled);
+      return const Ok(null);
+    } on Exception catch (error, trace) {
+      log.warning(
+        'Failed to persist wizard backup choice',
+        error: error.runtimeType,
+        trace: trace,
+      );
+      return const Err(WizardPersistenceFailure());
     }
   }
 
@@ -63,10 +89,12 @@ class WizardRepositoryImpl implements WizardRepository {
     final themeName = await _datasource.readPendingThemeMode();
     final currency = await _datasource.readPendingCurrency();
     final errorReporting = await _datasource.readPendingErrorReporting();
+    final metadataBackupEnabled = await _datasource.readPendingMetadataBackup();
     if (languageName == null &&
         themeName == null &&
         currency == null &&
-        errorReporting == null) {
+        errorReporting == null &&
+        metadataBackupEnabled == null) {
       return null;
     }
     final pendingVersion = await _datasource.readPendingVersion() ?? 0;
@@ -79,6 +107,9 @@ class WizardRepositoryImpl implements WizardRepository {
     if (themeName != null) touched.add(WizardField.themeMode);
     if (currency != null) touched.add(WizardField.defaultCurrency);
     if (errorReporting != null) touched.add(WizardField.reportingConsent);
+    if (metadataBackupEnabled != null) {
+      touched.add(WizardField.metadataBackupEnabled);
+    }
     return WizardChoices(
       language: languageName == null
           ? Language.unitedStatesEnglish
@@ -87,6 +118,7 @@ class WizardRepositoryImpl implements WizardRepository {
           ? AppThemeMode.system
           : AppThemeMode.fromName(themeName),
       defaultCurrency: currency ?? 'USD',
+      metadataBackupEnabled: metadataBackupEnabled,
       reportingConsent: errorReporting,
       touched: touched,
     );

--- a/lib/features/wizard/domain/entity/wizard_choices.dart
+++ b/lib/features/wizard/domain/entity/wizard_choices.dart
@@ -6,7 +6,13 @@ import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 /// the wizard merely *displayed* (e.g. brightness-detected theme,
 /// keyboard-detected language) stay out of the touched set and never
 /// clobber existing user values when `kCurrentWizardVersion` bumps.
-enum WizardField { language, themeMode, defaultCurrency, reportingConsent }
+enum WizardField {
+  metadataBackupEnabled,
+  language,
+  themeMode,
+  defaultCurrency,
+  reportingConsent,
+}
 
 /// Tagged variant for the `reportingConsent` parameter of
 /// [WizardChoices.copyWith].
@@ -37,6 +43,7 @@ class WizardChoices {
     this.language = Language.unitedStatesEnglish,
     this.themeMode = AppThemeMode.system,
     this.defaultCurrency = 'USD',
+    this.metadataBackupEnabled,
     this.reportingConsent,
     this.touched = const <WizardField>{},
   });
@@ -44,8 +51,9 @@ class WizardChoices {
   final Language language;
   final AppThemeMode themeMode;
   final String defaultCurrency;
+  final bool? metadataBackupEnabled;
   // `null` means the user has not yet answered the error-reporting question.
-  // Page 3 of the wizard requires an explicit Yes/No before the wizard can
+  // The mission page requires an explicit Yes/No before the wizard can
   // be completed via Next/Skip/Get started.
   final bool? reportingConsent;
 
@@ -64,12 +72,16 @@ class WizardChoices {
     Language? language,
     AppThemeMode? themeMode,
     String? defaultCurrency,
+    ConsentArg metadataBackupEnabled = _consentUnset,
     ConsentArg reportingConsent = _consentUnset,
   }) {
     final t = Set<WizardField>.from(touched);
     if (language != null) t.add(WizardField.language);
     if (themeMode != null) t.add(WizardField.themeMode);
     if (defaultCurrency != null) t.add(WizardField.defaultCurrency);
+    if (metadataBackupEnabled is ConsentValue) {
+      t.add(WizardField.metadataBackupEnabled);
+    }
     if (reportingConsent is ConsentValue) {
       t.add(WizardField.reportingConsent);
     }
@@ -77,6 +89,10 @@ class WizardChoices {
       language: language ?? this.language,
       themeMode: themeMode ?? this.themeMode,
       defaultCurrency: defaultCurrency ?? this.defaultCurrency,
+      metadataBackupEnabled: switch (metadataBackupEnabled) {
+        ConsentValue(:final value) => value,
+        _ConsentUnset() => this.metadataBackupEnabled,
+      },
       reportingConsent: switch (reportingConsent) {
         ConsentValue(:final value) => value,
         _ConsentUnset() => this.reportingConsent,
@@ -94,6 +110,7 @@ class WizardChoices {
       language: language,
       themeMode: themeMode ?? this.themeMode,
       defaultCurrency: defaultCurrency,
+      metadataBackupEnabled: metadataBackupEnabled,
       reportingConsent: reportingConsent,
       touched: touched,
     );

--- a/lib/features/wizard/domain/repository/wizard_repository.dart
+++ b/lib/features/wizard/domain/repository/wizard_repository.dart
@@ -1,4 +1,7 @@
 import 'package:bb_mobile/features/wizard/domain/entity/wizard_choices.dart';
+import 'package:bb_mobile/features/wizard/domain/wizard_failure.dart';
+import 'package:primitives/primitives.dart';
+import 'package:meta/meta.dart';
 
 abstract class WizardRepository {
   /// `true` once the user has completed the wizard for the current
@@ -9,6 +12,8 @@ abstract class WizardRepository {
   Future<void> markComplete();
 
   Future<void> savePending(WizardChoices choices);
+  @useResult
+  Future<Result<void, WizardFailure>> saveMetadataBackupChoice(bool enabled);
   Future<WizardChoices?> readPending();
   Future<void> clearPending();
 }

--- a/lib/features/wizard/domain/wizard_failure.dart
+++ b/lib/features/wizard/domain/wizard_failure.dart
@@ -1,0 +1,13 @@
+import 'package:bb_mobile/core/failures/failure.dart';
+
+sealed class WizardFailure extends Failure {
+  const WizardFailure([super.logMessage]);
+}
+
+final class WizardPersistenceFailure extends WizardFailure {
+  const WizardPersistenceFailure([super.logMessage]);
+}
+
+final class WizardApplyFailure extends WizardFailure {
+  const WizardApplyFailure([super.logMessage]);
+}

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14704,5 +14704,23 @@
   "@walletBackupManifestView": {},
   "walletBackupManifestCopy": "Copy",
   "@walletBackupManifestCopy": {},
+  "walletBackupFileUnencryptedWarning": "Export unencrypted wallet data?",
+  "walletBackupFileUnencryptedConfirmation": "This file contains public descriptors, labels, Nostr public keys, and wallet metadata. Anyone who reads it may be able to identify your wallet activity. It contains no seed phrase or private key.",
+  "walletBackupFileContinue": "Export anyway",
+  "walletBackupFileImportTitle": "Recover from a backup file",
+  "walletBackupFileImportExplanation": "The app validates the whole file. If automatic Bull backup is on and the server is reachable, you'll compare it with the server backup before choosing. Recovery restores wallet data and never deletes local wallets.",
+  "walletBackupFileChoose": "Choose file",
+  "walletBackupFileExportEncrypted": "Export encrypted",
+  "@walletBackupFileExportEncrypted": {
+    "description": "Manual data backup action that encrypts the exported file."
+  },
+  "walletBackupFileExportUnencrypted": "Export unencrypted",
+  "@walletBackupFileExportUnencrypted": {
+    "description": "Manual data backup action that exports readable JSON after confirmation."
+  },
+  "walletBackupFileImportAction": "Import",
+  "@walletBackupFileImportAction": {
+    "description": "Manual data backup import action."
+  },
   "walletBackupManifestPassphraseWallet": "Passphrase Wallet"
 }

--- a/test/features/backup_settings/data/file_picker_wallet_backup_file_repository_test.dart
+++ b/test/features/backup_settings/data/file_picker_wallet_backup_file_repository_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bb_mobile/features/backup_settings/data/file_picker_wallet_backup_file_repository.dart';
+import 'package:bb_mobile/features/backup_settings/domain/backup_settings_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:primitives/primitives.dart';
+
+class _MockFilePicker extends Mock implements FilePicker {}
+
+void main() {
+  late _MockFilePicker picker;
+  late FilePickerWalletBackupFileRepository repository;
+
+  setUpAll(() => registerFallbackValue(Uint8List(0)));
+
+  setUp(() {
+    picker = _MockFilePicker();
+    repository = FilePickerWalletBackupFileRepository(picker);
+  });
+
+  test('picker cancellation is not an error', () async {
+    when(
+      () => picker.pickFiles(type: FileType.any),
+    ).thenAnswer((_) async => null);
+
+    expect(
+      await repository.pick(maximumBytes: 10),
+      isA<Ok<Uint8List?, BackupSettingsFailure>>().having(
+        (result) => result.value,
+        'value',
+        isNull,
+      ),
+    );
+  });
+
+  test('rejects the declared size before reading file bytes', () async {
+    when(() => picker.pickFiles(type: FileType.any)).thenAnswer(
+      (_) async =>
+          FilePickerResult([PlatformFile(name: 'large.json.enc', size: 11)]),
+    );
+
+    expect(
+      await repository.pick(maximumBytes: 10),
+      isA<Err<Uint8List?, BackupSettingsFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<BackupSettingsFileTooLargeFailure>(),
+      ),
+    );
+  });
+
+  test(
+    'rejects oversized in-memory bytes despite a smaller declared size',
+    () async {
+      when(() => picker.pickFiles(type: FileType.any)).thenAnswer(
+        (_) async => FilePickerResult([
+          PlatformFile(
+            name: 'large.json.enc',
+            size: 10,
+            bytes: Uint8List.fromList(List.filled(11, 1)),
+          ),
+        ]),
+      );
+
+      expect(
+        await repository.pick(maximumBytes: 10),
+        isA<Err<Uint8List?, BackupSettingsFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<BackupSettingsFileTooLargeFailure>(),
+        ),
+      );
+    },
+  );
+
+  test('caps path reads and rejects an oversized changed file', () async {
+    final temporary = await Directory.systemTemp.createTemp('backup-read-');
+    addTearDown(() => temporary.delete(recursive: true));
+    final file = File('${temporary.path}/backup.json.enc');
+    await file.writeAsBytes(List.filled(11, 1));
+    when(() => picker.pickFiles(type: FileType.any)).thenAnswer(
+      (_) async => FilePickerResult([
+        PlatformFile(name: file.path, path: file.path, size: 10),
+      ]),
+    );
+
+    expect(
+      await repository.pick(maximumBytes: 10),
+      isA<Err<Uint8List?, BackupSettingsFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<BackupSettingsFileTooLargeFailure>(),
+      ),
+    );
+  });
+
+  test('rejects in-memory bytes that do not match the declared size', () async {
+    when(() => picker.pickFiles(type: FileType.any)).thenAnswer(
+      (_) async => FilePickerResult([
+        PlatformFile(
+          name: 'backup.json.enc',
+          size: 3,
+          bytes: Uint8List.fromList([1, 2]),
+        ),
+      ]),
+    );
+
+    expect(
+      await repository.pick(maximumBytes: 10),
+      isA<Err<Uint8List?, BackupSettingsFailure>>().having(
+        (result) => result.failure,
+        'failure',
+        isA<BackupSettingsFileReadFailure>(),
+      ),
+    );
+  });
+
+  test('saves the exact bytes with the suggested filename', () async {
+    final export = WalletBackupExport(
+      suggestedFilename: 'backup.json.enc',
+      bytes: const [1, 2, 3],
+    );
+    when(
+      () => picker.saveFile(
+        bytes: any(named: 'bytes'),
+        fileName: 'backup.json.enc',
+      ),
+    ).thenAnswer((_) async => '/saved/backup.json.enc');
+
+    expect(
+      await repository.save(export),
+      isA<Ok<bool, BackupSettingsFailure>>().having(
+        (result) => result.value,
+        'value',
+        isTrue,
+      ),
+    );
+    final captured =
+        verify(
+              () => picker.saveFile(
+                bytes: captureAny(named: 'bytes'),
+                fileName: 'backup.json.enc',
+              ),
+            ).captured.single
+            as Uint8List;
+    expect(captured, orderedEquals([1, 2, 3]));
+  });
+
+  test('save cancellation is a neutral false result', () async {
+    final export = WalletBackupExport(
+      suggestedFilename: 'backup.json.enc',
+      bytes: const [1, 2, 3],
+    );
+    when(
+      () => picker.saveFile(
+        bytes: any(named: 'bytes'),
+        fileName: 'backup.json.enc',
+      ),
+    ).thenAnswer((_) async => null);
+
+    expect(
+      await repository.save(export),
+      isA<Ok<bool, BackupSettingsFailure>>().having(
+        (result) => result.value,
+        'value',
+        isFalse,
+      ),
+    );
+  });
+}

--- a/test/features/backup_settings/ui/wallet_backup_file_actions_test.dart
+++ b/test/features/backup_settings/ui/wallet_backup_file_actions_test.dart
@@ -1,0 +1,89 @@
+import 'package:bb_mobile/core/themes/app_theme.dart';
+import 'package:bb_mobile/features/backup_settings/ui/widgets/wallet_backup_file_actions.dart';
+import 'package:bb_mobile/features/wallet_backup/public/wallet_backup_facade.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows all three manual actions and exports encrypted directly', (
+    tester,
+  ) async {
+    WalletBackupFileProtection? selected;
+    bool? confirmed;
+    await _pump(
+      tester,
+      onExport: (protection, confirmation) async {
+        selected = protection;
+        confirmed = confirmation;
+      },
+    );
+
+    expect(find.text('Export encrypted'), findsOneWidget);
+    expect(find.text('Export unencrypted'), findsOneWidget);
+    expect(find.text('Import'), findsOneWidget);
+    await tester.tap(find.text('Export encrypted'));
+    await tester.pumpAndSettle();
+
+    expect(selected, WalletBackupFileProtection.encrypted);
+    expect(confirmed, isFalse);
+  });
+
+  testWidgets('plaintext warning cannot be bypassed', (tester) async {
+    var exports = 0;
+    await _pump(tester, onExport: (_, _) async => exports++);
+
+    await tester.tap(find.text('Export unencrypted'));
+    await tester.pumpAndSettle();
+    expect(find.text('Export unencrypted wallet data?'), findsOneWidget);
+    expect(
+      find.textContaining('no seed phrase or private key'),
+      findsOneWidget,
+    );
+    expect(exports, 0);
+
+    await tester.tap(find.text('Export anyway'));
+    await tester.pumpAndSettle();
+    expect(exports, 1);
+  });
+
+  testWidgets('explains comparison and additive recovery before file choice', (
+    tester,
+  ) async {
+    var imports = 0;
+    await _pump(tester, onImport: () async => imports++);
+
+    await tester.tap(find.text('Import'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('never deletes local wallets'), findsOneWidget);
+    expect(find.textContaining('automatic Bull backup is on'), findsOneWidget);
+    expect(imports, 0);
+
+    await tester.tap(find.text('Choose file'));
+    await tester.pumpAndSettle();
+    expect(imports, 1);
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  Future<void> Function(WalletBackupFileProtection, bool)? onExport,
+  Future<void> Function()? onImport,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.themeData(AppThemeType.light),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: WalletBackupFileActions(
+          busy: false,
+          onExport: onExport ?? (_, _) async {},
+          onImport: onImport ?? () async {},
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/test/features/wallet_backup/backup_behavior_baseline_test.dart
+++ b/test/features/wallet_backup/backup_behavior_baseline_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
@@ -242,7 +243,7 @@ void main() {
     });
 
     test(
-      'a file exported by another seed is rejected as the wrong seed',
+      'a file signed by another seed is rejected before comparison',
       () async {
         final device = await _device();
         expect(await device.facade.setEnabled(true), _succeeds);
@@ -264,11 +265,36 @@ void main() {
           isA<Err<WalletBackupImportComparison, WalletBackupFailure>>().having(
             (result) => result.failure,
             'failure',
-            isA<WalletBackupParentFingerprintMismatchFailure>(),
+            isA<WalletBackupInvalidEnvelopeFailure>(),
           ),
         );
       },
     );
+
+    test('a modified readable backup is rejected before comparison', () async {
+      final device = await _device();
+      await _addWallet(device, walletId: 'signed-wallet', label: 'Original');
+      final export = _value(
+        await device.facade.buildExport(
+          protection: WalletBackupFileProtection.unencrypted,
+          confirmedUnencrypted: true,
+        ),
+      );
+      final modified = utf8
+          .decode(export.copyBytes())
+          .replaceFirst('Original', 'Modified');
+
+      expect(
+        await device.facade.compareFile(
+          Uint8List.fromList(utf8.encode(modified)),
+        ),
+        isA<Err<WalletBackupImportComparison, WalletBackupFailure>>().having(
+          (result) => result.failure,
+          'failure',
+          isA<WalletBackupInvalidEnvelopeFailure>(),
+        ),
+      );
+    });
   });
 }
 
@@ -330,9 +356,12 @@ Future<WalletBackupCiphertext> _foreignRootedBackup(
       confirmedUnencrypted: true,
     ),
   );
+  final root =
+      jsonDecode(utf8.decode(export.copyBytes())) as Map<String, dynamic>
+        ..remove('signature');
   final envelope = _value(
     otherWallet.encryption.decodeCanonical(
-      bytes: export.copyBytes(),
+      bytes: Uint8List.fromList(utf8.encode(jsonEncode(root))),
       expectedParentFingerprint: foreignSeedFingerprint,
     ),
   );
@@ -350,9 +379,12 @@ Future<WalletBackupCiphertext> _backupFromTheFuture(
       confirmedUnencrypted: true,
     ),
   );
-  final plaintext = utf8
-      .decode(export.copyBytes())
-      .replaceFirst('"version":1,', '"version":2,');
+  final root =
+      jsonDecode(utf8.decode(export.copyBytes())) as Map<String, dynamic>
+        ..remove('signature');
+  final plaintext = jsonEncode(
+    root,
+  ).replaceFirst('"version":1,', '"version":2,');
   final backup = RecoverBull.createBackup(
     secret: utf8.encode(plaintext),
     backupKey: hex.decode(device.encryptionKey.hex),

--- a/test/features/wallet_backup/support/wallet_backup_behavior_harness.dart
+++ b/test/features/wallet_backup/support/wallet_backup_behavior_harness.dart
@@ -449,6 +449,7 @@ final class WalletBackupBehaviorHarness {
     final decodeFile = DecodeWalletBackupFileUsecase(
       resolveKey.execute,
       encryption,
+      nostrIdentity,
     );
     final recover = RecoverWalletBackupUsecase(
       fetchImport: fetchImport.execute,
@@ -489,6 +490,7 @@ final class WalletBackupBehaviorHarness {
         buildSnapshot: buildSnapshot.execute,
         resolveKey: resolveKey.execute,
         encryption: encryption,
+        identity: nostrIdentity,
       ),
       CompareWalletBackupFileUsecase(
         decodeFile.execute,

--- a/test/features/wallet_backup/wallet_backup_file_usecases_test.dart
+++ b/test/features/wallet_backup/wallet_backup_file_usecases_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_encryption.dart';
+import 'package:bb_mobile/features/nostr_identity/public/nostr_identity_facade.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_definition.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_provenance.dart';
@@ -14,24 +15,47 @@ import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_r
 import 'package:bb_mobile/features/wallet_backup/domain/entities/wallet_backup_state.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/repositories/wallet_backup_encryption_repository.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/usecases/compare_wallet_backup_file_usecase.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/usecases/build_wallet_backup_export_usecase.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/usecases/decode_wallet_backup_file_usecase.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/usecases/recover_wallet_backup_file_usecase.dart';
 import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_failure.dart';
+import 'package:bb_mobile/features/wallet_backup/domain/wallet_backup_file_signature.dart';
 import 'package:bb_mobile/features/wallet_backup/metadata/domain/entities/wallet_metadata_snapshot.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/frozen_wallet_outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_preferences.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:convert/convert.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:primitives/primitives.dart';
 
 import '../keychain_manifest/support/manifest_fixtures.dart';
 import 'metadata/support/portable_settings_fixture.dart';
 import 'support/canonical_backup_snapshot.dart';
 
+class _MockNostrIdentityFacade extends Mock implements NostrIdentityFacade {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('file validation', () {
+    test('freezes the readable-backup signature contract', () {
+      final bytes = Uint8List.fromList(utf8.encode('{"v":1}'));
+      final digest = WalletBackupFileSignature.digest(bytes);
+      final privateKey = ECPrivate.fromHex('0' * 63 + '1');
+
+      expect(
+        hex.encode(digest),
+        'd2dc6330bf12b435230e3ad9e2d783b037f498d766e45629c50ae126ecbbd1c3',
+      );
+      expect(
+        privateKey.signBip340(digest, tweak: false),
+        'dec994004ef579cddaa70e57aa7d9131042c906a500897b8c25a9e4446993d3'
+        'd87f8ac1a181ec2d6b7e3e81192d10dd1c9fe34ad0c68bda11f8fb8be0b969507',
+      );
+    });
+
     test('an export cannot contain zero bytes', () {
       expect(
         () => WalletBackupExport(suggestedFilename: 'backup.json', bytes: []),
@@ -45,6 +69,7 @@ void main() {
         final decoder = DecodeWalletBackupFileUsecase(
           () async => Ok(_key),
           _Encryption(),
+          _testIdentity(),
         );
 
         expect(
@@ -79,17 +104,65 @@ void main() {
     test(
       'decode accepts conventional whitespace before plaintext JSON',
       () async {
+        final identity = _testIdentity();
+        final signed = _signedReadableJson('{"v":1}');
+        final root = jsonDecode(utf8.decode(signed)) as Map<String, dynamic>;
+        final reordered = utf8.encode(
+          ' \n${jsonEncode({'signature': root['signature'], 'v': 1})}',
+        );
         final decoder = DecodeWalletBackupFileUsecase(
           () async => Ok(_key),
           const _Encryption(acceptPlaintext: true),
+          identity,
         );
 
         expect(
-          await decoder.execute(Uint8List.fromList(utf8.encode(' \n{"v":1}'))),
+          await decoder.execute(Uint8List.fromList(reordered)),
           isA<Ok<WalletBackupSnapshot, WalletBackupFailure>>(),
         );
       },
     );
+
+    test('readable export is signed and unsigned JSON is rejected', () async {
+      final identity = _testIdentity();
+      final exporter = BuildWalletBackupExportUsecase(
+        buildSnapshot:
+            ({required parentFingerprint, allowEmpty = false}) async =>
+                Ok(_fileSnapshot()),
+        resolveKey: () async => Ok(_key),
+        encryption: const _Encryption(acceptPlaintext: true),
+        identity: identity,
+        nowUtc: () => DateTime.utc(2026),
+      );
+      final export = await exporter.execute(
+        protection: WalletBackupFileProtection.unencrypted,
+        confirmedUnencrypted: true,
+      );
+      final bytes = (export as Ok<WalletBackupExport, WalletBackupFailure>)
+          .value
+          .copyBytes();
+      final root = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+
+      expect(root.keys.last, 'signature');
+      expect(root['signature'], matches(RegExp(r'^[0-9a-f]{128}$')));
+      final decoder = DecodeWalletBackupFileUsecase(
+        () async => Ok(_key),
+        const _Encryption(acceptPlaintext: true),
+        identity,
+      );
+      expect(
+        await decoder.execute(bytes),
+        isA<Ok<WalletBackupSnapshot, WalletBackupFailure>>(),
+      );
+      expect(
+        await decoder.execute(Uint8List.fromList(utf8.encode('{"v":1}'))),
+        isA<Err>().having(
+          (value) => value.failure,
+          'failure',
+          isA<WalletBackupInvalidEnvelopeFailure>(),
+        ),
+      );
+    });
   });
 
   group('comparison', () {
@@ -1016,11 +1089,44 @@ final class _Encryption implements WalletBackupEncryptionRepository {
   @override
   Result<Uint8List, WalletBackupFailure> encodeCanonical(
     WalletBackupSnapshot envelope,
-  ) => throw UnimplementedError();
+  ) => acceptPlaintext
+      ? Ok(Uint8List.fromList(utf8.encode('{"v":1}')))
+      : throw UnimplementedError();
 
   @override
   Result<WalletBackupCiphertext, WalletBackupFailure> encrypt({
     required WalletBackupSnapshot envelope,
     required WalletBackupEncryptionKey key,
   }) => throw UnimplementedError();
+}
+
+NostrIdentityFacade _testIdentity() {
+  final identity = _MockNostrIdentityFacade();
+  final privateKey = ECPrivate.fromHex('0' * 63 + '1');
+  final publicKey = hex.encode(privateKey.getPublic().toXOnly());
+  when(
+    identity.walletBackupPublicKey,
+  ).thenAnswer((_) async => Ok<String, NostrIdentityFailure>(publicKey));
+  when(() => identity.signWalletBackupHash(any())).thenAnswer((
+    invocation,
+  ) async {
+    final digest = invocation.positionalArguments.single as String;
+    return Ok<String, NostrIdentityFailure>(
+      privateKey.signBip340(hex.decode(digest), tweak: false),
+    );
+  });
+  return identity;
+}
+
+Uint8List _signedReadableJson(String canonicalUnsignedJson) {
+  final privateKey = ECPrivate.fromHex('0' * 63 + '1');
+  final unsignedBytes = Uint8List.fromList(utf8.encode(canonicalUnsignedJson));
+  final signature = privateKey.signBip340(
+    WalletBackupFileSignature.digest(unsignedBytes),
+    tweak: false,
+  );
+  final root = jsonDecode(canonicalUnsignedJson) as Map<String, dynamic>;
+  return Uint8List.fromList(
+    utf8.encode(jsonEncode({...root, 'signature': signature})),
+  );
 }


### PR DESCRIPTION
## What this adds

This allows users to export and recover the complete wallet data backup directly, without relying on the backup server.

- Saves encrypted backups as conventional .json.enc documents.
- Saves readable .json only after explicit confirmation.
- Signs every readable backup with the seed-derived wallet-backup identity.
- Rejects unsigned, modified, malformed, oversized, or wrong-seed files before comparison or recovery.
- Compares an imported file with any existing server backup, even when automatic backup is off.
- Shows the differences and lets the user choose the complete file backup or the complete server backup.
- Applies either choice through the same validation and recovery path used by automatic backups.

## Approach

Readable JSON uses a domain-separated BIP-340 signature over the canonical backup document. The public key is not stored in the file; import derives the trusted wallet-backup public key from the active seed. Encrypted files retain their existing authenticated encryption.

Export sends the exact bytes and suggested filename to the platform document saver. Cancellation leaves state unchanged, and an invalid or empty export cannot report success.

Import is validate-first: the file is bounded, decoded, decrypted when necessary, fingerprint checked, signature checked for readable JSON, parsed, and compared before local state changes. If the user selects the server copy, or if selecting the file will replace an enabled automatic backup, the compared server generation and ETag are revalidated before applying anything.

## Verification

Tests cover deterministic signed JSON, encrypted and readable round trips, content and signature mutation, missing signatures, wrong seeds, canonical whitespace and key ordering, exact saved bytes and filenames, cancellation, empty files, malformed input, size limits, server comparison, stale server races, complete-source selection, and local recovery without network access.