### PR TITLE
feat(wallet): reserve BIP48 signer accounts

### DIFF
--- a/lib/core/utils/bip48_derivation.dart
+++ b/lib/core/utils/bip48_derivation.dart
@@ -1,0 +1,33 @@
+abstract final class Bip48Derivation {
+  static const maxAccount = 0x7fffffff;
+
+  static final _accountPath = RegExp(
+    r"^m/48(?:'|h)/([0-9]+)(?:'|h)/([0-9]+)(?:'|h)/2(?:'|h)$",
+  );
+
+  static String path({required int coinType, required int account}) {
+    RangeError.checkValueInInterval(account, 0, maxAccount, 'account');
+    return "m/48'/$coinType'/$account'/2'";
+  }
+
+  static int? account(String? path, {required int coinType}) {
+    final match = path == null ? null : _accountPath.firstMatch(path);
+    if (match == null || int.tryParse(match.group(1)!) != coinType) return null;
+    final account = int.tryParse(match.group(2)!);
+    return account != null && account <= maxAccount ? account : null;
+  }
+
+  static bool isAccountPath(String? path) =>
+      path != null && _accountPath.hasMatch(path);
+
+  static String accountKeyExpression({
+    required String masterFingerprint,
+    required String derivationPath,
+    required String xpub,
+  }) {
+    final originPath = derivationPath.startsWith('m/')
+        ? derivationPath.substring(2)
+        : derivationPath;
+    return '[${masterFingerprint.toLowerCase()}/$originPath]$xpub';
+  }
+}

--- a/lib/core/wallet/data/bip48_account_repository_impl.dart
+++ b/lib/core/wallet/data/bip48_account_repository_impl.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:bb_mobile/core/utils/bip48_derivation.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bip48_account_datasource.dart';
+import 'package:bb_mobile/core/wallet/domain/bip48_account_usage_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:bull_logger/bull_logger.dart';
+
+final class Bip48AccountRepositoryImpl implements Bip48AccountRepository {
+  final Bip48AccountDatasource _datasource;
+  final Bip48AccountUsagePort _usagePort;
+  final SeedVerificationPort _seedVerification;
+  final Map<(String, int, int), String> _claims = {};
+  Future<void> _lock = Future.value();
+
+  Bip48AccountRepositoryImpl(
+    this._datasource,
+    this._usagePort,
+    this._seedVerification,
+  );
+
+  @override
+  Future<Result<int, Bip48AccountAllocationFailure>> nextAvailable({
+    required String seedFingerprint,
+    required int coinType,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      final account = _nextAvailable({
+        ...accounts,
+        ..._claimedAccounts(seedFingerprint, coinType),
+      });
+      return account == null
+          ? const Err(Bip48AccountAllocationFailure())
+          : Ok(account);
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<bool, Bip48AccountAllocationFailure>> isReserved({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType) || !_validAccount(account)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      return Ok(accounts.contains(account));
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<int, Bip48AccountAllocationFailure>> reserveNext({
+    required String seedFingerprint,
+    required int coinType,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      final account = _nextAvailable({
+        ...accounts,
+        ..._claimedAccounts(seedFingerprint, coinType),
+      });
+      if (account == null) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      accounts.add(account);
+      await _datasource.write(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+        accounts: accounts,
+      );
+      return Ok(account);
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claimNext({
+    required String seedFingerprint,
+    required int coinType,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      final account = _nextAvailable({
+        ...accounts,
+        ..._claimedAccounts(seedFingerprint, coinType),
+      });
+      if (account == null) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      final token = _claimToken(_claims.values.toSet());
+      _claims[_claimKey(seedFingerprint, coinType, account)] = token;
+      return Ok(Bip48AccountClaim(account: account, token: token));
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claim({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType) || !_validAccount(account)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      final key = _claimKey(seedFingerprint, coinType, account);
+      if (accounts.contains(account) || _claims.containsKey(key)) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      final token = _claimToken(_claims.values.toSet());
+      _claims[key] = token;
+      return Ok(Bip48AccountClaim(account: account, token: token));
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> commitClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType) ||
+        !_validAccount(claim.account) ||
+        claim.token.isEmpty) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final key = _claimKey(seedFingerprint, coinType, claim.account);
+      if (_claims[key] != claim.token) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      accounts.add(claim.account);
+      await _datasource.write(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+        accounts: accounts,
+      );
+      _claims.remove(key);
+      return const Ok(null);
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> releaseClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType) ||
+        !_validAccount(claim.account) ||
+        claim.token.isEmpty) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final key = _claimKey(seedFingerprint, coinType, claim.account);
+      if (_claims[key] == claim.token) {
+        _claims.remove(key);
+      }
+      return const Ok(null);
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> reserve({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) => _serialized(() async {
+    if (!_validScope(seedFingerprint, coinType) || !_validAccount(account)) {
+      return const Err(Bip48AccountAllocationFailure());
+    }
+    try {
+      final accounts = await _readAccounts(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      if (_claims.containsKey(_claimKey(seedFingerprint, coinType, account))) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      if (!accounts.add(account)) return const Ok(null);
+      await _datasource.write(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+        accounts: accounts,
+      );
+      return const Ok(null);
+    } on Exception catch (error, stackTrace) {
+      _logFailure(error, stackTrace);
+      return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  bool _validScope(String seedFingerprint, int coinType) =>
+      RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(seedFingerprint) &&
+      (coinType == 0 || coinType == 1);
+
+  bool _validAccount(int account) =>
+      account >= 0 && account <= Bip48Derivation.maxAccount;
+
+  Future<Set<int>> _readAccounts({
+    required String seedFingerprint,
+    required int coinType,
+  }) async {
+    final accounts = await _datasource.read(
+      seedFingerprint: seedFingerprint,
+      coinType: coinType,
+    );
+    final usages = await _usagePort.getBip48AccountUsages();
+    var changed = false;
+    for (final usage in usages) {
+      if (usage.seedFingerprint.toLowerCase() !=
+              seedFingerprint.toLowerCase() ||
+          usage.coinType != coinType ||
+          accounts.contains(usage.account)) {
+        continue;
+      }
+      final matches = await _seedVerification.matchesXpubs(
+        fingerprint: usage.seedFingerprint,
+        keys: [(derivationPath: usage.derivationPath, xpub: usage.xpub)],
+      );
+      if (matches) changed = accounts.add(usage.account) || changed;
+    }
+    if (changed) {
+      await _datasource.write(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+        accounts: accounts,
+      );
+    }
+    return accounts;
+  }
+
+  int? _nextAvailable(Set<int> accounts) {
+    var account = 0;
+    while (accounts.contains(account) &&
+        account <= Bip48Derivation.maxAccount) {
+      account++;
+    }
+    return account > Bip48Derivation.maxAccount ? null : account;
+  }
+
+  Set<int> _claimedAccounts(String seedFingerprint, int coinType) => {
+    for (final key in _claims.keys)
+      if (key.$1 == seedFingerprint.toLowerCase() && key.$2 == coinType) key.$3,
+  };
+
+  (String, int, int) _claimKey(
+    String seedFingerprint,
+    int coinType,
+    int account,
+  ) => (seedFingerprint.toLowerCase(), coinType, account);
+
+  String _claimToken(Set<String> existing) {
+    final random = Random.secure();
+    while (true) {
+      final token = List.generate(
+        16,
+        (_) => random.nextInt(256).toRadixString(16).padLeft(2, '0'),
+      ).join();
+      if (!existing.contains(token)) return token;
+    }
+  }
+
+  void _logFailure(Object error, StackTrace stackTrace) => log.warning(
+    'Failed to access BIP48 account reservations',
+    error: error.runtimeType,
+    trace: stackTrace,
+  );
+
+  Future<T> _serialized<T>(Future<T> Function() action) {
+    final completer = Completer<void>();
+    final previous = _lock;
+    _lock = completer.future;
+    return previous
+        .catchError((_) {})
+        .then((_) => action())
+        .whenComplete(completer.complete);
+  }
+}

--- a/lib/core/wallet/data/datasources/bip48_account_datasource.dart
+++ b/lib/core/wallet/data/datasources/bip48_account_datasource.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+
+final class Bip48AccountDatasource {
+  static const _keyPrefix = 'bip48_reserved_accounts_';
+
+  final KeyValueStorageDatasource<String> _storage;
+
+  const Bip48AccountDatasource(this._storage);
+
+  Future<Set<int>> read({
+    required String seedFingerprint,
+    required int coinType,
+  }) async {
+    final value = await _storage.getValue(
+      _key(seedFingerprint: seedFingerprint, coinType: coinType),
+    );
+    if (value == null) return {};
+    return (jsonDecode(value) as List<dynamic>).cast<int>().toSet();
+  }
+
+  Future<void> write({
+    required String seedFingerprint,
+    required int coinType,
+    required Set<int> accounts,
+  }) => _storage.saveValue(
+    key: _key(seedFingerprint: seedFingerprint, coinType: coinType),
+    value: jsonEncode(accounts.toList()..sort()),
+  );
+
+  String _key({required String seedFingerprint, required int coinType}) =>
+      '$_keyPrefix${seedFingerprint.toLowerCase()}_$coinType';
+}

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -10,6 +10,7 @@ import 'package:bb_mobile/core/entities/signer_device_entity.dart';
 import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/seed/domain/entity/seed.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
+import 'package:bb_mobile/core/utils/bip48_derivation.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_facade.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
@@ -20,6 +21,8 @@ import 'package:bb_mobile/core/wallet/data/models/balance_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
+import 'package:bb_mobile/core/wallet/domain/bip48_account_usage_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_usage.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_balances.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
@@ -31,7 +34,10 @@ import 'package:bull_logger/bull_logger.dart';
 import 'package:crypto/crypto.dart';
 
 class WalletRepository
-    implements BitcoinDescriptorPort, WalletSignerDevicePort {
+    implements
+        BitcoinDescriptorPort,
+        WalletSignerDevicePort,
+        Bip48AccountUsagePort {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final BdkWalletDatasource _bdkWallet;
   final LwkWalletDatasource _lwkWallet;
@@ -68,6 +74,29 @@ class WalletRepository
   bool isWalletSyncing({String? walletId}) =>
       _bdkWallet.isWalletSyncing(walletId: walletId) ||
       _lwkWallet.isWalletSyncing(walletId: walletId);
+
+  @override
+  Future<List<Bip48AccountUsage>> getBip48AccountUsages() async {
+    final wallets = await _walletMetadataDatasource.fetchAll();
+    return [
+      for (final wallet in wallets)
+        if (wallet.network.isBitcoin)
+          for (final signer in wallet.signers)
+            for (final key in signer.descriptorKeys)
+              if (Bip48Derivation.account(
+                    key.derivationPath,
+                    coinType: wallet.network.coinType,
+                  )
+                  case final account?)
+                Bip48AccountUsage(
+                  seedFingerprint: key.masterFingerprint.toLowerCase(),
+                  coinType: wallet.network.coinType,
+                  account: account,
+                  derivationPath: key.derivationPath!,
+                  xpub: key.xpub,
+                ),
+    ];
+  }
 
   Future<Wallet> createWallet({
     required Seed seed,

--- a/lib/core/wallet/domain/bip48_account_usage_port.dart
+++ b/lib/core/wallet/domain/bip48_account_usage_port.dart
@@ -1,0 +1,5 @@
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_usage.dart';
+
+abstract interface class Bip48AccountUsagePort {
+  Future<List<Bip48AccountUsage>> getBip48AccountUsages();
+}

--- a/lib/core/wallet/domain/entities/bip48_account_claim.dart
+++ b/lib/core/wallet/domain/entities/bip48_account_claim.dart
@@ -1,0 +1,6 @@
+final class Bip48AccountClaim {
+  final int account;
+  final String token;
+
+  const Bip48AccountClaim({required this.account, required this.token});
+}

--- a/lib/core/wallet/domain/entities/bip48_account_usage.dart
+++ b/lib/core/wallet/domain/entities/bip48_account_usage.dart
@@ -1,0 +1,27 @@
+import 'package:bb_mobile/core/utils/bip48_derivation.dart';
+
+final class Bip48AccountUsage {
+  final String seedFingerprint;
+  final int coinType;
+  final int account;
+  final String derivationPath;
+  final String xpub;
+
+  Bip48AccountUsage({
+    required this.seedFingerprint,
+    required this.coinType,
+    required this.account,
+    required this.derivationPath,
+    required this.xpub,
+  }) {
+    if (!RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(seedFingerprint) ||
+        (coinType != 0 && coinType != 1) ||
+        account < 0 ||
+        account > Bip48Derivation.maxAccount ||
+        Bip48Derivation.account(derivationPath, coinType: coinType) !=
+            account ||
+        xpub.isEmpty) {
+      throw ArgumentError('Invalid BIP48 account usage');
+    }
+  }
+}

--- a/lib/core/wallet/domain/repositories/bip48_account_repository.dart
+++ b/lib/core/wallet/domain/repositories/bip48_account_repository.dart
@@ -1,0 +1,59 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+abstract interface class Bip48AccountRepository {
+  @useResult
+  Future<Result<int, Bip48AccountAllocationFailure>> nextAvailable({
+    required String seedFingerprint,
+    required int coinType,
+  });
+
+  @useResult
+  Future<Result<bool, Bip48AccountAllocationFailure>> isReserved({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  });
+
+  @useResult
+  Future<Result<int, Bip48AccountAllocationFailure>> reserveNext({
+    required String seedFingerprint,
+    required int coinType,
+  });
+
+  @useResult
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claimNext({
+    required String seedFingerprint,
+    required int coinType,
+  });
+
+  @useResult
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claim({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  });
+
+  @useResult
+  Future<Result<void, Bip48AccountAllocationFailure>> commitClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  });
+
+  @useResult
+  Future<Result<void, Bip48AccountAllocationFailure>> releaseClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  });
+
+  @useResult
+  Future<Result<void, Bip48AccountAllocationFailure>> reserve({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  });
+}

--- a/lib/core/wallet/domain/usecases/get_bip48_account_status_usecase.dart
+++ b/lib/core/wallet/domain/usecases/get_bip48_account_status_usecase.dart
@@ -1,0 +1,32 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+class GetBip48AccountStatusUsecase {
+  final Bip48AccountRepository _repository;
+
+  const GetBip48AccountStatusUsecase(this._repository);
+
+  @useResult
+  Future<
+    Result<({int account, bool isReserved}), Bip48AccountAllocationFailure>
+  >
+  execute({
+    required String seedFingerprint,
+    required int coinType,
+    int? account,
+  }) async {
+    if (account == null) {
+      return (await _repository.nextAvailable(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      )).map((value) => (account: value, isReserved: false));
+    }
+    return (await _repository.isReserved(
+      seedFingerprint: seedFingerprint,
+      coinType: coinType,
+      account: account,
+    )).map((value) => (account: account, isReserved: value));
+  }
+}

--- a/lib/core/wallet/domain/usecases/reserve_bip48_account_usecase.dart
+++ b/lib/core/wallet/domain/usecases/reserve_bip48_account_usecase.dart
@@ -1,0 +1,30 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+class ReserveBip48AccountUsecase {
+  final Bip48AccountRepository _repository;
+
+  const ReserveBip48AccountUsecase(this._repository);
+
+  @useResult
+  Future<Result<int, Bip48AccountAllocationFailure>> execute({
+    required String seedFingerprint,
+    required int coinType,
+    int? account,
+  }) async {
+    if (account == null) {
+      return _repository.reserveNext(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+    }
+    final result = await _repository.reserve(
+      seedFingerprint: seedFingerprint,
+      coinType: coinType,
+      account: account,
+    );
+    return result.map((_) => account);
+  }
+}

--- a/lib/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart
+++ b/lib/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart
@@ -1,0 +1,80 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
+import 'package:bb_mobile/core/utils/bip48_derivation.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+class ReserveBullOwnedBip48AccountsUsecase {
+  final Bip48AccountRepository _repository;
+  final SeedVerificationPort _seedVerification;
+
+  const ReserveBullOwnedBip48AccountsUsecase(
+    this._repository,
+    this._seedVerification,
+  );
+
+  @useResult
+  Future<Result<void, Bip48AccountAllocationFailure>> execute({
+    required Network network,
+    required List<WalletSigner> signers,
+  }) async {
+    final accounts =
+        <
+          ({String fingerprint, int account, String xpub}),
+          ({WalletDescriptorKey key, bool requiresOwnership})
+        >{};
+    for (final signer in signers) {
+      for (final key in signer.descriptorKeys) {
+        final path = key.derivationPath;
+        if (!Bip48Derivation.isAccountPath(path)) continue;
+        final account = Bip48Derivation.account(
+          path,
+          coinType: network.coinType,
+        );
+        if (account == null || key.masterFingerprint.isEmpty) {
+          return const Err(Bip48AccountAllocationFailure());
+        }
+        final identity = (
+          fingerprint: key.masterFingerprint.toLowerCase(),
+          account: account,
+          xpub: key.xpub,
+        );
+        final existing = accounts[identity];
+        accounts[identity] = (
+          key: key,
+          requiresOwnership:
+              (existing?.requiresOwnership ?? false) ||
+              signer.signer == SignerEntity.local,
+        );
+      }
+    }
+
+    for (final entry in accounts.entries) {
+      final identity = entry.key;
+      final usage = entry.value;
+      final key = usage.key;
+      final matches = await _seedVerification.matchesXpubs(
+        fingerprint: identity.fingerprint,
+        keys: [(derivationPath: key.derivationPath!, xpub: identity.xpub)],
+      );
+      if (!matches) {
+        if (usage.requiresOwnership) {
+          return const Err(Bip48AccountAllocationFailure());
+        }
+        continue;
+      }
+      final reserved = await _repository.reserve(
+        seedFingerprint: identity.fingerprint,
+        coinType: network.coinType,
+        account: identity.account,
+      );
+      if (reserved case Err()) return reserved;
+    }
+    return const Ok(null);
+  }
+}

--- a/lib/core/wallet/domain/wallet_failure.dart
+++ b/lib/core/wallet/domain/wallet_failure.dart
@@ -8,6 +8,10 @@ final class WalletTransactionLookupFailure extends WalletFailure {
   const WalletTransactionLookupFailure([super.logMessage]);
 }
 
+final class Bip48AccountAllocationFailure extends WalletFailure {
+  const Bip48AccountAllocationFailure([super.logMessage]);
+}
+
 enum BitcoinSigningFailureKind {
   invalidPsbt,
   walletMismatch,

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -2,10 +2,14 @@ import 'package:bb_mobile/core/electrum/domain/ports/electrum_servers_port.dart'
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/seed/data/services/mnemonic_generator.dart';
+import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
 import 'package:bb_mobile/core/swaps/data/repository/boltz_swap_repository.dart';
 import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/data/bip48_account_repository_impl.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bip48_account_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/bdk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
@@ -18,6 +22,8 @@ import 'package:bb_mobile/core/wallet/data/repositories/wallet_transaction_repos
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_utxo_repository_impl.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_transaction_repository.dart';
 import 'package:bb_mobile/core/wallet/domain/repositories/wallet_utxo_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/bip48_account_usage_port.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_signing_port.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_signer_device_port.dart';
@@ -27,6 +33,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/check_wallet_syncing_useca
 import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_address_at_index_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_bip48_account_status_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transaction_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_transactions_usecase.dart';
@@ -34,6 +41,8 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bip48_account_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_electrum_sync_results_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/watch_finished_wallet_syncs_usecase.dart';
@@ -56,12 +65,27 @@ class WalletLocator {
       () => WalletMetadataDatasource(sqlite: locator<SqliteDatabase>()),
     );
 
+    locator.registerLazySingleton<Bip48AccountDatasource>(
+      () => Bip48AccountDatasource(
+        locator<KeyValueStorageDatasource<String>>(
+          instanceName: LocatorInstanceNameConstants.secureStorageDatasource,
+        ),
+      ),
+    );
+
     locator.registerLazySingleton<FrozenWalletUtxoDatasource>(
       () => FrozenWalletUtxoDatasource(db: locator<SqliteDatabase>()),
     );
   }
 
   static void registerRepositories(GetIt locator) {
+    locator.registerLazySingleton<Bip48AccountRepository>(
+      () => Bip48AccountRepositoryImpl(
+        locator(),
+        locator<Bip48AccountUsagePort>(),
+        locator<SeedVerificationPort>(),
+      ),
+    );
     locator.registerLazySingleton<BitcoinWalletRepository>(
       () => BitcoinWalletRepository(
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
@@ -97,6 +121,9 @@ class WalletLocator {
     locator.registerLazySingleton<WalletSignerDevicePort>(
       () => locator<WalletRepository>(),
     );
+    locator.registerLazySingleton<Bip48AccountUsagePort>(
+      () => locator<WalletRepository>(),
+    );
 
     locator.registerLazySingleton<WalletUtxoRepository>(
       () => WalletUtxoRepositoryImpl(
@@ -129,6 +156,15 @@ class WalletLocator {
   }
 
   static void registerUsecases(GetIt locator) {
+    locator.registerFactory<GetBip48AccountStatusUsecase>(
+      () => GetBip48AccountStatusUsecase(locator()),
+    );
+    locator.registerFactory<ReserveBip48AccountUsecase>(
+      () => ReserveBip48AccountUsecase(locator()),
+    );
+    locator.registerFactory<ReserveBullOwnedBip48AccountsUsecase>(
+      () => ReserveBullOwnedBip48AccountsUsecase(locator(), locator()),
+    );
     locator.registerFactory<CreateDefaultWalletsUsecase>(
       () => CreateDefaultWalletsUsecase(
         seedRepository: locator<SeedRepository>(),

--- a/lib/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart
+++ b/lib/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart
@@ -2,14 +2,22 @@ import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/domain/import_watch_only_failure.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
 import 'package:meta/meta.dart';
 
 class ImportWatchOnlyDescriptorUsecase {
   final BitcoinDescriptorPort _descriptorPort;
+  final ReserveBullOwnedBip48AccountsUsecase _reserveBip48AccountsUsecase;
+  final DeleteWalletUsecase _deleteWalletUsecase;
 
-  ImportWatchOnlyDescriptorUsecase(this._descriptorPort);
+  ImportWatchOnlyDescriptorUsecase(
+    this._descriptorPort,
+    this._reserveBip48AccountsUsecase,
+    this._deleteWalletUsecase,
+  );
 
   /// Maps failures from the core descriptor boundary to the feature's
   /// sanitized [ImportWatchOnlyFailure].
@@ -24,6 +32,14 @@ class ImportWatchOnlyDescriptorUsecase {
         label: watchOnlyDescriptor.label,
         signers: watchOnlyDescriptor.signers,
       );
+      final reserved = await _reserveBip48AccountsUsecase.execute(
+        network: watchOnlyDescriptor.network,
+        signers: watchOnlyDescriptor.signers,
+      );
+      if (reserved case Err()) {
+        await _deleteWalletUsecase.execute(walletId: wallet.id);
+        return const Err(ImportFailedFailure());
+      }
       return Ok(wallet);
     } on Exception catch (_, st) {
       // Descriptor parser errors can contain key material.

--- a/lib/features/import_watch_only_wallet/import_watch_only_locator.dart
+++ b/lib/features/import_watch_only_wallet/import_watch_only_locator.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_xpub_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/parse_watch_only_input_usecase.dart';
@@ -23,11 +24,19 @@ class ImportWatchOnlyLocator {
     );
 
     locator.registerFactory<ImportWatchOnlyDescriptorUsecase>(
-      () => ImportWatchOnlyDescriptorUsecase(locator<BitcoinDescriptorPort>()),
+      () => ImportWatchOnlyDescriptorUsecase(
+        locator<BitcoinDescriptorPort>(),
+        locator<ReserveBullOwnedBip48AccountsUsecase>(),
+        locator(),
+      ),
     );
 
     locator.registerFactory<ImportWatchOnlyXpubUsecase>(
-      () => ImportWatchOnlyXpubUsecase(locator<BitcoinDescriptorPort>()),
+      () => ImportWatchOnlyXpubUsecase(
+        locator<BitcoinDescriptorPort>(),
+        locator<ReserveBullOwnedBip48AccountsUsecase>(),
+        locator(),
+      ),
     );
   }
 }

--- a/lib/features/import_watch_only_wallet/import_watch_only_xpub_usecase.dart
+++ b/lib/features/import_watch_only_wallet/import_watch_only_xpub_usecase.dart
@@ -4,6 +4,8 @@ import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/domain/import_watch_only_failure.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
 import 'package:bull_logger/bull_logger.dart';
@@ -11,8 +13,14 @@ import 'package:meta/meta.dart';
 
 class ImportWatchOnlyXpubUsecase {
   final BitcoinDescriptorPort _descriptorPort;
+  final ReserveBullOwnedBip48AccountsUsecase _reserveBip48AccountsUsecase;
+  final DeleteWalletUsecase _deleteWalletUsecase;
 
-  ImportWatchOnlyXpubUsecase(this._descriptorPort);
+  ImportWatchOnlyXpubUsecase(
+    this._descriptorPort,
+    this._reserveBip48AccountsUsecase,
+    this._deleteWalletUsecase,
+  );
 
   /// Maps failures from the core descriptor boundary to the feature's
   /// sanitized [ImportWatchOnlyFailure].
@@ -53,6 +61,14 @@ class ImportWatchOnlyXpubUsecase {
         label: watchOnlyXpub.label,
         signers: signers,
       );
+      final reserved = await _reserveBip48AccountsUsecase.execute(
+        network: watchOnlyXpub.network,
+        signers: signers,
+      );
+      if (reserved case Err()) {
+        await _deleteWalletUsecase.execute(walletId: wallet.id);
+        return const Err(ImportFailedFailure());
+      }
       return Ok(wallet);
     } on Exception catch (_, st) {
       // Parser errors may contain key material.

--- a/lib/features/settings/domain/signing_key_account_session.dart
+++ b/lib/features/settings/domain/signing_key_account_session.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:meta/meta.dart';
+
+typedef SigningKeyAccountSelection = ({
+  int account,
+  bool isReserved,
+  int? markedAccount,
+});
+
+final class SigningKeyAccountSession {
+  final Bip48AccountRepository _repository;
+  Future<void> _lock = Future.value();
+  Bip48AccountClaim? _activeClaim;
+  String? _activeFingerprint;
+  int? _activeCoinType;
+
+  SigningKeyAccountSession(this._repository);
+
+  @useResult
+  Future<Result<SigningKeyAccountSelection, Bip48AccountAllocationFailure>>
+  select({
+    required String seedFingerprint,
+    required int coinType,
+    int? account,
+    bool markUsed = false,
+  }) => _serialized(() async {
+    int? markedAccount;
+    if (markUsed) {
+      final claim = _activeClaim;
+      if (account == null ||
+          claim == null ||
+          claim.account != account ||
+          _activeFingerprint?.toLowerCase() != seedFingerprint.toLowerCase() ||
+          _activeCoinType != coinType) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      final reservation = await _repository.commitClaim(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+        claim: claim,
+      );
+      if (reservation case Err()) {
+        return const Err(Bip48AccountAllocationFailure());
+      }
+      _clearActiveClaim();
+      markedAccount = account;
+    }
+
+    if (markUsed || account == null) {
+      if (!markUsed) {
+        final released = await _releaseActiveClaim();
+        if (released case Err()) {
+          return const Err(Bip48AccountAllocationFailure());
+        }
+      }
+      final claimResult = await _repository.claimNext(
+        seedFingerprint: seedFingerprint,
+        coinType: coinType,
+      );
+      return switch (claimResult) {
+        Ok(:final value) => Ok((
+          account: _rememberClaim(
+            value,
+            fingerprint: seedFingerprint,
+            coinType: coinType,
+          ),
+          isReserved: false,
+          markedAccount: markedAccount,
+        )),
+        Err() => const Err(Bip48AccountAllocationFailure()),
+      };
+    }
+
+    final released = await _releaseActiveClaim();
+    if (released case Err()) return const Err(Bip48AccountAllocationFailure());
+    final reservedResult = await _repository.isReserved(
+      seedFingerprint: seedFingerprint,
+      coinType: coinType,
+      account: account,
+    );
+    switch (reservedResult) {
+      case Ok(value: true):
+        return Ok((account: account, isReserved: true, markedAccount: null));
+      case Ok(value: false):
+        final claimResult = await _repository.claim(
+          seedFingerprint: seedFingerprint,
+          coinType: coinType,
+          account: account,
+        );
+        return switch (claimResult) {
+          Ok(:final value) => Ok((
+            account: _rememberClaim(
+              value,
+              fingerprint: seedFingerprint,
+              coinType: coinType,
+            ),
+            isReserved: false,
+            markedAccount: null,
+          )),
+          Err() => const Err(Bip48AccountAllocationFailure()),
+        };
+      case Err():
+        return const Err(Bip48AccountAllocationFailure());
+    }
+  });
+
+  @useResult
+  Future<Result<void, Bip48AccountAllocationFailure>> release() =>
+      _serialized(_releaseActiveClaim);
+
+  Future<Result<void, Bip48AccountAllocationFailure>>
+  _releaseActiveClaim() async {
+    final claim = _activeClaim;
+    final fingerprint = _activeFingerprint;
+    final coinType = _activeCoinType;
+    if (claim == null || fingerprint == null || coinType == null) {
+      return const Ok(null);
+    }
+    final result = await _repository.releaseClaim(
+      seedFingerprint: fingerprint,
+      coinType: coinType,
+      claim: claim,
+    );
+    if (result case Ok()) _clearActiveClaim();
+    return result;
+  }
+
+  int _rememberClaim(
+    Bip48AccountClaim claim, {
+    required String fingerprint,
+    required int coinType,
+  }) {
+    _activeClaim = claim;
+    _activeFingerprint = fingerprint;
+    _activeCoinType = coinType;
+    return claim.account;
+  }
+
+  void _clearActiveClaim() {
+    _activeClaim = null;
+    _activeFingerprint = null;
+    _activeCoinType = null;
+  }
+
+  Future<T> _serialized<T>(Future<T> Function() action) {
+    final completer = Completer<void>();
+    final previous = _lock;
+    _lock = completer.future;
+    return previous
+        .catchError((_) {})
+        .then((_) => action())
+        .whenComplete(completer.complete);
+  }
+}

--- a/lib/features/settings/domain/usecases/export_signing_key_usecase.dart
+++ b/lib/features/settings/domain/usecases/export_signing_key_usecase.dart
@@ -1,35 +1,61 @@
 import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/utils/bip32_derivation.dart';
-import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
+import 'package:bb_mobile/features/settings/domain/signing_key_account_session.dart';
 import 'package:bb_mobile/features/settings/domain/signing_key_derivation.dart';
+import 'package:bull_logger/bull_logger.dart';
 import 'package:meta/meta.dart';
 
 class ExportSigningKeyUsecase {
   final GetDefaultSeedUsecase _getDefaultSeedUsecase;
   final GetSettingsUsecase _getSettingsUsecase;
+  final SigningKeyAccountSession _accountSession;
 
-  const ExportSigningKeyUsecase({
+  ExportSigningKeyUsecase(
+    this._accountSession, {
     required this._getDefaultSeedUsecase,
     required this._getSettingsUsecase,
   });
 
   @useResult
-  Future<Result<String, SettingsFailure>> execute({
-    required int account,
-  }) async {
+  Future<
+    Result<
+      ({
+        int account,
+        String descriptorKey,
+        bool isReserved,
+        int? markedAccount,
+      }),
+      SettingsFailure
+    >
+  >
+  execute({int? account, bool markUsed = false}) async {
     try {
       final settings = await _getSettingsUsecase.execute();
       final seed = await _getDefaultSeedUsecase.execute(
         environment: settings.environment,
       );
       final isTestnet = settings.environment.isTestnet;
+      final coinType = isTestnet ? 1 : 0;
+      final selectionResult = await _accountSession.select(
+        seedFingerprint: seed.masterFingerprint,
+        coinType: coinType,
+        account: account,
+        markUsed: markUsed,
+      );
+      final SigningKeyAccountSelection selection;
+      switch (selectionResult) {
+        case Ok(:final value):
+          selection = value;
+        case Err():
+          return const Err(SettingsSigningKeyExportFailure());
+      }
       final derivationPath = SigningKeyDerivation.path(
         isTestnet: isTestnet,
-        account: account,
+        account: selection.account,
       );
       final network = isTestnet
           ? Network.bitcoinTestnet
@@ -41,7 +67,13 @@ class ExportSigningKeyUsecase {
       );
       final originPath = derivationPath.substring(2).replaceAll("'", 'h');
 
-      return Ok('[${seed.masterFingerprint.toLowerCase()}/$originPath]$xpub');
+      return Ok((
+        account: selection.account,
+        descriptorKey:
+            '[${seed.masterFingerprint.toLowerCase()}/$originPath]$xpub',
+        isReserved: selection.isReserved,
+        markedAccount: selection.markedAccount,
+      ));
     } on Exception catch (error, stackTrace) {
       log.severe(
         message: 'Failed to export signing key',

--- a/lib/features/settings/domain/usecases/release_signing_key_account_usecase.dart
+++ b/lib/features/settings/domain/usecases/release_signing_key_account_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
+import 'package:bb_mobile/features/settings/domain/signing_key_account_session.dart';
+import 'package:meta/meta.dart';
+
+class ReleaseSigningKeyAccountUsecase {
+  final SigningKeyAccountSession _session;
+
+  const ReleaseSigningKeyAccountUsecase(this._session);
+
+  @useResult
+  Future<Result<void, SettingsFailure>> execute() async =>
+      (await _session.release()).mapErr(
+        (_) => const SettingsSigningKeyExportFailure(),
+      );
+}

--- a/lib/features/settings/presentation/bloc/signing_key_export_cubit.dart
+++ b/lib/features/settings/presentation/bloc/signing_key_export_cubit.dart
@@ -1,57 +1,124 @@
+import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/export_signing_key_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/release_signing_key_account_usecase.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SigningKeyExportState {
   final int account;
   final String descriptorKey;
+  final bool isReserved;
+  final bool isLoading;
+  final int? markedAccount;
   final SettingsFailure? failure;
 
   const SigningKeyExportState({
     this.account = 0,
     this.descriptorKey = '',
+    this.isReserved = false,
+    this.isLoading = false,
+    this.markedAccount,
     this.failure,
   });
 
   SigningKeyExportState copyWith({
     int? account,
     String? descriptorKey,
+    bool? isReserved,
+    bool? isLoading,
+    int? markedAccount,
+    bool clearMarkedAccount = false,
     SettingsFailure? failure,
     bool clearFailure = false,
   }) => SigningKeyExportState(
     account: account ?? this.account,
     descriptorKey: descriptorKey ?? this.descriptorKey,
+    isReserved: isReserved ?? this.isReserved,
+    isLoading: isLoading ?? this.isLoading,
+    markedAccount: clearMarkedAccount
+        ? null
+        : markedAccount ?? this.markedAccount,
     failure: clearFailure ? null : failure ?? this.failure,
   );
 }
 
 class SigningKeyExportCubit extends Cubit<SigningKeyExportState> {
   final ExportSigningKeyUsecase _exportSigningKeyUsecase;
+  final ReleaseSigningKeyAccountUsecase _releaseSigningKeyAccountUsecase;
   int _requestId = 0;
+  int? _requestedAccount;
+  bool _markUsed = false;
 
-  SigningKeyExportCubit({required this._exportSigningKeyUsecase})
-    : super(const SigningKeyExportState());
+  SigningKeyExportCubit({
+    required this._exportSigningKeyUsecase,
+    required this._releaseSigningKeyAccountUsecase,
+  }) : super(const SigningKeyExportState());
 
-  Future<void> load() => _export(state.account);
-
-  Future<void> selectAccount(int account) async {
-    if (state.account == account) return;
-    emit(state.copyWith(account: account));
-    await _export(account);
+  Future<void> load() async {
+    await _export(account: _requestedAccount, markUsed: _markUsed);
   }
 
-  Future<void> _export(int account) async {
-    final requestId = ++_requestId;
-    emit(state.copyWith(descriptorKey: '', clearFailure: true));
+  Future<void> selectAccount(int account) async {
+    if ((!state.isLoading && state.account == account) ||
+        (state.isLoading && _requestedAccount == account)) {
+      return;
+    }
+    _requestedAccount = account;
+    _markUsed = false;
+    await _export(account: account);
+  }
 
-    final result = await _exportSigningKeyUsecase.execute(account: account);
+  Future<void> markAccountUsed() async {
+    if (state.isReserved || state.descriptorKey.isEmpty) return;
+    _requestedAccount = state.account;
+    _markUsed = true;
+    await _export(account: state.account, markUsed: true);
+  }
+
+  @override
+  Future<void> close() async {
+    switch (await _releaseSigningKeyAccountUsecase.execute()) {
+      case Ok():
+      case Err():
+        break;
+    }
+    return super.close();
+  }
+
+  Future<void> _export({int? account, bool markUsed = false}) async {
+    final requestId = ++_requestId;
+    emit(
+      state.copyWith(
+        account: account,
+        descriptorKey: '',
+        isReserved: false,
+        isLoading: true,
+        clearFailure: true,
+        clearMarkedAccount: !markUsed,
+      ),
+    );
+
+    final result = await _exportSigningKeyUsecase.execute(
+      account: account,
+      markUsed: markUsed,
+    );
     if (isClosed || requestId != _requestId) return;
 
-    result.fold(
-      (descriptorKey) => emit(
-        state.copyWith(descriptorKey: descriptorKey, clearFailure: true),
-      ),
-      (failure) => emit(state.copyWith(failure: failure)),
-    );
+    result.fold((export) {
+      if (markUsed) {
+        _requestedAccount = null;
+        _markUsed = false;
+      }
+      emit(
+        state.copyWith(
+          account: export.account,
+          descriptorKey: export.descriptorKey,
+          isReserved: export.isReserved,
+          isLoading: false,
+          markedAccount: export.markedAccount,
+          clearFailure: true,
+        ),
+      );
+    }, (failure) => emit(state.copyWith(isLoading: false, failure: failure)));
   }
 }

--- a/lib/features/settings/settings_locator.dart
+++ b/lib/features/settings/settings_locator.dart
@@ -5,6 +5,8 @@ import 'package:bb_mobile/features/settings/domain/repositories/payjoin_disclaim
 import 'package:bb_mobile/features/settings/domain/usecases/get_payjoin_disclaimer_shown_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/get_wallet_registration_options_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/export_signing_key_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/signing_key_account_session.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/release_signing_key_account_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/get_wallet_policy_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/mark_payjoin_disclaimer_shown_usecase.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/set_bitcoin_unit_usecase.dart';
@@ -28,11 +30,13 @@ import 'package:bb_mobile/features/settings/presentation/bloc/signing_key_export
 import 'package:bb_mobile/features/settings/presentation/bloc/wallet_details_cubit.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/wallet_registration_cubit.dart';
 import 'package:bb_mobile/features/settings/public/settings_facade.dart';
+import 'package:bb_mobile/features/settings/public/settings_entry_registry.dart';
 import 'package:bull_payjoin/bull_payjoin.dart';
 import 'package:get_it/get_it.dart';
 
 class SettingsLocator {
   static void setup(GetIt locator) {
+    locator.registerLazySingleton(SettingsEntryRegistry.new);
     // Usecases
     locator.registerFactory<SetEnvironmentUsecase>(
       () => SetEnvironmentUsecase(
@@ -128,12 +132,6 @@ class SettingsLocator {
     locator.registerFactory<WatchPayjoinPolicyUsecase>(
       () => WatchPayjoinPolicyUsecase(locator<PayjoinPolicyAccess>()),
     );
-    locator.registerFactory<ExportSigningKeyUsecase>(
-      () => ExportSigningKeyUsecase(
-        getDefaultSeedUsecase: locator(),
-        getSettingsUsecase: locator(),
-      ),
-    );
     locator.registerFactory<GetWalletPolicyUsecase>(
       () => GetWalletPolicyUsecase(bitcoinSigningPort: locator()),
     );
@@ -148,6 +146,7 @@ class SettingsLocator {
       () => SettingsFacade(
         setPayjoinEnabledUsecase: locator<SetPayjoinEnabledUsecase>(),
         watchPayjoinPolicyUsecase: locator<WatchPayjoinPolicyUsecase>(),
+        entryRegistry: locator<SettingsEntryRegistry>(),
       ),
     );
 
@@ -175,9 +174,19 @@ class SettingsLocator {
             locator<SetPayjoinExpireAfterSecUsecase>(),
       ),
     );
-    locator.registerFactory<SigningKeyExportCubit>(
-      () => SigningKeyExportCubit(exportSigningKeyUsecase: locator()),
-    );
+    locator.registerFactory<SigningKeyExportCubit>(() {
+      final accountSession = SigningKeyAccountSession(locator());
+      return SigningKeyExportCubit(
+        exportSigningKeyUsecase: ExportSigningKeyUsecase(
+          accountSession,
+          getDefaultSeedUsecase: locator(),
+          getSettingsUsecase: locator(),
+        ),
+        releaseSigningKeyAccountUsecase: ReleaseSigningKeyAccountUsecase(
+          accountSession,
+        ),
+      );
+    });
     locator.registerFactory<WalletDetailsCubit>(
       () => WalletDetailsCubit(
         getWalletPolicyUsecase: locator(),

--- a/lib/features/settings/ui/screens/bitcoin/signing_key_export_screen.dart
+++ b/lib/features/settings/ui/screens/bitcoin/signing_key_export_screen.dart
@@ -20,11 +20,13 @@ class SigningKeyExportScreen extends StatefulWidget {
 }
 
 class _SigningKeyExportScreenState extends State<SigningKeyExportScreen> {
-  bool _isAccountDirty = false;
+  int? _revealedReservedAccount;
 
-  void _setAccountDirty(bool isDirty) {
-    if (_isAccountDirty == isDirty) return;
-    setState(() => _isAccountDirty = isDirty);
+  void _selectAccount(BuildContext context, int account) {
+    if (_revealedReservedAccount != null) {
+      setState(() => _revealedReservedAccount = null);
+    }
+    context.read<SigningKeyExportCubit>().selectAccount(account);
   }
 
   @override
@@ -51,10 +53,7 @@ class _SigningKeyExportScreenState extends State<SigningKeyExportScreen> {
                   const Gap(24),
                   _SigningKeyAccountInput(
                     account: state.account,
-                    onChanged: context
-                        .read<SigningKeyExportCubit>()
-                        .selectAccount,
-                    onDirtyChanged: _setAccountDirty,
+                    onChanged: (account) => _selectAccount(context, account),
                   ),
                   const Gap(8),
                   Text(
@@ -64,6 +63,10 @@ class _SigningKeyExportScreenState extends State<SigningKeyExportScreen> {
                     ),
                   ),
                   const Gap(24),
+                  if (state.isLoading) ...[
+                    const LinearProgressIndicator(),
+                    const Gap(16),
+                  ],
                   if (state.failure case final failure?) ...[
                     InfoCard(
                       description: failure.toTranslated(context),
@@ -77,25 +80,69 @@ class _SigningKeyExportScreenState extends State<SigningKeyExportScreen> {
                       bgColor: context.appColors.primary,
                       textColor: context.appColors.onPrimary,
                     ),
-                  ] else if (!_isAccountDirty) ...[
-                    Center(
-                      child: QrDisplayWidget(
-                        data: state.descriptorKey,
-                        size: 240,
+                  ] else if (state.descriptorKey.isNotEmpty) ...[
+                    if (state.markedAccount case final markedAccount?) ...[
+                      InfoCard(
+                        description: context.loc.signingKeyExportAccountMarked(
+                          markedAccount,
+                          state.account,
+                        ),
+                        tagColor: context.appColors.secondary,
+                        bgColor: context.appColors.onSecondary,
                       ),
-                    ),
-                    const Gap(24),
-                    CopyInput(
-                      text: state.descriptorKey,
-                      canShowValueModal: true,
-                      modalTitle: context.loc.signingKeyExportTitle,
-                    ),
-                    const Gap(24),
-                    InfoCard(
-                      description: context.loc.signingKeyExportPrivacyNotice,
-                      tagColor: context.appColors.secondary,
-                      bgColor: context.appColors.onSecondary,
-                    ),
+                      const Gap(24),
+                    ],
+                    if (state.isReserved) ...[
+                      InfoCard(
+                        description: context.loc.signingKeyExportAccountUsed,
+                        tagColor: context.appColors.warning,
+                        bgColor: context.appColors.warningContainer,
+                      ),
+                      const Gap(16),
+                    ],
+                    if (!state.isReserved ||
+                        _revealedReservedAccount == state.account) ...[
+                      Center(
+                        child: QrDisplayWidget(
+                          data: state.descriptorKey,
+                          size: 240,
+                        ),
+                      ),
+                      const Gap(24),
+                      CopyInput(
+                        text: state.descriptorKey,
+                        canShowValueModal: true,
+                        modalTitle: context.loc.signingKeyExportTitle,
+                      ),
+                      const Gap(24),
+                      InfoCard(
+                        description: context.loc.signingKeyExportPrivacyNotice,
+                        tagColor: context.appColors.secondary,
+                        bgColor: context.appColors.onSecondary,
+                      ),
+                    ] else ...[
+                      BBButton.big(
+                        label: context.loc.signingKeyExportShowDetails,
+                        onPressed: () => setState(
+                          () => _revealedReservedAccount = state.account,
+                        ),
+                        bgColor: context.appColors.secondary,
+                        textColor: context.appColors.onSecondary,
+                        outlined: true,
+                        borderColor: context.appColors.secondary,
+                      ),
+                    ],
+                    if (!state.isReserved) ...[
+                      const Gap(24),
+                      BBButton.big(
+                        label: context.loc.signingKeyExportMarkUsed,
+                        onPressed: context
+                            .read<SigningKeyExportCubit>()
+                            .markAccountUsed,
+                        bgColor: context.appColors.primary,
+                        textColor: context.appColors.onPrimary,
+                      ),
+                    ],
                   ],
                 ],
               );
@@ -110,12 +157,10 @@ class _SigningKeyExportScreenState extends State<SigningKeyExportScreen> {
 class _SigningKeyAccountInput extends StatefulWidget {
   final int account;
   final ValueChanged<int> onChanged;
-  final ValueChanged<bool> onDirtyChanged;
 
   const _SigningKeyAccountInput({
     required this.account,
     required this.onChanged,
-    required this.onDirtyChanged,
   });
 
   @override
@@ -137,7 +182,7 @@ class _SigningKeyAccountInputState extends State<_SigningKeyAccountInput> {
   @override
   void didUpdateWidget(_SigningKeyAccountInput oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.account != oldWidget.account) {
+    if (widget.account != oldWidget.account && !_focusNode.hasFocus) {
       _controller.text = widget.account.toString();
     }
   }
@@ -161,10 +206,18 @@ class _SigningKeyAccountInputState extends State<_SigningKeyAccountInput> {
         account < 0 ||
         account > SigningKeyDerivation.maxAccount) {
       _controller.text = widget.account.toString();
-      widget.onDirtyChanged(false);
       return;
     }
-    widget.onDirtyChanged(false);
+    if (account != widget.account) widget.onChanged(account);
+  }
+
+  void _onChanged(String value) {
+    final account = int.tryParse(value);
+    if (account == null ||
+        account < 0 ||
+        account > SigningKeyDerivation.maxAccount) {
+      return;
+    }
     widget.onChanged(account);
   }
 
@@ -183,8 +236,7 @@ class _SigningKeyAccountInputState extends State<_SigningKeyAccountInput> {
           controller: _controller,
           focusNode: _focusNode,
           onlyNumbers: true,
-          onChanged: (value) =>
-              widget.onDirtyChanged(int.tryParse(value) != widget.account),
+          onChanged: _onChanged,
           onDone: _submit,
         ),
       ],

--- a/localization/app_en.arb
+++ b/localization/app_en.arb
@@ -14989,7 +14989,7 @@
   "@signingKeyExportAccount": {
     "description": "Label for the BIP48 account number used when exporting a signing key"
   },
-  "signingKeyExportAccountHelp": "Use a different account number when you need a separate key for another wallet.",
+  "signingKeyExportAccountHelp": "Use a different account for each separate wallet. After adding this key to a wallet, mark the account as used.",
   "@signingKeyExportAccountHelp": {
     "description": "Explains how to avoid reusing an exported signing key across wallets"
   },
@@ -15759,5 +15759,29 @@
   "copiedToClipboardMessage": "Copied to clipboard",
   "@copiedToClipboardMessage": {
     "description": "Snackbar confirmation message after copying to clipboard"
+  },
+  "signingKeyExportMarkUsed": "I used this key",
+  "@signingKeyExportMarkUsed": {
+    "description": "Action confirming that the displayed Bull signing key was added to a wallet"
+  },
+  "signingKeyExportAccountUsed": "This account is already marked as used. Reuse it only if you intend to use the same key again.",
+  "@signingKeyExportAccountUsed": {
+    "description": "Warning shown when the selected BIP48 signing-key account is already reserved"
+  },
+  "signingKeyExportAccountMarked": "Account {account} is marked as used. Account {nextAccount} is ready for another wallet.",
+  "@signingKeyExportAccountMarked": {
+    "description": "Confirmation after reserving a manually exported signing-key account",
+    "placeholders": {
+      "account": {
+        "type": "int"
+      },
+      "nextAccount": {
+        "type": "int"
+      }
+    }
+  },
+  "signingKeyExportShowDetails": "Show key details",
+  "@signingKeyExportShowDetails": {
+    "description": "Action to deliberately reveal a signing key for an account already marked as used"
   }
 }

--- a/test/core_test/wallet/data/bip48_account_repository_impl_test.dart
+++ b/test/core_test/wallet/data/bip48_account_repository_impl_test.dart
@@ -1,0 +1,452 @@
+import 'package:bb_mobile/core/storage/data/datasources/key_value_storage/key_value_storage_datasource.dart';
+import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/data/bip48_account_repository_impl.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/bip48_account_datasource.dart';
+import 'package:bb_mobile/core/wallet/domain/bip48_account_usage_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_usage.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _MemoryStorage implements KeyValueStorageDatasource<String> {
+  final Map<String, String> values = {};
+
+  @override
+  Future<void> deleteAll() async => values.clear();
+
+  @override
+  Future<void> deleteValue(String key) async => values.remove(key);
+
+  @override
+  Future<Map<String, String>> getAll() async => Map.of(values);
+
+  @override
+  Future<String?> getValue(String key) async => values[key];
+
+  @override
+  Future<bool> hasValue(String key) async => values.containsKey(key);
+
+  @override
+  Future<void> saveValue({required String key, required String value}) async {
+    values[key] = value;
+  }
+}
+
+final class _UsagePort implements Bip48AccountUsagePort {
+  final List<Bip48AccountUsage> usages;
+
+  const _UsagePort([this.usages = const []]);
+
+  @override
+  Future<List<Bip48AccountUsage>> getBip48AccountUsages() async => usages;
+}
+
+final class _SeedVerification implements SeedVerificationPort {
+  final bool matches;
+
+  const _SeedVerification({this.matches = true});
+
+  @override
+  Future<bool> matchesXpubs({
+    required String fingerprint,
+    required List<({String derivationPath, String xpub})> keys,
+  }) async => matches;
+}
+
+void main() {
+  const fingerprint = 'deadbeef';
+
+  test('reads the next account without reserving it', () async {
+    final repository = _repository(_MemoryStorage());
+
+    expect(
+      _account(
+        await repository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      0,
+    );
+    expect(
+      _account(
+        await repository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      0,
+    );
+    final reservation = await repository.isReserved(
+      seedFingerprint: fingerprint,
+      coinType: 0,
+      account: 0,
+    );
+    expect(switch (reservation) {
+      Ok(:final value) => value,
+      Err(:final failure) => throw TestFailure('$failure'),
+    }, isFalse);
+  });
+
+  test('serializes concurrent reservations within one repository', () async {
+    final storage = _MemoryStorage();
+    final repository = _repository(storage);
+
+    final reservations = await Future.wait([
+      repository.reserveNext(seedFingerprint: fingerprint, coinType: 0),
+      repository.reserveNext(seedFingerprint: fingerprint, coinType: 0),
+    ]);
+    final restored = _repository(storage);
+
+    expect(reservations.map(_account).toList()..sort(), [0, 1]);
+    expect(
+      _account(
+        await restored.reserveNext(seedFingerprint: fingerprint, coinType: 0),
+      ),
+      2,
+    );
+    expect(
+      _account(
+        await restored.reserveNext(seedFingerprint: fingerprint, coinType: 1),
+      ),
+      0,
+    );
+  });
+
+  test(
+    'reserves exact accounts without skipping lower free accounts',
+    () async {
+      final repository = _repository(_MemoryStorage());
+
+      expect(
+        await repository.reserve(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+          account: 100,
+        ),
+        isA<Ok<void, Bip48AccountAllocationFailure>>(),
+      );
+      expect(
+        await repository.reserve(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+          account: 0,
+        ),
+        isA<Ok<void, Bip48AccountAllocationFailure>>(),
+      );
+      expect(
+        _account(
+          await repository.reserveNext(
+            seedFingerprint: fingerprint,
+            coinType: 0,
+          ),
+        ),
+        1,
+      );
+    },
+  );
+
+  test('reserving an exact account is idempotent', () async {
+    final repository = _repository(_MemoryStorage());
+
+    for (var count = 0; count < 2; count++) {
+      expect(
+        await repository.reserve(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+          account: 7,
+        ),
+        isA<Ok<void, Bip48AccountAllocationFailure>>(),
+      );
+    }
+    expect(
+      _account(
+        await repository.reserveNext(seedFingerprint: fingerprint, coinType: 0),
+      ),
+      0,
+    );
+  });
+
+  test('claims block reuse until they are committed or released', () async {
+    final storage = _MemoryStorage();
+    final repository = _repository(storage);
+    final first = _claim(
+      await repository.claimNext(seedFingerprint: fingerprint, coinType: 0),
+    );
+
+    expect(first.account, 0);
+    expect(
+      _account(
+        await repository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      1,
+    );
+
+    expect(
+      await repository.releaseClaim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        claim: first,
+      ),
+      isA<Ok<void, Bip48AccountAllocationFailure>>(),
+    );
+    final replacement = _claim(
+      await repository.claimNext(seedFingerprint: fingerprint, coinType: 0),
+    );
+    expect(replacement.account, 0);
+
+    expect(
+      await repository.commitClaim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        claim: replacement,
+      ),
+      isA<Ok<void, Bip48AccountAllocationFailure>>(),
+    );
+    final restored = _repository(storage);
+    expect(
+      _account(
+        await restored.nextAvailable(seedFingerprint: fingerprint, coinType: 0),
+      ),
+      1,
+    );
+  });
+
+  test('claims an exact unreserved account without persisting it', () async {
+    final storage = _MemoryStorage();
+    final repository = _repository(storage);
+
+    final claim = _claim(
+      await repository.claim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        account: 7,
+      ),
+    );
+
+    expect(claim.account, 7);
+    expect(
+      await repository.claim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        account: 7,
+      ),
+      isA<Err<Bip48AccountClaim, Bip48AccountAllocationFailure>>(),
+    );
+    final reservation = await repository.isReserved(
+      seedFingerprint: fingerprint,
+      coinType: 0,
+      account: 7,
+    );
+    expect(switch (reservation) {
+      Ok(:final value) => value,
+      Err(:final failure) => throw TestFailure('$failure'),
+    }, isFalse);
+
+    await repository.releaseClaim(
+      seedFingerprint: fingerprint,
+      coinType: 0,
+      claim: claim,
+    );
+    expect(
+      _claim(
+        await repository.claim(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+          account: 7,
+        ),
+      ).account,
+      7,
+    );
+  });
+
+  test('an exact claim prevents automatic allocation reuse', () async {
+    final repository = _repository(_MemoryStorage());
+
+    final exactClaim = _claim(
+      await repository.claim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        account: 0,
+      ),
+    );
+    final nextClaim = _claim(
+      await repository.claimNext(seedFingerprint: fingerprint, coinType: 0),
+    );
+
+    expect(exactClaim.account, 0);
+    expect(nextClaim.account, 1);
+  });
+
+  test('stale claim owners cannot alter a replacement claim', () async {
+    final repository = _repository(_MemoryStorage());
+    final stale = _claim(
+      await repository.claimNext(seedFingerprint: fingerprint, coinType: 0),
+    );
+    await repository.releaseClaim(
+      seedFingerprint: fingerprint,
+      coinType: 0,
+      claim: stale,
+    );
+    final current = _claim(
+      await repository.claimNext(seedFingerprint: fingerprint, coinType: 0),
+    );
+
+    expect(current.account, stale.account);
+    expect(current.token, isNot(stale.token));
+    expect(
+      await repository.releaseClaim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        claim: stale,
+      ),
+      isA<Ok<void, Bip48AccountAllocationFailure>>(),
+    );
+    expect(
+      await repository.commitClaim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        claim: stale,
+      ),
+      isA<Err<void, Bip48AccountAllocationFailure>>(),
+    );
+    expect(
+      await repository.commitClaim(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        claim: current,
+      ),
+      isA<Ok<void, Bip48AccountAllocationFailure>>(),
+    );
+  });
+
+  test('unfinished claims do not consume an account after restart', () async {
+    final storage = _MemoryStorage();
+    final firstRepository = _repository(storage);
+    final claim = _claim(
+      await firstRepository.claimNext(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+      ),
+    );
+    final restartedRepository = _repository(storage);
+
+    expect(claim.account, 0);
+    expect(
+      _account(
+        await restartedRepository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      0,
+    );
+    expect(
+      await restartedRepository.reserve(
+        seedFingerprint: fingerprint,
+        coinType: 0,
+        account: claim.account,
+      ),
+      isA<Ok<void, Bip48AccountAllocationFailure>>(),
+    );
+    expect(
+      _account(
+        await restartedRepository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      1,
+    );
+  });
+
+  test(
+    'reconciles a verified persisted local account before allocation',
+    () async {
+      final storage = _MemoryStorage();
+      final repository = _repository(
+        storage,
+        usages: [
+          Bip48AccountUsage(
+            seedFingerprint: fingerprint,
+            coinType: 0,
+            account: 0,
+            derivationPath: "m/48'/0'/0'/2'",
+            xpub: 'xpub-account-0',
+          ),
+        ],
+      );
+
+      expect(
+        _account(
+          await repository.nextAvailable(
+            seedFingerprint: fingerprint,
+            coinType: 0,
+          ),
+        ),
+        1,
+      );
+      expect(
+        _account(
+          await _repository(
+            storage,
+          ).nextAvailable(seedFingerprint: fingerprint, coinType: 0),
+        ),
+        1,
+      );
+    },
+  );
+
+  test('does not trust an unverified persisted local account', () async {
+    final repository = _repository(
+      _MemoryStorage(),
+      usages: [
+        Bip48AccountUsage(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+          account: 0,
+          derivationPath: "m/48'/0'/0'/2'",
+          xpub: 'xpub-account-0',
+        ),
+      ],
+      matches: false,
+    );
+
+    expect(
+      _account(
+        await repository.nextAvailable(
+          seedFingerprint: fingerprint,
+          coinType: 0,
+        ),
+      ),
+      0,
+    );
+  });
+}
+
+Bip48AccountRepositoryImpl _repository(
+  _MemoryStorage storage, {
+  List<Bip48AccountUsage> usages = const [],
+  bool matches = true,
+}) => Bip48AccountRepositoryImpl(
+  Bip48AccountDatasource(storage),
+  _UsagePort(usages),
+  _SeedVerification(matches: matches),
+);
+
+int _account(Result<int, Bip48AccountAllocationFailure> result) =>
+    switch (result) {
+      Ok(:final value) => value,
+      Err(:final failure) => throw TestFailure('$failure'),
+    };
+
+Bip48AccountClaim _claim(
+  Result<Bip48AccountClaim, Bip48AccountAllocationFailure> result,
+) => switch (result) {
+  Ok(:final value) => value,
+  Err(:final failure) => throw TestFailure('$failure'),
+};

--- a/test/core_test/wallet/data/repositories/wallet_repository_import_test.dart
+++ b/test/core_test/wallet/data/repositories/wallet_repository_import_test.dart
@@ -178,6 +178,50 @@ void main() {
     ).thenAnswer((_) async => true);
   });
 
+  test(
+    'reports persisted BIP48 accounts for ownership reconciliation',
+    () async {
+      final local = _signer(
+        masterFingerprint: _fingerprint,
+        signer: SignerEntity.local,
+      );
+      final remote = _signer(
+        id: 'signer-1',
+        descriptorKeyId: 'key-1',
+        masterFingerprint: _secondFingerprint,
+        signer: SignerEntity.remote,
+      );
+      when(metadataDatasource.fetchAll).thenAnswer(
+        (_) async => [
+          WalletMetadataModel(
+            id: 'wallet-id',
+            network: Network.bitcoinMainnet,
+            signers: [local.toModel(), remote.toModel()],
+            isEncryptedVaultTested: false,
+            isPhysicalBackupTested: false,
+            publicDescriptor: _multisigDescriptor,
+            isDefault: false,
+          ),
+        ],
+      );
+
+      final usages = await repository.getBip48AccountUsages();
+
+      expect(usages, hasLength(2));
+      expect(
+        usages.map((usage) => usage.seedFingerprint),
+        containsAll([_fingerprint, _secondFingerprint]),
+      );
+      final localUsage = usages.firstWhere(
+        (usage) => usage.seedFingerprint == _fingerprint,
+      );
+      expect(localUsage.coinType, 0);
+      expect(localUsage.account, 0);
+      expect(localUsage.derivationPath, "m/48h/0h/0h/2h");
+      expect(localUsage.xpub, _xpub);
+    },
+  );
+
   test('imports descriptors with structured signer metadata', () async {
     final wallet = await repository.importDescriptor(
       descriptor: _multipathDescriptor,

--- a/test/core_test/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase_test.dart
+++ b/test/core_test/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase_test.dart
@@ -1,0 +1,161 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/seed/domain/seed_verification_port.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final class _AccountRepository implements Bip48AccountRepository {
+  final List<int> reservedAccounts = [];
+
+  @override
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claim({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<Bip48AccountClaim, Bip48AccountAllocationFailure>> claimNext({
+    required String seedFingerprint,
+    required int coinType,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> commitClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<bool, Bip48AccountAllocationFailure>> isReserved({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<int, Bip48AccountAllocationFailure>> nextAvailable({
+    required String seedFingerprint,
+    required int coinType,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> reserve({
+    required String seedFingerprint,
+    required int coinType,
+    required int account,
+  }) async {
+    reservedAccounts.add(account);
+    return const Ok(null);
+  }
+
+  @override
+  Future<Result<void, Bip48AccountAllocationFailure>> releaseClaim({
+    required String seedFingerprint,
+    required int coinType,
+    required Bip48AccountClaim claim,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Result<int, Bip48AccountAllocationFailure>> reserveNext({
+    required String seedFingerprint,
+    required int coinType,
+  }) => throw UnimplementedError();
+}
+
+final class _SeedVerification implements SeedVerificationPort {
+  final bool matches;
+
+  const _SeedVerification(this.matches);
+
+  @override
+  Future<bool> matchesXpubs({
+    required String fingerprint,
+    required List<({String derivationPath, String xpub})> keys,
+  }) async => matches;
+}
+
+void main() {
+  test('reserves only verified local BIP48 accounts', () async {
+    final repository = _AccountRepository();
+    final usecase = ReserveBullOwnedBip48AccountsUsecase(
+      repository,
+      const _SeedVerification(true),
+    );
+
+    final result = await usecase.execute(
+      network: Network.bitcoinMainnet,
+      signers: [_signer(account: 100, signer: SignerEntity.local)],
+    );
+
+    expect(result, isA<Ok<void, Bip48AccountAllocationFailure>>());
+    expect(repository.reservedAccounts, [100]);
+  });
+
+  test('does not reserve an account whose xpub is not seed-owned', () async {
+    final repository = _AccountRepository();
+    final usecase = ReserveBullOwnedBip48AccountsUsecase(
+      repository,
+      const _SeedVerification(false),
+    );
+
+    final result = await usecase.execute(
+      network: Network.bitcoinMainnet,
+      signers: [_signer(account: 3, signer: SignerEntity.local)],
+    );
+
+    expect(result, isA<Err<void, Bip48AccountAllocationFailure>>());
+    expect(repository.reservedAccounts, isEmpty);
+  });
+
+  test(
+    'reserves a remote signer account verified against the Bull seed',
+    () async {
+      final repository = _AccountRepository();
+      final usecase = ReserveBullOwnedBip48AccountsUsecase(
+        repository,
+        const _SeedVerification(true),
+      );
+
+      final result = await usecase.execute(
+        network: Network.bitcoinMainnet,
+        signers: [_signer(account: 3, signer: SignerEntity.remote)],
+      );
+
+      expect(result, isA<Ok<void, Bip48AccountAllocationFailure>>());
+      expect(repository.reservedAccounts, [3]);
+    },
+  );
+
+  test('ignores a remote signer account not owned by the Bull seed', () async {
+    final repository = _AccountRepository();
+    final usecase = ReserveBullOwnedBip48AccountsUsecase(
+      repository,
+      const _SeedVerification(false),
+    );
+
+    final result = await usecase.execute(
+      network: Network.bitcoinMainnet,
+      signers: [_signer(account: 3, signer: SignerEntity.remote)],
+    );
+
+    expect(result, isA<Ok<void, Bip48AccountAllocationFailure>>());
+    expect(repository.reservedAccounts, isEmpty);
+  });
+}
+
+WalletSigner _signer({required int account, required SignerEntity signer}) =>
+    WalletSigner.single(
+      masterFingerprint: 'deadbeef',
+      xpubFingerprint: 'cafebabe',
+      xpub: 'xpub-account-$account',
+      derivationPath: "m/48'/0'/$account'/2'",
+      signer: signer,
+      signerDevice: null,
+    );

--- a/test/features/import_watch_only_wallet/import_watch_only_descriptor_usecase_test.dart
+++ b/test/features/import_watch_only_wallet/import_watch_only_descriptor_usecase_test.dart
@@ -3,6 +3,8 @@ import 'package:bb_mobile/core/entities/signer_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/domain/import_watch_only_failure.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_descriptor_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
@@ -12,14 +14,33 @@ import 'package:mocktail/mocktail.dart';
 class _MockBitcoinDescriptorPort extends Mock
     implements BitcoinDescriptorPort {}
 
+class _MockReserveBullOwnedBip48AccountsUsecase extends Mock
+    implements ReserveBullOwnedBip48AccountsUsecase {}
+
+class _MockDeleteWalletUsecase extends Mock implements DeleteWalletUsecase {}
+
 void main() {
   late _MockBitcoinDescriptorPort descriptorPort;
+  late _MockReserveBullOwnedBip48AccountsUsecase reserveAccounts;
+  late _MockDeleteWalletUsecase deleteWallet;
   late ImportWatchOnlyDescriptorUsecase usecase;
   late WatchOnlyDescriptorEntity entity;
 
   setUp(() {
     descriptorPort = _MockBitcoinDescriptorPort();
-    usecase = ImportWatchOnlyDescriptorUsecase(descriptorPort);
+    reserveAccounts = _MockReserveBullOwnedBip48AccountsUsecase();
+    deleteWallet = _MockDeleteWalletUsecase();
+    when(
+      () => reserveAccounts.execute(
+        network: Network.bitcoinMainnet,
+        signers: any(named: 'signers'),
+      ),
+    ).thenAnswer((_) async => const Ok(null));
+    usecase = ImportWatchOnlyDescriptorUsecase(
+      descriptorPort,
+      reserveAccounts,
+      deleteWallet,
+    );
     entity =
         WatchOnlyWalletEntity.descriptor(
               descriptor: 'wpkh(xpub/<0;1>/*)',
@@ -58,10 +79,17 @@ void main() {
       expect(failure, isA<ImportFailedFailure>());
       // The sanitized failure carries no raw reason for the UI to render.
       expect(failure.logMessage, isNull);
+      verifyNever(
+        () => reserveAccounts.execute(
+          network: entity.network,
+          signers: entity.signers,
+        ),
+      );
     });
 
     test('returns Ok with the wallet on success', () async {
       final wallet = _MockWallet();
+      final events = <String>[];
       when(
         () => descriptorPort.importDescriptor(
           descriptor: entity.descriptor,
@@ -69,7 +97,19 @@ void main() {
           label: entity.label,
           signers: entity.signers,
         ),
-      ).thenAnswer((_) async => wallet);
+      ).thenAnswer((_) async {
+        events.add('import');
+        return wallet;
+      });
+      when(
+        () => reserveAccounts.execute(
+          network: entity.network,
+          signers: entity.signers,
+        ),
+      ).thenAnswer((_) async {
+        events.add('reserve');
+        return const Ok(null);
+      });
 
       final result = await usecase.execute(watchOnlyDescriptor: entity);
 
@@ -78,6 +118,13 @@ void main() {
         (result as Ok<Wallet, ImportWatchOnlyFailure>).value,
         same(wallet),
       );
+      verify(
+        () => reserveAccounts.execute(
+          network: entity.network,
+          signers: entity.signers,
+        ),
+      ).called(1);
+      expect(events, ['import', 'reserve']);
     });
   });
 }

--- a/test/features/import_watch_only_wallet/import_watch_only_xpub_usecase_test.dart
+++ b/test/features/import_watch_only_wallet/import_watch_only_xpub_usecase_test.dart
@@ -1,6 +1,8 @@
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/bitcoin_descriptor_port.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/delete_wallet_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/domain/import_watch_only_failure.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/import_watch_only_xpub_usecase.dart';
 import 'package:bb_mobile/features/import_watch_only_wallet/watch_only_wallet_entity.dart';
@@ -10,6 +12,11 @@ import 'package:mocktail/mocktail.dart';
 class _MockBitcoinDescriptorPort extends Mock
     implements BitcoinDescriptorPort {}
 
+class _MockReserveBullOwnedBip48AccountsUsecase extends Mock
+    implements ReserveBullOwnedBip48AccountsUsecase {}
+
+class _MockDeleteWalletUsecase extends Mock implements DeleteWalletUsecase {}
+
 class _MockWallet extends Mock implements Wallet {}
 
 const _xpub =
@@ -17,12 +24,26 @@ const _xpub =
 
 void main() {
   late _MockBitcoinDescriptorPort descriptorPort;
+  late _MockReserveBullOwnedBip48AccountsUsecase reserveAccounts;
+  late _MockDeleteWalletUsecase deleteWallet;
   late ImportWatchOnlyXpubUsecase usecase;
   late WatchOnlyXpubEntity entity;
 
   setUp(() {
     descriptorPort = _MockBitcoinDescriptorPort();
-    usecase = ImportWatchOnlyXpubUsecase(descriptorPort);
+    reserveAccounts = _MockReserveBullOwnedBip48AccountsUsecase();
+    deleteWallet = _MockDeleteWalletUsecase();
+    when(
+      () => reserveAccounts.execute(
+        network: Network.bitcoinMainnet,
+        signers: any(named: 'signers'),
+      ),
+    ).thenAnswer((_) async => const Ok(null));
+    usecase = ImportWatchOnlyXpubUsecase(
+      descriptorPort,
+      reserveAccounts,
+      deleteWallet,
+    );
     entity =
         const WatchOnlyWalletEntity.xpub(
               extendedPublicKey: _xpub,
@@ -50,17 +71,36 @@ void main() {
       final failure = (result as Err<Wallet, ImportWatchOnlyFailure>).failure;
       expect(failure, isA<ImportFailedFailure>());
       expect(failure.logMessage, isNull);
+      verifyNever(
+        () => reserveAccounts.execute(
+          network: entity.network,
+          signers: any(named: 'signers'),
+        ),
+      );
     });
 
     test('imports the xpub through a two-path descriptor', () async {
       final wallet = _MockWallet();
+      final events = <String>[];
       when(
         () => descriptorPort.importDescriptor(
           descriptor: any(named: 'descriptor'),
           network: Network.bitcoinMainnet,
           label: 'My xpub wallet',
         ),
-      ).thenAnswer((_) async => wallet);
+      ).thenAnswer((_) async {
+        events.add('import');
+        return wallet;
+      });
+      when(
+        () => reserveAccounts.execute(
+          network: Network.bitcoinMainnet,
+          signers: any(named: 'signers'),
+        ),
+      ).thenAnswer((_) async {
+        events.add('reserve');
+        return const Ok(null);
+      });
 
       final result = await usecase.execute(watchOnlyXpub: entity);
 
@@ -80,6 +120,7 @@ void main() {
         (result as Ok<Wallet, ImportWatchOnlyFailure>).value,
         same(wallet),
       );
+      expect(events, ['import', 'reserve']);
     });
 
     test('preserves a fingerprint-only origin', () async {

--- a/test/features/settings/domain/usecases/export_signing_key_usecase_test.dart
+++ b/test/features/settings/domain/usecases/export_signing_key_usecase_test.dart
@@ -5,8 +5,13 @@ import 'package:bb_mobile/core/seed/domain/usecases/get_default_seed_usecase.dar
 import 'package:bb_mobile/core/settings/domain/get_settings_usecase.dart';
 import 'package:bb_mobile/core/settings/domain/settings_entity.dart';
 import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/bip48_account_claim.dart';
+import 'package:bb_mobile/core/wallet/domain/repositories/bip48_account_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_failure.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
+import 'package:bb_mobile/features/settings/domain/signing_key_account_session.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/export_signing_key_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/release_signing_key_account_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -15,26 +20,80 @@ class _MockGetDefaultSeedUsecase extends Mock
 
 class _MockGetSettingsUsecase extends Mock implements GetSettingsUsecase {}
 
+class _MockBip48AccountRepository extends Mock
+    implements Bip48AccountRepository {}
+
 void main() {
   late _MockGetDefaultSeedUsecase getDefaultSeed;
   late _MockGetSettingsUsecase getSettings;
+  late _MockBip48AccountRepository accountRepository;
   late ExportSigningKeyUsecase usecase;
+  late ReleaseSigningKeyAccountUsecase releaseUsecase;
 
   final seed = Seed.bytes(
     bytes: Uint8List.fromList(List<int>.generate(32, (index) => index)),
     masterFingerprint: '5A3469B6',
   );
 
+  setUpAll(() {
+    registerFallbackValue(
+      const Bip48AccountClaim(account: 0, token: 'fallback'),
+    );
+  });
+
   setUp(() {
     getDefaultSeed = _MockGetDefaultSeedUsecase();
     getSettings = _MockGetSettingsUsecase();
+    accountRepository = _MockBip48AccountRepository();
+    final accountSession = SigningKeyAccountSession(accountRepository);
     usecase = ExportSigningKeyUsecase(
+      accountSession,
       getDefaultSeedUsecase: getDefaultSeed,
       getSettingsUsecase: getSettings,
     );
+    releaseUsecase = ReleaseSigningKeyAccountUsecase(accountSession);
     when(
       () => getDefaultSeed.execute(environment: any(named: 'environment')),
     ).thenAnswer((_) async => seed);
+    when(
+      () => accountRepository.claimNext(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+      ),
+    ).thenAnswer(
+      (_) async => const Ok(Bip48AccountClaim(account: 0, token: 'next')),
+    );
+    when(
+      () => accountRepository.isReserved(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+        account: any(named: 'account'),
+      ),
+    ).thenAnswer((_) async => const Ok(false));
+    when(
+      () => accountRepository.claim(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+        account: any(named: 'account'),
+      ),
+    ).thenAnswer((invocation) async {
+      final account = invocation.namedArguments[#account]! as int;
+      return Ok(Bip48AccountClaim(account: account, token: 'exact-$account'));
+    });
+    when(
+      () => accountRepository.releaseClaim(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+        claim: any(named: 'claim'),
+      ),
+    ).thenAnswer((_) async => const Ok(null));
+    when(
+      () => accountRepository.commitClaim(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+        claim: any(named: 'claim'),
+      ),
+    ).thenAnswer((_) async => const Ok(null));
   });
 
   test('exports the compatibility signing key on mainnet', () async {
@@ -46,44 +105,135 @@ void main() {
       ),
     );
 
-    final result = await usecase.execute(account: 0);
+    final result = await usecase.execute();
 
-    expect(result, isA<Ok<String, SettingsFailure>>());
-    final descriptorKey = (result as Ok<String, SettingsFailure>).value;
+    expect(result, isA<Ok>());
+    final export = (result as Ok).value;
     expect(
-      descriptorKey,
+      export.descriptorKey,
       '[5a3469b6/48h/0h/0h/2h]'
       'xpub6ECRn8ehyKtWTtyqrmt8Dt5Vs7VSbh9Y8Zcyq7vcLEufmoo86VxqdYBEHEtt'
       '3H342PrmAiUyUkdNiFzdmGNEyUg7xLYt922WvfMEn2h8pnR',
     );
+    expect(export.account, 0);
+    expect(export.isReserved, isFalse);
+    expect(export.markedAccount, isNull);
     verify(
       () => getDefaultSeed.execute(environment: Environment.mainnet),
     ).called(1);
+    verify(
+      () => accountRepository.claimNext(
+        seedFingerprint: seed.masterFingerprint,
+        coinType: 0,
+      ),
+    ).called(1);
+    verifyNever(
+      () => accountRepository.commitClaim(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+        claim: any(named: 'claim'),
+      ),
+    );
   });
 
-  test(
-    'exports the testnet compatibility key for the selected account',
-    () async {
-      when(() => getSettings.execute()).thenAnswer(
-        (_) async => const SettingsEntity(
-          environment: Environment.testnet,
-          bitcoinUnit: BitcoinUnit.sats,
-          currencyCode: 'USD',
-        ),
-      );
+  test('exports an explicitly selected testnet account', () async {
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.testnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+      ),
+    );
 
-      final result = await usecase.execute(account: 7);
+    final result = await usecase.execute(account: 7);
 
-      expect(result, isA<Ok<String, SettingsFailure>>());
-      expect(
-        (result as Ok<String, SettingsFailure>).value,
-        startsWith('[5a3469b6/48h/1h/7h/2h]tpub'),
-      );
-      verify(
-        () => getDefaultSeed.execute(environment: Environment.testnet),
-      ).called(1);
-    },
-  );
+    expect(result, isA<Ok>());
+    expect(
+      (result as Ok).value.descriptorKey,
+      startsWith('[5a3469b6/48h/1h/7h/2h]tpub'),
+    );
+    verify(
+      () => getDefaultSeed.execute(environment: Environment.testnet),
+    ).called(1);
+  });
+
+  test('exports an already reserved account with a reuse warning', () async {
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+      ),
+    );
+    when(
+      () => accountRepository.isReserved(
+        seedFingerprint: seed.masterFingerprint,
+        coinType: 0,
+        account: 7,
+      ),
+    ).thenAnswer((_) async => const Ok(true));
+
+    final result = await usecase.execute(account: 7);
+
+    expect(result, isA<Ok>());
+    final export = (result as Ok).value;
+    expect(export.account, 7);
+    expect(export.descriptorKey, startsWith('[5a3469b6/48h/0h/7h/2h]xpub'));
+    expect(export.isReserved, isTrue);
+  });
+
+  test('releases an unconfirmed export claim', () async {
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+      ),
+    );
+
+    expect(await usecase.execute(account: 7), isA<Ok>());
+    expect(await releaseUsecase.execute(), isA<Ok>());
+
+    final released =
+        verify(
+              () => accountRepository.releaseClaim(
+                seedFingerprint: seed.masterFingerprint,
+                coinType: 0,
+                claim: captureAny(named: 'claim'),
+              ),
+            ).captured.single
+            as Bip48AccountClaim;
+    expect((released.account, released.token), (7, 'exact-7'));
+  });
+
+  test('marks an exported account and returns the next suggestion', () async {
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+      ),
+    );
+    expect(await usecase.execute(account: 7), isA<Ok>());
+
+    final result = await usecase.execute(account: 7, markUsed: true);
+
+    expect(result, isA<Ok>());
+    final export = (result as Ok).value;
+    expect(export.account, 0);
+    expect(export.markedAccount, 7);
+    expect(export.descriptorKey, isNotEmpty);
+    final committed =
+        verify(
+              () => accountRepository.commitClaim(
+                seedFingerprint: seed.masterFingerprint,
+                coinType: 0,
+                claim: captureAny(named: 'claim'),
+              ),
+            ).captured.single
+            as Bip48AccountClaim;
+    expect((committed.account, committed.token), (7, 'exact-7'));
+  });
 
   test('maps seed lookup errors to a settings failure', () async {
     when(
@@ -97,12 +247,29 @@ void main() {
       ),
     );
 
-    final result = await usecase.execute(account: 0);
+    final result = await usecase.execute();
 
-    expect(result, isA<Err<String, SettingsFailure>>());
-    expect(
-      (result as Err<String, SettingsFailure>).failure,
-      isA<SettingsSigningKeyExportFailure>(),
+    expect(result, isA<Err>());
+    expect((result as Err).failure, isA<SettingsSigningKeyExportFailure>());
+  });
+
+  test('maps account lookup failures to a settings failure', () async {
+    when(() => getSettings.execute()).thenAnswer(
+      (_) async => const SettingsEntity(
+        environment: Environment.mainnet,
+        bitcoinUnit: BitcoinUnit.sats,
+        currencyCode: 'USD',
+      ),
     );
+    when(
+      () => accountRepository.claimNext(
+        seedFingerprint: any(named: 'seedFingerprint'),
+        coinType: any(named: 'coinType'),
+      ),
+    ).thenAnswer((_) async => const Err(Bip48AccountAllocationFailure()));
+
+    final result = await usecase.execute();
+
+    expect((result as Err).failure, isA<SettingsSigningKeyExportFailure>());
   });
 }

--- a/test/features/settings/presentation/bloc/signing_key_export_cubit_test.dart
+++ b/test/features/settings/presentation/bloc/signing_key_export_cubit_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/features/settings/domain/settings_failure.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/export_signing_key_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/release_signing_key_account_usecase.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/signing_key_export_cubit.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,47 +11,208 @@ import 'package:mocktail/mocktail.dart';
 class _MockExportSigningKeyUsecase extends Mock
     implements ExportSigningKeyUsecase {}
 
+class _MockReleaseSigningKeyAccountUsecase extends Mock
+    implements ReleaseSigningKeyAccountUsecase {}
+
 void main() {
   late _MockExportSigningKeyUsecase exportSigningKey;
+  late _MockReleaseSigningKeyAccountUsecase releaseSigningKeyAccount;
   late SigningKeyExportCubit cubit;
 
   setUp(() {
     exportSigningKey = _MockExportSigningKeyUsecase();
-    cubit = SigningKeyExportCubit(exportSigningKeyUsecase: exportSigningKey);
+    releaseSigningKeyAccount = _MockReleaseSigningKeyAccountUsecase();
+    when(
+      releaseSigningKeyAccount.execute,
+    ).thenAnswer((_) async => const Ok(null));
+    cubit = SigningKeyExportCubit(
+      exportSigningKeyUsecase: exportSigningKey,
+      releaseSigningKeyAccountUsecase: releaseSigningKeyAccount,
+    );
   });
 
   tearDown(() => cubit.close());
 
   test('loads the signing key', () async {
     when(
-      () => exportSigningKey.execute(account: 0),
-    ).thenAnswer((_) async => const Ok('signing-key'));
+      () => exportSigningKey.execute(account: null, markUsed: false),
+    ).thenAnswer(
+      (_) async => const Ok((
+        account: 0,
+        descriptorKey: 'signing-key',
+        isReserved: false,
+        markedAccount: null,
+      )),
+    );
 
     await cubit.load();
 
     expect(cubit.state.descriptorKey, 'signing-key');
+    expect(cubit.state.account, 0);
     expect(cubit.state.failure, isNull);
   });
 
-  test('selecting an account replaces the displayed key', () async {
+  test('exports an explicitly selected account', () async {
     when(
-      () => exportSigningKey.execute(account: 7),
-    ).thenAnswer((_) async => const Ok('account-7-key'));
+      () => exportSigningKey.execute(account: 7, markUsed: false),
+    ).thenAnswer(
+      (_) async => const Ok((
+        account: 7,
+        descriptorKey: 'signing-key-7',
+        isReserved: false,
+        markedAccount: null,
+      )),
+    );
 
     await cubit.selectAccount(7);
 
     expect(cubit.state.account, 7);
-    expect(cubit.state.descriptorKey, 'account-7-key');
+    expect(cubit.state.descriptorKey, 'signing-key-7');
+  });
+
+  test('clears the previous key while a different account loads', () async {
+    final delayed = Completer<void>();
+    when(
+      () => exportSigningKey.execute(account: null, markUsed: false),
+    ).thenAnswer(
+      (_) async => const Ok((
+        account: 0,
+        descriptorKey: 'signing-key-0',
+        isReserved: false,
+        markedAccount: null,
+      )),
+    );
+    when(
+      () => exportSigningKey.execute(account: 1, markUsed: false),
+    ).thenAnswer((_) async {
+      await delayed.future;
+      return const Ok((
+        account: 1,
+        descriptorKey: 'signing-key-1',
+        isReserved: false,
+        markedAccount: null,
+      ));
+    });
+
+    await cubit.load();
+    final selection = cubit.selectAccount(1);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(cubit.state.account, 1);
+    expect(cubit.state.isLoading, isTrue);
+    expect(cubit.state.descriptorKey, isEmpty);
+
+    await cubit.markAccountUsed();
+    verifyNever(() => exportSigningKey.execute(account: 1, markUsed: true));
+
+    delayed.complete();
+    await selection;
+    expect(cubit.state.descriptorKey, 'signing-key-1');
+  });
+
+  test(
+    'keeps the latest selection when returning to the displayed account',
+    () async {
+      final accountOne = Completer<void>();
+      when(
+        () => exportSigningKey.execute(account: 1, markUsed: false),
+      ).thenAnswer((_) async {
+        await accountOne.future;
+        return const Ok((
+          account: 1,
+          descriptorKey: 'signing-key-1',
+          isReserved: false,
+          markedAccount: null,
+        ));
+      });
+      when(
+        () => exportSigningKey.execute(account: 0, markUsed: false),
+      ).thenAnswer(
+        (_) async => const Ok((
+          account: 0,
+          descriptorKey: 'signing-key-0',
+          isReserved: false,
+          markedAccount: null,
+        )),
+      );
+
+      final selectOne = cubit.selectAccount(1);
+      await Future<void>.delayed(Duration.zero);
+      await cubit.selectAccount(0);
+      accountOne.complete();
+      await selectOne;
+
+      expect(cubit.state.account, 0);
+      expect(cubit.state.descriptorKey, 'signing-key-0');
+    },
+  );
+
+  test(
+    'marks the selected account and advances to the next suggestion',
+    () async {
+      when(
+        () => exportSigningKey.execute(account: null, markUsed: false),
+      ).thenAnswer(
+        (_) async => const Ok((
+          account: 0,
+          descriptorKey: 'signing-key-0',
+          isReserved: false,
+          markedAccount: null,
+        )),
+      );
+      when(
+        () => exportSigningKey.execute(account: 0, markUsed: true),
+      ).thenAnswer(
+        (_) async => const Ok((
+          account: 1,
+          descriptorKey: 'signing-key-1',
+          isReserved: false,
+          markedAccount: 0,
+        )),
+      );
+
+      await cubit.load();
+      await cubit.markAccountUsed();
+
+      expect(cubit.state.account, 1);
+      expect(cubit.state.markedAccount, 0);
+      expect(cubit.state.descriptorKey, 'signing-key-1');
+    },
+  );
+
+  test('exports a reserved selection with its warning state', () async {
+    when(
+      () => exportSigningKey.execute(account: 7, markUsed: false),
+    ).thenAnswer(
+      (_) async => const Ok((
+        account: 7,
+        descriptorKey: 'signing-key-7',
+        isReserved: true,
+        markedAccount: null,
+      )),
+    );
+
+    await cubit.selectAccount(7);
+
+    expect(cubit.state.account, 7);
+    expect(cubit.state.isReserved, isTrue);
+    expect(cubit.state.descriptorKey, 'signing-key-7');
   });
 
   test('holds a typed failure when export fails', () async {
     when(
-      () => exportSigningKey.execute(account: any(named: 'account')),
+      () => exportSigningKey.execute(account: null, markUsed: false),
     ).thenAnswer((_) async => const Err(SettingsSigningKeyExportFailure()));
 
     await cubit.load();
 
     expect(cubit.state.descriptorKey, isEmpty);
     expect(cubit.state.failure, isA<SettingsSigningKeyExportFailure>());
+  });
+
+  test('releases the displayed account when closed', () async {
+    await cubit.close();
+
+    verify(releaseSigningKeyAccount.execute).called(1);
   });
 }

--- a/test/features/settings/ui/signing_key_export_screen_test.dart
+++ b/test/features/settings/ui/signing_key_export_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:bb_mobile/core/themes/app_theme.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/widgets/qr_display_widget.dart';
 import 'package:bb_mobile/features/settings/domain/usecases/export_signing_key_usecase.dart';
+import 'package:bb_mobile/features/settings/domain/usecases/release_signing_key_account_usecase.dart';
 import 'package:bb_mobile/features/settings/presentation/bloc/signing_key_export_cubit.dart';
 import 'package:bb_mobile/features/settings/ui/screens/bitcoin/signing_key_export_screen.dart';
 import 'package:bb_mobile/generated/l10n/localization.dart';
@@ -13,17 +14,44 @@ import 'package:mocktail/mocktail.dart';
 class _MockExportSigningKeyUsecase extends Mock
     implements ExportSigningKeyUsecase {}
 
+class _MockReleaseSigningKeyAccountUsecase extends Mock
+    implements ReleaseSigningKeyAccountUsecase {}
+
 void main() {
-  testWidgets('keeps an account edit until it is submitted', (tester) async {
+  testWidgets('shows the suggested account and keeps submitted edits', (
+    tester,
+  ) async {
     final exportSigningKey = _MockExportSigningKeyUsecase();
+    final releaseSigningKeyAccount = _MockReleaseSigningKeyAccountUsecase();
     when(
-      () => exportSigningKey.execute(account: any(named: 'account')),
+      releaseSigningKeyAccount.execute,
+    ).thenAnswer((_) async => const Ok(null));
+    when(
+      () => exportSigningKey.execute(
+        account: any(named: 'account'),
+        markUsed: any(named: 'markUsed'),
+      ),
     ).thenAnswer((invocation) async {
-      final account = invocation.namedArguments[#account] as int;
-      return Ok('signing-key-$account');
+      final account = invocation.namedArguments[#account] as int? ?? 0;
+      final markUsed = invocation.namedArguments[#markUsed] as bool;
+      if (markUsed) {
+        return Ok((
+          account: 1,
+          descriptorKey: 'signing-key-1',
+          isReserved: false,
+          markedAccount: account,
+        ));
+      }
+      return Ok((
+        account: account,
+        descriptorKey: 'signing-key-$account',
+        isReserved: false,
+        markedAccount: null,
+      ));
     });
     final cubit = SigningKeyExportCubit(
       exportSigningKeyUsecase: exportSigningKey,
+      releaseSigningKeyAccountUsecase: releaseSigningKeyAccount,
     );
     addTearDown(cubit.close);
     await cubit.load();
@@ -40,6 +68,12 @@ void main() {
       ),
     );
 
+    expect(find.byType(TextField), findsOneWidget);
+    expect(cubit.state.account, 0);
+    expect(cubit.state.descriptorKey, 'signing-key-0');
+    expect(find.text('0'), findsOneWidget);
+    expect(find.byType(QrDisplayWidget), findsOneWidget);
+
     await tester.enterText(find.byType(TextField), '12');
     await tester.pump();
 
@@ -47,13 +81,68 @@ void main() {
       tester.widget<TextField>(find.byType(TextField)).controller?.text,
       '12',
     );
-    expect(find.byType(QrDisplayWidget), findsNothing);
-
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(cubit.state.account, 12);
     expect(cubit.state.descriptorKey, 'signing-key-12');
     expect(find.byType(QrDisplayWidget), findsOneWidget);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -600));
+    await tester.pumpAndSettle();
+    final markUsed = find.text('I used this key').first;
+    await tester.tap(markUsed);
+    await tester.pump();
+
+    expect(cubit.state.account, 1);
+    expect(cubit.state.markedAccount, 12);
+    expect(find.textContaining('Account 12 is marked as used'), findsOneWidget);
+  });
+
+  testWidgets('warns before showing a reserved account key', (tester) async {
+    final exportSigningKey = _MockExportSigningKeyUsecase();
+    final releaseSigningKeyAccount = _MockReleaseSigningKeyAccountUsecase();
+    when(
+      releaseSigningKeyAccount.execute,
+    ).thenAnswer((_) async => const Ok(null));
+    when(
+      () => exportSigningKey.execute(
+        account: any(named: 'account'),
+        markUsed: any(named: 'markUsed'),
+      ),
+    ).thenAnswer(
+      (_) async => const Ok((
+        account: 7,
+        descriptorKey: 'reserved-signing-key',
+        isReserved: true,
+        markedAccount: null,
+      )),
+    );
+    final cubit = SigningKeyExportCubit(
+      exportSigningKeyUsecase: exportSigningKey,
+      releaseSigningKeyAccountUsecase: releaseSigningKeyAccount,
+    );
+    addTearDown(cubit.close);
+    await cubit.load();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.themeData(AppThemeType.light),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BlocProvider.value(
+          value: cubit,
+          child: const SigningKeyExportScreen(),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('already marked as used'), findsOneWidget);
+    expect(find.byType(QrDisplayWidget), findsNothing);
+
+    await tester.tap(find.text('Show key details'));
+    await tester.pump();
+
+    expect(find.byType(QrDisplayWidget), findsOneWidget);
+    expect(find.text('I used this key'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

- persist exact BIP48 account reservations per Bull seed fingerprint and Bitcoin coin type
- suggest the lowest unused account for Bull signer exports while preserving explicit account selection
- reserve manual exports only after explicit confirmation and reserve wallet accounts after verified creation or import
- cryptographically verify Bull-owned account xpubs before recording descriptor usage
- keep reservations after wallet deletion so exposed account keys are never silently reused

## Validation

- whole-project analysis, formatting, fix, and boundary checks
- root Flutter test suite
- focused wallet, signing-key export, and watch-only import tests

## Stack

Draft stacked on #2726.