### PR TITLE
feat(backup): verify a specific seed backup

### DIFF
--- a/lib/core/recoverbull/domain/usecases/create_encrypted_vault_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/create_encrypted_vault_usecase.dart
@@ -27,9 +27,12 @@ class CreateEncryptedVaultUsecase {
   // repo. The local try/catch is the boundary for the wallet/seed calls; the
   // recoverbull repo already returns a Result that we forward.
   Future<
-    Result<({EncryptedVault vault, String vaultKey}), RecoverBullCoreFailure>
+    Result<
+      ({EncryptedVault vault, String vaultKey, String walletId}),
+      RecoverBullCoreFailure
+    >
   >
-  execute() async {
+  execute({String? fingerprint}) async {
     try {
       final defaultBitcoinWallets = await _walletRepository.getWallets(
         onlyBitcoin: true,
@@ -43,11 +46,13 @@ class CreateEncryptedVaultUsecase {
       }
 
       // The default wallet is used to derive the backup key
-      final defaultWallet = defaultBitcoinWallets.first;
-      await _walletRepository.updateEncryptedBackupTime(
-        time: DateTime.now(),
-        walletId: defaultWallet.id,
-      );
+      final defaultWallet = fingerprint == null
+          ? defaultBitcoinWallets.first
+          : defaultBitcoinWallets.firstWhere(
+              (wallet) => wallet.localMasterFingerprints.any(
+                (value) => value.toLowerCase() == fingerprint.toLowerCase(),
+              ),
+            );
       final defaultSeed = await _seedRepository.get(
         defaultWallet.masterFingerprint,
       );
@@ -90,7 +95,10 @@ class CreateEncryptedVaultUsecase {
             plaintext: plaintext,
             derivationPath: derivationPath,
           )
-          .map((vault) => (vault: vault, vaultKey: backupKey));
+          .map(
+            (vault) =>
+                (vault: vault, vaultKey: backupKey, walletId: defaultWallet.id),
+          );
     } catch (e, st) {
       log.severe(message: 'createEncryptedVault failed', error: e, trace: st);
       return Err(RecoverBullUnexpectedCoreFailure(e.toString()));

--- a/lib/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart
+++ b/lib/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart
@@ -1,0 +1,31 @@
+import 'package:bb_mobile/core/recoverbull/domain/recoverbull_failure.dart';
+import 'package:bb_mobile/core/utils/result.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_backup_metadata_port.dart';
+import 'package:bull_logger/bull_logger.dart';
+
+class RecordEncryptedBackupCreatedUsecase {
+  final WalletBackupMetadataPort _walletBackupMetadataPort;
+
+  const RecordEncryptedBackupCreatedUsecase(this._walletBackupMetadataPort);
+
+  Future<Result<Null, RecoverBullCoreFailure>> execute({
+    required String walletId,
+  }) async {
+    try {
+      await _walletBackupMetadataPort.recordEncryptedBackupCreated(
+        walletId: walletId,
+        time: DateTime.now(),
+      );
+      return const Ok(null);
+    } catch (e, st) {
+      log.severe(
+        message: 'recordEncryptedBackupCreated failed',
+        error: e,
+        trace: st,
+      );
+      return const Err(
+        RecoverBullUnexpectedCoreFailure('Could not record backup creation'),
+      );
+    }
+  }
+}

--- a/lib/core/recoverbull/recoverbull_locator.dart
+++ b/lib/core/recoverbull/recoverbull_locator.dart
@@ -21,6 +21,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_la
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_vault_from_drive_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/save_to_google_drive_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/pick_vault_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_recoverbull_url_usecase.dart';
@@ -31,6 +32,7 @@ import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/domain/repositories/settings_repository.dart';
 import 'package:bb_mobile/core/storage/sqlite_database.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_backup_metadata_port.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/create_default_wallets_usecase.dart';
 import 'package:get_it/get_it.dart';
 import 'package:bull_tor/tor.dart';
@@ -89,6 +91,11 @@ class RecoverbullLocator {
         seedRepository: locator<SeedRepository>(),
         walletRepository: locator<WalletRepository>(),
         recoverBullRepository: locator<RecoverBullRepository>(),
+      ),
+    );
+    locator.registerFactory<RecordEncryptedBackupCreatedUsecase>(
+      () => RecordEncryptedBackupCreatedUsecase(
+        locator<WalletBackupMetadataPort>(),
       ),
     );
     locator.registerFactory<ConnectToGoogleDriveUsecase>(

--- a/lib/core/wallet/data/repositories/wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/wallet_repository.dart
@@ -27,6 +27,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_balances.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_descriptor_key.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_backup_metadata_port.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_error.dart';
 import 'package:bb_mobile/core/wallet/domain/wallet_signer_device_port.dart';
 import 'package:bb_mobile/core/wallet/wallet_metadata_service.dart';
@@ -36,6 +37,7 @@ import 'package:crypto/crypto.dart';
 class WalletRepository
     implements
         BitcoinDescriptorPort,
+        WalletBackupMetadataPort,
         WalletSignerDevicePort,
         Bip48AccountUsagePort {
   final WalletMetadataDatasource _walletMetadataDatasource;
@@ -364,6 +366,22 @@ class WalletRepository
         latestEncryptedBackup: time?.millisecondsSinceEpoch,
         isEncryptedVaultTested: time != null,
       ),
+    );
+  }
+
+  @override
+  Future<void> recordEncryptedBackupCreated({
+    required DateTime time,
+    required String walletId,
+  }) async {
+    final metadata = await _walletMetadataDatasource.fetch(walletId);
+
+    if (metadata == null) {
+      throw WalletError.notFound(walletId);
+    }
+
+    await _walletMetadataDatasource.store(
+      metadata.copyWith(latestEncryptedBackup: time.millisecondsSinceEpoch),
     );
   }
 

--- a/lib/core/wallet/domain/wallet_backup_metadata_port.dart
+++ b/lib/core/wallet/domain/wallet_backup_metadata_port.dart
@@ -1,0 +1,6 @@
+abstract interface class WalletBackupMetadataPort {
+  Future<void> recordEncryptedBackupCreated({
+    required String walletId,
+    required DateTime time,
+  });
+}

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -41,6 +41,7 @@ import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallet_utxos_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/wallet_backup_metadata_port.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bip48_account_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/reserve_bull_owned_bip48_accounts_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/sync_wallet_usecase.dart';
@@ -116,6 +117,9 @@ class WalletLocator {
       ),
     );
     locator.registerLazySingleton<BitcoinDescriptorPort>(
+      () => locator<WalletRepository>(),
+    );
+    locator.registerLazySingleton<WalletBackupMetadataPort>(
       () => locator<WalletRepository>(),
     );
     locator.registerLazySingleton<WalletSignerDevicePort>(

--- a/lib/core/widgets/backup_success_screen.dart
+++ b/lib/core/widgets/backup_success_screen.dart
@@ -16,11 +16,13 @@ class BackupSuccessScreen extends StatelessWidget {
     required this.title,
     required this.message,
     required this.buttonLabel,
+    this.onDone,
   });
 
   final String title;
   final String message;
   final String buttonLabel;
+  final VoidCallback? onDone;
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +66,11 @@ class BackupSuccessScreen extends StatelessWidget {
                 textColor: context.appColors.onSecondary,
                 onPressed: () {
                   context.read<WalletBloc>().add(const VerifyBackupStatus());
-                  context.goNamed(WalletRoute.walletHome.name);
+                  if (onDone case final callback?) {
+                    callback();
+                  } else {
+                    context.goNamed(WalletRoute.walletHome.name);
+                  }
                 },
               ),
             ),

--- a/lib/features/backup_settings/ui/screens/backup_options_screen.dart
+++ b/lib/features/backup_settings/ui/screens/backup_options_screen.dart
@@ -8,7 +8,7 @@ import 'package:bb_mobile/features/backup_settings/ui/backup_settings_router.dar
 import 'package:bb_mobile/features/backup_settings/ui/widgets/how_to_decide.dart';
 import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/features/recoverbull/router.dart';
-import 'package:bb_mobile/features/test_wallet_backup/ui/test_wallet_backup_router.dart';
+import 'package:bb_mobile/features/test_wallet_backup/public/test_wallet_backup_facade.dart';
 import 'package:bb_mobile/generated/flutter_gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
@@ -85,7 +85,7 @@ class _BackupOptionsScreenState extends State<BackupOptionsScreen> {
                 tag: context.loc.backupWalletPhysicalBackupTag,
                 onTap: () {
                   context.pushNamed(
-                    TestWalletBackupRoute.testPhysicalBackupFlow.name,
+                    TestWalletBackupFacade.routeName,
                     extra: switch (widget.flow) {
                       BackupSettingsFlow.backup =>
                         TestPhysicalBackupFlow.backup,

--- a/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
+++ b/lib/features/backup_settings/ui/screens/backup_settings_screen.dart
@@ -107,7 +107,7 @@ class _ViewVaultKeyButton extends StatelessWidget {
   Widget build(BuildContext context) => SettingsEntryItem(
     icon: Icons.vpn_key,
     title: context.loc.backupSettingsViewVaultKey,
-    onTap: () => const RecoverBullFacade().openViewVaultKey(context),
+    onTap: () => RecoverBullFacade.openViewVaultKey(context),
   );
 }
 

--- a/lib/features/onboarding/complete_physical_backup_verification_usecase.dart
+++ b/lib/features/onboarding/complete_physical_backup_verification_usecase.dart
@@ -1,6 +1,7 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 
 class CompletePhysicalBackupVerificationUsecase {
   final WalletRepository _walletRepository;
@@ -11,30 +12,45 @@ class CompletePhysicalBackupVerificationUsecase {
     required this._settingsRepository,
   });
 
-  Future<void> execute() async {
+  Future<void> execute({String? fingerprint}) async {
     try {
-      final settings = await _settingsRepository.fetch();
-      final defaultWallets = await _walletRepository.getWallets(
-        onlyDefaults: true,
-        environment: settings.environment,
-      );
-      if (defaultWallets.isEmpty) {
-        throw Exception('No default wallet found');
+      final wallets = fingerprint == null
+          ? await _defaultWallets()
+          : await _walletRepository.getWallets(onlyBitcoin: true);
+      final normalizedFingerprint = fingerprint?.toLowerCase();
+      final matchingWallets = normalizedFingerprint == null
+          ? wallets
+          : wallets
+                .where(
+                  (wallet) => wallet.localMasterFingerprints.any(
+                    (value) => value.toLowerCase() == normalizedFingerprint,
+                  ),
+                )
+                .toList();
+      if (matchingWallets.isEmpty) {
+        throw Exception('No wallet found for physical backup verification');
       }
-      // There should only be one default Bitcoin wallet
 
-      for (final defaultWallet in defaultWallets) {
+      for (final wallet in matchingWallets) {
         await _walletRepository.updateBackupInfo(
-          walletId: defaultWallet.id,
-          isEncryptedVaultTested: defaultWallet.isEncryptedVaultTested,
+          walletId: wallet.id,
+          isEncryptedVaultTested: wallet.isEncryptedVaultTested,
           isPhysicalBackupTested: true,
-          latestEncryptedBackup: defaultWallet.latestEncryptedBackup,
+          latestEncryptedBackup: wallet.latestEncryptedBackup,
           latestPhysicalBackup: DateTime.now(),
         );
       }
     } catch (e) {
       throw CompletePhysicalBackupVerificationException(e.toString());
     }
+  }
+
+  Future<List<Wallet>> _defaultWallets() async {
+    final settings = await _settingsRepository.fetch();
+    return _walletRepository.getWallets(
+      onlyDefaults: true,
+      environment: settings.environment,
+    );
   }
 }
 

--- a/lib/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase.dart
+++ b/lib/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+
+class CheckRecoverBullBackupUsecase {
+  final GetWalletsUsecase _getWalletsUsecase;
+
+  const CheckRecoverBullBackupUsecase(this._getWalletsUsecase);
+
+  Future<bool> execute(String fingerprint) async {
+    final normalized = fingerprint.toLowerCase();
+    if (!RegExp(r'^[0-9a-f]{8}$').hasMatch(normalized)) return false;
+
+    final wallets = await _getWalletsUsecase.execute(onlyBitcoin: true);
+    return wallets.any(
+      (wallet) =>
+          wallet.isEncryptedVaultTested &&
+          wallet.latestEncryptedBackup != null &&
+          wallet.localMasterFingerprints.any(
+            (value) => value.toLowerCase() == normalized,
+          ),
+    );
+  }
+}

--- a/lib/features/recoverbull/presentation/bloc.dart
+++ b/lib/features/recoverbull/presentation/bloc.dart
@@ -14,6 +14,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/connect_
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_latest_google_drive_backup_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/save_to_google_drive_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/pick_vault_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
@@ -40,6 +41,8 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
   final SaveVaultToGoogleDriveUsecase _saveToGoogleDriveUsecase;
   final CreateEncryptedVaultUsecase _createEncryptedVaultUsecase;
   final StoreVaultKeyIntoServerUsecase _storeVaultKeyIntoServerUsecase;
+  final RecordEncryptedBackupCreatedUsecase
+  _recordEncryptedBackupCreatedUsecase;
 
   /// Single-shot: the pre-flight check before storing a vault key, where the
   /// user is already committed and a retry budget would only delay the error.
@@ -65,11 +68,14 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
 
   RecoverBullBloc({
     required RecoverBullFlow flow,
+    bool returnToCaller = false,
+    String? seedFingerprint,
     EncryptedVault? preSelectedVault,
     required this._pickVaultUsecase,
     required this._saveFileToSystemUsecase,
     required this._createEncryptedVaultUsecase,
     required this._storeVaultKeyIntoServerUsecase,
+    required this._recordEncryptedBackupCreatedUsecase,
     required this._checkKeyServerConnectionUsecase,
     required this._connectToKeyServerUsecase,
     required this._fetchVaultKeyFromServerUsecase,
@@ -82,7 +88,14 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
     required this._fetchLatestGoogleDriveVaultUsecase,
     required this._updateLatestEncryptedVaultTestUsecase,
     required this._watchTorConnectionUsecase,
-  }) : super(RecoverBullState(flow: flow, vault: preSelectedVault)) {
+  }) : super(
+         RecoverBullState(
+           flow: flow,
+           returnToCaller: returnToCaller,
+           seedFingerprint: seedFingerprint,
+           vault: preSelectedVault,
+         ),
+       ) {
     on<OnVaultProviderSelection>(_onVaultProviderSelection);
     on<OnVaultSelection>(_onVaultSelection);
     on<OnVaultPasswordSet>(_onVaultPasswordSet);
@@ -386,10 +399,17 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
 
       final EncryptedVault vault;
       final String vaultKey;
-      switch (await _createEncryptedVaultUsecase.execute()) {
+      final String walletId;
+      final creation = state.seedFingerprint == null
+          ? await _createEncryptedVaultUsecase.execute()
+          : await _createEncryptedVaultUsecase.execute(
+              fingerprint: state.seedFingerprint,
+            );
+      switch (creation) {
         case Ok(:final value):
           vault = value.vault;
           vaultKey = value.vaultKey;
+          walletId = value.walletId;
         case Err():
           emit(state.copyWith(failure: const VaultCreationFailure()));
           return;
@@ -440,6 +460,14 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
         // Keep the typed key-server detail (rate-limit cooldown, invalid
         // credentials) instead of collapsing it to the generic creation error.
         emit(state.copyWith(failure: _storeKeyFailure(failure)));
+        return;
+      }
+
+      final recorded = await _recordEncryptedBackupCreatedUsecase.execute(
+        walletId: walletId,
+      );
+      if (recorded case Err()) {
+        emit(state.copyWith(failure: const VaultCreationFailure()));
         return;
       }
 

--- a/lib/features/recoverbull/presentation/state.dart
+++ b/lib/features/recoverbull/presentation/state.dart
@@ -14,6 +14,8 @@ enum KeyServerStatus { unknown, connecting, online, offline }
 sealed class RecoverBullState with _$RecoverBullState {
   const factory RecoverBullState({
     required RecoverBullFlow flow,
+    @Default(false) bool returnToCaller,
+    @Default(null) String? seedFingerprint,
     @Default(null) VaultProvider? vaultProvider,
     @Default(null) EncryptedVault? vault,
     @Default(null) String? vaultKey,

--- a/lib/features/recoverbull/public/recoverbull_facade.dart
+++ b/lib/features/recoverbull/public/recoverbull_facade.dart
@@ -1,18 +1,40 @@
 import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
+import 'package:bb_mobile/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase.dart';
 import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:bb_mobile/features/recoverbull/ui/widgets/view_vault_key_warning_bottom_sheet.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 class RecoverBullFacade {
-  const RecoverBullFacade();
+  final CheckRecoverBullBackupUsecase _checkRecoverBullBackupUsecase;
 
-  void openSettings(BuildContext context) => context.pushNamed(
+  const RecoverBullFacade(CheckRecoverBullBackupUsecase usecase)
+    : _checkRecoverBullBackupUsecase = usecase;
+
+  Future<bool> hasTestedBackup(String fingerprint) =>
+      _checkRecoverBullBackupUsecase.execute(fingerprint);
+
+  static Future<bool> openSetup(
+    BuildContext context, {
+    required String seedFingerprint,
+  }) async =>
+      await context.pushNamed<bool>(
+        RecoverBullRoute.recoverbullFlows.name,
+        extra: RecoverBullFlowsExtra(
+          flow: RecoverBullFlow.secureVault,
+          vault: null,
+          returnToCaller: true,
+          seedFingerprint: seedFingerprint,
+        ),
+      ) ??
+      false;
+
+  static void openSettings(BuildContext context) => context.pushNamed(
     RecoverBullRoute.recoverbullFlows.name,
     extra: RecoverBullFlowsExtra(flow: RecoverBullFlow.settings, vault: null),
   );
 
-  Future<void> openViewVaultKey(BuildContext context) async {
+  static Future<void> openViewVaultKey(BuildContext context) async {
     final confirmed = await ViewVaultKeyWarningBottomSheet.show(context);
     if (confirmed != true || !context.mounted) return;
     openRecoverBullFlow(context, flow: RecoverBullFlow.viewVaultKey);

--- a/lib/features/recoverbull/recoverbull_locator.dart
+++ b/lib/features/recoverbull/recoverbull_locator.dart
@@ -1,0 +1,23 @@
+import 'package:bb_mobile/core/recoverbull/domain/usecases/check_server_connection_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase.dart';
+import 'package:bb_mobile/features/recoverbull/domain/usecases/connect_to_key_server_usecase.dart';
+import 'package:bb_mobile/features/recoverbull/public/recoverbull_facade.dart';
+import 'package:get_it/get_it.dart';
+
+abstract final class RecoverBullLocator {
+  static void setup(GetIt locator) {
+    locator.registerFactory<ConnectToKeyServerUsecase>(
+      () => ConnectToKeyServerUsecase(
+        locator<CheckServerConnectionUsecase>(),
+        locator<EnsureRecoverBullTorSessionUsecase>(),
+      ),
+    );
+    locator.registerLazySingleton<RecoverBullFacade>(
+      () => RecoverBullFacade(
+        CheckRecoverBullBackupUsecase(locator<GetWalletsUsecase>()),
+      ),
+    );
+  }
+}

--- a/lib/features/recoverbull/router.dart
+++ b/lib/features/recoverbull/router.dart
@@ -7,6 +7,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/connect_
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_latest_google_drive_backup_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/save_to_google_drive_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/pick_vault_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
@@ -32,8 +33,15 @@ enum RecoverBullRoute {
 class RecoverBullFlowsExtra {
   final RecoverBullFlow flow;
   final EncryptedVault? vault;
+  final bool returnToCaller;
+  final String? seedFingerprint;
 
-  RecoverBullFlowsExtra({required this.flow, required this.vault});
+  RecoverBullFlowsExtra({
+    required this.flow,
+    required this.vault,
+    this.returnToCaller = false,
+    this.seedFingerprint,
+  });
 }
 
 void openRecoverBullFlow(
@@ -55,21 +63,19 @@ class RecoverBullRouter {
       return BlocProvider(
         create: (context) => RecoverBullBloc(
           flow: extra.flow,
+          returnToCaller: extra.returnToCaller,
+          seedFingerprint: extra.seedFingerprint,
           preSelectedVault: extra.vault,
           pickVaultUsecase: locator<PickVaultUsecase>(),
           saveFileToSystemUsecase: locator<SaveFileToSystemUsecase>(),
           createEncryptedVaultUsecase: locator<CreateEncryptedVaultUsecase>(),
           storeVaultKeyIntoServerUsecase:
               locator<StoreVaultKeyIntoServerUsecase>(),
+          recordEncryptedBackupCreatedUsecase:
+              locator<RecordEncryptedBackupCreatedUsecase>(),
           checkKeyServerConnectionUsecase:
               locator<CheckServerConnectionUsecase>(),
-          // Composed here rather than registered: this feature has no
-          // locator of its own, and the use case is a thin retry policy
-          // over registered core use cases.
-          connectToKeyServerUsecase: ConnectToKeyServerUsecase(
-            locator<CheckServerConnectionUsecase>(),
-            locator<EnsureRecoverBullTorSessionUsecase>(),
-          ),
+          connectToKeyServerUsecase: locator<ConnectToKeyServerUsecase>(),
           fetchVaultKeyFromServerUsecase:
               locator<FetchVaultKeyFromServerUsecase>(),
           decryptVaultUsecase: locator<DecryptVaultUsecase>(),

--- a/lib/features/recoverbull/ui/pages/test_completed_page.dart
+++ b/lib/features/recoverbull/ui/pages/test_completed_page.dart
@@ -1,6 +1,9 @@
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/widgets/backup_success_screen.dart';
+import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 
 class TestCompletedPage extends StatelessWidget {
   const TestCompletedPage({super.key});
@@ -11,6 +14,9 @@ class TestCompletedPage extends StatelessWidget {
       title: context.loc.recoverbullTestCompletedTitle,
       message: context.loc.recoverbullTestSuccessDescription,
       buttonLabel: context.loc.recoverbullGotIt,
+      onDone: context.read<RecoverBullBloc>().state.returnToCaller
+          ? () => context.pop(true)
+          : null,
     );
   }
 }

--- a/lib/features/recoverbull/ui/pages/vault_created_page.dart
+++ b/lib/features/recoverbull/ui/pages/vault_created_page.dart
@@ -3,6 +3,7 @@ import 'package:bb_mobile/core/widgets/loading/status_screen.dart';
 import 'package:bb_mobile/features/recoverbull/presentation/bloc.dart';
 import 'package:bb_mobile/features/recoverbull/router.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 class VaultCreatedPage extends StatelessWidget {
@@ -15,13 +16,36 @@ class VaultCreatedPage extends StatelessWidget {
       description: context.loc.recoverbullTestBackupDescription,
       isLoading: false,
       buttonText: context.loc.recoverbullTestRecovery,
-      onTap: () => context.goNamed(
-        RecoverBullRoute.recoverbullFlows.name,
-        extra: RecoverBullFlowsExtra(
-          flow: RecoverBullFlow.testVault,
-          vault: null,
-        ),
-      ),
+      onTap: () async {
+        final returnToCaller = context
+            .read<RecoverBullBloc>()
+            .state
+            .returnToCaller;
+        final seedFingerprint = context
+            .read<RecoverBullBloc>()
+            .state
+            .seedFingerprint;
+        if (!returnToCaller) {
+          context.goNamed(
+            RecoverBullRoute.recoverbullFlows.name,
+            extra: RecoverBullFlowsExtra(
+              flow: RecoverBullFlow.testVault,
+              vault: null,
+            ),
+          );
+          return;
+        }
+        final completed = await context.pushNamed<bool>(
+          RecoverBullRoute.recoverbullFlows.name,
+          extra: RecoverBullFlowsExtra(
+            flow: RecoverBullFlow.testVault,
+            vault: null,
+            returnToCaller: true,
+            seedFingerprint: seedFingerprint,
+          ),
+        );
+        if (completed == true && context.mounted) context.pop(true);
+      },
     );
   }
 }

--- a/lib/features/settings/ui/settings_item.dart
+++ b/lib/features/settings/ui/settings_item.dart
@@ -224,7 +224,7 @@ List<SettingsItem> buildSettingsItems({
         localization.backupSettingsRecoverBullSettings,
       ),
       icon: Icons.cloud_circle,
-      open: (context) => const RecoverBullFacade().openSettings(context),
+      open: (context) => RecoverBullFacade.openSettings(context),
       keywords: _keywords(
         localization.settingsSearchRecoverbullKeywords,
         english.settingsSearchRecoverbullKeywords,

--- a/lib/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase.dart
+++ b/lib/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+
+class CheckPhysicalBackupVerifiedUsecase {
+  final WalletRepository _walletRepository;
+
+  const CheckPhysicalBackupVerifiedUsecase(this._walletRepository);
+
+  Future<bool> execute(String fingerprint) async {
+    final normalized = fingerprint.toLowerCase();
+    if (!RegExp(r'^[0-9a-f]{8}$').hasMatch(normalized)) return false;
+
+    final wallets = await _walletRepository.getWallets(onlyBitcoin: true);
+    return wallets.any(
+      (wallet) =>
+          wallet.isPhysicalBackupTested &&
+          wallet.localMasterFingerprints.any(
+            (value) => value.toLowerCase() == normalized,
+          ),
+    );
+  }
+}

--- a/lib/features/test_wallet_backup/flow.dart
+++ b/lib/features/test_wallet_backup/flow.dart
@@ -1,11 +1,17 @@
 import 'package:bb_mobile/features/test_wallet_backup/ui/screens/show_mnemonic_screen.dart';
 import 'package:bb_mobile/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart';
-import 'package:bb_mobile/features/test_wallet_backup/ui/test_wallet_backup_router.dart';
+import 'package:bb_mobile/features/test_wallet_backup/public/test_wallet_backup_facade.dart';
 import 'package:flutter/material.dart';
 
 class TestPhysicalBackupFlowNavigator extends StatelessWidget {
   final TestPhysicalBackupFlow flow;
-  const TestPhysicalBackupFlowNavigator({super.key, required this.flow});
+  final VoidCallback? onVerified;
+
+  const TestPhysicalBackupFlowNavigator({
+    super.key,
+    required this.flow,
+    this.onVerified,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +30,9 @@ class TestPhysicalBackupFlowNavigator extends StatelessWidget {
           return MaterialPageRoute(
             builder: (context) => switch (flow) {
               TestPhysicalBackupFlow.backup => const ShowMnemonicScreen(),
-              TestPhysicalBackupFlow.verify => const VerifyMnemonicScreen(),
+              TestPhysicalBackupFlow.verify => VerifyMnemonicScreen(
+                onVerified: onVerified,
+              ),
             },
           );
         },

--- a/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart
+++ b/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart
@@ -61,10 +61,20 @@ class TestWalletBackupBloc
     try {
       final wallets = await _loadWalletsForNetworkUsecase.execute();
       if (wallets.isEmpty) throw Exception('No wallets found');
-      final Wallet selected = wallets.firstWhere(
-        (w) => w.isDefault,
-        orElse: () => wallets.first,
-      );
+      final Wallet selected;
+      if (event.fingerprint case final fingerprint?) {
+        final normalizedFingerprint = fingerprint.toLowerCase();
+        selected = wallets.firstWhere(
+          (wallet) => wallet.localMasterFingerprints.any(
+            (value) => value.toLowerCase() == normalizedFingerprint,
+          ),
+        );
+      } else {
+        selected = wallets.firstWhere(
+          (wallet) => wallet.isDefault,
+          orElse: () => wallets.first,
+        );
+      }
       emit(
         state.copyWith(
           wallets: wallets,
@@ -107,7 +117,9 @@ class TestWalletBackupBloc
       );
 
       if (isCorrect) {
-        await _completePhysicalBackupVerificationUsecase.execute();
+        await _completePhysicalBackupVerificationUsecase.execute(
+          fingerprint: wallet.localMasterFingerprints.single,
+        );
         emit(
           state.copyWith(
             verificationStatus: BackupVerificationStatus.success,

--- a/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_event.dart
+++ b/lib/features/test_wallet_backup/presentation/bloc/test_wallet_backup_event.dart
@@ -5,7 +5,9 @@ sealed class TestWalletBackupEvent {
 }
 
 class LoadWallets extends TestWalletBackupEvent {
-  const LoadWallets();
+  final String? fingerprint;
+
+  const LoadWallets({this.fingerprint});
 }
 
 class WalletSelected extends TestWalletBackupEvent {

--- a/lib/features/test_wallet_backup/public/test_wallet_backup_facade.dart
+++ b/lib/features/test_wallet_backup/public/test_wallet_backup_facade.dart
@@ -1,0 +1,24 @@
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase.dart';
+
+enum TestPhysicalBackupFlow { backup, verify }
+
+final class VerifyPhysicalBackupRequest {
+  final String fingerprint;
+
+  VerifyPhysicalBackupRequest({required this.fingerprint}) {
+    if (fingerprint.isEmpty) {
+      throw ArgumentError.value(fingerprint, 'fingerprint');
+    }
+  }
+}
+
+class TestWalletBackupFacade {
+  static const routeName = 'testPhysicalBackupFlow';
+
+  final CheckPhysicalBackupVerifiedUsecase _checkPhysicalBackupVerifiedUsecase;
+
+  const TestWalletBackupFacade(this._checkPhysicalBackupVerifiedUsecase);
+
+  Future<bool> isPhysicalBackupVerified(String fingerprint) =>
+      _checkPhysicalBackupVerifiedUsecase.execute(fingerprint);
+}

--- a/lib/features/test_wallet_backup/test_wallet_backup_locator.dart
+++ b/lib/features/test_wallet_backup/test_wallet_backup_locator.dart
@@ -2,13 +2,22 @@ import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
 import 'package:bb_mobile/core/settings/data/settings_repository.dart';
 import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_backup_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/get_mnemonic_from_fingerprint_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_wallets_for_network_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
+import 'package:bb_mobile/features/test_wallet_backup/public/test_wallet_backup_facade.dart';
 import 'package:get_it/get_it.dart';
 
 class TestWalletBackupLocator {
   static void setup(GetIt locator) {
+    locator.registerLazySingleton<CheckPhysicalBackupVerifiedUsecase>(
+      () => CheckPhysicalBackupVerifiedUsecase(locator<WalletRepository>()),
+    );
+    locator.registerLazySingleton<TestWalletBackupFacade>(
+      () =>
+          TestWalletBackupFacade(locator<CheckPhysicalBackupVerifiedUsecase>()),
+    );
     locator.registerLazySingleton<LoadWalletsForNetworkUsecase>(
       () => LoadWalletsForNetworkUsecase(
         walletRepository: locator<WalletRepository>(),

--- a/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
+++ b/lib/features/test_wallet_backup/ui/screens/verify_mnemonic_screen.dart
@@ -13,7 +13,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:bull_ui/bull_ui.dart' show Gap;
 
 class VerifyMnemonicScreen extends StatefulWidget {
-  const VerifyMnemonicScreen({super.key});
+  final VoidCallback? onVerified;
+
+  const VerifyMnemonicScreen({super.key, this.onVerified});
 
   @override
   State<VerifyMnemonicScreen> createState() => _VerifyMnemonicScreenState();
@@ -122,11 +124,16 @@ class _VerifyMnemonicScreenState extends State<VerifyMnemonicScreen>
             switch (state.verificationStatus) {
               case BackupVerificationStatus.success:
                 context.read<TestWalletBackupBloc>().add(const ClearError());
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const BackupTestSuccessScreen(),
-                  ),
-                );
+                final onVerified = widget.onVerified;
+                if (onVerified != null) {
+                  onVerified();
+                } else {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const BackupTestSuccessScreen(),
+                    ),
+                  );
+                }
               case BackupVerificationStatus.failure:
                 _resetGame();
                 SnackBarUtils.showSnackBar(

--- a/lib/features/test_wallet_backup/ui/test_wallet_backup_router.dart
+++ b/lib/features/test_wallet_backup/ui/test_wallet_backup_router.dart
@@ -4,11 +4,10 @@ import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/load_walle
 import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/verify_physical_backup_usecase.dart';
 import 'package:bb_mobile/features/test_wallet_backup/flow.dart';
 import 'package:bb_mobile/features/test_wallet_backup/presentation/bloc/test_wallet_backup_bloc.dart';
+import 'package:bb_mobile/features/test_wallet_backup/public/test_wallet_backup_facade.dart';
 import 'package:bb_mobile/locator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-
-enum TestPhysicalBackupFlow { backup, verify }
 
 enum TestWalletBackupRoute {
   testPhysicalBackupFlow('/test-physical-backup-flow');
@@ -20,12 +19,16 @@ enum TestWalletBackupRoute {
 
 class TestWalletBackupRouter {
   static final route = GoRoute(
-    name: TestWalletBackupRoute.testPhysicalBackupFlow.name,
+    name: TestWalletBackupFacade.routeName,
     path: TestWalletBackupRoute.testPhysicalBackupFlow.path,
     builder: (context, state) {
-      final flow =
-          state.extra as TestPhysicalBackupFlow? ??
-          TestPhysicalBackupFlow.backup;
+      final extra = state.extra;
+      final request = extra is VerifyPhysicalBackupRequest ? extra : null;
+      final flow = switch (extra) {
+        TestPhysicalBackupFlow value => value,
+        VerifyPhysicalBackupRequest() => TestPhysicalBackupFlow.verify,
+        _ => TestPhysicalBackupFlow.backup,
+      };
 
       return BlocProvider(
         create: (context) => TestWalletBackupBloc(
@@ -35,8 +38,11 @@ class TestWalletBackupRouter {
           verifyPhysicalBackupUsecase: locator<VerifyPhysicalBackupUsecase>(),
           completePhysicalBackupVerificationUsecase:
               locator<CompletePhysicalBackupVerificationUsecase>(),
-        )..add(const LoadWallets()),
-        child: TestPhysicalBackupFlowNavigator(flow: flow),
+        )..add(LoadWallets(fingerprint: request?.fingerprint)),
+        child: TestPhysicalBackupFlowNavigator(
+          flow: flow,
+          onVerified: request == null ? null : () => context.pop(true),
+        ),
       );
     },
   );

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -36,6 +36,7 @@ import 'package:bb_mobile/features/pin_code/pin_code_locator.dart';
 import 'package:bb_mobile/features/psbt_signing/psbt_signing_locator.dart';
 import 'package:bb_mobile/features/receive/receive_locator.dart';
 import 'package:bb_mobile/features/recipients/recipients_locator.dart';
+import 'package:bb_mobile/features/recoverbull/recoverbull_locator.dart';
 import 'package:bb_mobile/features/replace_by_fee/locator.dart';
 import 'package:bb_mobile/features/sell/sell_locator.dart';
 import 'package:bb_mobile/features/send/send_locator.dart';
@@ -144,6 +145,7 @@ class AppLocator {
     ConsolidationLocator.setup(locator);
     BackupSettingsLocator.setup(locator);
     TestWalletBackupLocator.setup(locator);
+    RecoverBullLocator.setup(locator);
     ImportWatchOnlyLocator.setup(locator);
     BroadcastSignedTxLocator.setup(locator);
     SwapLocator.setup(locator);

--- a/test/features/onboarding/complete_physical_backup_verification_usecase_test.dart
+++ b/test/features/onboarding/complete_physical_backup_verification_usecase_test.dart
@@ -1,0 +1,71 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/settings/data/settings_repository.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/features/onboarding/complete_physical_backup_verification_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockWalletRepository extends Mock implements WalletRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  test(
+    'persists verification only for wallets using the requested seed',
+    () async {
+      final walletRepository = _MockWalletRepository();
+      final settingsRepository = _MockSettingsRepository();
+      final requested = _wallet(origin: 'requested', fingerprint: 'deadbeef');
+      final other = _wallet(origin: 'other', fingerprint: 'cafebabe');
+      when(
+        () => walletRepository.getWallets(onlyBitcoin: true),
+      ).thenAnswer((_) async => [requested, other]);
+      when(
+        () => walletRepository.updateBackupInfo(
+          walletId: any(named: 'walletId'),
+          isEncryptedVaultTested: any(named: 'isEncryptedVaultTested'),
+          isPhysicalBackupTested: any(named: 'isPhysicalBackupTested'),
+          latestEncryptedBackup: any(named: 'latestEncryptedBackup'),
+          latestPhysicalBackup: any(named: 'latestPhysicalBackup'),
+        ),
+      ).thenAnswer((_) async {});
+      final usecase = CompletePhysicalBackupVerificationUsecase(
+        walletRepository: walletRepository,
+        settingsRepository: settingsRepository,
+      );
+
+      await usecase.execute(fingerprint: 'DEADBEEF');
+
+      final captured = verify(
+        () => walletRepository.updateBackupInfo(
+          walletId: captureAny(named: 'walletId'),
+          isEncryptedVaultTested: false,
+          isPhysicalBackupTested: true,
+          latestEncryptedBackup: null,
+          latestPhysicalBackup: any(named: 'latestPhysicalBackup'),
+        ),
+      ).captured;
+      expect(captured, ['requested']);
+    },
+  );
+}
+
+Wallet _wallet({required String origin, required String fingerprint}) => Wallet(
+  origin: origin,
+  network: Network.bitcoinMainnet,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: fingerprint,
+      xpubFingerprint: '01234567',
+      xpub: 'xpub-$origin',
+      derivationPath: "m/84'/0'/0'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: ScriptType.bip84,
+  publicDescriptor: 'wpkh(xpub-$origin/<0;1>/*)',
+  balanceSat: BigInt.zero,
+);

--- a/test/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase_test.dart
+++ b/test/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase_test.dart
@@ -1,0 +1,42 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/core/wallet/domain/usecases/get_wallets_usecase.dart';
+import 'package:bb_mobile/features/recoverbull/domain/usecases/check_recoverbull_backup_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetWalletsUsecase extends Mock implements GetWalletsUsecase {}
+
+void main() {
+  test('finds a tested RecoverBull backup for the requested seed', () async {
+    final getWallets = _MockGetWalletsUsecase();
+    when(
+      () => getWallets.execute(onlyBitcoin: true),
+    ).thenAnswer((_) async => [_wallet(fingerprint: 'deadbeef')]);
+    final usecase = CheckRecoverBullBackupUsecase(getWallets);
+
+    expect(await usecase.execute('DEADBEEF'), isTrue);
+    expect(await usecase.execute('cafebabe'), isFalse);
+  });
+}
+
+Wallet _wallet({required String fingerprint}) => Wallet(
+  origin: 'wallet',
+  network: Network.bitcoinMainnet,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: fingerprint,
+      xpubFingerprint: fingerprint,
+      xpub: 'xpub',
+      derivationPath: "m/84'/0'/0'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: ScriptType.bip84,
+  publicDescriptor: 'wpkh(xpub/<0;1>/*)',
+  balanceSat: BigInt.zero,
+  isEncryptedVaultTested: true,
+  latestEncryptedBackup: DateTime.utc(2026, 8, 28),
+);

--- a/test/features/recoverbull/recoverbull_bloc_test.dart
+++ b/test/features/recoverbull/recoverbull_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/connect_
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/fetch_latest_google_drive_backup_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/google_drive/save_to_google_drive_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/pick_vault_usecase.dart';
+import 'package:bb_mobile/core/recoverbull/domain/usecases/record_encrypted_backup_created_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/restore_vault_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/save_file_to_system_usecase.dart';
 import 'package:bb_mobile/core/recoverbull/domain/usecases/store_vault_key_into_server_usecase.dart';
@@ -34,6 +35,9 @@ class _MockSaveFile extends Mock implements SaveFileToSystemUsecase {}
 class _MockCreateVault extends Mock implements CreateEncryptedVaultUsecase {}
 
 class _MockStoreKey extends Mock implements StoreVaultKeyIntoServerUsecase {}
+
+class _MockRecordBackupCreated extends Mock
+    implements RecordEncryptedBackupCreatedUsecase {}
 
 class _MockCheckConnection extends Mock
     implements CheckServerConnectionUsecase {}
@@ -69,6 +73,7 @@ void main() {
   late _MockSaveFile saveFile;
   late _MockCreateVault createVault;
   late _MockStoreKey storeKey;
+  late _MockRecordBackupCreated recordBackupCreated;
   late _MockCheckConnection checkConnection;
   late _MockFetchKey fetchKey;
   late _MockDecrypt decrypt;
@@ -90,6 +95,7 @@ void main() {
     saveFile = _MockSaveFile();
     createVault = _MockCreateVault();
     storeKey = _MockStoreKey();
+    recordBackupCreated = _MockRecordBackupCreated();
     checkConnection = _MockCheckConnection();
     when(
       () => checkConnection.execute(),
@@ -118,14 +124,19 @@ void main() {
   // test drives the matching flow — the Tor subscription above excepted.
   RecoverBullBloc buildBloc({
     required RecoverBullFlow flow,
+    bool returnToCaller = false,
+    String? seedFingerprint,
     EncryptedVault? preSelectedVault,
   }) => RecoverBullBloc(
     flow: flow,
+    returnToCaller: returnToCaller,
+    seedFingerprint: seedFingerprint,
     preSelectedVault: preSelectedVault,
     pickVaultUsecase: pickVault,
     saveFileToSystemUsecase: saveFile,
     createEncryptedVaultUsecase: createVault,
     storeVaultKeyIntoServerUsecase: storeKey,
+    recordEncryptedBackupCreatedUsecase: recordBackupCreated,
     checkKeyServerConnectionUsecase: checkConnection,
     connectToKeyServerUsecase: ConnectToKeyServerUsecase(
       checkConnection,
@@ -143,6 +154,39 @@ void main() {
     updateLatestEncryptedVaultTestUsecase: updateLatest,
     watchTorConnectionUsecase: watchTor,
   );
+
+  test('retains the caller-return mode through the recovery flow', () async {
+    final bloc = buildBloc(
+      flow: RecoverBullFlow.secureVault,
+      returnToCaller: true,
+    );
+
+    expect(bloc.state.returnToCaller, isTrue);
+
+    await bloc.close();
+  });
+
+  test('backs up the BullVault seed selected by fingerprint', () async {
+    when(() => createVault.execute(fingerprint: 'deadbeef')).thenAnswer(
+      (_) async =>
+          const Err(core.RecoverBullUnexpectedCoreFailure('not configured')),
+    );
+    final bloc = buildBloc(
+      flow: RecoverBullFlow.secureVault,
+      seedFingerprint: 'deadbeef',
+    );
+
+    bloc.add(
+      const OnVaultCreation(
+        provider: VaultProvider.customLocation,
+        password: 'pw',
+      ),
+    );
+    await pumpEventQueue();
+
+    verify(() => createVault.execute(fingerprint: 'deadbeef')).called(1);
+    await bloc.close();
+  });
 
   group('OnVaultPasswordSet guard', () {
     test('no vault set -> VaultNotSetFailure, password not stored, key never '
@@ -202,9 +246,10 @@ void main() {
         when(() => vault.toFile()).thenReturn('{}');
         when(() => vault.filename).thenReturn('vault.json');
 
-        when(
-          () => createVault.execute(),
-        ).thenAnswer((_) async => Ok((vault: vault, vaultKey: 'deadbeef')));
+        when(() => createVault.execute()).thenAnswer(
+          (_) async =>
+              Ok((vault: vault, vaultKey: 'deadbeef', walletId: 'wallet-id')),
+        );
         when(
           () => checkConnection.execute(),
         ).thenAnswer((_) async => const Ok(true));
@@ -279,9 +324,9 @@ void main() {
     'maps external failure while storing without announcing creation',
     () async {
       final vault = _MockEncryptedVault();
-      when(
-        () => createVault.execute(),
-      ).thenAnswer((_) async => Ok((vault: vault, vaultKey: 'key')));
+      when(() => createVault.execute()).thenAnswer(
+        (_) async => Ok((vault: vault, vaultKey: 'key', walletId: 'wallet-id')),
+      );
       when(
         () => connectDrive.execute(),
       ).thenAnswer((_) async => const Ok(null));
@@ -309,8 +354,45 @@ void main() {
       verify(
         () => storeKey.execute(password: 'pw', vault: vault, vaultKey: 'key'),
       ).called(1);
+      verifyNever(
+        () => recordBackupCreated.execute(walletId: any(named: 'walletId')),
+      );
     },
   );
+
+  test('records backup only after the vault and key are stored', () async {
+    final vault = _MockEncryptedVault();
+    when(() => vault.toFile()).thenReturn('{}');
+    when(() => vault.filename).thenReturn('vault.json');
+    when(() => createVault.execute()).thenAnswer(
+      (_) async => Ok((vault: vault, vaultKey: 'key', walletId: 'wallet-id')),
+    );
+    when(
+      () => saveFile.execute(
+        content: any(named: 'content'),
+        filename: any(named: 'filename'),
+      ),
+    ).thenAnswer((_) async => const Ok(null));
+    when(
+      () => storeKey.execute(password: 'pw', vault: vault, vaultKey: 'key'),
+    ).thenAnswer((_) async => const Ok(null));
+    when(
+      () => recordBackupCreated.execute(walletId: 'wallet-id'),
+    ).thenAnswer((_) async => const Ok(null));
+    final bloc = buildBloc(flow: RecoverBullFlow.secureVault);
+    addTearDown(bloc.close);
+
+    bloc.add(
+      const OnVaultCreation(
+        provider: VaultProvider.customLocation,
+        password: 'pw',
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(bloc.state.vault, vault);
+    verify(() => recordBackupCreated.execute(walletId: 'wallet-id')).called(1);
+  });
 
   group('Tor retry concurrency', () {
     test('drops a second retry while the first one is in flight', () async {

--- a/test/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase_test.dart
+++ b/test/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase_test.dart
@@ -1,0 +1,49 @@
+import 'package:bb_mobile/core/entities/signer_entity.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_signer.dart';
+import 'package:bb_mobile/features/test_wallet_backup/domain/usecases/check_physical_backup_verified_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockWalletRepository extends Mock implements WalletRepository {}
+
+void main() {
+  test(
+    'finds a verified local wallet for the exact seed fingerprint',
+    () async {
+      final repository = _MockWalletRepository();
+      when(() => repository.getWallets(onlyBitcoin: true)).thenAnswer(
+        (_) async => [
+          _wallet(fingerprint: 'deadbeef', isPhysicalBackupTested: true),
+        ],
+      );
+      final usecase = CheckPhysicalBackupVerifiedUsecase(repository);
+
+      expect(await usecase.execute('DEADBEEF'), isTrue);
+      expect(await usecase.execute('cafebabe'), isFalse);
+    },
+  );
+}
+
+Wallet _wallet({
+  required String fingerprint,
+  required bool isPhysicalBackupTested,
+}) => Wallet(
+  origin: fingerprint,
+  network: Network.bitcoinMainnet,
+  signers: [
+    WalletSigner.single(
+      masterFingerprint: fingerprint,
+      xpubFingerprint: '01234567',
+      xpub: 'xpub',
+      derivationPath: "m/84'/0'/0'",
+      signer: SignerEntity.local,
+      signerDevice: null,
+    ),
+  ],
+  scriptType: ScriptType.bip84,
+  publicDescriptor: 'wpkh(xpub/<0;1>/*)',
+  balanceSat: BigInt.zero,
+  isPhysicalBackupTested: isPhysicalBackupTested,
+);

--- a/test/features/test_wallet_backup/presentation/test_wallet_backup_bloc_test.dart
+++ b/test/features/test_wallet_backup/presentation/test_wallet_backup_bloc_test.dart
@@ -110,6 +110,44 @@ void main() {
       await bloc.close();
     });
 
+    test('selects the wallet that owns a requested seed fingerprint', () async {
+      final defaultWallet = _wallet(isDefault: true, origin: 'a');
+      final requestedWallet = Wallet(
+        origin: 'b',
+        label: 'Requested',
+        network: Network.bitcoinMainnet,
+        publicDescriptor: 'wpkh([beef1234/84h/0h/0h]xpub/<0;1>/*)',
+        signers: [
+          WalletSigner.single(
+            masterFingerprint: 'beef1234',
+            xpubFingerprint: 'beef1234',
+            xpub: 'xpub',
+            derivationPath: "m/84'/0'/0'",
+            signer: SignerEntity.local,
+            signerDevice: null,
+          ),
+        ],
+        scriptType: ScriptType.bip84,
+        balanceSat: BigInt.zero,
+      );
+      when(
+        () => loadWalletsUsecase.execute(),
+      ).thenAnswer((_) async => [defaultWallet, requestedWallet]);
+      final bloc = buildBloc();
+
+      final expectation = expectLater(
+        bloc.stream,
+        emits(
+          predicate<TestWalletBackupState>(
+            (state) => state.selectedWallet == requestedWallet,
+          ),
+        ),
+      );
+      bloc.add(const LoadWallets(fingerprint: 'BEEF1234'));
+      await expectation;
+      await bloc.close();
+    });
+
     test(
       'emits success and completes the backup when words are correct',
       () async {
@@ -119,7 +157,9 @@ void main() {
             mnemonic: _mnemonicWords,
           ),
         ).thenAnswer((_) async => true);
-        when(() => completeUsecase.execute()).thenAnswer((_) async {});
+        when(
+          () => completeUsecase.execute(fingerprint: _fingerprint),
+        ).thenAnswer((_) async {});
         final bloc = buildBloc();
         bloc.seed(
           TestWalletBackupState(
@@ -144,7 +184,9 @@ void main() {
             mnemonic: _mnemonicWords,
           ),
         ).called(1);
-        verify(() => completeUsecase.execute()).called(1);
+        verify(
+          () => completeUsecase.execute(fingerprint: _fingerprint),
+        ).called(1);
         await bloc.close();
       },
     );
@@ -176,7 +218,9 @@ void main() {
         bloc.add(const VerifyPhysicalBackup(reorderedWords: _mnemonicWords));
         await expectation;
 
-        verifyNever(() => completeUsecase.execute());
+        verifyNever(
+          () => completeUsecase.execute(fingerprint: any(named: 'fingerprint')),
+        );
         await bloc.close();
       },
     );


### PR DESCRIPTION
## Summary

- verify physical mnemonic backup status for an exact Bull seed fingerprint instead of the default wallet
- persist successful mnemonic verification against every local wallet using that seed
- expose fingerprint-scoped backup verification through the test-wallet-backup facade
- expose tested RecoverBull backup status for the same seed and return completion through its public flow
- preserve existing backup and recovery screens while allowing BullVault to reuse them safely

## Validation

- whole-project analysis, formatting, fix, and boundary checks
- root Flutter test suite
- focused physical-backup and RecoverBull tests

## Stack

Draft stacked on #2774.