### PR TITLE
fix(send): stop coin control from spending unselected coins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to Bull Bitcoin Mobile will be documented in this file.
 
 ### Fixed
 
-- Fixed coin control selection, fee changes, and frozen-coin handling.
+- Fixed coin control so regular sends, MAX/drain, and transfers spend only the selected coins, reject stale or unavailable selections before broadcast, and show actionable frozen-balance and insufficient-selection errors. ([#2766](https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/2766))
 - Fixed fee shortfalls in swaps and enabled Payjoin retries.
 - Fixed Passport UR fountain decoding.
 - Fixed Receive QR codes retaining Payjoin after the toggle is turned off.

--- a/integration_test/coins_test.dart
+++ b/integration_test/coins_test.dart
@@ -10,10 +10,12 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_address_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_environment_usecase.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:bb_mobile/main.dart';
+import 'package:bull_sdk/bdk.dart' as bdk;
 import 'package:drift/drift.dart' show driftRuntimeOptions;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -126,7 +128,10 @@ Future<void> main({bool isInitialized = false}) async {
   // is provided. Without it the structure compiles and is skipped — never
   // silently omitted.
   // -------------------------------------------------------------------------
-  final mnemonic = Platform.environment['TEST_ALICE_MNEMONIC'];
+  const mnemonicDefine = String.fromEnvironment('TEST_ALICE_MNEMONIC');
+  final mnemonic = mnemonicDefine.isNotEmpty
+      ? mnemonicDefine
+      : Platform.environment['TEST_ALICE_MNEMONIC'];
   final hasFunds = mnemonic != null && mnemonic.isNotEmpty;
 
   group(
@@ -187,6 +192,75 @@ Future<void> main({bool isInitialized = false}) async {
           // always present (possibly empty) — assert the contract, not content.
           expect(utxo.labels, isNotNull);
         }
+      });
+
+      test('a manual drain spends exactly the selected outpoint', () async {
+        final utxos = await utxoRepository.getWalletUtxos(walletId: wallet.id);
+        final spendable = utxos.where((utxo) => !utxo.isFrozen).toList();
+        if (spendable.length < 2) {
+          markTestSkipped('requires at least two testnet UTXOs');
+          return;
+        }
+        final selected = spendable.reduce(
+          (largest, candidate) =>
+              candidate.amountSat > largest.amountSat ? candidate : largest,
+        );
+        final receive = await addressRepository.generateNewReceiveAddress(
+          walletId: wallet.id,
+        );
+
+        final prepared = await prepareBitcoinSendUsecase.execute(
+          walletId: wallet.id,
+          address: receive.address,
+          drain: true,
+          selectedInputs: [selected],
+          networkFee: NetworkFee.relativeFromSatPerVbyte(2),
+        );
+
+        final inputs = bdk.Psbt(
+          psbtBase64: prepared.unsignedPsbt,
+        ).extractTx().input();
+        expect(inputs, hasLength(1));
+        expect(inputs.single.previousOutput.txid.toString(), selected.txId);
+        expect(inputs.single.previousOutput.vout, selected.vout);
+      });
+
+      test('a partly frozen manual selection fails closed', () async {
+        final utxos = await utxoRepository.getWalletUtxos(walletId: wallet.id);
+        final spendable = utxos.where((utxo) => !utxo.isFrozen).toList();
+        if (spendable.length < 2) {
+          markTestSkipped('requires at least two testnet UTXOs');
+          return;
+        }
+        final selection = spendable.take(2).toList();
+        final frozenOutpoint = (
+          txId: selection.first.txId,
+          vout: selection.first.vout,
+        );
+        await utxoRepository.freezeUtxos(
+          walletId: wallet.id,
+          outpoints: [frozenOutpoint],
+        );
+        addTearDown(
+          () => utxoRepository.unfreezeUtxos(
+            walletId: wallet.id,
+            outpoints: [frozenOutpoint],
+          ),
+        );
+        final receive = await addressRepository.generateNewReceiveAddress(
+          walletId: wallet.id,
+        );
+
+        await expectLater(
+          prepareBitcoinSendUsecase.execute(
+            walletId: wallet.id,
+            address: receive.address,
+            drain: true,
+            selectedInputs: selection,
+            networkFee: NetworkFee.relativeFromSatPerVbyte(2),
+          ),
+          throwsA(isA<InsufficientFundsException>()),
+        );
       });
 
       test('frozen coins are excluded from every PSBT build (D7)', () async {

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -271,12 +271,10 @@ class BdkWalletDatasource {
       // In bdk_wallet 3.0.0's `create_tx` that is `required = params.utxos` plus `optional = filter_utxos(..)`, and `manually_selected_only` is what empties the optional pool (`filter_utxos` returns `vec![]`).
       // Without it, hand-picking coins that fall short produces a perfectly valid PSBT containing a coin the user deliberately excluded — an irreversible on-chain privacy leak, since the common-input-ownership heuristic then links that coin's history to the rest of the selection. With it, the shortfall surfaces as InsufficientFundsException instead, which is the honest answer.
       //
-      // Drain is deliberately left out. `drain_wallet` folds the optional pool into the required set, so the two combined would spend only the selection while the UI still derives the MAX amount from the whole spendable balance — signing a smaller payment than the confirm screen displays. MAX-with-coin-control needs its own fix (the amount must come from the selection first).
+      // Drain gets no carve-out: `manually_selected_only` empties the optional pool BEFORE `drain_wallet` folds it into the required set, so draining with a selection spends — and drains — exactly the picked coins. MAX with coin control therefore means "MAX of the selection", and callers must derive the displayed amount from the selection total, not the whole spendable balance (SendCubit.createTransaction does). Flows that lock an amount in before the build (chain swaps, exchange payins) are covered by their amount-verification usecases: a drain that pays less than the quoted amount fails explicitly there instead of silently spending coins the user excluded.
       //
       // Guarded by the enclosing isNotEmpty check for a second reason: `create_tx` rejects `manually_selected_only` with an empty selection (`CreateTxError::NoUtxosSelected`).
-      if (drain != true) {
-        txBuilder = txBuilder.manuallySelectedOnly();
-      }
+      txBuilder = txBuilder.manuallySelectedOnly();
     }
 
     // bdk_dart always has RBF (nSequence = 0xFFFFFFFD) enabled by default,

--- a/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/bdk_wallet_datasource.dart
@@ -267,6 +267,16 @@ class BdkWalletDatasource {
       // return value (as this call did before) silently drops the manual
       // UTXO selection and leaves BDK to pick inputs automatically.
       txBuilder = txBuilder.addUtxos(outpoints: selectableOutPoints);
+      // `addUtxos` makes these inputs MANDATORY, not EXCLUSIVE: BDK documents them as "the internal list of UTXOs that must be spent", and coin selection stays free to append more of the wallet's coins when the selection alone can't cover outputs + fee.
+      // In bdk_wallet 3.0.0's `create_tx` that is `required = params.utxos` plus `optional = filter_utxos(..)`, and `manually_selected_only` is what empties the optional pool (`filter_utxos` returns `vec![]`).
+      // Without it, hand-picking coins that fall short produces a perfectly valid PSBT containing a coin the user deliberately excluded — an irreversible on-chain privacy leak, since the common-input-ownership heuristic then links that coin's history to the rest of the selection. With it, the shortfall surfaces as InsufficientFundsException instead, which is the honest answer.
+      //
+      // Drain is deliberately left out. `drain_wallet` folds the optional pool into the required set, so the two combined would spend only the selection while the UI still derives the MAX amount from the whole spendable balance — signing a smaller payment than the confirm screen displays. MAX-with-coin-control needs its own fix (the amount must come from the selection first).
+      //
+      // Guarded by the enclosing isNotEmpty check for a second reason: `create_tx` rejects `manually_selected_only` with an empty selection (`CreateTxError::NoUtxosSelected`).
+      if (drain != true) {
+        txBuilder = txBuilder.manuallySelectedOnly();
+      }
     }
 
     // bdk_dart always has RBF (nSequence = 0xFFFFFFFD) enabled by default,

--- a/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/bitcoin_wallet_repository.dart
@@ -95,8 +95,12 @@ class BitcoinWalletRepository implements BitcoinSendPort {
           (utxo) => !unspendableKeys.contains('${utxo.txId}:${utxo.vout}'),
         )
         .toList();
-    if (selected != null && selected.isNotEmpty && spendableSelected!.isEmpty) {
-      throw NoSpendableUtxoException('All selected UTXOs are unspendable');
+    if (selected != null &&
+        selected.isNotEmpty &&
+        spendableSelected!.length != selected.length) {
+      throw NoSpendableUtxoException(
+        'At least one selected UTXO is unspendable',
+      );
     }
 
     final psbt = await _bdkWallet.buildPsbt(

--- a/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
+++ b/lib/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart
@@ -6,19 +6,25 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
-import 'package:primitives/primitives.dart' show Err, Ok, Outpoint;
 
 class PrepareBitcoinSendUsecase {
   final PayjoinSessions _payjoin;
   final BitcoinSendPort _bitcoinWalletRepository;
   final WalletUtxoRepository _walletUtxoRepository;
+  late final ValidateBitcoinSelectionUsecase _validateBitcoinSelectionUsecase;
 
   PrepareBitcoinSendUsecase({
     required PayjoinSessions payjoinSessions,
     required this._walletUtxoRepository,
     required this._bitcoinWalletRepository,
-  }) : _payjoin = payjoinSessions;
+  }) : _payjoin = payjoinSessions {
+    _validateBitcoinSelectionUsecase = ValidateBitcoinSelectionUsecase(
+      payjoinSessions: _payjoin,
+      walletUtxoRepository: _walletUtxoRepository,
+    );
+  }
 
   Future<({String unsignedPsbt, int txSize, bool isToSelf})> execute({
     required String walletId,
@@ -39,21 +45,14 @@ class PrepareBitcoinSendUsecase {
       // to every PSBT build (normal send + drain). The two sources are kept
       // explicit on purpose; the future payjoin-unification collapses
       // `_unspendableFor` to a single read.
-      final unspendableUtxos = await _unspendableFor(walletId);
+      final unspendableUtxos = await _validateBitcoinSelectionUsecase.execute(
+        walletId: walletId,
+        selectedInputs: selectedInputs,
+      );
 
       log.info(
         'Bitcoin wallet id $walletId building psbt. Unspendable utxos: $unspendableUtxos',
       );
-
-      // Belt-and-suspenders: defensively strip any selected input that falls in
-      // the unspendable set before building (guards a future send-from-selected
-      // path from ever pinning a frozen coin).
-      final filteredSelectedInputs = selectedInputs
-          ?.where(
-            (utxo) =>
-                !unspendableUtxos.contains((txId: utxo.txId, vout: utxo.vout)),
-          )
-          .toList();
 
       final psbt = await _bitcoinWalletRepository.buildPsbt(
         walletId: walletId,
@@ -62,7 +61,7 @@ class PrepareBitcoinSendUsecase {
         networkFee: networkFee,
         drain: drain,
         unspendable: unspendableUtxos,
-        selected: filteredSelectedInputs,
+        selected: selectedInputs,
         replaceByFee: replaceByFee,
       );
       final size = await _bitcoinWalletRepository.getTxSize(psbt: psbt);
@@ -78,24 +77,6 @@ class PrepareBitcoinSendUsecase {
     } catch (e) {
       throw PrepareBitcoinSendException(e.toString());
     }
-  }
-
-  /// The set of outpoints that must never be spent for [walletId]:
-  /// dedup(user-frozen ∪ payjoin-derived). Two explicit sources by design
-  /// (§6.1) — this is the single seam the future payjoin-unification collapses
-  /// to one read.
-  Future<List<Outpoint>> _unspendableFor(String walletId) async {
-    // Freeze is matched by outpoint (globally unique), so the full frozen set
-    // is safe to pass: buildPsbt ignores any outpoint this wallet doesn't own.
-    final userFrozen = await _walletUtxoRepository.getAllFrozenOutpoints();
-    final payjoinResult = await _payjoin.reservedOutpoints();
-    final payjoinFrozen = switch (payjoinResult) {
-      Ok(:final value) => value,
-      Err() => throw PrepareBitcoinSendException(
-        'Failed to load Payjoin-reserved UTXOs',
-      ),
-    };
-    return {...userFrozen, ...payjoinFrozen}.toList();
   }
 }
 

--- a/lib/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart
+++ b/lib/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart
@@ -1,0 +1,64 @@
+import 'package:bb_mobile/core/errors/bull_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bull_payjoin/bull_payjoin.dart';
+import 'package:primitives/primitives.dart' show Err, Ok, Outpoint;
+
+class ValidateBitcoinSelectionUsecase {
+  final PayjoinSessions _payjoin;
+  final WalletUtxoRepository _walletUtxoRepository;
+
+  ValidateBitcoinSelectionUsecase({
+    required PayjoinSessions payjoinSessions,
+    required this._walletUtxoRepository,
+  }) : _payjoin = payjoinSessions;
+
+  Future<List<Outpoint>> execute({
+    required String walletId,
+    List<WalletUtxo>? selectedInputs,
+  }) async {
+    try {
+      final userFrozen = await _walletUtxoRepository.getAllFrozenOutpoints();
+      final payjoinResult = await _payjoin.reservedOutpoints();
+      final payjoinReserved = switch (payjoinResult) {
+        Ok(:final value) => value,
+        Err() => throw ValidateBitcoinSelectionException(
+          'Failed to load Payjoin-reserved UTXOs',
+        ),
+      };
+      final unspendable = {...userFrozen, ...payjoinReserved};
+
+      if (selectedInputs != null && selectedInputs.isNotEmpty) {
+        final liveUtxos = await _walletUtxoRepository.getWalletUtxos(
+          walletId: walletId,
+        );
+        final spendableOutpoints = liveUtxos
+            .where(
+              (utxo) => !utxo.isFrozen && !unspendable.contains(utxo.outpoint),
+            )
+            .map((utxo) => utxo.outpoint)
+            .toSet();
+        if (selectedInputs.any(
+          (utxo) => !spendableOutpoints.contains(utxo.outpoint),
+        )) {
+          throw InsufficientFundsException(
+            'A selected coin is no longer spendable',
+          );
+        }
+      }
+
+      return unspendable.toList();
+    } on InsufficientFundsException {
+      rethrow;
+    } on ValidateBitcoinSelectionException {
+      rethrow;
+    } catch (error) {
+      throw ValidateBitcoinSelectionException(error.toString());
+    }
+  }
+}
+
+class ValidateBitcoinSelectionException extends BullException {
+  ValidateBitcoinSelectionException(super.message);
+}

--- a/lib/features/send/domain/send_failure.dart
+++ b/lib/features/send/domain/send_failure.dart
@@ -35,6 +35,14 @@ final class SendInsufficientFundsForFeesFailure extends SendFailure {
   const SendInsufficientFundsForFeesFailure([super.logMessage]);
 }
 
+final class SendSelectedCoinsUnavailableFailure extends SendFailure {
+  const SendSelectedCoinsUnavailableFailure([super.logMessage]);
+}
+
+final class SendSelectedCoinsInsufficientFailure extends SendFailure {
+  const SendSelectedCoinsInsufficientFailure([super.logMessage]);
+}
+
 final class SendAmountOutOfBoundsFailure extends SendFailure {
   final BigInt? minimumSat;
   final BigInt? maximumSat;

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -1648,9 +1648,18 @@ class SendCubit extends Cubit<SendState>
         }
         if (state.sendMax) {
           // See above: MAX must be capped by the spendable balance, which
-          // excludes user-frozen coins.
-          final maxAmountSat =
-              state.spendableBalanceSat - (state.absoluteFees ?? 0);
+          // excludes user-frozen coins. With a manual coin selection the
+          // build drains only the selected coins (`manuallySelectedOnly` in
+          // BdkWalletDatasource.buildPsbt), so MAX is the selection's total —
+          // deriving it from the whole spendable balance would confirm a
+          // larger amount than the PSBT actually pays.
+          final drainableSat = state.selectedUtxos.isEmpty
+              ? state.spendableBalanceSat
+              : state.selectedUtxos.fold(
+                  0,
+                  (sum, utxo) => sum + utxo.amountSat.toInt(),
+                );
+          final maxAmountSat = drainableSat - (state.absoluteFees ?? 0);
           final maxAmount =
               state.inputAmountCurrencyCode == BitcoinUnit.btc.code
               ? ConvertAmount.satsToBtc(maxAmountSat)

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -12,6 +12,7 @@ import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
@@ -40,6 +41,7 @@ import 'package:bb_mobile/features/send/domain/usecases/get_send_swap_quote_usec
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/get_send_payjoin_enabled_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
@@ -76,6 +78,7 @@ class SendCubit extends Cubit<SendState>
     required this._getWalletUtxosUsecase,
     required this._getAvailableCurrenciesUsecase,
     required this._prepareBitcoinSendUsecase,
+    required this._validateBitcoinSelectionUsecase,
     required this._prepareLiquidSendUsecase,
     required this._sendWithPayjoinUsecase,
     required this._watchPayjoinUsecase,
@@ -129,6 +132,7 @@ class SendCubit extends Cubit<SendState>
   final GetWalletsUsecase _getWalletsUsecase;
   final GetWalletUsecase _getWalletUsecase;
   final PrepareBitcoinSendUsecase _prepareBitcoinSendUsecase;
+  final ValidateBitcoinSelectionUsecase _validateBitcoinSelectionUsecase;
   final PrepareLiquidSendUsecase _prepareLiquidSendUsecase;
   final CalculateLiquidPsetSizeUsecase _calculateLiquidPsetSizeUsecase;
   final CreateSendSwapUsecase _createSendSwapUsecase;
@@ -175,6 +179,7 @@ class SendCubit extends Cubit<SendState>
   /// built for the previous tx shape for broadcast).
   int _bitcoinPreviewEpoch = 0;
   int _paymentRequestInputGeneration = 0;
+  int _transactionGeneration = 0;
 
   @override
   Future<void> close() async {
@@ -223,6 +228,7 @@ class SendCubit extends Cubit<SendState>
 
   int _startNewPaymentRequestInput() {
     final generation = ++_paymentRequestInputGeneration;
+    _invalidateSignedTransaction();
     if (state.loadingBestWallet) {
       emit(state.copyWith(loadingBestWallet: false));
     }
@@ -262,7 +268,6 @@ class SendCubit extends Cubit<SendState>
   ) async {
     _startNewPaymentRequestInput();
     clearFailure();
-    _invalidateSignedTransaction();
     final sanitizedText = scannedRawPaymentRequest.trim().replaceAll(
       RegExp(r'^["\"]+|["\"]+$'),
       '',
@@ -291,7 +296,6 @@ class SendCubit extends Cubit<SendState>
     final inputGeneration = _startNewPaymentRequestInput();
     try {
       clearFailure();
-      _invalidateSignedTransaction();
       final sanitizedText = text.trim().replaceAll(
         RegExp(r'^["\"]+|["\"]+$'),
         '',
@@ -677,7 +681,7 @@ class SendCubit extends Cubit<SendState>
         // D7: Max drains only spendable coins (frozen are excluded at build),
         // so the Max amount must reflect spendable balance, not the raw
         // wallet balance — otherwise Max overshoots by the frozen total.
-        final spendableSat = state.spendableBalanceSat;
+        final spendableSat = state.maxAvailableBalanceSat;
         if (state.inputAmountCurrencyCode == BitcoinUnit.sats.code) {
           validatedAmount = spendableSat.toString();
         } else {
@@ -727,7 +731,7 @@ class SendCubit extends Cubit<SendState>
       final amountChanged =
           state.amount != validatedAmount || state.sendMax != isMax;
       emit(state.copyWith(amount: validatedAmount, sendMax: isMax));
-      _invalidateSignedTransaction();
+      if (amountChanged) _invalidateSignedTransaction();
       // Amount is part of the cache fingerprint — any change invalidates
       // every previously-built preview PSBT. Without this clear, the user
       // can open the fee modal at amount A, change the amount to B
@@ -962,13 +966,17 @@ class SendCubit extends Cubit<SendState>
     }
   }
 
-  Future<void> loadUtxos() async {
+  Future<void> loadUtxos({int? transactionGeneration}) async {
     if (state.selectedWallet == null) return;
 
     try {
       final utxos = await _getWalletUtxosUsecase.execute(
         walletId: state.selectedWallet!.id,
       );
+      if (transactionGeneration != null &&
+          transactionGeneration != _transactionGeneration) {
+        return;
+      }
       // A wallet sync can change the available coins. Any cached preview
       // PSBT was built against the prior UTXO set, so drop it — otherwise
       // a sync landing mid-flow could leave a stale PSBT staged for
@@ -991,6 +999,10 @@ class SendCubit extends Cubit<SendState>
           await _checkLiquidConsolidationUsecase.execute(
             walletId: state.selectedWallet!.id,
           );
+      if (transactionGeneration != null &&
+          transactionGeneration != _transactionGeneration) {
+        return;
+      }
       // Re-projected onto the fresh entities, not just filtered, so the sheet's
       // `selected` check still matches what it renders. Frozen coins drop out:
       // the sheet hides them, so a coin frozen after being picked could not be
@@ -998,19 +1010,36 @@ class SendCubit extends Cubit<SendState>
       final selectedOutpoints = state.selectedUtxos
           .map((u) => u.outpoint)
           .toSet();
+      final refreshedSelection = utxos
+          .where((u) => selectedOutpoints.contains(u.outpoint) && !u.isFrozen)
+          .toList();
+      final selectionWasLost =
+          state.selectedUtxos.isNotEmpty &&
+          refreshedSelection.length != state.selectedUtxos.length;
       emit(
         state.copyWith(
           utxos: utxos,
-          selectedUtxos: utxos
-              .where(
-                (u) => selectedOutpoints.contains(u.outpoint) && !u.isFrozen,
-              )
-              .toList(),
+          selectedUtxos: refreshedSelection,
           consolidationRequired: consolidationRequired,
+          failure: selectionWasLost
+              ? const SendSelectedCoinsUnavailableFailure(
+                  'A selected coin is no longer spendable',
+                )
+              : state.failure,
         ),
       );
+      if (selectionWasLost) {
+        _invalidateSignedTransaction(
+          cancelInFlightBuild: transactionGeneration == null,
+        );
+        clearBitcoinFeePreviews();
+      }
       if (utxosChanged) clearBitcoinFeePreviews();
     } catch (e) {
+      if (transactionGeneration != null &&
+          transactionGeneration != _transactionGeneration) {
+        return;
+      }
       emit(state.copyWith(failure: SendUnexpectedFailure(e.toString())));
     }
   }
@@ -1380,6 +1409,8 @@ class SendCubit extends Cubit<SendState>
   // type the dummies in Step 2a must be updated to match, otherwise Step 3b
   // will fire.
   Future<void> createTransaction() async {
+    _invalidateSignedTransaction();
+    final generation = _transactionGeneration;
     try {
       if (state.bitcoinFeesList == null || state.liquidFeesList == null) {
         await loadFees();
@@ -1387,6 +1418,7 @@ class SendCubit extends Cubit<SendState>
           return;
         }
       }
+      if (generation != _transactionGeneration) return;
       clearFailure();
       // Clear the previous build's absolute fee before loadUtxos so the UI
       // doesn't briefly pair a stale Bitcoin fee with newly-changed inputs
@@ -1395,7 +1427,13 @@ class SendCubit extends Cubit<SendState>
       emit(
         state.copyWith(buildingTransaction: true, bitcoinAbsoluteFeesSat: null),
       );
-      await loadUtxos();
+      await loadUtxos(transactionGeneration: generation);
+      if (state.failure != null || generation != _transactionGeneration) {
+        if (generation == _transactionGeneration) {
+          emit(state.copyWith(buildingTransaction: false));
+        }
+        return;
+      }
       final address = state.lightningOrder?.order != null
           ? state.lightningOrder!.order!.payinAddress
           : (state.chainSwap != null)
@@ -1420,6 +1458,7 @@ class SendCubit extends Cubit<SendState>
           amountSat: amount,
           drain: drain,
         );
+        if (generation != _transactionGeneration) return;
         final pset = await _prepareLiquidSendUsecase.execute(
           walletId: state.selectedWallet!.id,
           address: address,
@@ -1427,12 +1466,14 @@ class SendCubit extends Cubit<SendState>
           amountSat: amount,
           drain: drain,
         );
+        if (generation != _transactionGeneration) return;
         if (state.lightningOrder case final order?) {
           await _verifyExchangePayinUsecase.execute(
             psbtOrPset: pset,
             record: order,
             walletId: state.selectedWallet!.id,
           );
+          if (generation != _transactionGeneration) return;
         }
         if (state.chainSwap != null) {
           // [CHAIN SWAP LIFECYCLE — Step 3b: fail-safe verification]
@@ -1447,6 +1488,7 @@ class SendCubit extends Cubit<SendState>
             swap: state.chainSwap!,
             walletId: state.selectedWallet!.id,
           );
+          if (generation != _transactionGeneration) return;
         }
         // final signedPset = await _signLiquidTxUsecase.execute(
         //   walletId: state.selectedWallet!.id,
@@ -1455,6 +1497,7 @@ class SendCubit extends Cubit<SendState>
         final absoluteFees = await _calculateLiquidAbsoluteFeesUsecase.execute(
           pset: pset,
         );
+        if (generation != _transactionGeneration) return;
         if (state.lightningOrder != null) {
           emit(
             state.copyWith(
@@ -1473,11 +1516,9 @@ class SendCubit extends Cubit<SendState>
           );
         }
         if (state.sendMax) {
-          // Frozen coins are never spendable, so MAX is the spendable
-          // balance — using the full balance overstates it and confirms an
-          // amount the build can't cover.
-          final maxAmountSat =
-              state.spendableBalanceSat - (state.absoluteFees ?? 0);
+          // Use the selected total when coin control is active; otherwise use
+          // the spendable wallet balance.
+          final maxAmountSat = state.maxSpendableBalanceSat;
           // convert to btc or fiat based on selected currency
           final maxAmount = state.bitcoinUnit == BitcoinUnit.btc
               ? ConvertAmount.satsToBtc(maxAmountSat)
@@ -1513,6 +1554,13 @@ class SendCubit extends Cubit<SendState>
           state.selectedFeeOption,
         );
         final canUseCache = cachedSlot.isCacheReady;
+        if (canUseCache && state.selectedUtxos.isNotEmpty) {
+          await _validateBitcoinSelectionUsecase.execute(
+            walletId: state.selectedWallet!.id,
+            selectedInputs: state.selectedUtxos,
+          );
+          if (generation != _transactionGeneration) return;
+        }
         log.info(
           '[create-tx] build address=$address amount=$amount '
           'rate=${selectedFee is RelativeFee ? selectedFee.satPerVbyte : selectedFee.value} '
@@ -1544,6 +1592,7 @@ class SendCubit extends Cubit<SendState>
         final builtFee = await _calculateBitcoinAbsoluteFeesUsecase.execute(
           psbt: txPreparation.unsignedPsbt,
         );
+        if (generation != _transactionGeneration) return;
         if (state.lightningOrder case final order?) {
           await _verifyExchangePayinUsecase.execute(
             psbtOrPset: txPreparation.unsignedPsbt,
@@ -1551,6 +1600,7 @@ class SendCubit extends Cubit<SendState>
             walletId: state.selectedWallet!.id,
           );
         }
+        if (generation != _transactionGeneration) return;
         log.info(
           '[create-tx] built vsize=${txPreparation.txSize} '
           'realFee=$builtFee sats '
@@ -1570,6 +1620,7 @@ class SendCubit extends Cubit<SendState>
           floorSatPerKwu: state.bitcoinFeesList?.minRelay.satPerKwu,
         );
         if (!clearsRelay) {
+          if (generation != _transactionGeneration) return;
           log.warning(
             '[create-tx] ABORT — built fee $builtFee sats at '
             '${txPreparation.txSize} vbytes is below the relay floor '
@@ -1587,6 +1638,8 @@ class SendCubit extends Cubit<SendState>
           return;
         }
 
+        if (generation != _transactionGeneration) return;
+
         if (state.chainSwap != null) {
           // [CHAIN SWAP LIFECYCLE — Step 3b: fail-safe verification]
           // See note on the liquid branch above. Do not remove.
@@ -1595,6 +1648,7 @@ class SendCubit extends Cubit<SendState>
             swap: state.chainSwap!,
             walletId: state.selectedWallet!.id,
           );
+          if (generation != _transactionGeneration) return;
         }
 
         if (state.selectedWallet!.signsRemotely) {
@@ -1604,6 +1658,7 @@ class SendCubit extends Cubit<SendState>
               await _calculateBitcoinAbsoluteFeesUsecase.execute(
                 psbt: txPreparation.unsignedPsbt,
               );
+          if (generation != _transactionGeneration) return;
           emit(
             state.copyWith(
               unsignedPsbt: txPreparation.unsignedPsbt,
@@ -1622,6 +1677,7 @@ class SendCubit extends Cubit<SendState>
               await _calculateBitcoinAbsoluteFeesUsecase.execute(
                 psbt: signedPsbtAndTxSize.signedPsbt,
               );
+          if (generation != _transactionGeneration) return;
           if (state.lightningOrder != null) {
             emit(
               state.copyWith(
@@ -1647,19 +1703,8 @@ class SendCubit extends Cubit<SendState>
           }
         }
         if (state.sendMax) {
-          // See above: MAX must be capped by the spendable balance, which
-          // excludes user-frozen coins. With a manual coin selection the
-          // build drains only the selected coins (`manuallySelectedOnly` in
-          // BdkWalletDatasource.buildPsbt), so MAX is the selection's total —
-          // deriving it from the whole spendable balance would confirm a
-          // larger amount than the PSBT actually pays.
-          final drainableSat = state.selectedUtxos.isEmpty
-              ? state.spendableBalanceSat
-              : state.selectedUtxos.fold(
-                  0,
-                  (sum, utxo) => sum + utxo.amountSat.toInt(),
-                );
-          final maxAmountSat = drainableSat - (state.absoluteFees ?? 0);
+          // Keep the displayed MAX amount aligned with the built PSBT inputs.
+          final maxAmountSat = state.maxSpendableBalanceSat;
           final maxAmount =
               state.inputAmountCurrencyCode == BitcoinUnit.btc.code
               ? ConvertAmount.satsToBtc(maxAmountSat)
@@ -1675,6 +1720,8 @@ class SendCubit extends Cubit<SendState>
         }
       }
     } catch (e) {
+      if (generation != _transactionGeneration) return;
+      _invalidateSignedTransaction();
       log.severe(error: e, trace: StackTrace.current);
       if (e is ConsolidationRequiredException) {
         emit(
@@ -1685,15 +1732,27 @@ class SendCubit extends Cubit<SendState>
         );
         return;
       }
+      if (e is NoSpendableUtxoException) {
+        emit(
+          state.copyWith(
+            failure: SendInsufficientBalanceFailure(e.message),
+            buildingTransaction: false,
+          ),
+        );
+        return;
+      }
       if (e is InsufficientFundsException) {
-        // Frozen or hand-picked coins can be the real cause, not the fee. Both
-        // need the generic failure
+        // Frozen or hand-picked coins can be the real cause, not the fee.
+        // Give manual selection its actionable failure; keep automatic
+        // selection on the existing balance/fee paths.
         final blamesFees =
             state.selectedUtxos.isEmpty && state.frozenBalanceSat == 0;
         emit(
           state.copyWith(
             failure: blamesFees
                 ? SendInsufficientFundsForFeesFailure(e.message)
+                : state.selectedUtxos.isNotEmpty
+                ? SendSelectedCoinsInsufficientFailure(e.message)
                 : SendInsufficientBalanceFailure(e.message),
             buildingTransaction: false,
           ),
@@ -1855,6 +1914,7 @@ class SendCubit extends Cubit<SendState>
       // label, swap update and wallet sync would be lost to a null-check
       // crash instead.
       final wallet = state.selectedWallet!;
+      if (!await _validateSelectedBitcoinInputsForBroadcast(wallet)) return;
       final label = state.label;
       final chainSwap = state.chainSwap;
 
@@ -2009,6 +2069,30 @@ class SendCubit extends Cubit<SendState>
         );
       }
     }
+  }
+
+  Future<bool> _validateSelectedBitcoinInputsForBroadcast(Wallet wallet) async {
+    if (wallet.isLiquid || state.selectedUtxos.isEmpty) return true;
+    try {
+      await _validateBitcoinSelectionUsecase.execute(
+        walletId: wallet.id,
+        selectedInputs: state.selectedUtxos,
+      );
+      return true;
+    } on InsufficientFundsException {
+      _invalidateSignedTransaction();
+    } on ValidateBitcoinSelectionException {
+      _invalidateSignedTransaction();
+    }
+    emit(
+      state.copyWith(
+        failure: const SendSelectedCoinsUnavailableFailure(
+          'selected_coins_unavailable',
+        ),
+        broadcastingTransaction: false,
+      ),
+    );
+    return false;
   }
 
   Future<void> onConfirmTransactionClicked() async {
@@ -2374,11 +2458,13 @@ class SendCubit extends Cubit<SendState>
   /// with a broadcastable signature attached to the old recipient/amount.
   /// The unsigned PSBT goes too: it is the reference
   /// [updateSignedBitcoinTx] verifies a hardware signature against.
-  void _invalidateSignedTransaction() {
+  void _invalidateSignedTransaction({bool cancelInFlightBuild = true}) {
+    if (cancelInFlightBuild) _transactionGeneration++;
     if (state.signedBitcoinTx == null &&
         state.signedBitcoinPsbt == null &&
         state.signedLiquidTx == null &&
-        state.unsignedPsbt == null) {
+        state.unsignedPsbt == null &&
+        !state.buildingTransaction) {
       return;
     }
     emit(
@@ -2387,6 +2473,9 @@ class SendCubit extends Cubit<SendState>
         signedBitcoinPsbt: null,
         signedLiquidTx: null,
         unsignedPsbt: null,
+        buildingTransaction: cancelInFlightBuild
+            ? false
+            : state.buildingTransaction,
       ),
     );
   }
@@ -2400,6 +2489,7 @@ class SendCubit extends Cubit<SendState>
   /// the silent override regressed cold-wallet sends. See #1918.
   Future<void> _setSelectedWallet(Wallet wallet, {required bool manual}) async {
     final walletChanged = state.selectedWallet?.id != wallet.id;
+    if (walletChanged) _invalidateSignedTransaction();
     emit(
       state.copyWith(
         selectedWallet: wallet,

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -430,6 +430,19 @@ abstract class SendState with _$SendState {
   int get spendableBalanceSat =>
       (selectedWallet?.balanceSat.toInt() ?? 0) - frozenBalanceSat;
 
+  int get maxAvailableBalanceSat {
+    final selectedBalance = selectedUtxos.fold(
+      0,
+      (sum, utxo) => sum + utxo.amountSat.toInt(),
+    );
+    return selectedUtxos.isEmpty ? spendableBalanceSat : selectedBalance;
+  }
+
+  int get maxSpendableBalanceSat {
+    final maxAmount = maxAvailableBalanceSat - (absoluteFees ?? 0);
+    return maxAmount < 0 ? 0 : maxAmount;
+  }
+
   bool get walletHasBalance =>
       // ignore: avoid_bool_literals_in_conditional_expressions
       selectedWallet == null

--- a/lib/features/send/presentation/send_failure_l10n.dart
+++ b/lib/features/send/presentation/send_failure_l10n.dart
@@ -18,6 +18,10 @@ extension SendFailureL10n on SendFailure {
       context.loc.sendErrorInsufficientBalanceForPayment,
     SendInsufficientFundsForFeesFailure() =>
       context.loc.sendErrorInsufficientFundsForFees,
+    SendSelectedCoinsUnavailableFailure() =>
+      context.loc.sendErrorSelectedCoinsUnavailable,
+    SendSelectedCoinsInsufficientFailure() =>
+      context.loc.sendErrorSelectedCoinsInsufficient,
     SendAmountOutOfBoundsFailure(:final minimumSat?) =>
       context.loc.sendErrorAmountBelowMinimum(minimumSat.toString()),
     SendAmountOutOfBoundsFailure(:final maximumSat?) =>

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -32,6 +32,7 @@ import 'package:bb_mobile/features/send/domain/usecases/verify_exchange_payin_us
 import 'package:bb_mobile/features/send/domain/usecases/get_send_swap_quote_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/get_send_cross_chain_quote_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
@@ -70,6 +71,12 @@ class SendLocator {
         payjoinSessions: locator<PayjoinSessions>(),
         walletUtxoRepository: locator<WalletUtxoRepository>(),
         bitcoinWalletRepository: locator<BitcoinWalletRepository>(),
+      ),
+    );
+    locator.registerFactory<ValidateBitcoinSelectionUsecase>(
+      () => ValidateBitcoinSelectionUsecase(
+        payjoinSessions: locator<PayjoinSessions>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
       ),
     );
     locator.registerFactory<PrepareLiquidSendUsecase>(
@@ -184,6 +191,8 @@ class SendLocator {
         getAvailableCurrenciesUsecase: locator<GetAvailableCurrenciesUsecase>(),
         getWalletUtxosUsecase: locator<GetWalletUtxosUsecase>(),
         prepareBitcoinSendUsecase: locator<PrepareBitcoinSendUsecase>(),
+        validateBitcoinSelectionUsecase:
+            locator<ValidateBitcoinSelectionUsecase>(),
         prepareLiquidSendUsecase: locator<PrepareLiquidSendUsecase>(),
         signBitcoinTxUsecase: locator<SignBitcoinTxUsecase>(),
         signLiquidTxUsecase: locator<SignLiquidTxUsecase>(),

--- a/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
@@ -13,6 +13,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
 import 'package:go_router/go_router.dart';
 
+bool selectionFailureShowsWarning(SendFailure? failure) {
+  return failure is SendInsufficientBalanceFailure ||
+      failure is SendInsufficientFundsForFeesFailure ||
+      failure is SendSelectedCoinsInsufficientFailure ||
+      failure is SendSelectedCoinsUnavailableFailure;
+}
+
 class CoinSelectionBottomSheet extends StatelessWidget {
   const CoinSelectionBottomSheet({super.key});
 
@@ -66,9 +73,7 @@ class CoinSelectionBottomSheet extends StatelessWidget {
     // Tied to the failure rather than to `!isAmountSufficient` so the warning
     // doesn't flash during the in-flight rebuild after every tap.
     final selectionIsShort = context.select(
-      (SendCubit send) =>
-          send.state.failure is SendInsufficientBalanceFailure ||
-          send.state.failure is SendInsufficientFundsForFeesFailure,
+      (SendCubit send) => selectionFailureShowsWarning(send.state.failure),
     );
 
     return SingleChildScrollView(
@@ -136,7 +141,7 @@ class CoinSelectionBottomSheet extends StatelessWidget {
             onPressed: context.pop,
             bgColor: context.appColors.secondary,
             textColor: context.appColors.onSecondary,
-            disabled: !isAmountSufficient,
+            disabled: !isAmountSufficient || selectionIsShort,
           ),
           const Gap(24),
         ],

--- a/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/coin_selection_bottom_sheet.dart
@@ -5,6 +5,7 @@ import 'package:bb_mobile/core/utils/amount_formatting.dart';
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/buttons/button.dart';
 import 'package:bb_mobile/core/widgets/text/text.dart';
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
 import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
 import 'package:bb_mobile/features/send/ui/widgets/coin_select_tile.dart';
 import 'package:flutter/material.dart';
@@ -49,7 +50,26 @@ class CoinSelectionBottomSheet extends StatelessWidget {
     final amountToSend = bitcoinUnit == BitcoinUnit.btc
         ? FormatAmount.btc(ConvertAmount.satsToBtc(amountToSendSat))
         : FormatAmount.sats(amountToSendSat);
-    final isAmountSufficient = selectedUtxoTotalSat > amountToSendSat;
+    // This used to be `selectedUtxoTotalSat > amountToSendSat`, which left the fee out: 2 020 sats picked for a 2 000 sat send read as sufficient although the transaction needed ~2 500, so Done stayed enabled and BDK made up the difference from a coin the user never picked.
+    //
+    // The fee can't be recomputed here. It moves with the input count, so amount + fee only settles once a PSBT exists, and the `absoluteFees` contract in send_state.dart forbids substituting local `rate × vsize` arithmetic. The gate is therefore the builder's own verdict: `utxoSelected` rebuilds on every tap, `createTransaction` clears the fee and the failure up front, and only a completed build puts a real fee back. So a fee means the current selection genuinely pays for the transaction, and no fee means it does not.
+    //
+    // An empty selection is "let BDK choose" and always passes; the wallet-wide insufficient-funds case belongs to the confirm screen, not here.
+    final buildingTransaction = context.select(
+      (SendCubit send) => send.state.buildingTransaction,
+    );
+    final hasBuiltFee = context.select(
+      (SendCubit send) => send.state.absoluteFees != null,
+    );
+    final isAmountSufficient =
+        selectedUtxos.isEmpty || (!buildingTransaction && hasBuiltFee);
+    // Tied to the failure rather than to `!isAmountSufficient` so the warning
+    // doesn't flash during the in-flight rebuild after every tap.
+    final selectionIsShort = context.select(
+      (SendCubit send) =>
+          send.state.failure is SendInsufficientBalanceFailure ||
+          send.state.failure is SendInsufficientFundsForFeesFailure,
+    );
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
@@ -82,7 +102,7 @@ class CoinSelectionBottomSheet extends StatelessWidget {
             '${context.loc.sendAmountRequested}$amountToSend',
             style: context.font.bodySmall,
           ),
-          if (!isAmountSufficient) ...[
+          if (selectionIsShort) ...[
             const Gap(8),
             BBText(
               context.loc.sendSelectedUtxosInsufficient,

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -30,6 +30,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
@@ -45,6 +46,7 @@ import 'package:bb_mobile/features/swap/domain/usecases/refresh_order_swap_useca
 import 'package:bb_mobile/features/swap/domain/usecases/save_prepared_order_swap_payin_usecase.dart';
 import 'package:bb_mobile/features/swap/domain/usecases/watch_order_swap_usecase.dart';
 import 'package:bb_mobile/features/swap/public/swap_facade.dart';
+import 'package:bb_mobile/features/swap/presentation/transfer_confirm_error.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -62,6 +64,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     required this._getWalletsUsecase,
     required this._getNetworkFeesUsecase,
     required this._prepareBitcoinSendUsecase,
+    required this._validateBitcoinSelectionUsecase,
     required this._prepareLiquidSendUsecase,
     required this._calculateBitcoinAbsoluteFeesUsecase,
     required this._calculateLiquidAbsoluteFeesUsecase,
@@ -113,6 +116,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
   final GetWalletsUsecase _getWalletsUsecase;
   final GetNetworkFeesUsecase _getNetworkFeesUsecase;
   final PrepareBitcoinSendUsecase _prepareBitcoinSendUsecase;
+  final ValidateBitcoinSelectionUsecase _validateBitcoinSelectionUsecase;
   final PrepareLiquidSendUsecase _prepareLiquidSendUsecase;
   final CalculateBitcoinAbsoluteFeesUsecase
   _calculateBitcoinAbsoluteFeesUsecase;
@@ -143,6 +147,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
   final PreviewBitcoinFeeUsecase _previewBitcoinFeeUsecase;
   final PreviewBitcoinFeePresetsUsecase _previewBitcoinFeePresetsUsecase;
   final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
+  int _transactionGeneration = 0;
 
   /// Bumped by [_clearBitcoinFeePreviews]; a preview build captures it
   /// before its `await` and re-checks before writing back, so an
@@ -394,6 +399,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       }
     }
     final wasFromWalletChanged = newFromWallet != state.fromWallet;
+    final wasToWalletChanged = newToWallet != state.toWallet;
     final hadExternalAddress = state.externalAddress.isNotEmpty;
     final externalAddressToRevalidate = state.externalAddress;
     final sendToExternal = state.sendToExternal;
@@ -410,7 +416,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     // Wallet swap invalidates every cached preview (different UTXOs +
     // descriptor + script type). Skip when the picker landed on the
     // same fromWallet.
-    if (wasFromWalletChanged) _clearBitcoinFeePreviews(emit);
+    if (wasFromWalletChanged || wasToWalletChanged) {
+      _invalidateTransactionContract(emit);
+    }
 
     // Proactively flag consolidation when the source is a Liquid wallet with
     // too many UTXOs, so the card shows before the swap build is attempted.
@@ -457,13 +465,14 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     }
     emit(updated);
     // Amount is part of the cache fingerprint (see _clearBitcoinFeePreviews).
-    _clearBitcoinFeePreviews(emit);
+    _invalidateTransactionContract(emit);
   }
 
   Future<void> _onSwapCreated(
     TransferSwapCreated event,
     Emitter<TransferState> emit,
   ) async {
+    final generation = ++_transactionGeneration;
     emit(
       state.copyWith(
         swap: null,
@@ -498,6 +507,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           emit,
           inputAmountSat: inputAmountSat,
           isMaxSend: isMaxSend,
+          generation: generation,
         );
         return;
       }
@@ -509,6 +519,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           final address = await _getReceiveAddressUsecase.execute(
             walletId: state.toWallet!.id,
           );
+          if (generation != _transactionGeneration) return;
           receiveAddress = address.address;
         } catch (e) {
           emit(
@@ -545,15 +556,18 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
             : null,
         replaceByFee: state.replaceByFee,
       );
+      if (generation != _transactionGeneration) return;
 
       final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
         walletId: bitcoinWalletId,
         psbt: unsignedPsbtAndTxSize.unsignedPsbt,
       );
+      if (generation != _transactionGeneration) return;
 
       final signedPsbt = signedPsbtAndTxSize.signedPsbt;
       final bitcoinAbsoluteFeesSat = await _calculateBitcoinAbsoluteFeesUsecase
           .execute(psbt: signedPsbt);
+      if (generation != _transactionGeneration) return;
 
       emit(
         state.copyWith(
@@ -565,8 +579,10 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         ),
       );
     } on ConsolidationRequiredException {
+      if (generation != _transactionGeneration) return;
       emit(state.copyWith(consolidationRequired: true));
     } catch (e) {
+      if (generation != _transactionGeneration) return;
       log.severe(
         message: '[Transfer] swap creation failed (${e.runtimeType})',
         error: e.runtimeType,
@@ -577,7 +593,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           : SwapCreationException(e.toString());
       emit(state.copyWith(swapCreationException: swapCreationException));
     } finally {
-      emit(state.copyWith(isCreatingSwap: false, continueClicked: false));
+      if (generation == _transactionGeneration) {
+        emit(state.copyWith(isCreatingSwap: false, continueClicked: false));
+      }
     }
   }
 
@@ -585,6 +603,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     Emitter<TransferState> emit, {
     required int inputAmountSat,
     required bool isMaxSend,
+    required int generation,
   }) async {
     final fromWallet = state.fromWallet;
     if (fromWallet == null) {
@@ -612,12 +631,14 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         : (await _getReceiveAddressUsecase.execute(
             walletId: destinationWallet!.id,
           )).address;
+    if (generation != _transactionGeneration) return;
     if (destinationAddress.isEmpty) {
       throw SwapCreationException('destination_address_required');
     }
     final fallbackAddress = (await _getReceiveAddressUsecase.execute(
       walletId: fromWallet.id,
     )).address;
+    if (generation != _transactionGeneration) return;
     final isInAmountFixed = isMaxSend || !state.receiveExactAmount;
 
     final quoteResult = await _getOrderSwapQuoteUsecase.execute(
@@ -627,6 +648,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       inNetwork: inNetwork,
       outNetwork: outNetwork,
     );
+    if (generation != _transactionGeneration) return;
     if (quoteResult case Err(:final failure)) {
       log.warning('[Transfer] quote failed (${failure.runtimeType})');
       emit(state.copyWith(swapFailure: failure));
@@ -655,6 +677,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           ? quote.outAmountSat
           : quote.inAmountSat,
     );
+    if (generation != _transactionGeneration) return;
     if (createResult case Err(:final failure)) {
       log.warning('[Transfer] create failed (${failure.runtimeType})');
       emit(state.copyWith(swapFailure: failure));
@@ -703,18 +726,22 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         feeRate: selectedFee as RelativeFee,
         drain: isMaxSend,
       );
+      if (generation != _transactionGeneration) return;
       await _verifyChainSwapAmountSendUsecase.execute(
         psbtOrPset: unsignedPset,
         swap: displaySwap,
         walletId: fromWallet.id,
       );
+      if (generation != _transactionGeneration) return;
       signedPayin = await _signLiquidTxUsecase.execute(
         walletId: fromWallet.id,
         pset: unsignedPset,
       );
+      if (generation != _transactionGeneration) return;
       liquidAbsoluteFeesSat = await _calculateLiquidAbsoluteFeesUsecase.execute(
         pset: signedPayin,
       );
+      if (generation != _transactionGeneration) return;
       isPsbt = false;
     } else {
       final selectedFee =
@@ -730,19 +757,23 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
             : state.selectedUtxos,
         replaceByFee: state.replaceByFee,
       );
+      if (generation != _transactionGeneration) return;
       await _verifyChainSwapAmountSendUsecase.execute(
         psbtOrPset: unsigned.unsignedPsbt,
         swap: displaySwap,
         walletId: fromWallet.id,
       );
+      if (generation != _transactionGeneration) return;
       final signed = await _signBitcoinTxUsecase.execute(
         walletId: fromWallet.id,
         psbt: unsigned.unsignedPsbt,
       );
+      if (generation != _transactionGeneration) return;
       signedPayin = signed.signedPsbt;
       bitcoinTxSize = signed.txSize;
       bitcoinAbsoluteFeesSat = await _calculateBitcoinAbsoluteFeesUsecase
           .execute(psbt: signedPayin);
+      if (generation != _transactionGeneration) return;
       if (!_builtFeeClearsRelay(
         stateToUse: state,
         builtFeeSat: bitcoinAbsoluteFeesSat,
@@ -758,6 +789,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       signedTransaction: signedPayin,
       isPsbt: isPsbt,
     );
+    if (generation != _transactionGeneration) return;
     if (prepareResult case Err(:final failure)) {
       log.warning(
         '[Transfer] payin persistence failed (${failure.runtimeType})',
@@ -788,6 +820,10 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     TransferSendToExternalToggled event,
     Emitter<TransferState> emit,
   ) async {
+    final receiveExactAmountChanged = state.receiveExactAmount != event.enabled;
+    if (state.sendToExternal == event.enabled && !receiveExactAmountChanged) {
+      return;
+    }
     emit(
       state.copyWith(
         sendToExternal: event.enabled,
@@ -796,6 +832,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         receiveExactAmount: event.enabled,
       ),
     );
+    _invalidateTransactionContract(emit);
   }
 
   Future<void> _onExternalAddressChanged(
@@ -805,7 +842,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     if (state.externalAddress == event.address) return;
     // Recipient is part of the cache fingerprint — drop every cached
     // preview when the new value differs from what we had cached against.
-    _clearBitcoinFeePreviews(emit);
+    _invalidateTransactionContract(emit);
     if (event.address.isEmpty) {
       emit(state.copyWith(externalAddress: '', externalAddressError: null));
       return;
@@ -963,7 +1000,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       // Max send and exact receivable are mutually exclusive.
       return;
     }
+    if (state.receiveExactAmount == event.enabled) return;
     emit(state.copyWith(receiveExactAmount: event.enabled));
+    _invalidateTransactionContract(emit);
   }
 
   Future<void> _onReplaceByFeeChanged(
@@ -980,16 +1019,47 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     TransferUtxosSelected event,
     Emitter<TransferState> emit,
   ) async {
+    final wasMaxSelected = state.isMaxSelected;
     // The UTXO set is an unordered selection — compare as sets so a
     // re-emit of the same set (different list order) doesn't invalidate.
-    final utxosChanged =
-        state.selectedUtxos
-            .toSet()
-            .difference(event.utxos.toSet())
-            .isNotEmpty ||
-        event.utxos.toSet().difference(state.selectedUtxos.toSet()).isNotEmpty;
-    emit(state.copyWith(selectedUtxos: event.utxos));
-    if (utxosChanged) _clearBitcoinFeePreviews(emit);
+    final previousOutpoints = state.selectedUtxos
+        .map((utxo) => utxo.outpoint)
+        .toSet();
+    final nextOutpoints = event.utxos.map((utxo) => utxo.outpoint).toSet();
+    final utxosChanged = !setEquals(previousOutpoints, nextOutpoints);
+    emit(
+      state.copyWith(
+        selectedUtxos: event.utxos,
+        signedPsbt: utxosChanged ? '' : state.signedPsbt,
+        buildTransactionException: utxosChanged
+            ? null
+            : state.buildTransactionException,
+      ),
+    );
+    if (!utxosChanged) return;
+
+    var generation = ++_transactionGeneration;
+    if (wasMaxSelected) {
+      _invalidateTransactionContract(emit);
+    } else {
+      _clearBitcoinFeePreviews(emit);
+    }
+    generation = _transactionGeneration;
+    final fromWallet = state.fromWallet;
+    if (fromWallet != null) {
+      final maxAmountSat = await getMaxAmountSat(fromWallet);
+      if (generation != _transactionGeneration) return;
+      emit(
+        state.copyWith(
+          maxAmountSat: maxAmountSat,
+          amount: wasMaxSelected && maxAmountSat != null
+              ? state.bitcoinUnit == BitcoinUnit.sats
+                    ? maxAmountSat.toString()
+                    : ConvertAmount.satsToBtc(maxAmountSat).toString()
+              : state.amount,
+        ),
+      );
+    }
     await _rebuildTransaction(emit);
   }
 
@@ -1010,7 +1080,25 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         (state.utxos ?? const <WalletUtxo>[]).toSet(),
         utxos.toSet(),
       );
-      emit(state.copyWith(utxos: utxos));
+      final spendableOutpoints = utxos
+          .where((utxo) => !utxo.isFrozen)
+          .map((utxo) => utxo.outpoint)
+          .toSet();
+      final selectionInvalid =
+          state.selectedUtxos.isNotEmpty &&
+          state.selectedUtxos.any(
+            (utxo) => !spendableOutpoints.contains(utxo.outpoint),
+          );
+      if (selectionInvalid) _transactionGeneration++;
+      emit(
+        state.copyWith(
+          utxos: utxos,
+          signedPsbt: selectionInvalid ? '' : state.signedPsbt,
+          buildTransactionException: selectionInvalid
+              ? BuildTransactionException(selectedCoinsUnavailableCode)
+              : state.buildTransactionException,
+        ),
+      );
       if (utxosChanged) _clearBitcoinFeePreviews(emit);
     } catch (e) {
       log.severe(
@@ -1240,7 +1328,22 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
   /// those moving invalidates the cached PSBTs we'd otherwise broadcast.
   void _clearBitcoinFeePreviews(Emitter<TransferState> emit) {
     _bitcoinPreviewEpoch++;
-    emit(state.copyWith(feePreviewCache: BitcoinFeePreviewCache.empty));
+    _transactionGeneration++;
+    emit(
+      state.copyWith(
+        feePreviewCache: BitcoinFeePreviewCache.empty,
+        signedPsbt: '',
+        isCreatingSwap: false,
+        continueClicked: false,
+      ),
+    );
+  }
+
+  /// A contract-shape change makes a prepared remote swap belong to an old
+  /// transfer, not merely an old fee/PSBT preview.
+  void _invalidateTransactionContract(Emitter<TransferState> emit) {
+    _clearBitcoinFeePreviews(emit);
+    emit(state.copyWith(swap: null, orderSwap: null));
   }
 
   /// Belt-and-suspenders relay-floor re-assert, mirroring
@@ -1274,6 +1377,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       return;
     }
 
+    final generation = ++_transactionGeneration;
+    emit(stateToUse.copyWith(signedPsbt: '', buildTransactionException: null));
+
     try {
       final fromWallet = stateToUse.fromWallet!;
       if (fromWallet.isLiquid) return;
@@ -1285,6 +1391,17 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         stateToUse.selectedFeeOption,
       );
       final canUseCache = cachedSlot.isCacheReady;
+      if (canUseCache && stateToUse.selectedUtxos.isNotEmpty) {
+        try {
+          await _validateBitcoinSelectionUsecase.execute(
+            walletId: fromWallet.id,
+            selectedInputs: stateToUse.selectedUtxos,
+          );
+        } on InsufficientFundsException {
+          throw BuildTransactionException(selectedCoinsUnavailableCode);
+        }
+        if (generation != _transactionGeneration) return;
+      }
       if (stateToUse.isSameChainTransfer) {
         final receiveAddress = stateToUse.receiveAddress;
         if (receiveAddress == null || receiveAddress.isEmpty) return;
@@ -1313,16 +1430,19 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
                     : null,
                 replaceByFee: stateToUse.replaceByFee,
               );
+        if (generation != _transactionGeneration) return;
 
         final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
           walletId: fromWallet.id,
           psbt: unsignedPsbtAndTxSize.unsignedPsbt,
         );
+        if (generation != _transactionGeneration) return;
 
         final bitcoinAbsoluteFeesSat =
             await _calculateBitcoinAbsoluteFeesUsecase.execute(
               psbt: signedPsbtAndTxSize.signedPsbt,
             );
+        if (generation != _transactionGeneration) return;
 
         if (!_builtFeeClearsRelay(
           stateToUse: stateToUse,
@@ -1379,22 +1499,26 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
                     : null,
                 replaceByFee: stateToUse.replaceByFee,
               );
+        if (generation != _transactionGeneration) return;
 
         await _verifyChainSwapAmountSendUsecase.execute(
           psbtOrPset: unsignedPsbtAndTxSize.unsignedPsbt,
           swap: swap,
           walletId: fromWallet.id,
         );
+        if (generation != _transactionGeneration) return;
 
         final signedPsbtAndTxSize = await _signBitcoinTxUsecase.execute(
           walletId: fromWallet.id,
           psbt: unsignedPsbtAndTxSize.unsignedPsbt,
         );
+        if (generation != _transactionGeneration) return;
 
         final bitcoinAbsoluteFeesSat =
             await _calculateBitcoinAbsoluteFeesUsecase.execute(
               psbt: signedPsbtAndTxSize.signedPsbt,
             );
+        if (generation != _transactionGeneration) return;
 
         if (!_builtFeeClearsRelay(
           stateToUse: stateToUse,
@@ -1422,6 +1546,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
               signedTransaction: signedPsbtAndTxSize.signedPsbt,
               isPsbt: true,
             );
+        if (generation != _transactionGeneration) return;
         final prepared = switch (replaceResult) {
           Ok(:final value) => value,
           Err(:final failure) => throw BuildTransactionException(
@@ -1443,10 +1568,24 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         );
       }
     } catch (e) {
+      if (generation != _transactionGeneration) return;
       log.severe(
         message: 'Error rebuilding transaction',
         error: e.runtimeType,
         trace: StackTrace.current,
+      );
+      emit(
+        stateToUse.copyWith(
+          signedPsbt: '',
+          buildTransactionException: BuildTransactionException(
+            e is BuildTransactionException
+                ? e.message
+                : e is InsufficientFundsException &&
+                      stateToUse.selectedUtxos.isNotEmpty
+                ? selectedCoinsInsufficientCode
+                : transactionRebuildFailedCode,
+          ),
+        ),
       );
     }
   }
@@ -1470,6 +1609,16 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     try {
       final signedPsbt = state.signedPsbt;
       if (signedPsbt.isEmpty) return;
+
+      final fromWallet = state.fromWallet;
+      if (fromWallet != null &&
+          !fromWallet.isLiquid &&
+          state.selectedUtxos.isNotEmpty) {
+        await _validateBitcoinSelectionUsecase.execute(
+          walletId: fromWallet.id,
+          selectedInputs: state.selectedUtxos,
+        );
+      }
 
       String txId;
       final orderSwap = state.orderSwap;
@@ -1541,6 +1690,24 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         return;
       }
       emit(state.copyWith(txId: txId));
+    } on InsufficientFundsException {
+      _clearBitcoinFeePreviews(emit);
+      emit(
+        state.copyWith(
+          buildTransactionException: BuildTransactionException(
+            selectedCoinsUnavailableCode,
+          ),
+        ),
+      );
+    } on ValidateBitcoinSelectionException {
+      _clearBitcoinFeePreviews(emit);
+      emit(
+        state.copyWith(
+          buildTransactionException: BuildTransactionException(
+            selectedCoinsUnavailableCode,
+          ),
+        ),
+      );
     } catch (e) {
       emit(
         state.copyWith(
@@ -1597,6 +1764,7 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           address: receiveAddress.address,
           networkFee: networkFee,
           drain: true,
+          selectedInputs: state.selectedUtxos,
         );
 
         absoluteFees = await _calculateBitcoinAbsoluteFeesUsecase.execute(
@@ -1619,9 +1787,15 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         log.info("Absolute fees: $absoluteFees");
       }
 
-      final balanceSat = fromWallet.balanceSat.toInt();
+      final selectedBalanceSat = state.selectedUtxos.fold(
+        0,
+        (sum, utxo) => sum + utxo.amountSat.toInt(),
+      );
+      final balanceSat = state.selectedUtxos.isEmpty
+          ? fromWallet.balanceSat.toInt()
+          : selectedBalanceSat;
       final maxAmountSat = balanceSat - absoluteFees;
-      return maxAmountSat;
+      return maxAmountSat < 0 ? 0 : maxAmountSat;
     } catch (e) {
       log.severe(
         message: 'Error getting max amount sat in transfer bloc',

--- a/lib/features/swap/presentation/transfer_confirm_error.dart
+++ b/lib/features/swap/presentation/transfer_confirm_error.dart
@@ -1,11 +1,26 @@
 import 'package:bb_mobile/core/errors/send_errors.dart';
 
+const selectedCoinsUnavailableCode = 'selected_coins_unavailable';
+const selectedCoinsInsufficientCode = 'selected_coins_insufficient';
+const transactionRebuildFailedCode = 'transaction_rebuild_failed';
+
 String? transferConfirmErrorMessage({
   required BuildTransactionException? buildTransactionException,
   required String? swapFailureMessage,
   required String buildFailureMessage,
+  required String selectedCoinsUnavailableMessage,
+  required String selectedCoinsInsufficientMessage,
+  required String transactionChangedMessage,
 }) {
   if (swapFailureMessage != null) return swapFailureMessage;
+  final code = buildTransactionException?.message;
+  if (code == selectedCoinsUnavailableCode) {
+    return selectedCoinsUnavailableMessage;
+  }
+  if (code == selectedCoinsInsufficientCode) {
+    return selectedCoinsInsufficientMessage;
+  }
+  if (code == transactionRebuildFailedCode) return transactionChangedMessage;
   if (buildTransactionException != null) return buildFailureMessage;
   return null;
 }

--- a/lib/features/swap/swap_locator.dart
+++ b/lib/features/swap/swap_locator.dart
@@ -21,6 +21,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute
 import 'package:bb_mobile/features/send/domain/usecases/calculate_liquid_absolute_fees_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/detect_bitcoin_string_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/prepare_liquid_send_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_presets_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/preview_bitcoin_fee_usecase.dart';
@@ -205,6 +206,12 @@ class SwapLocator {
         bitcoinWalletRepository: locator<BitcoinWalletRepository>(),
       ),
     );
+    locator.registerFactory<ValidateBitcoinSelectionUsecase>(
+      () => ValidateBitcoinSelectionUsecase(
+        payjoinSessions: locator<PayjoinSessions>(),
+        walletUtxoRepository: locator<WalletUtxoRepository>(),
+      ),
+    );
     locator.registerFactory<PrepareLiquidSendUsecase>(
       () => PrepareLiquidSendUsecase(
         liquidWalletRepository: locator<LiquidWalletRepository>(),
@@ -260,6 +267,8 @@ class SwapLocator {
         getWalletsUsecase: locator<GetWalletsUsecase>(),
         getNetworkFeesUsecase: locator<GetNetworkFeesUsecase>(),
         prepareBitcoinSendUsecase: locator<PrepareBitcoinSendUsecase>(),
+        validateBitcoinSelectionUsecase:
+            locator<ValidateBitcoinSelectionUsecase>(),
         prepareLiquidSendUsecase: locator<PrepareLiquidSendUsecase>(),
         calculateBitcoinAbsoluteFeesUsecase:
             locator<CalculateBitcoinAbsoluteFeesUsecase>(),

--- a/lib/features/swap/ui/pages/swap_confirm_page.dart
+++ b/lib/features/swap/ui/pages/swap_confirm_page.dart
@@ -164,6 +164,12 @@ class SwapConfirmPage extends StatelessWidget {
                     buildTransactionException: buildTransactionException,
                     swapFailureMessage: swapFailure?.toTranslated(context),
                     buildFailureMessage: context.loc.sendErrorBuildFailed,
+                    selectedCoinsUnavailableMessage:
+                        context.loc.sendErrorSelectedCoinsUnavailable,
+                    selectedCoinsInsufficientMessage:
+                        context.loc.sendErrorSelectedCoinsInsufficient,
+                    transactionChangedMessage:
+                        context.loc.sendErrorTransactionChanged,
                   ),
                 ),
               ],

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14570,5 +14570,17 @@
   "swapErrorRouteUnavailableGeneric": "This swap is not available.",
   "@swapErrorRouteUnavailableGeneric": {
     "description": "Fallback for ERR_ORD_PO404 when the source or destination network is unknown."
+  },
+  "sendErrorSelectedCoinsUnavailable": "One or more selected coins are no longer available. Review your coin selection and try again.",
+  "@sendErrorSelectedCoinsUnavailable": {
+    "description": "Message shown when a manually selected coin is no longer spendable."
+  },
+  "sendErrorSelectedCoinsInsufficient": "The selected coins do not cover the amount and fees. Select more coins or reduce the amount.",
+  "@sendErrorSelectedCoinsInsufficient": {
+    "description": "Message shown when manually selected coins do not cover the payment amount and fees."
+  },
+  "sendErrorTransactionChanged": "The transaction details changed. Review the amount, destination, and fees, then confirm again.",
+  "@sendErrorTransactionChanged": {
+    "description": "Message shown when a transaction must be rebuilt because its details changed."
   }
 }

--- a/localization/app_fr.arb
+++ b/localization/app_fr.arb
@@ -5023,5 +5023,8 @@
   "announcementAppUpdateRequiredDescription": "Pour utiliser le service de paiement Lightning et de swap, veuillez mettre à jour l’application mobile BULL vers la nouvelle version.",
   "mempoolErrorNetworkMismatch": "Ce serveur est sur un autre réseau Bitcoin.",
   "swapErrorRouteUnavailable": "{fromNetwork} vers {toNetwork} n'est pas disponible.",
-  "swapErrorRouteUnavailableGeneric": "Ce swap n'est pas disponible."
+  "swapErrorRouteUnavailableGeneric": "Ce swap n'est pas disponible.",
+  "sendErrorSelectedCoinsUnavailable": "Un ou plusieurs coins sélectionnés ne sont plus disponibles. Vérifiez votre sélection et réessayez.",
+  "sendErrorSelectedCoinsInsufficient": "Les coins sélectionnés ne couvrent pas le montant et les frais. Sélectionnez plus de coins ou réduisez le montant.",
+  "sendErrorTransactionChanged": "Les détails de la transaction ont changé. Vérifiez le montant, la destination et les frais, puis confirmez à nouveau."
 }

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -399,9 +399,10 @@ void main() {
     },
   );
 
-  // The amount fits the picked coin but not the fee. The large coin must be
-  // unspendable too: `addUtxos` only makes a coin required, so BDK would
-  // otherwise top the transaction up from it and never fall short.
+  // The amount fits the picked coin but not the fee. Marking the large coin
+  // unspendable is belt-and-braces here: `manuallySelectedOnly` already keeps
+  // BDK from topping the transaction up, and the test below covers that on
+  // its own.
   test(
     'buildPsbt reports a fee-only shortfall as insufficient funds',
     () async {
@@ -427,6 +428,114 @@ void main() {
         ),
         throwsA(isA<InsufficientFundsException>()),
       );
+    },
+  );
+
+  // The reported bug, reproduced with nothing marked unspendable.
+  //
+  // `addUtxos` makes a coin REQUIRED, not EXCLUSIVE, so BDK's coin selection stayed free to append any other wallet coin to cover the shortfall. Picking coins that fell a few hundred sats short of amount + fee therefore produced a valid, broadcastable PSBT that spent a coin the user had deliberately left unselected — linking its history to the selection under the common-input-ownership heuristic, irreversibly and on-chain.
+  //
+  // `manuallySelectedOnly` empties BDK's optional pool, so the shortfall has to surface as an error instead.
+  test(
+    'buildPsbt does not top up a short manual selection with an unselected coin',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      await expectLater(
+        datasource.buildPsbt(
+          wallet: walletModel,
+          address: _externalTestnetAddress,
+          // Exactly the picked coin's value: covered before fees, short once
+          // the fee lands — the shape of the original report (2 020 sats
+          // selected for a 2 000 sat send at a ~500 sat fee).
+          amountSat: utxoSmallAmountSat,
+          networkFee: const NetworkFee.relativeSatPerKwu(1000),
+          selected: [
+            WalletUtxoModel.bitcoin(
+              txId: utxoLargeTxId,
+              vout: utxoSmallVout,
+              amountSat: BigInt.from(utxoSmallAmountSat),
+              scriptPubkey: Uint8List(0),
+              address: '',
+              isExternalKeyChain: true,
+            ),
+          ],
+          replaceByFee: true,
+        ),
+        throwsA(isA<InsufficientFundsException>()),
+      );
+    },
+  );
+
+  // The other half of the contract: restricting the pool must not make BDK
+  // pad a selection that is genuinely sufficient.
+  test(
+    'buildPsbt spends only the selected coin when it covers amount and fee',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        // Leaves ~10 000 sats of headroom over the 30 000 sat coin, far more
+        // than the fee at 4 sat/vB.
+        amountSat: 20000,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoSmallVout,
+            amountSat: BigInt.from(utxoSmallAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      final inputs = bdk.Psbt(psbtBase64: psbt).extractTx().input();
+
+      expect(
+        inputs.length,
+        1,
+        reason:
+            'a sufficient selection must be spent as-is, with no extra coin '
+            'pulled in from the wallet',
+      );
+      expect(inputs.single.previousOutput.txid.toString(), utxoLargeTxId);
+      expect(inputs.single.previousOutput.vout, utxoSmallVout);
+    },
+  );
+
+  // Drain is deliberately excluded from `manuallySelectedOnly`: MAX derives
+  // its displayed amount from the whole spendable balance, so restricting the
+  // inputs would sign a smaller payment than the confirm screen shows. Pins
+  // that carve-out so it can't be "tidied up" without also fixing MAX.
+  test(
+    'buildPsbt still drains every coin when draining with a selection',
+    () async {
+      final datasource = BdkWalletDatasource();
+
+      final psbt = await datasource.buildPsbt(
+        wallet: walletModel,
+        address: _externalTestnetAddress,
+        networkFee: const NetworkFee.relativeSatPerKwu(1000),
+        drain: true,
+        selected: [
+          WalletUtxoModel.bitcoin(
+            txId: utxoLargeTxId,
+            vout: utxoSmallVout,
+            amountSat: BigInt.from(utxoSmallAmountSat),
+            scriptPubkey: Uint8List(0),
+            address: '',
+            isExternalKeyChain: true,
+          ),
+        ],
+        replaceByFee: true,
+      );
+
+      expect(bdk.Psbt(psbtBase64: psbt).extractTx().input().length, 2);
     },
   );
 }

--- a/test/core_test/wallet/bdk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/bdk_wallet_datasource_test.dart
@@ -508,12 +508,13 @@ void main() {
     },
   );
 
-  // Drain is deliberately excluded from `manuallySelectedOnly`: MAX derives
-  // its displayed amount from the whole spendable balance, so restricting the
-  // inputs would sign a smaller payment than the confirm screen shows. Pins
-  // that carve-out so it can't be "tidied up" without also fixing MAX.
+  // Drain gets no carve-out from `manuallySelectedOnly`: BDK empties the
+  // optional pool before `drain_wallet` folds it into the required set, so
+  // draining with a selection spends — and drains — exactly the picked coins.
+  // MAX with coin control means "MAX of the selection"; SendCubit derives the
+  // displayed amount from the selection total to match.
   test(
-    'buildPsbt still drains every coin when draining with a selection',
+    'buildPsbt drains only the selected coin when draining with a selection',
     () async {
       final datasource = BdkWalletDatasource();
 
@@ -535,7 +536,32 @@ void main() {
         replaceByFee: true,
       );
 
-      expect(bdk.Psbt(psbtBase64: psbt).extractTx().input().length, 2);
+      final tx = bdk.Psbt(psbtBase64: psbt).extractTx();
+      final inputs = tx.input();
+      expect(
+        inputs.length,
+        1,
+        reason:
+            'a drain with a manual selection must spend only the picked '
+            'coin, never the rest of the wallet',
+      );
+      expect(inputs.single.previousOutput.txid.toString(), utxoLargeTxId);
+      expect(inputs.single.previousOutput.vout, utxoSmallVout);
+
+      // A drain of one coin has a single output paying the coin's value
+      // minus the fee — proving the drained amount comes from the
+      // selection, not the whole wallet balance.
+      final outputs = tx.output();
+      expect(outputs.length, 1);
+      final drainedSat = outputs.single.value.toSat();
+      expect(drainedSat, lessThan(utxoSmallAmountSat));
+      expect(
+        drainedSat,
+        greaterThan(utxoSmallAmountSat - 2000),
+        reason:
+            'the drain output must be the selected coin minus a plausible '
+            'fee (~440 sats at 4 sat/vB for a 1-in-1-out P2WPKH tx)',
+      );
     },
   );
 }

--- a/test/core_test/wallet/bitcoin_wallet_repository_test.dart
+++ b/test/core_test/wallet/bitcoin_wallet_repository_test.dart
@@ -184,23 +184,36 @@ void main() {
   );
 
   group('D7 — frozen store is read live at build time', () {
-    test('a coin frozen in the store is stripped from the selection even when '
-        'the caller passes NO unspendable list', () async {
-      when(() => frozenDatasource.getAllFrozen()).thenAnswer(
-        (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
-      );
+    test(
+      'fails closed when one selected coin was frozen since selection',
+      () async {
+        when(() => frozenDatasource.getAllFrozen()).thenAnswer(
+          (_) async => [(walletId: _walletId, txId: 'tx-frozen', vout: 0)],
+        );
 
-      await buildPsbt(
-        selected: [
-          _utxo(txId: 'tx-frozen', vout: 0), // frozen in DB -> stripped
-          _utxo(txId: 'tx-free', vout: 1), // passes through
-        ],
-      );
-
-      final selected = capturedSelected();
-      expect(selected, hasLength(1));
-      expect(selected!.single.txId, 'tx-free');
-    });
+        await expectLater(
+          buildPsbt(
+            selected: [
+              _utxo(txId: 'tx-frozen', vout: 0),
+              _utxo(txId: 'tx-free', vout: 1),
+            ],
+          ),
+          throwsA(isA<NoSpendableUtxoException>()),
+        );
+        verifyNever(
+          () => bdkDatasource.buildPsbt(
+            wallet: any(named: 'wallet'),
+            address: any(named: 'address'),
+            amountSat: any(named: 'amountSat'),
+            networkFee: any(named: 'networkFee'),
+            drain: any(named: 'drain'),
+            unspendable: any(named: 'unspendable'),
+            selected: any(named: 'selected'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        );
+      },
+    );
 
     test('frozen outpoints are merged into the unspendable list passed down, '
         'so automatic selection cannot pick them either', () async {
@@ -262,23 +275,30 @@ void main() {
       },
     );
 
-    test(
-      'a selected coin that is also unspendable never reaches the datasource',
-      () async {
-        await buildPsbt(
+    test('fails closed when the caller excludes one selected coin', () async {
+      await expectLater(
+        buildPsbt(
           unspendable: const [(txId: 'tx-frozen', vout: 0)],
           selected: [
-            _utxo(txId: 'tx-frozen', vout: 0), // must be stripped
-            _utxo(txId: 'tx-free', vout: 1), // must pass through
+            _utxo(txId: 'tx-frozen', vout: 0),
+            _utxo(txId: 'tx-free', vout: 1),
           ],
-        );
-
-        final selected = capturedSelected();
-        expect(selected, hasLength(1));
-        expect(selected!.single.txId, 'tx-free');
-        expect(selected.single.vout, 1);
-      },
-    );
+        ),
+        throwsA(isA<NoSpendableUtxoException>()),
+      );
+      verifyNever(
+        () => bdkDatasource.buildPsbt(
+          wallet: any(named: 'wallet'),
+          address: any(named: 'address'),
+          amountSat: any(named: 'amountSat'),
+          networkFee: any(named: 'networkFee'),
+          drain: any(named: 'drain'),
+          unspendable: any(named: 'unspendable'),
+          selected: any(named: 'selected'),
+          replaceByFee: any(named: 'replaceByFee'),
+        ),
+      );
+    });
 
     test('same txId but different vout is NOT stripped', () async {
       await buildPsbt(

--- a/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
+++ b/test/features/send/domain/usecases/prepare_bitcoin_send_usecase_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/bitcoin_wallet_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
@@ -73,6 +74,9 @@ void main() {
         walletId: any(named: 'walletId'),
       ),
     ).thenAnswer((_) async => false);
+    when(
+      () => walletUtxo.getWalletUtxos(walletId: any(named: 'walletId')),
+    ).thenAnswer((_) async => []);
   });
 
   // Capture the `unspendable` arg passed to buildPsbt.
@@ -90,22 +94,6 @@ void main() {
       ),
     ).captured;
     return captured.single as List<Outpoint>?;
-  }
-
-  List<WalletUtxo>? capturedSelected() {
-    final captured = verify(
-      () => bitcoinWallet.buildPsbt(
-        walletId: any(named: 'walletId'),
-        address: any(named: 'address'),
-        amountSat: any(named: 'amountSat'),
-        networkFee: any(named: 'networkFee'),
-        drain: any(named: 'drain'),
-        unspendable: any(named: 'unspendable'),
-        selected: captureAny(named: 'selected'),
-        replaceByFee: any(named: 'replaceByFee'),
-      ),
-    ).captured;
-    return captured.single as List<WalletUtxo>?;
   }
 
   test(
@@ -266,7 +254,7 @@ void main() {
     },
   );
 
-  test('a selectedInput that is frozen is stripped before buildPsbt', () async {
+  test('a partly filtered selection fails before buildPsbt', () async {
     when(
       () => walletUtxo.getAllFrozenOutpoints(),
     ).thenAnswer((_) async => [(txId: 'tx-frozen', vout: 0)]);
@@ -276,19 +264,66 @@ void main() {
 
     final frozenInput = _utxo(txId: 'tx-frozen', vout: 0);
     final spendableInput = _utxo(txId: 'tx-ok', vout: 1);
+    when(
+      () => walletUtxo.getWalletUtxos(walletId: walletId),
+    ).thenAnswer((_) async => [frozenInput, spendableInput]);
 
-    await usecase.execute(
-      walletId: walletId,
-      address: address,
-      networkFee: networkFee,
-      amountSat: 50000,
-      selectedInputs: [frozenInput, spendableInput],
+    await expectLater(
+      usecase.execute(
+        walletId: walletId,
+        address: address,
+        networkFee: networkFee,
+        amountSat: 50000,
+        selectedInputs: [frozenInput, spendableInput],
+      ),
+      throwsA(isA<InsufficientFundsException>()),
     );
+    verifyNever(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    );
+  });
 
-    final selected = capturedSelected()!;
-    expect(selected, hasLength(1));
-    expect(selected.single.txId, 'tx-ok');
-    expect(selected.any((u) => u.txId == 'tx-frozen'), isFalse);
+  test('a Payjoin-reserved selected coin fails before buildPsbt', () async {
+    final reservedInput = _utxo(txId: 'tx-reserved', vout: 0);
+    when(() => walletUtxo.getAllFrozenOutpoints()).thenAnswer((_) async => []);
+    when(() => payjoin.reservedOutpoints()).thenAnswer(
+      (_) async => const Ok(<Outpoint>{(txId: 'tx-reserved', vout: 0)}),
+    );
+    when(
+      () => walletUtxo.getWalletUtxos(walletId: walletId),
+    ).thenAnswer((_) async => [reservedInput]);
+
+    await expectLater(
+      usecase.execute(
+        walletId: walletId,
+        address: address,
+        networkFee: networkFee,
+        amountSat: 50000,
+        selectedInputs: [reservedInput],
+      ),
+      throwsA(isA<InsufficientFundsException>()),
+    );
+    verifyNever(
+      () => bitcoinWallet.buildPsbt(
+        walletId: any(named: 'walletId'),
+        address: any(named: 'address'),
+        amountSat: any(named: 'amountSat'),
+        networkFee: any(named: 'networkFee'),
+        drain: any(named: 'drain'),
+        unspendable: any(named: 'unspendable'),
+        selected: any(named: 'selected'),
+        replaceByFee: any(named: 'replaceByFee'),
+      ),
+    );
   });
 
   test(
@@ -302,6 +337,9 @@ void main() {
       ).thenAnswer((_) async => const Ok(<Outpoint>{}));
 
       final input = _utxo(txId: 'tx-ok', vout: 0);
+      when(
+        () => walletUtxo.getWalletUtxos(walletId: walletId),
+      ).thenAnswer((_) async => [input]);
 
       final result = await usecase.execute(
         walletId: walletId,

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -9,16 +9,19 @@ import 'package:bb_mobile/core/exchange/domain/usecases/get_available_currencies
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/fees/domain/get_network_fees_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
+import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
@@ -78,6 +81,9 @@ class _MockGetAvailableCurrenciesUsecase extends Mock
 
 class _MockPrepareBitcoinSendUsecase extends Mock
     implements PrepareBitcoinSendUsecase {}
+
+class _MockValidateBitcoinSelectionUsecase extends Mock
+    implements ValidateBitcoinSelectionUsecase {}
 
 class _MockPrepareLiquidSendUsecase extends Mock
     implements PrepareLiquidSendUsecase {}
@@ -179,6 +185,7 @@ class _TestableSendCubit extends SendCubit {
     required super.getWalletUtxosUsecase,
     required super.getAvailableCurrenciesUsecase,
     required super.prepareBitcoinSendUsecase,
+    required super.validateBitcoinSelectionUsecase,
     required super.prepareLiquidSendUsecase,
     required super.sendWithPayjoinUsecase,
     required super.watchPayjoinUsecase,
@@ -253,6 +260,19 @@ Wallet _bitcoinWallet({required int balanceSat}) => Wallet(
   balanceSat: BigInt.from(balanceSat),
 );
 
+Wallet _bitcoinRemoteWallet() => Wallet(
+  origin: 'w-remote',
+  network: Network.bitcoinMainnet,
+  xpubFingerprint: '00000000',
+  scriptType: ScriptType.bip84,
+  xpub: '',
+  externalPublicDescriptor: '',
+  internalPublicDescriptor: '',
+  signer: SignerEntity.remote,
+  signerDevice: null,
+  balanceSat: BigInt.from(1000000),
+);
+
 WalletUtxo _utxo({
   required int amountSat,
   int vout = 0,
@@ -319,6 +339,7 @@ void main() {
   late _MockGetWalletUtxosUsecase getWalletUtxosUsecase;
   late _MockGetAvailableCurrenciesUsecase getAvailableCurrenciesUsecase;
   late _MockPrepareBitcoinSendUsecase prepareBitcoinSendUsecase;
+  late _MockValidateBitcoinSelectionUsecase validateBitcoinSelectionUsecase;
   late _MockPrepareLiquidSendUsecase prepareLiquidSendUsecase;
   late _MockSendWithPayjoinUsecase sendWithPayjoinUsecase;
   late _MockWatchPayjoinUsecase watchPayjoinUsecase;
@@ -365,6 +386,7 @@ void main() {
     getWalletUtxosUsecase: getWalletUtxosUsecase,
     getAvailableCurrenciesUsecase: getAvailableCurrenciesUsecase,
     prepareBitcoinSendUsecase: prepareBitcoinSendUsecase,
+    validateBitcoinSelectionUsecase: validateBitcoinSelectionUsecase,
     prepareLiquidSendUsecase: prepareLiquidSendUsecase,
     sendWithPayjoinUsecase: sendWithPayjoinUsecase,
     watchPayjoinUsecase: watchPayjoinUsecase,
@@ -437,6 +459,7 @@ void main() {
     getWalletUtxosUsecase = _MockGetWalletUtxosUsecase();
     getAvailableCurrenciesUsecase = _MockGetAvailableCurrenciesUsecase();
     prepareBitcoinSendUsecase = _MockPrepareBitcoinSendUsecase();
+    validateBitcoinSelectionUsecase = _MockValidateBitcoinSelectionUsecase();
     prepareLiquidSendUsecase = _MockPrepareLiquidSendUsecase();
     sendWithPayjoinUsecase = _MockSendWithPayjoinUsecase();
     watchPayjoinUsecase = _MockWatchPayjoinUsecase();
@@ -468,6 +491,17 @@ void main() {
     previewBitcoinFeePresetsUsecase = _MockPreviewBitcoinFeePresetsUsecase();
     checkLiquidConsolidationUsecase = _MockCheckLiquidConsolidationUsecase();
     verifySignedTxUsecase = _MockVerifySignedTxUsecase();
+    when(
+      () => checkLiquidConsolidationUsecase.execute(
+        walletId: any(named: 'walletId'),
+      ),
+    ).thenAnswer((_) async => false);
+    when(
+      () => validateBitcoinSelectionUsecase.execute(
+        walletId: any(named: 'walletId'),
+        selectedInputs: any(named: 'selectedInputs'),
+      ),
+    ).thenAnswer((_) async => []);
     // A hardware signer that returns what it was asked to sign: the default
     // is acceptance, tests that need a tampered device re-stub it.
     when(
@@ -917,6 +951,32 @@ void main() {
       expect(stored.reference, 'broadcast-txid');
       expect(stored.label, 'coffee');
     });
+
+    test('a newly reserved selected coin cannot be broadcast', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final selected = _utxo(amountSat: 50000);
+      when(
+        () => validateBitcoinSelectionUsecase.execute(
+          walletId: 'w1',
+          selectedInputs: [selected],
+        ),
+      ).thenThrow(InsufficientFundsException('reserved'));
+      cubit.setStateForTest(
+        plainSignedState().copyWith(selectedUtxos: [selected]),
+      );
+
+      await cubit.broadcastTransaction();
+
+      verifyNever(
+        () => broadcastBitcoinTxUsecase.execute(
+          any(),
+          isPsbt: any(named: 'isPsbt'),
+        ),
+      );
+      expect(cubit.state.signedBitcoinPsbt, isNull);
+      expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
+    });
   });
 
   group('SendCubit.onChangedText stale detection results', () {
@@ -1101,7 +1161,7 @@ void main() {
 
     // With hand-picked coins the amount was only checked against the whole
     // balance, so the shortfall may be the selection rather than the fee.
-    test('with hand-picked coins the message stays generic', () async {
+    test('with hand-picked coins shows selected-coins insufficiency', () async {
       final cubit = buildCubit();
       addTearDown(cubit.close);
       when(
@@ -1140,7 +1200,7 @@ void main() {
 
       await cubit.onAmountConfirmed();
 
-      expect(cubit.state.failure, isA<SendInsufficientBalanceFailure>());
+      expect(cubit.state.failure, isA<SendSelectedCoinsInsufficientFailure>());
       expect(
         cubit.state.failure,
         isNot(isA<SendInsufficientFundsForFeesFailure>()),
@@ -1192,6 +1252,260 @@ void main() {
         isNot(isA<SendInsufficientFundsForFeesFailure>()),
       );
     });
+
+    test(
+      'with every coin frozen shows the frozen-balance hint failure',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        when(
+          () => prepareBitcoinSendUsecase.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            networkFee: any(named: 'networkFee'),
+            amountSat: any(named: 'amountSat'),
+            drain: any(named: 'drain'),
+            selectedInputs: any(named: 'selectedInputs'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        ).thenThrow(NoSpendableUtxoException('All unspents are unspendable'));
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => [_utxo(amountSat: 20000, isFrozen: true)]);
+        cubit.setStateForTest(
+          SendState(
+            step: SendStep.amount,
+            sendType: SendType.bitcoin,
+            selectedWallet: _bitcoinWallet(balanceSat: 20000),
+            paymentRequest: const PaymentRequest.bitcoin(
+              address: 'bc1-address',
+              isTestnet: false,
+            ),
+            amount: '10000',
+            inputAmountCurrencyCode: 'sats',
+            liquidFeesList: _feeOptions(),
+            bitcoinFeesList: _feeOptions(),
+          ),
+        );
+
+        await cubit.onAmountConfirmed();
+
+        expect(cubit.state.frozenBalanceSat, 20000);
+        expect(cubit.state.failure, isA<SendInsufficientBalanceFailure>());
+        expect(cubit.state.failure, isNot(isA<SendTransactionBuildFailure>()));
+      },
+    );
+
+    test(
+      'a failed rebuild cannot broadcast the previously signed PSBT',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        final oldSelection = _utxo(amountSat: 10000);
+        final newSelection = _utxo(amountSat: 1000, vout: 1);
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => [oldSelection, newSelection]);
+        when(
+          () => prepareBitcoinSendUsecase.execute(
+            walletId: any(named: 'walletId'),
+            address: any(named: 'address'),
+            networkFee: any(named: 'networkFee'),
+            amountSat: any(named: 'amountSat'),
+            drain: any(named: 'drain'),
+            selectedInputs: any(named: 'selectedInputs'),
+            replaceByFee: any(named: 'replaceByFee'),
+          ),
+        ).thenThrow(InsufficientFundsException('selection is too small'));
+        cubit.setStateForTest(
+          SendState(
+            step: SendStep.confirm,
+            sendType: SendType.bitcoin,
+            selectedWallet: _bitcoinWallet(balanceSat: 11000),
+            paymentRequest: const PaymentRequest.bitcoin(
+              address: 'bc1-address',
+              isTestnet: false,
+            ),
+            amount: '10000',
+            confirmedAmountSat: 10000,
+            inputAmountCurrencyCode: 'sats',
+            bitcoinFeesList: _feeOptions(),
+            liquidFeesList: _feeOptions(),
+            utxos: [oldSelection, newSelection],
+            selectedUtxos: [oldSelection],
+            signedBitcoinPsbt: 'old-signed-psbt',
+            unsignedPsbt: 'old-unsigned-psbt',
+          ),
+        );
+
+        await cubit.utxoSelected(newSelection);
+        await cubit.onConfirmTransactionClicked();
+
+        expect(cubit.state.signedBitcoinPsbt, isNull);
+        expect(cubit.state.unsignedPsbt, isNull);
+        expect(cubit.state.buildingTransaction, isFalse);
+        verifyNever(
+          () => broadcastBitcoinTxUsecase.execute(
+            any(),
+            isPsbt: any(named: 'isPsbt'),
+          ),
+        );
+        verifyNever(
+          () => signBitcoinTxUsecase.execute(
+            psbt: any(named: 'psbt'),
+            walletId: any(named: 'walletId'),
+          ),
+        );
+      },
+    );
+
+    test('an older build cannot overwrite the newer selection', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final oldSelection = _utxo(amountSat: 10000);
+      final newSelection = _utxo(amountSat: 20000, vout: 1);
+      final oldBuild =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      final newBuild =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      var buildCount = 0;
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+      ).thenAnswer((_) async => [oldSelection, newSelection]);
+      when(
+        () => prepareBitcoinSendUsecase.execute(
+          walletId: any(named: 'walletId'),
+          address: any(named: 'address'),
+          networkFee: any(named: 'networkFee'),
+          amountSat: any(named: 'amountSat'),
+          drain: any(named: 'drain'),
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: any(named: 'replaceByFee'),
+        ),
+      ).thenAnswer((_) {
+        buildCount++;
+        return buildCount == 1 ? oldBuild.future : newBuild.future;
+      });
+      when(
+        () => calculateBitcoinAbsoluteFeesUsecase.execute(
+          psbt: any(named: 'psbt'),
+        ),
+      ).thenAnswer((invocation) async {
+        final psbt = invocation.namedArguments[#psbt] as String;
+        return psbt == 'new-psbt' ? 22 : 11;
+      });
+      cubit.setStateForTest(
+        SendState(
+          sendType: SendType.bitcoin,
+          selectedWallet: _bitcoinRemoteWallet(),
+          paymentRequest: const PaymentRequest.bitcoin(
+            address: 'bc1-address',
+            isTestnet: false,
+          ),
+          confirmedAmountSat: 1000,
+          inputAmountCurrencyCode: 'sats',
+          bitcoinFeesList: _feeOptions(),
+          liquidFeesList: _feeOptions(),
+          utxos: [oldSelection, newSelection],
+          selectedUtxos: [oldSelection],
+        ),
+      );
+
+      final oldRequest = cubit.createTransaction();
+      await pumpEventQueue();
+      cubit.setStateForTest(
+        cubit.state.copyWith(selectedUtxos: [newSelection]),
+      );
+      final newRequest = cubit.createTransaction();
+      await pumpEventQueue();
+      newBuild.complete((
+        unsignedPsbt: 'new-psbt',
+        txSize: 100,
+        isToSelf: false,
+      ));
+      await newRequest;
+      oldBuild.complete((
+        unsignedPsbt: 'old-psbt',
+        txSize: 90,
+        isToSelf: false,
+      ));
+      await oldRequest;
+
+      expect(cubit.state.unsignedPsbt, 'new-psbt');
+      expect(cubit.state.bitcoinAbsoluteFeesSat, 22);
+    });
+
+    test('a recipient change invalidates every staged payload', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      when(
+        () => detectBitcoinStringUsecase.execute(data: 'new recipient'),
+      ).thenAnswer(
+        (_) async => const PaymentRequest.bitcoin(
+          address: 'bc1-new-address',
+          isTestnet: false,
+        ),
+      );
+      cubit.setStateForTest(
+        SendState(
+          paymentRequest: const PaymentRequest.bitcoin(
+            address: 'bc1-old-address',
+            isTestnet: false,
+          ),
+          signedBitcoinTx: 'old-signed-tx',
+          signedBitcoinPsbt: 'old-signed-psbt',
+          unsignedPsbt: 'old-unsigned-psbt',
+        ),
+      );
+
+      await cubit.onChangedText('new recipient');
+
+      expect(cubit.state.signedBitcoinTx, isNull);
+      expect(cubit.state.signedBitcoinPsbt, isNull);
+      expect(cubit.state.unsignedPsbt, isNull);
+    });
+
+    test('an amount change invalidates every staged payload', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      cubit.setStateForTest(
+        const SendState(
+          amount: '1000',
+          inputAmountCurrencyCode: 'sats',
+          signedBitcoinTx: 'old-signed-tx',
+          signedBitcoinPsbt: 'old-signed-psbt',
+          unsignedPsbt: 'old-unsigned-psbt',
+        ),
+      );
+
+      await cubit.amountChanged(amount: '2000');
+
+      expect(cubit.state.amount, '2000');
+      expect(cubit.state.signedBitcoinTx, isNull);
+      expect(cubit.state.signedBitcoinPsbt, isNull);
+      expect(cubit.state.unsignedPsbt, isNull);
+    });
+
+    test(
+      'MAX starts from the selected total before the build completes',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        cubit.setStateForTest(
+          SendState(
+            selectedWallet: _bitcoinWallet(balanceSat: 130000),
+            selectedUtxos: [_utxo(amountSat: 30000)],
+            inputAmountCurrencyCode: BitcoinUnit.sats.code,
+            bitcoinUnit: BitcoinUnit.sats,
+          ),
+        );
+
+        await cubit.amountChanged(isMax: true);
+
+        expect(cubit.state.amount, '30000');
+        expect(cubit.state.sendMax, isTrue);
+      },
+    );
   });
 
   // A manual coin selection is re-validated against a fresh read of the wallet
@@ -1280,6 +1594,7 @@ void main() {
 
       expect(cubit.state.selectedUtxos, isEmpty);
       expect(cubit.state.utxos, hasLength(1));
+      expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
     });
 
     test('still drops a selected coin that left the wallet', () async {
@@ -1293,7 +1608,29 @@ void main() {
       await cubit.loadUtxos();
 
       expect(cubit.state.selectedUtxos, isEmpty);
+      expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
     });
+
+    test(
+      'clears the build flag when refresh eliminates the selection',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        when(
+          () => getWalletUtxosUsecase.execute(walletId: any(named: 'walletId')),
+        ).thenAnswer((_) async => <WalletUtxo>[]);
+        final state = stateWith([_utxo(amountSat: 5000)]).copyWith(
+          bitcoinFeesList: _feeOptions(),
+          liquidFeesList: _feeOptions(),
+        );
+        cubit.setStateForTest(state);
+
+        await cubit.createTransaction();
+
+        expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
+        expect(cubit.state.buildingTransaction, isFalse);
+      },
+    );
 
     // Tapping a selected coin must deselect it, even though the tapped
     // instance comes from state.utxos and the held one from state.selectedUtxos.

--- a/test/features/send/presentation/bloc/send_state_test.dart
+++ b/test/features/send/presentation/bloc/send_state_test.dart
@@ -10,8 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../coins/wallet_utxo_fixture.dart';
 
-/// Stubs only [Wallet.balanceSat]/[Wallet.id] — all [SendState] spendable math
-/// reads from the utxo list plus the wallet balance, so nothing else is needed.
+/// Stubs the wallet properties read by [SendState] balance and fee math.
 class _FakeWallet extends Fake implements Wallet {
   _FakeWallet(this._balanceSat);
 
@@ -22,6 +21,9 @@ class _FakeWallet extends Fake implements Wallet {
 
   @override
   BigInt get balanceSat => BigInt.from(_balanceSat);
+
+  @override
+  bool get isLiquid => false;
 }
 
 /// Tests for [SendState.absoluteFees] — the getter that decides which number
@@ -193,6 +195,39 @@ void main() {
       );
       expect(state.absoluteFees, 100);
     });
+  });
+
+  test('MAX uses selected balance and the real built fee', () {
+    final state = SendState(
+      selectedWallet: _FakeWallet(130000),
+      utxos: [
+        walletUtxoFixture(sats: 100000),
+        walletUtxoFixture(sats: 30000, vout: 1),
+      ],
+      selectedUtxos: [walletUtxoFixture(sats: 30000, vout: 1)],
+      bitcoinAbsoluteFeesSat: 1200,
+    );
+
+    expect(state.maxSpendableBalanceSat, 28800);
+  });
+
+  test('MAX available balance uses the selected total before fees', () {
+    final state = SendState(
+      selectedWallet: _FakeWallet(130000),
+      selectedUtxos: [walletUtxoFixture(sats: 30000)],
+    );
+
+    expect(state.maxAvailableBalanceSat, 30000);
+  });
+
+  test('MAX clamps a selected balance that cannot cover its fee', () {
+    final state = SendState(
+      selectedWallet: _FakeWallet(10000),
+      selectedUtxos: [walletUtxoFixture(sats: 1000)],
+      bitcoinAbsoluteFeesSat: 1200,
+    );
+
+    expect(state.maxSpendableBalanceSat, 0);
   });
 
   group('SendState.absoluteFees — Bitcoin, no PSBT means no number', () {

--- a/test/features/send/presentation/send_failure_l10n_test.dart
+++ b/test/features/send/presentation/send_failure_l10n_test.dart
@@ -1,0 +1,69 @@
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/presentation/send_failure_l10n.dart';
+import 'package:bb_mobile/generated/l10n/localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<String> translated(
+    WidgetTester tester,
+    Locale locale,
+    SendFailure failure,
+  ) async {
+    late String message;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            message = failure.toTranslated(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return message;
+  }
+
+  testWidgets('selected coin failures use the English messages', (
+    tester,
+  ) async {
+    expect(
+      await translated(
+        tester,
+        const Locale('en'),
+        const SendSelectedCoinsUnavailableFailure(),
+      ),
+      'One or more selected coins are no longer available. Review your coin selection and try again.',
+    );
+    expect(
+      await translated(
+        tester,
+        const Locale('en'),
+        const SendSelectedCoinsInsufficientFailure(),
+      ),
+      'The selected coins do not cover the amount and fees. Select more coins or reduce the amount.',
+    );
+  });
+
+  testWidgets('selected coin failures use the French messages', (tester) async {
+    expect(
+      await translated(
+        tester,
+        const Locale('fr'),
+        const SendSelectedCoinsUnavailableFailure(),
+      ),
+      'Un ou plusieurs coins sélectionnés ne sont plus disponibles. Vérifiez votre sélection et réessayez.',
+    );
+    expect(
+      await translated(
+        tester,
+        const Locale('fr'),
+        const SendSelectedCoinsInsufficientFailure(),
+      ),
+      'Les coins sélectionnés ne couvrent pas le montant et les frais. Sélectionnez plus de coins ou réduisez le montant.',
+    );
+  });
+}

--- a/test/features/send/ui/widgets/coin_selection_bottom_sheet_test.dart
+++ b/test/features/send/ui/widgets/coin_selection_bottom_sheet_test.dart
@@ -1,0 +1,29 @@
+import 'package:bb_mobile/features/send/domain/send_failure.dart';
+import 'package:bb_mobile/features/send/ui/widgets/coin_selection_bottom_sheet.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('recognizes every manual-selection shortfall failure', () {
+    expect(
+      selectionFailureShowsWarning(
+        const SendSelectedCoinsInsufficientFailure(),
+      ),
+      isTrue,
+    );
+    expect(
+      selectionFailureShowsWarning(const SendSelectedCoinsUnavailableFailure()),
+      isTrue,
+    );
+  });
+
+  test('does not show the selection warning for unrelated failures', () {
+    expect(
+      selectionFailureShowsWarning(const SendInsufficientBalanceFailure()),
+      isTrue,
+    );
+    expect(
+      selectionFailureShowsWarning(const SendUnexpectedFailure()),
+      isFalse,
+    );
+  });
+}

--- a/test/features/swap/presentation/transfer_bloc_test.dart
+++ b/test/features/swap/presentation/transfer_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_transaction_usecase.dart';
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
@@ -10,10 +11,14 @@ import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/swaps/domain/entity/swap.dart';
 import 'package:bb_mobile/core/swaps/domain/usecases/verify_chain_swap_amount_send_usecase.dart';
 import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/fees/domain/fee_preview_cache.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
@@ -41,6 +46,7 @@ import 'package:bb_mobile/features/swap/domain/usecases/refresh_order_swap_useca
 import 'package:bb_mobile/features/swap/domain/usecases/save_prepared_order_swap_payin_usecase.dart';
 import 'package:bb_mobile/features/swap/domain/usecases/watch_order_swap_usecase.dart';
 import 'package:bb_mobile/features/swap/presentation/transfer_bloc.dart';
+import 'package:bb_mobile/features/swap/presentation/transfer_confirm_error.dart';
 import 'package:bb_mobile/features/swap/domain/swap_failure.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -53,6 +59,9 @@ class _MockGetWallets extends Mock implements GetWalletsUsecase {}
 class _MockGetNetworkFees extends Mock implements GetNetworkFeesUsecase {}
 
 class _MockPrepareBitcoin extends Mock implements PrepareBitcoinSendUsecase {}
+
+class _MockValidateBitcoinSelection extends Mock
+    implements ValidateBitcoinSelectionUsecase {}
 
 class _MockPrepareLiquid extends Mock implements PrepareLiquidSendUsecase {}
 
@@ -134,6 +143,13 @@ void main() {
   late _MockWatchOrder watchOrder;
   late _MockGetWallet getWallet;
   late _MockPrepareBitcoin prepareBitcoin;
+  late _MockValidateBitcoinSelection validateBitcoinSelection;
+  late _MockCalculateBitcoin calculateBitcoin;
+  late _MockGetReceiveAddress getReceiveAddress;
+  late _MockGetUtxos getUtxos;
+  late _MockSignBitcoin signBitcoin;
+  late _MockReplacePrepared replacePrepared;
+  late _MockVerifyChain verifyChain;
   late OrderSwapRecord prepared;
   late TransferBloc bloc;
 
@@ -150,37 +166,51 @@ void main() {
     watchOrder = _MockWatchOrder();
     getWallet = _MockGetWallet();
     prepareBitcoin = _MockPrepareBitcoin();
+    validateBitcoinSelection = _MockValidateBitcoinSelection();
+    calculateBitcoin = _MockCalculateBitcoin();
+    getReceiveAddress = _MockGetReceiveAddress();
+    getUtxos = _MockGetUtxos();
+    signBitcoin = _MockSignBitcoin();
+    replacePrepared = _MockReplacePrepared();
+    verifyChain = _MockVerifyChain();
     prepared = _prepared();
     when(
       () => getWallet.execute('wallet-1', sync: true),
     ).thenAnswer((_) async => _wallet());
+    when(
+      () => validateBitcoinSelection.execute(
+        walletId: any(named: 'walletId'),
+        selectedInputs: any(named: 'selectedInputs'),
+      ),
+    ).thenAnswer((_) async => []);
 
     bloc = TransferBloc(
       getSettingsUsecase: getSettings,
       getWalletsUsecase: getWallets,
       getNetworkFeesUsecase: getNetworkFees,
       prepareBitcoinSendUsecase: prepareBitcoin,
+      validateBitcoinSelectionUsecase: validateBitcoinSelection,
       prepareLiquidSendUsecase: _MockPrepareLiquid(),
-      calculateBitcoinAbsoluteFeesUsecase: _MockCalculateBitcoin(),
+      calculateBitcoinAbsoluteFeesUsecase: calculateBitcoin,
       calculateLiquidAbsoluteFeesUsecase: _MockCalculateLiquid(),
       getWalletUsecase: getWallet,
-      signBitcoinTxUsecase: _MockSignBitcoin(),
+      signBitcoinTxUsecase: signBitcoin,
       signLiquidTxUsecase: _MockSignLiquid(),
       broadcastBitcoinTxUsecase: broadcastBitcoin,
       broadcastLiquidTxUsecase: _MockBroadcastLiquid(),
-      verifyChainSwapAmountSendUsecase: _MockVerifyChain(),
+      verifyChainSwapAmountSendUsecase: verifyChain,
       getOrderSwapQuoteUsecase: _MockGetQuote(),
       getPendingOrderSwapsUsecase: getPendingOrders,
       createOrderSwapUsecase: _MockCreateOrder(),
       savePreparedOrderSwapPayinUsecase: _MockSavePrepared(),
-      replacePreparedOrderSwapPayinUsecase: _MockReplacePrepared(),
+      replacePreparedOrderSwapPayinUsecase: replacePrepared,
       refreshOrderSwapUsecase: refreshOrder,
       markOrderSwapBroadcastUnknownUsecase: markUnknown,
       markOrderSwapPayinBroadcastUsecase: markBroadcast,
       watchOrderSwapUsecase: watchOrder,
       detectBitcoinStringUsecase: _MockDetectBitcoin(),
-      getReceiveAddressUsecase: _MockGetReceiveAddress(),
-      getWalletUtxosUsecase: _MockGetUtxos(),
+      getReceiveAddressUsecase: getReceiveAddress,
+      getWalletUtxosUsecase: getUtxos,
       convertSatsToCurrencyAmountUsecase: convertSats,
       previewBitcoinFeeUsecase: _MockPreviewFee(),
       previewBitcoinFeePresetsUsecase: _MockPreviewPresets(),
@@ -222,6 +252,45 @@ void main() {
       expect(
         bloc.state.swapCreationException,
         isA<InsufficientFundsSwapException>(),
+      );
+    },
+  );
+
+  test(
+    'maps selected-coin rebuild shortfall to the insufficient code',
+    () async {
+      final selected = _bitcoinUtxo('selected-tx');
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: [selected],
+          replaceByFee: true,
+        ),
+      ).thenThrow(InsufficientFundsException('shortfall'));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          selectedUtxos: [selected],
+          signedPsbt: 'stale-psbt',
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.feeOptionSelected(FeeSelection.fastest));
+      await bloc.stream.firstWhere(
+        (state) => state.buildTransactionException != null,
+      );
+
+      expect(
+        bloc.state.buildTransactionException?.message,
+        selectedCoinsInsufficientCode,
       );
     },
   );
@@ -277,6 +346,693 @@ void main() {
       expect(states.any((state) => state.txId == 'txid-1'), isTrue);
     },
   );
+
+  test('Transfer MAX prices and builds from the selected UTXOs', () async {
+    final selected = WalletUtxo.bitcoin(
+      walletId: 'wallet-1',
+      txId: 'selected-tx',
+      vout: 2,
+      scriptPubkey: Uint8List(0),
+      amountSat: BigInt.from(30000),
+      address: 'tb1qselected',
+    );
+    when(() => getReceiveAddress.execute(walletId: 'wallet-1')).thenAnswer(
+      (_) async => WalletAddress(
+        walletId: 'wallet-1',
+        index: 0,
+        address: 'tb1qreceive',
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+      ),
+    );
+    when(
+      () => prepareBitcoin.execute(
+        walletId: 'wallet-1',
+        address: 'tb1qreceive',
+        networkFee: any(named: 'networkFee'),
+        amountSat: any(named: 'amountSat'),
+        drain: true,
+        selectedInputs: [selected],
+        replaceByFee: true,
+      ),
+    ).thenAnswer(
+      (_) async => (unsignedPsbt: 'psbt', txSize: 100, isToSelf: false),
+    );
+    when(
+      () => calculateBitcoin.execute(psbt: 'psbt'),
+    ).thenAnswer((_) async => 1200);
+    bloc.emit(
+      TransferState(
+        fromWallet: _wallet(balanceSat: BigInt.from(130000)),
+        bitcoinNetworkFees: _feeOptions(),
+        selectedUtxos: [selected],
+      ),
+    );
+
+    expect(
+      await bloc.getMaxAmountSat(_wallet(balanceSat: BigInt.from(130000))),
+      28800,
+    );
+    verify(
+      () => prepareBitcoin.execute(
+        walletId: 'wallet-1',
+        address: 'tb1qreceive',
+        networkFee: any(named: 'networkFee'),
+        amountSat: any(named: 'amountSat'),
+        drain: true,
+        selectedInputs: [selected],
+        replaceByFee: true,
+      ),
+    ).called(1);
+  });
+
+  test('coin selection recomputes an active Transfer MAX', () async {
+    final selected = WalletUtxo.bitcoin(
+      walletId: 'wallet-1',
+      txId: 'selected-tx',
+      vout: 2,
+      scriptPubkey: Uint8List(0),
+      amountSat: BigInt.from(30000),
+      address: 'tb1qselected',
+    );
+    when(() => getReceiveAddress.execute(walletId: 'wallet-1')).thenAnswer(
+      (_) async => WalletAddress(
+        walletId: 'wallet-1',
+        index: 0,
+        address: 'tb1qreceive',
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+      ),
+    );
+    when(
+      () => prepareBitcoin.execute(
+        walletId: 'wallet-1',
+        address: 'tb1qreceive',
+        networkFee: any(named: 'networkFee'),
+        amountSat: any(named: 'amountSat'),
+        drain: true,
+        selectedInputs: [selected],
+        replaceByFee: true,
+      ),
+    ).thenAnswer(
+      (_) async => (unsignedPsbt: 'psbt', txSize: 100, isToSelf: false),
+    );
+    when(
+      () => calculateBitcoin.execute(psbt: 'psbt'),
+    ).thenAnswer((_) async => 1200);
+    bloc.emit(
+      TransferState(
+        fromWallet: _wallet(balanceSat: BigInt.from(130000)),
+        toWallet: _liquidWallet(id: 'liquid-wallet'),
+        bitcoinNetworkFees: _feeOptions(),
+        maxAmountSat: 128800,
+        amount: '128800',
+      ),
+    );
+
+    bloc.add(TransferEvent.utxosSelected([selected]));
+    await bloc.stream.firstWhere((state) => state.maxAmountSat == 28800);
+
+    expect(bloc.state.amount, '28800');
+    expect(bloc.state.isMaxSelected, isTrue);
+    expect(bloc.state.selectedUtxos, [selected]);
+  });
+
+  test(
+    'Transfer MAX clamps a selected balance below the fee to zero',
+    () async {
+      final selected = WalletUtxo.bitcoin(
+        walletId: 'wallet-1',
+        txId: 'selected-tx',
+        vout: 2,
+        scriptPubkey: Uint8List(0),
+        amountSat: BigInt.from(1000),
+        address: 'tb1qselected',
+      );
+      when(() => getReceiveAddress.execute(walletId: 'wallet-1')).thenAnswer(
+        (_) async => WalletAddress(
+          walletId: 'wallet-1',
+          index: 0,
+          address: 'tb1qreceive',
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        ),
+      );
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          networkFee: any(named: 'networkFee'),
+          amountSat: any(named: 'amountSat'),
+          drain: true,
+          selectedInputs: [selected],
+          replaceByFee: true,
+        ),
+      ).thenAnswer(
+        (_) async => (unsignedPsbt: 'psbt', txSize: 100, isToSelf: false),
+      );
+      when(
+        () => calculateBitcoin.execute(psbt: 'psbt'),
+      ).thenAnswer((_) async => 1200);
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(130000)),
+          bitcoinNetworkFees: _feeOptions(),
+          selectedUtxos: [selected],
+        ),
+      );
+
+      expect(
+        await bloc.getMaxAmountSat(_wallet(balanceSat: BigInt.from(130000))),
+        0,
+      );
+    },
+  );
+
+  test(
+    'a failed selection rebuild cannot broadcast the previous PSBT',
+    () async {
+      final oldSelection = WalletUtxo.bitcoin(
+        walletId: 'wallet-1',
+        txId: 'old-selected-tx',
+        vout: 0,
+        scriptPubkey: Uint8List(0),
+        amountSat: BigInt.from(30000),
+        address: 'tb1qold',
+      );
+      final unavailableSelection = WalletUtxo.bitcoin(
+        walletId: 'wallet-1',
+        txId: 'unavailable-selected-tx',
+        vout: 1,
+        scriptPubkey: Uint8List(0),
+        amountSat: BigInt.from(1000),
+        address: 'tb1qunavailable',
+      );
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          networkFee: any(named: 'networkFee'),
+          amountSat: 1000,
+          drain: false,
+          selectedInputs: [unavailableSelection],
+          replaceByFee: true,
+        ),
+      ).thenThrow(InsufficientFundsException('selected coin unavailable'));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+          selectedUtxos: [oldSelection],
+          signedPsbt: 'old-signed-psbt',
+        ),
+      );
+
+      bloc.add(TransferEvent.utxosSelected([unavailableSelection]));
+      await pumpEventQueue();
+      bloc.add(const TransferEvent.confirmed());
+      await pumpEventQueue();
+
+      expect(bloc.state.signedPsbt, isEmpty);
+      expect(bloc.state.buildTransactionException, isNotNull);
+      verifyNever(
+        () => broadcastBitcoin.execute('old-signed-psbt', isPsbt: true),
+      );
+    },
+  );
+
+  test('freezing a selected coin invalidates the staged PSBT', () async {
+    final selected = WalletUtxo.bitcoin(
+      walletId: 'wallet-1',
+      txId: 'selected-tx',
+      vout: 2,
+      scriptPubkey: Uint8List(0),
+      amountSat: BigInt.from(30000),
+      address: 'tb1qselected',
+    );
+    final frozen = selected.copyWith(isFrozen: true);
+    when(
+      () => getUtxos.execute(walletId: 'wallet-1'),
+    ).thenAnswer((_) async => [frozen]);
+    bloc.emit(
+      TransferState(
+        fromWallet: _wallet(),
+        selectedUtxos: [selected],
+        utxos: [selected],
+        signedPsbt: 'old-signed-psbt',
+      ),
+    );
+
+    bloc.add(const TransferEvent.loadUtxos());
+    await pumpEventQueue();
+
+    expect(bloc.state.signedPsbt, isEmpty);
+    expect(bloc.state.selectedUtxos, [selected]);
+    expect(bloc.state.buildTransactionException, isNotNull);
+  });
+
+  test(
+    'a newly reserved selected coin invalidates the cached PSBT before confirm',
+    () async {
+      final selected = WalletUtxo.bitcoin(
+        walletId: 'wallet-1',
+        txId: 'selected-tx',
+        vout: 2,
+        scriptPubkey: Uint8List(0),
+        amountSat: BigInt.from(30000),
+        address: 'tb1qselected',
+      );
+      when(
+        () => validateBitcoinSelection.execute(
+          walletId: 'wallet-1',
+          selectedInputs: [selected],
+        ),
+      ).thenThrow(InsufficientFundsException('reserved'));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+          selectedUtxos: [selected],
+          utxos: [selected],
+          signedPsbt: 'old-signed-psbt',
+          feePreviewCache: const BitcoinFeePreviewCache(
+            fastest: BitcoinFeePreviewSlot(
+              feeSat: 250,
+              unsignedPsbt: 'old-unsigned-psbt',
+              txSize: 100,
+            ),
+          ),
+        ),
+      );
+
+      bloc.add(const TransferEvent.confirmed());
+      await pumpEventQueue();
+
+      expect(bloc.state.signedPsbt, isEmpty);
+      expect(bloc.state.feePreviewCache.fastest.isCacheReady, isFalse);
+      expect(bloc.state.buildTransactionException, isNotNull);
+      verifyNever(
+        () => broadcastBitcoin.execute('old-signed-psbt', isPsbt: true),
+      );
+    },
+  );
+
+  test(
+    'an in-flight old amount rebuild cannot repopulate signedPsbt after amountChanged',
+    () async {
+      final prepareStarted = Completer<void>();
+      final prepareCompleter =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: true,
+        ),
+      ).thenAnswer((_) {
+        prepareStarted.complete();
+        return prepareCompleter.future;
+      });
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+          signedPsbt: 'previous-psbt',
+        ),
+      );
+
+      bloc.add(const TransferEvent.feeOptionSelected(FeeSelection.economic));
+      await prepareStarted.future;
+      bloc.add(const TransferEvent.amountChanged('2000'));
+      prepareCompleter.complete((
+        unsignedPsbt: 'old-unsigned-psbt',
+        txSize: 100,
+        isToSelf: true,
+      ));
+      await pumpEventQueue();
+
+      expect(bloc.state.amount, '2000');
+      expect(bloc.state.signedPsbt, isEmpty);
+      verifyNever(
+        () => signBitcoin.execute(
+          walletId: 'wallet-1',
+          psbt: 'old-unsigned-psbt',
+        ),
+      );
+    },
+  );
+
+  test(
+    'an in-flight swap creation cannot repopulate signedPsbt after amountChanged',
+    () async {
+      final prepareStarted = Completer<void>();
+      final prepareCompleter =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: true,
+        ),
+      ).thenAnswer((_) {
+        prepareStarted.complete();
+        return prepareCompleter.future;
+      });
+      when(
+        () => signBitcoin.execute(
+          walletId: 'wallet-1',
+          psbt: 'old-unsigned-psbt',
+        ),
+      ).thenAnswer((_) async => (signedPsbt: 'old-signed-psbt', txSize: 100));
+      when(
+        () => calculateBitcoin.execute(psbt: 'old-signed-psbt'),
+      ).thenAnswer((_) async => 1200);
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.swapCreated('1000'));
+      await prepareStarted.future;
+      bloc.add(const TransferEvent.amountChanged('2000'));
+      prepareCompleter.complete((
+        unsignedPsbt: 'old-unsigned-psbt',
+        txSize: 100,
+        isToSelf: true,
+      ));
+      await pumpEventQueue();
+
+      expect(bloc.state.amount, '2000');
+      expect(bloc.state.signedPsbt, isEmpty);
+    },
+  );
+
+  test(
+    'an in-flight swap creation cannot repopulate after destination wallet changes',
+    () async {
+      final prepareStarted = Completer<void>();
+      final prepareCompleter =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      final destination = _destinationWallet();
+      final replacementDestination = _destinationWallet(id: 'wallet-3');
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: true,
+        ),
+      ).thenAnswer((_) {
+        prepareStarted.complete();
+        return prepareCompleter.future;
+      });
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: destination,
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.swapCreated('1000'));
+      await prepareStarted.future;
+      bloc.add(
+        TransferEvent.walletsChanged(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: replacementDestination,
+        ),
+      );
+      prepareCompleter.complete((
+        unsignedPsbt: 'old-unsigned-psbt',
+        txSize: 100,
+        isToSelf: true,
+      ));
+      await pumpEventQueue();
+
+      expect(bloc.state.toWallet, replacementDestination);
+      expect(bloc.state.signedPsbt, isEmpty);
+      expect(bloc.state.isCreatingSwap, isFalse);
+      expect(bloc.state.continueClicked, isFalse);
+      verifyNever(
+        () => signBitcoin.execute(
+          walletId: 'wallet-1',
+          psbt: 'old-unsigned-psbt',
+        ),
+      );
+    },
+  );
+
+  test(
+    'same selected outpoints do not invalidate in-flight swap creation',
+    () async {
+      final selected = _bitcoinUtxo('selected-tx');
+      final prepareStarted = Completer<void>();
+      final prepareCompleter =
+          Completer<({String unsignedPsbt, int txSize, bool isToSelf})>();
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: [selected],
+          replaceByFee: true,
+        ),
+      ).thenAnswer((_) {
+        prepareStarted.complete();
+        return prepareCompleter.future;
+      });
+      when(
+        () => signBitcoin.execute(walletId: 'wallet-1', psbt: 'unsigned-psbt'),
+      ).thenAnswer((_) async => (signedPsbt: 'signed-psbt', txSize: 100));
+      when(
+        () => calculateBitcoin.execute(psbt: 'signed-psbt'),
+      ).thenAnswer((_) async => 1200);
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          selectedUtxos: [selected],
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.swapCreated('1000'));
+      await prepareStarted.future;
+      bloc.add(TransferEvent.utxosSelected([selected]));
+      prepareCompleter.complete((
+        unsignedPsbt: 'unsigned-psbt',
+        txSize: 100,
+        isToSelf: true,
+      ));
+      await bloc.stream.firstWhere(
+        (state) => state.signedPsbt == 'signed-psbt',
+      );
+
+      expect(bloc.state.isCreatingSwap, isFalse);
+      expect(bloc.state.signedPsbt, 'signed-psbt');
+    },
+  );
+
+  test('send-to-external changes invalidate transaction work', () async {
+    bloc.emit(
+      TransferState(
+        signedPsbt: 'stale-psbt',
+        isCreatingSwap: true,
+        continueClicked: true,
+        receiveExactAmount: false,
+      ),
+    );
+
+    bloc.add(const TransferEvent.sendToExternalToggled(true));
+    await pumpEventQueue();
+
+    expect(bloc.state.sendToExternal, isTrue);
+    expect(bloc.state.receiveExactAmount, isTrue);
+    expect(bloc.state.signedPsbt, isEmpty);
+    expect(bloc.state.isCreatingSwap, isFalse);
+    expect(bloc.state.continueClicked, isFalse);
+  });
+
+  test('receive-exact-amount changes invalidate transaction work', () async {
+    bloc.emit(
+      TransferState(
+        signedPsbt: 'stale-psbt',
+        isCreatingSwap: true,
+        continueClicked: true,
+        receiveExactAmount: false,
+      ),
+    );
+
+    bloc.add(const TransferEvent.receiveExactAmountToggled(true));
+    await pumpEventQueue();
+
+    expect(bloc.state.receiveExactAmount, isTrue);
+    expect(bloc.state.signedPsbt, isEmpty);
+    expect(bloc.state.isCreatingSwap, isFalse);
+    expect(bloc.state.continueClicked, isFalse);
+  });
+
+  test(
+    'contract changes detach a prepared swap before an RBF rebuild',
+    () async {
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'payin-address',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: any(named: 'selectedInputs'),
+          replaceByFee: false,
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (unsignedPsbt: 'new-unsigned-psbt', txSize: 100, isToSelf: false),
+      );
+      when(
+        () => verifyChain.execute(
+          psbtOrPset: 'new-unsigned-psbt',
+          swap: _swap(),
+          walletId: 'wallet-1',
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => signBitcoin.execute(
+          walletId: 'wallet-1',
+          psbt: 'new-unsigned-psbt',
+        ),
+      ).thenAnswer((_) async => (signedPsbt: 'new-signed-psbt', txSize: 100));
+      when(
+        () => calculateBitcoin.execute(psbt: 'new-signed-psbt'),
+      ).thenAnswer((_) async => 1200);
+      when(
+        () => replacePrepared.execute(
+          localId: 'local-1',
+          signedTransaction: 'new-signed-psbt',
+          isPsbt: true,
+        ),
+      ).thenAnswer((_) async => Ok(prepared));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: _liquidWallet(id: 'wallet-2'),
+          swap: _swap(),
+          orderSwap: prepared,
+          amount: '1000',
+          bitcoinNetworkFees: _feeOptions(),
+          signedPsbt: 'old-signed-psbt',
+        ),
+      );
+
+      bloc.add(const TransferEvent.amountChanged('2000'));
+      await pumpEventQueue();
+
+      bloc.add(const TransferEvent.replaceByFeeChanged(false));
+      await pumpEventQueue();
+
+      verifyNever(
+        () => replacePrepared.execute(
+          localId: 'local-1',
+          signedTransaction: 'new-signed-psbt',
+          isPsbt: true,
+        ),
+      );
+      expect(bloc.state.swap, isNull);
+      expect(bloc.state.orderSwap, isNull);
+    },
+  );
+
+  test('RBF rebuild preserves an unchanged prepared swap context', () async {
+    when(
+      () => prepareBitcoin.execute(
+        walletId: 'wallet-1',
+        address: 'payin-address',
+        amountSat: 1000,
+        networkFee: any(named: 'networkFee'),
+        drain: false,
+        selectedInputs: any(named: 'selectedInputs'),
+        replaceByFee: false,
+      ),
+    ).thenAnswer(
+      (_) async =>
+          (unsignedPsbt: 'new-unsigned-psbt', txSize: 100, isToSelf: false),
+    );
+    when(
+      () => verifyChain.execute(
+        psbtOrPset: 'new-unsigned-psbt',
+        swap: _swap(),
+        walletId: 'wallet-1',
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () =>
+          signBitcoin.execute(walletId: 'wallet-1', psbt: 'new-unsigned-psbt'),
+    ).thenAnswer((_) async => (signedPsbt: 'new-signed-psbt', txSize: 100));
+    when(
+      () => calculateBitcoin.execute(psbt: 'new-signed-psbt'),
+    ).thenAnswer((_) async => 1200);
+    when(
+      () => replacePrepared.execute(
+        localId: 'local-1',
+        signedTransaction: 'new-signed-psbt',
+        isPsbt: true,
+      ),
+    ).thenAnswer((_) async => Ok(prepared));
+    bloc.emit(
+      TransferState(
+        fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+        toWallet: _liquidWallet(id: 'wallet-2'),
+        swap: _swap(),
+        orderSwap: prepared,
+        amount: '1000',
+        bitcoinNetworkFees: _feeOptions(),
+        signedPsbt: 'old-signed-psbt',
+      ),
+    );
+
+    bloc.add(const TransferEvent.replaceByFeeChanged(false));
+    await pumpEventQueue();
+
+    verify(
+      () => replacePrepared.execute(
+        localId: 'local-1',
+        signedTransaction: 'new-signed-psbt',
+        isPsbt: true,
+      ),
+    ).called(1);
+    expect(bloc.state.orderSwap, prepared);
+  });
 
   test('emits the transaction id before wallet sync completes', () async {
     final syncCompleter = Completer<Wallet>();
@@ -644,6 +1400,15 @@ Wallet _wallet({BigInt? balanceSat}) => Wallet(
   signer: SignerEntity.local,
   signerDevice: null,
   balanceSat: balanceSat ?? BigInt.zero,
+);
+
+WalletUtxo _bitcoinUtxo(String txId) => WalletUtxo.bitcoin(
+  walletId: 'wallet-1',
+  txId: txId,
+  vout: 0,
+  scriptPubkey: Uint8List.fromList([0]),
+  amountSat: BigInt.from(2000),
+  address: 'tb1qsource',
 );
 
 Wallet _liquidWallet({String id = 'wallet-1', bool isDefault = false}) =>

--- a/test/features/swap/presentation/transfer_confirm_error_test.dart
+++ b/test/features/swap/presentation/transfer_confirm_error_test.dart
@@ -3,13 +3,82 @@ import 'package:bb_mobile/features/swap/presentation/transfer_confirm_error.dart
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  const unavailable = 'Selected coins unavailable';
+  const insufficient = 'Selected coins insufficient';
+  const changed = 'Transaction changed';
+
   test('shows a localized build error when transaction construction fails', () {
     final message = transferConfirmErrorMessage(
       buildTransactionException: BuildTransactionException('relay floor'),
       swapFailureMessage: null,
       buildFailureMessage: 'Build Failed',
+      selectedCoinsUnavailableMessage: 'Selected coins unavailable',
+      selectedCoinsInsufficientMessage: insufficient,
+      transactionChangedMessage: 'Transaction changed',
     );
 
     expect(message, 'Build Failed');
+  });
+
+  test('maps selected coins unavailable to its localized message', () {
+    expect(
+      transferConfirmErrorMessage(
+        buildTransactionException: BuildTransactionException(
+          selectedCoinsUnavailableCode,
+        ),
+        swapFailureMessage: null,
+        buildFailureMessage: 'Build Failed',
+        selectedCoinsUnavailableMessage: unavailable,
+        selectedCoinsInsufficientMessage: insufficient,
+        transactionChangedMessage: changed,
+      ),
+      unavailable,
+    );
+  });
+
+  test('maps selected coins insufficient to its localized message', () {
+    expect(
+      transferConfirmErrorMessage(
+        buildTransactionException: BuildTransactionException(
+          selectedCoinsInsufficientCode,
+        ),
+        swapFailureMessage: null,
+        buildFailureMessage: 'Build Failed',
+        selectedCoinsUnavailableMessage: unavailable,
+        selectedCoinsInsufficientMessage: insufficient,
+        transactionChangedMessage: changed,
+      ),
+      insufficient,
+    );
+  });
+
+  test('maps transaction rebuild failure to its localized message', () {
+    expect(
+      transferConfirmErrorMessage(
+        buildTransactionException: BuildTransactionException(
+          transactionRebuildFailedCode,
+        ),
+        swapFailureMessage: null,
+        buildFailureMessage: 'Build Failed',
+        selectedCoinsUnavailableMessage: unavailable,
+        selectedCoinsInsufficientMessage: insufficient,
+        transactionChangedMessage: changed,
+      ),
+      changed,
+    );
+  });
+
+  test('keeps unknown build errors generic', () {
+    expect(
+      transferConfirmErrorMessage(
+        buildTransactionException: BuildTransactionException('unknown'),
+        swapFailureMessage: null,
+        buildFailureMessage: 'Build Failed',
+        selectedCoinsUnavailableMessage: unavailable,
+        selectedCoinsInsufficientMessage: insufficient,
+        transactionChangedMessage: changed,
+      ),
+      'Build Failed',
+    );
   });
 }

--- a/test/security_audit/behavior/send_signed_transaction_lifecycle_test.dart
+++ b/test/security_audit/behavior/send_signed_transaction_lifecycle_test.dart
@@ -27,6 +27,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_wallet_transaction_by_tx_id_usecase.dart';
 import 'package:bb_mobile/features/labels/labels_facade.dart';
@@ -81,6 +82,9 @@ class _MockGetWalletUtxosUsecase extends Mock
 
 class _MockPrepareBitcoinSendUsecase extends Mock
     implements PrepareBitcoinSendUsecase {}
+
+class _MockValidateBitcoinSelectionUsecase extends Mock
+    implements ValidateBitcoinSelectionUsecase {}
 
 class _MockPrepareLiquidSendUsecase extends Mock
     implements PrepareLiquidSendUsecase {}
@@ -175,6 +179,7 @@ class _TestSendCubit extends SendCubit {
     required super.getAvailableCurrenciesUsecase,
     required super.getWalletUtxosUsecase,
     required super.prepareBitcoinSendUsecase,
+    required super.validateBitcoinSelectionUsecase,
     required super.prepareLiquidSendUsecase,
     required super.signBitcoinTxUsecase,
     required super.signLiquidTxUsecase,
@@ -232,6 +237,7 @@ void main() {
   late _MockGetWalletUtxosUsecase getWalletUtxosUsecase;
   late _MockCheckLiquidConsolidationUsecase checkLiquidConsolidationUsecase;
   late _MockPrepareLiquidSendUsecase prepareLiquidSendUsecase;
+  late _MockValidateBitcoinSelectionUsecase validateBitcoinSelectionUsecase;
   late _MockCalculateLiquidAbsoluteFeesUsecase
   calculateLiquidAbsoluteFeesUsecase;
   late _TestSendCubit cubit;
@@ -250,8 +256,15 @@ void main() {
     getWalletUtxosUsecase = _MockGetWalletUtxosUsecase();
     checkLiquidConsolidationUsecase = _MockCheckLiquidConsolidationUsecase();
     prepareLiquidSendUsecase = _MockPrepareLiquidSendUsecase();
+    validateBitcoinSelectionUsecase = _MockValidateBitcoinSelectionUsecase();
     calculateLiquidAbsoluteFeesUsecase =
         _MockCalculateLiquidAbsoluteFeesUsecase();
+    when(
+      () => validateBitcoinSelectionUsecase.execute(
+        walletId: any(named: 'walletId'),
+        selectedInputs: any(named: 'selectedInputs'),
+      ),
+    ).thenAnswer((_) async => []);
 
     cubit = _TestSendCubit(
       labelsFacade: labelsFacade,
@@ -264,6 +277,7 @@ void main() {
       getAvailableCurrenciesUsecase: _MockGetAvailableCurrenciesUsecase(),
       getWalletUtxosUsecase: getWalletUtxosUsecase,
       prepareBitcoinSendUsecase: _MockPrepareBitcoinSendUsecase(),
+      validateBitcoinSelectionUsecase: validateBitcoinSelectionUsecase,
       prepareLiquidSendUsecase: prepareLiquidSendUsecase,
       signBitcoinTxUsecase: _MockSignBitcoinTxUsecase(),
       signLiquidTxUsecase: _MockSignLiquidTxUsecase(),

--- a/test/security_audit/issue_2631_test.dart
+++ b/test/security_audit/issue_2631_test.dart
@@ -8,20 +8,17 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Security audit #2631 stale coin-control selections', () {
-    test(
-      'loadUtxos assigns refreshed UTXOs without intersecting selection',
-      () {
-        final source = File(
-          'lib/features/send/presentation/bloc/send_cubit.dart',
-        ).readAsStringSync();
-        final loadUtxos = source.substring(
-          source.indexOf('Future<void> loadUtxos()'),
-          source.indexOf('Future<void> utxoSelected'),
-        );
+    test('loadUtxos intersects the selection with refreshed UTXOs', () {
+      final source = File(
+        'lib/features/send/presentation/bloc/send_cubit.dart',
+      ).readAsStringSync();
+      final loadUtxos = source.substring(
+        source.indexOf('Future<void> loadUtxos('),
+        source.indexOf('Future<void> utxoSelected'),
+      );
 
-        expect(loadUtxos, contains('utxos: utxos'));
-        expect(loadUtxos, contains('selectedUtxos:'));
-      },
-    );
+      expect(loadUtxos, contains('utxos: utxos'));
+      expect(loadUtxos, contains('selectedUtxos:'));
+    });
   });
 }


### PR DESCRIPTION
Hand-picking coins that fell short of amount plus fee let BDK silently top the transaction up from a coin the user had excluded; the selection is now exclusive and the `Done` button waits for a real fee.