### PR TITLE
fix(wallet): handle unavailable coins before broadcast

### DIFF
--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -2104,6 +2104,8 @@ class SendCubit extends Cubit<SendState>
         selectedInputs: state.selectedUtxos,
       );
       return true;
+    } on NoSpendableUtxoException {
+      _invalidateSignedTransaction();
     } on InsufficientFundsException {
       _invalidateSignedTransaction();
     } on ValidateBitcoinSelectionException {

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -4,6 +4,7 @@ import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_bitcoin_tran
 import 'package:bb_mobile/core/blockchain/domain/usecases/broadcast_liquid_transaction_usecase.dart';
 import 'package:bb_mobile/core/errors/send_errors.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/exchange/domain/usecases/convert_sats_to_currency_amount_usecase.dart';
@@ -1397,6 +1398,8 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
             walletId: fromWallet.id,
             selectedInputs: stateToUse.selectedUtxos,
           );
+        } on NoSpendableUtxoException {
+          throw BuildTransactionException(selectedCoinsUnavailableCode);
         } on InsufficientFundsException {
           throw BuildTransactionException(selectedCoinsUnavailableCode);
         }
@@ -1690,6 +1693,15 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
         return;
       }
       emit(state.copyWith(txId: txId));
+    } on NoSpendableUtxoException {
+      _clearBitcoinFeePreviews(emit);
+      emit(
+        state.copyWith(
+          buildTransactionException: BuildTransactionException(
+            selectedCoinsUnavailableCode,
+          ),
+        ),
+      );
     } on InsufficientFundsException {
       _clearBitcoinFeePreviews(emit);
       emit(

--- a/lib/features/swap/presentation/transfer_bloc.dart
+++ b/lib/features/swap/presentation/transfer_bloc.dart
@@ -1583,6 +1583,9 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
           buildTransactionException: BuildTransactionException(
             e is BuildTransactionException
                 ? e.message
+                : e is NoSpendableUtxoException &&
+                      stateToUse.selectedUtxos.isNotEmpty
+                ? selectedCoinsUnavailableCode
                 : e is InsufficientFundsException &&
                       stateToUse.selectedUtxos.isNotEmpty
                 ? selectedCoinsInsufficientCode
@@ -1694,32 +1697,11 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
       }
       emit(state.copyWith(txId: txId));
     } on NoSpendableUtxoException {
-      _clearBitcoinFeePreviews(emit);
-      emit(
-        state.copyWith(
-          buildTransactionException: BuildTransactionException(
-            selectedCoinsUnavailableCode,
-          ),
-        ),
-      );
+      _emitSelectionUnavailable(emit);
     } on InsufficientFundsException {
-      _clearBitcoinFeePreviews(emit);
-      emit(
-        state.copyWith(
-          buildTransactionException: BuildTransactionException(
-            selectedCoinsUnavailableCode,
-          ),
-        ),
-      );
+      _emitSelectionUnavailable(emit);
     } on ValidateBitcoinSelectionException {
-      _clearBitcoinFeePreviews(emit);
-      emit(
-        state.copyWith(
-          buildTransactionException: BuildTransactionException(
-            selectedCoinsUnavailableCode,
-          ),
-        ),
-      );
+      _emitSelectionUnavailable(emit);
     } catch (e) {
       emit(
         state.copyWith(
@@ -1730,6 +1712,20 @@ class TransferBloc extends Bloc<TransferEvent, TransferState>
     } finally {
       emit(state.copyWith(isConfirming: false));
     }
+  }
+
+  // Pre-broadcast confirmation validation failed: the staged selection can no
+  // longer be spent as previewed, so drop the fee previews and surface the
+  // unavailable-selection error for the user to re-review.
+  void _emitSelectionUnavailable(Emitter<TransferState> emit) {
+    _clearBitcoinFeePreviews(emit);
+    emit(
+      state.copyWith(
+        buildTransactionException: BuildTransactionException(
+          selectedCoinsUnavailableCode,
+        ),
+      ),
+    );
   }
 
   Future<void> _syncWalletAfterBroadcast(String walletId) async {

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -925,6 +925,42 @@ void main() {
     });
   });
 
+  test(
+    'does not broadcast when a selected coin becomes unavailable during validation',
+    () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      final selected = _utxo(amountSat: 10000);
+      when(
+        () => validateBitcoinSelectionUsecase.execute(
+          walletId: 'w-bitcoin',
+          selectedInputs: [selected],
+        ),
+      ).thenThrow(NoSpendableUtxoException('selected coin disappeared'));
+      cubit.setStateForTest(
+        SendState(
+          step: SendStep.confirm,
+          selectedWallet: _bitcoinWallet(balanceSat: 20000),
+          selectedUtxos: [selected],
+          unsignedPsbt: 'unsigned-psbt',
+          signedBitcoinPsbt: 'signed-psbt',
+        ),
+      );
+
+      await cubit.broadcastTransaction();
+
+      expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
+      expect(cubit.state.unsignedPsbt, isNull);
+      expect(cubit.state.signedBitcoinPsbt, isNull);
+      verifyNever(
+        () => broadcastBitcoinTxUsecase.execute(
+          any(),
+          isPsbt: any(named: 'isPsbt'),
+        ),
+      );
+    },
+  );
+
   group('SendCubit payment request input', () {
     test('stores sanitized input while parsing it', () async {
       final cubit = buildCubit();

--- a/test/features/swap/presentation/transfer_bloc_test.dart
+++ b/test/features/swap/presentation/transfer_bloc_test.dart
@@ -334,6 +334,49 @@ void main() {
   });
 
   test(
+    'maps unavailable selected coins in the non-cached rebuild path',
+    () async {
+      final selected = _bitcoinUtxo('selected-tx');
+      when(
+        () => prepareBitcoin.execute(
+          walletId: 'wallet-1',
+          address: 'tb1qreceive',
+          amountSat: 1000,
+          networkFee: any(named: 'networkFee'),
+          drain: false,
+          selectedInputs: [selected],
+          replaceByFee: true,
+        ),
+      ).thenThrow(NoSpendableUtxoException('selected coin disappeared'));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          selectedUtxos: [selected],
+          signedPsbt: 'stale-psbt',
+          bitcoinNetworkFees: _feeOptions(),
+        ),
+      );
+
+      bloc.add(const TransferEvent.feeOptionSelected(FeeSelection.fastest));
+      await bloc.stream.firstWhere(
+        (state) => state.buildTransactionException != null,
+      );
+
+      expect(
+        bloc.state.buildTransactionException?.message,
+        selectedCoinsUnavailableCode,
+      );
+      expect(bloc.state.signedPsbt, isEmpty);
+      verifyNever(
+        () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
+      );
+    },
+  );
+
+  test(
     'broadcasts a prepared order swap and emits its transaction id',
     () async {
       final broadcasting = _prepared(

--- a/test/features/swap/presentation/transfer_bloc_test.dart
+++ b/test/features/swap/presentation/transfer_bloc_test.dart
@@ -20,6 +20,7 @@ import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/prepare_bitcoin_send_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/validate_bitcoin_selection_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/calculate_bitcoin_absolute_fees_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/check_liquid_consolidation_usecase.dart';
 import 'package:bb_mobile/core/wallet/domain/usecases/get_receive_address_usecase.dart';
@@ -294,6 +295,43 @@ void main() {
       );
     },
   );
+
+  test('maps unavailable selected coins in the cached rebuild path', () async {
+    final selected = _bitcoinUtxo('selected-tx');
+    when(
+      () => validateBitcoinSelection.execute(
+        walletId: 'wallet-1',
+        selectedInputs: [selected],
+      ),
+    ).thenThrow(NoSpendableUtxoException('selected coin disappeared'));
+    bloc.emit(
+      TransferState(
+        fromWallet: _wallet(balanceSat: BigInt.from(100000)),
+        toWallet: _destinationWallet(),
+        receiveAddress: 'tb1qreceive',
+        amount: '1000',
+        selectedUtxos: [selected],
+        bitcoinNetworkFees: _feeOptions(),
+        feePreviewCache: const BitcoinFeePreviewCache(
+          fastest: BitcoinFeePreviewSlot(
+            feeSat: 250,
+            unsignedPsbt: 'cached-unsigned-psbt',
+            txSize: 100,
+          ),
+        ),
+      ),
+    );
+
+    bloc.add(const TransferEvent.feeOptionSelected(FeeSelection.fastest));
+    await bloc.stream.firstWhere(
+      (state) => state.buildTransactionException != null,
+    );
+
+    expect(
+      bloc.state.buildTransactionException?.message,
+      selectedCoinsUnavailableCode,
+    );
+  });
 
   test(
     'broadcasts a prepared order swap and emits its transaction id',
@@ -639,6 +677,48 @@ void main() {
       expect(bloc.state.buildTransactionException, isNotNull);
       verifyNever(
         () => broadcastBitcoin.execute('old-signed-psbt', isPsbt: true),
+      );
+    },
+  );
+
+  test(
+    'maps unavailable selected coins during confirm and clears fee previews',
+    () async {
+      final selected = _bitcoinUtxo('selected-tx');
+      when(
+        () => validateBitcoinSelection.execute(
+          walletId: 'wallet-1',
+          selectedInputs: [selected],
+        ),
+      ).thenThrow(NoSpendableUtxoException('selected coin disappeared'));
+      bloc.emit(
+        TransferState(
+          fromWallet: _wallet(),
+          toWallet: _destinationWallet(),
+          receiveAddress: 'tb1qreceive',
+          amount: '1000',
+          selectedUtxos: [selected],
+          signedPsbt: 'signed-psbt',
+          feePreviewCache: const BitcoinFeePreviewCache(
+            fastest: BitcoinFeePreviewSlot(
+              feeSat: 250,
+              unsignedPsbt: 'cached-unsigned-psbt',
+              txSize: 100,
+            ),
+          ),
+        ),
+      );
+
+      bloc.add(const TransferEvent.confirmed());
+      await bloc.stream.firstWhere((state) => !state.isConfirming);
+
+      expect(
+        bloc.state.buildTransactionException?.message,
+        selectedCoinsUnavailableCode,
+      );
+      expect(bloc.state.feePreviewCache.fastest.isCacheReady, isFalse);
+      verifyNever(
+        () => broadcastBitcoin.execute(any(), isPsbt: any(named: 'isPsbt')),
       );
     },
   );


### PR DESCRIPTION
`ValidateBitcoinSelectionUsecase` rethrows `NoSpendableUtxoException` when a selected coin is no longer available, but three send and swap broadcast/rebuild paths still handled `InsufficientFundsException` instead. The transactions remained fail-closed, but users received generic errors and signed transaction or fee-preview state was not consistently invalidated.

## Changes

- Handle unavailable selected coins before Send broadcasts, invalidate the staged transaction, and surface `SendSelectedCoinsUnavailableFailure`.
- Map unavailable selected coins to `selectedCoinsUnavailableCode` in the cached Swap rebuild path.
- Clear Swap fee previews and surface the unavailable-selection error when confirmation validation fails.
- Add one behavioral regression test for each path, including assertions that no broadcast occurs.

## Non-goals

- No change to coin-selection rules or normal insufficient-funds handling.
- No change to transaction construction or broadcast behavior after successful validation.

## Risk and security

The affected paths remain fail-closed: validation completes before any broadcast call, and the regression tests verify that unavailable selected coins cannot reach broadcast. This change corrects error mapping and stale-state cleanup only. It does not touch key material, signing logic, wallet secrets, or privacy-sensitive data.