### PR TITLE
fix(send): allow coins with labels to be selected in coin control

### DIFF
--- a/lib/core/wallet/domain/entities/wallet_utxo.dart
+++ b/lib/core/wallet/domain/entities/wallet_utxo.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
 import 'package:bb_mobile/features/labels/label.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -42,6 +43,10 @@ sealed class WalletUtxo with _$WalletUtxo {
   }) = LiquidWalletUtxo;
 
   const WalletUtxo._();
+
+  /// Use this to ask "same coin?". `==` also compares labels and
+  /// confirmations, which change between reads.
+  Outpoint get outpoint => (txId: txId, vout: vout);
 
   String get address => switch (this) {
     BitcoinWalletUtxo(:final address) => address,

--- a/lib/core/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/core/widgets/coin_selection_bottom_sheet.dart
@@ -47,15 +47,21 @@ class _CommonCoinSelectionBottomSheetState
     // [utxos]). Callers hide frozen coins (D7), so a coin selected earlier and
     // frozen since must not linger in the selection — it can't be shown or
     // deselected here and would otherwise inflate the total / "sufficient" check.
-    _selectedUtxos = widget.initialSelectedUtxos
-        .where(widget.utxos.contains)
+    final selectedOutpoints = widget.initialSelectedUtxos
+        .map((u) => u.outpoint)
+        .toSet();
+    _selectedUtxos = widget.utxos
+        .where((u) => selectedOutpoints.contains(u.outpoint))
         .toList();
   }
 
   void _onUtxoTapped(WalletUtxo utxo) {
     setState(() {
-      if (_selectedUtxos.contains(utxo)) {
-        _selectedUtxos.remove(utxo);
+      final selectedIndex = _selectedUtxos.indexWhere(
+        (u) => u.outpoint == utxo.outpoint,
+      );
+      if (selectedIndex >= 0) {
+        _selectedUtxos.removeAt(selectedIndex);
       } else {
         _selectedUtxos.add(utxo);
       }
@@ -154,7 +160,9 @@ class _CommonCoinSelectionBottomSheetState
               final utxo = widget.utxos[index];
               return CommonCoinSelectTile(
                 utxo: utxo,
-                selected: _selectedUtxos.contains(utxo),
+                selected: _selectedUtxos.any(
+                  (u) => u.outpoint == utxo.outpoint,
+                ),
                 onTap: () => _onUtxoTapped(utxo),
                 exchangeRate: widget.exchangeRate,
                 bitcoinUnit: widget.bitcoinUnit,

--- a/lib/features/labels/label.dart
+++ b/lib/features/labels/label.dart
@@ -44,4 +44,18 @@ class Label {
       origin: origin,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Label &&
+          other.runtimeType == runtimeType &&
+          other.id == id &&
+          other.type == type &&
+          other.label == label &&
+          other.reference == reference &&
+          other.origin == origin;
+
+  @override
+  int get hashCode => Object.hash(id, type, label, reference, origin);
 }

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -20,6 +20,7 @@ import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bb_mobile/core/utils/logger.dart';
 import 'package:bb_mobile/core/utils/payment_request.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_transaction.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
@@ -973,7 +974,10 @@ class SendCubit extends Cubit<SendState>
       // a sync landing mid-flow could leave a stale PSBT staged for
       // broadcast. Guarded so a no-op refresh doesn't needlessly
       // re-shimmer an open modal.
-      final utxosChanged = !setEquals(state.utxos.toSet(), utxos.toSet());
+      final utxosChanged = !setEquals(
+        _coinSetFingerprint(state.utxos),
+        _coinSetFingerprint(utxos),
+      );
       // Proactively flag consolidation for Liquid wallets whose UTXO count is
       // over the threshold, so the card shows before a build is attempted. The
       // ConsolidationRequiredException remains the backstop on the build path.
@@ -987,10 +991,21 @@ class SendCubit extends Cubit<SendState>
           await _checkLiquidConsolidationUsecase.execute(
             walletId: state.selectedWallet!.id,
           );
+      // Re-projected onto the fresh entities, not just filtered, so the sheet's
+      // `selected` check still matches what it renders. Frozen coins drop out:
+      // the sheet hides them, so a coin frozen after being picked could not be
+      // deselected yet would still inflate the total (D7).
+      final selectedOutpoints = state.selectedUtxos
+          .map((u) => u.outpoint)
+          .toSet();
       emit(
         state.copyWith(
           utxos: utxos,
-          selectedUtxos: state.selectedUtxos.where(utxos.contains).toList(),
+          selectedUtxos: utxos
+              .where(
+                (u) => selectedOutpoints.contains(u.outpoint) && !u.isFrozen,
+              )
+              .toList(),
           consolidationRequired: consolidationRequired,
         ),
       );
@@ -1000,10 +1015,20 @@ class SendCubit extends Cubit<SendState>
     }
   }
 
+  /// What can invalidate a cached preview PSBT: which coins exist and whether
+  /// each is spendable. Renaming a coin can't, and counting it re-shimmered
+  /// the open modal on every sync.
+  static Set<({Outpoint outpoint, bool isFrozen})> _coinSetFingerprint(
+    List<WalletUtxo> utxos,
+  ) => utxos.map((u) => (outpoint: u.outpoint, isFrozen: u.isFrozen)).toSet();
+
   Future<void> utxoSelected(WalletUtxo utxo) async {
     final selectedUtxos = List.of(state.selectedUtxos);
-    if (selectedUtxos.contains(utxo)) {
-      selectedUtxos.remove(utxo);
+    final selectedIndex = selectedUtxos.indexWhere(
+      (u) => u.outpoint == utxo.outpoint,
+    );
+    if (selectedIndex >= 0) {
+      selectedUtxos.removeAt(selectedIndex);
     } else {
       selectedUtxos.add(utxo);
     }

--- a/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
@@ -98,7 +98,7 @@ class CoinSelectionBottomSheet extends StatelessWidget {
               final utxo = utxos[index];
               return CoinSelectTile(
                 utxo: utxo,
-                selected: selectedUtxos.contains(utxo),
+                selected: selectedUtxos.any((u) => u.outpoint == utxo.outpoint),
                 onTap: () async =>
                     await context.read<SendCubit>().utxoSelected(utxo),
                 exchangeRate: exchangeRate,

--- a/test/features/labels/label_test.dart
+++ b/test/features/labels/label_test.dart
@@ -1,0 +1,61 @@
+import 'package:bb_mobile/features/labels/domain/primitive/label_type.dart';
+import 'package:bb_mobile/features/labels/label.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // `Label` is pure data read back from storage. Without value equality every
+  // read produced objects that compared unequal, which propagated into the
+  // `==` of every entity holding a `List<Label>` — most visibly `WalletUtxo`,
+  // where it made a labelled coin compare unequal to its own re-read.
+  group('Label equality', () {
+    test('two reads of the same row compare equal', () {
+      final a = Label.addr(id: 1, address: 'bc1-addr', label: 'Payjoin');
+      final b = Label.addr(id: 1, address: 'bc1-addr', label: 'Payjoin');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect([a], equals([b]));
+      expect({a}, equals({b}));
+    });
+
+    test('differs on any field', () {
+      final base = Label.addr(id: 1, address: 'bc1-addr', label: 'Payjoin');
+
+      expect(
+        base,
+        isNot(Label.addr(id: 2, address: 'bc1-addr', label: 'Payjoin')),
+      );
+      expect(
+        base,
+        isNot(Label.addr(id: 1, address: 'bc1-other', label: 'Payjoin')),
+      );
+      expect(
+        base,
+        isNot(Label.addr(id: 1, address: 'bc1-addr', label: 'Coinjoin')),
+      );
+      expect(
+        base,
+        isNot(
+          Label.addr(
+            id: 1,
+            address: 'bc1-addr',
+            label: 'Payjoin',
+            origin: 'bip329',
+          ),
+        ),
+      );
+    });
+
+    test(
+      'a tx label never equals an address label with the same reference',
+      () {
+        final tx = Label.tx(id: 1, transactionId: 'ref', label: 'Payjoin');
+        final addr = Label.addr(id: 1, address: 'ref', label: 'Payjoin');
+
+        expect(tx.type, LabelType.transaction);
+        expect(addr.type, LabelType.address);
+        expect(tx, isNot(addr));
+      },
+    );
+  });
+}

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -257,6 +257,8 @@ WalletUtxo _utxo({
   required int amountSat,
   int vout = 0,
   bool isFrozen = false,
+  List<Label> labels = const [],
+  int confirmations = 0,
 }) => WalletUtxo.bitcoin(
   walletId: 'w-bitcoin',
   txId: 'a' * 64,
@@ -265,7 +267,14 @@ WalletUtxo _utxo({
   amountSat: BigInt.from(amountSat),
   address: 'bc1-utxo',
   isFrozen: isFrozen,
+  labels: labels,
+  confirmations: confirmations,
 );
+
+/// A fresh `Label` instance for the same stored row, as a second read of the
+/// same coin would produce.
+Label _payjoinLabel() =>
+    Label.addr(id: 1, address: 'bc1-utxo', label: 'Payjoin');
 
 FeeOptions _feeOptions() => const FeeOptions(
   fastest: RelativeFee(25),
@@ -1182,6 +1191,128 @@ void main() {
         cubit.state.failure,
         isNot(isA<SendInsufficientFundsForFeesFailure>()),
       );
+    });
+  });
+
+  // A manual coin selection is re-validated against a fresh read of the wallet
+  // on every createTransaction(). The coin is the same coin — its outpoint is
+  // immutable — but the entity around it is not: labels, confirmations and
+  // freeze state all change under it. Keying that re-validation on entity
+  // equality made a labelled coin impossible to select at all: the tap landed,
+  // the total ticked up for a single frame, then loadUtxos() dropped it.
+  group('manual coin selection survives a re-read of the wallet', () {
+    SendState stateWith(List<WalletUtxo> selectedUtxos) => SendState(
+      step: SendStep.amount,
+      sendType: SendType.bitcoin,
+      selectedWallet: _bitcoinWallet(balanceSat: 20000),
+      selectedUtxos: selectedUtxos,
+      utxos: selectedUtxos,
+    );
+
+    test(
+      'keeps a selected coin whose labels are re-read as new instances',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        final selected = _utxo(amountSat: 5000, labels: [_payjoinLabel()]);
+        // Same row, distinct object — exactly what getWalletUtxos() rebuilds.
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer(
+          (_) async => [
+            _utxo(amountSat: 5000, labels: [_payjoinLabel()]),
+          ],
+        );
+        cubit.setStateForTest(stateWith([selected]));
+
+        await cubit.loadUtxos();
+
+        expect(cubit.state.selectedUtxos, hasLength(1));
+        expect(cubit.state.selectedUtxos.single.outpoint, selected.outpoint);
+      },
+    );
+
+    test('keeps a selected coin across a confirmation bump', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final selected = _utxo(amountSat: 5000);
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [_utxo(amountSat: 5000, confirmations: 1)]);
+      cubit.setStateForTest(stateWith([selected]));
+
+      await cubit.loadUtxos();
+
+      expect(cubit.state.selectedUtxos, hasLength(1));
+    });
+
+    // The sheet renders entities from state.utxos and asks whether each is in
+    // state.selectedUtxos. Holding the pre-refresh instances would keep the
+    // radio unfilled even though the selection technically survived.
+    test('re-projects the selection onto the freshly read entities', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final refreshed = _utxo(amountSat: 5000, confirmations: 3);
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [refreshed]);
+      cubit.setStateForTest(stateWith([_utxo(amountSat: 5000)]));
+
+      await cubit.loadUtxos();
+
+      expect(cubit.state.selectedUtxos.single, refreshed);
+      expect(cubit.state.utxos, contains(cubit.state.selectedUtxos.single));
+    });
+
+    // D7: the sheet hides frozen coins, so one frozen after being picked could
+    // never be deselected — it would sit invisible in the selection, inflate
+    // the total, and be stripped again at build time as an unexplained
+    // shortfall.
+    test('drops a selected coin that was frozen since', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [_utxo(amountSat: 5000, isFrozen: true)]);
+      cubit.setStateForTest(stateWith([_utxo(amountSat: 5000)]));
+
+      await cubit.loadUtxos();
+
+      expect(cubit.state.selectedUtxos, isEmpty);
+      expect(cubit.state.utxos, hasLength(1));
+    });
+
+    test('still drops a selected coin that left the wallet', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [_utxo(amountSat: 5000, vout: 1)]);
+      cubit.setStateForTest(stateWith([_utxo(amountSat: 5000)]));
+
+      await cubit.loadUtxos();
+
+      expect(cubit.state.selectedUtxos, isEmpty);
+    });
+
+    // Tapping a selected coin must deselect it, even though the tapped
+    // instance comes from state.utxos and the held one from state.selectedUtxos.
+    test('a second tap deselects rather than duplicating', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      // Leave the fee lists null so createTransaction() bails out early and
+      // this exercises the toggle alone.
+      when(
+        () => getNetworkFeesUsecase.execute(isLiquid: any(named: 'isLiquid')),
+      ).thenThrow(Exception('no network in test'));
+      final held = _utxo(amountSat: 5000, labels: [_payjoinLabel()]);
+      cubit.setStateForTest(stateWith([held]));
+
+      await cubit.utxoSelected(
+        _utxo(amountSat: 5000, labels: [_payjoinLabel()], confirmations: 2),
+      );
+
+      expect(cubit.state.selectedUtxos, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Fixes: #2762 

https://github.com/user-attachments/assets/b34c7911-eceb-4f08-ba0e-3e329259ae67


