### PR TITLE
feat(recoverbull): complete backup monitoring

### DIFF
--- a/features/recoverbull/lib/bull_recoverbull.dart
+++ b/features/recoverbull/lib/bull_recoverbull.dart
@@ -8,6 +8,7 @@ export 'src/public/recoverbull.dart'
         RecoverBullLifecycle,
         RecoverBullHealth,
         RecoverBullServerSettings,
+        RecoverBullMonitoringStatus,
         RecoverBullRecoveryResult,
         RecoverBullAttemptMonitoringController,
         RecoverBullAttemptAlert,

--- a/features/recoverbull/lib/l10n/recoverbull_en.arb
+++ b/features/recoverbull/lib/l10n/recoverbull_en.arb
@@ -735,5 +735,18 @@
   "torSettingsDescDisconnected": "Tor proxy is not running",
   "@torSettingsDescDisconnected": {
     "description": "Description when Tor is disconnected"
-  }
+  },
+  "recoverbullMonitoringTitle": "Backup monitoring",
+  "recoverbullMonitoringEnabled": "Monitor backups",
+  "recoverbullMonitoringCount": "Backups monitored: {count}",
+  "recoverbullMonitoringLastCheck": "Last successful check: {date}",
+  "recoverbullMonitoringUncovered": "No backups are currently covered.",
+  "recoverbullMonitoringExplanation": "RecoverBull uses one global attempts request and filters your monitored backups locally.",
+  "recoverbullAttemptAlertDetailsTitle": "Backup monitoring details",
+  "recoverbullAttemptAlertReference": "Backup reference: {reference}",
+  "recoverbullAttemptAlertAttempts": "Attempts: {observed} / expected: {expected}",
+  "recoverbullAttemptAlertWindow": "Window started: {date}",
+  "recoverbullAttemptAlertAction": "Recommended action: stop using this backup and contact support.",
+  "recoverbullAttemptAlertLockoutGuidance": "Never enter your seed, password, PIN, or key material in response to this alert.",
+  "recoverbullAttemptAlertInformational": "This is informational and does not indicate a security incident."
 }

--- a/features/recoverbull/lib/l10n/recoverbull_fr.arb
+++ b/features/recoverbull/lib/l10n/recoverbull_fr.arb
@@ -298,5 +298,18 @@
   "closeDialogButton": "Fermer",
   "@closeDialogButton": {
     "description": "Button to close the value dialog."
-  }
+  },
+  "recoverbullMonitoringTitle": "Surveillance des sauvegardes",
+  "recoverbullMonitoringEnabled": "Surveiller les sauvegardes",
+  "recoverbullMonitoringCount": "Sauvegardes surveillées : {count}",
+  "recoverbullMonitoringLastCheck": "Dernier contrôle réussi : {date}",
+  "recoverbullMonitoringUncovered": "Aucune sauvegarde n’est actuellement couverte.",
+  "recoverbullMonitoringExplanation": "RecoverBull utilise une requête globale des tentatives et filtre localement vos sauvegardes surveillées.",
+  "recoverbullAttemptAlertDetailsTitle": "Détails de la surveillance",
+  "recoverbullAttemptAlertReference": "Référence de sauvegarde : {reference}",
+  "recoverbullAttemptAlertAttempts": "Tentatives : {observed} / attendu : {expected}",
+  "recoverbullAttemptAlertWindow": "Début de la fenêtre : {date}",
+  "recoverbullAttemptAlertAction": "Action recommandée : cessez d’utiliser cette sauvegarde et contactez le support.",
+  "recoverbullAttemptAlertLockoutGuidance": "Ne saisissez jamais votre seed, mot de passe, code PIN ou clé en réponse à cette alerte.",
+  "recoverbullAttemptAlertInformational": "Cette information n’indique pas un incident de sécurité."
 }

--- a/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
+++ b/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
@@ -51,6 +51,8 @@ final class RecoverBullAttemptMonitoringSnapshotToken {
   });
 }
 
+enum MonitoredBackupOrigin { created, adopted }
+
 final class RecoverBullAttemptMonitoringApplyResult {
   final bool accepted;
   final int conflicts;
@@ -120,18 +122,36 @@ final class RecoverBullAttemptMonitoringStore {
   Future<bool> isMonitored(List<int> identifier) async =>
       await _row(_digest(identifier)) != null;
 
+  Future<void> removeBackup(String backupIdHex) async {
+    final digest = Uint8List.fromList(_decodeHash(backupIdHex));
+    await (database.delete(
+      database.recoverbullMonitoredBackup,
+    )..where((row) => row.digest.equals(digest))).go();
+  }
+
   List<int> digestFor(List<int> identifier) => _digest(identifier);
 
-  Future<void> registerBackup(List<int> identifier) async {
+  Future<void> registerBackup(
+    List<int> identifier, {
+    MonitoredBackupOrigin origin = MonitoredBackupOrigin.created,
+    int observedTotal = 0,
+    int window = 0,
+  }) async {
+    if (observedTotal < 0) throw ArgumentError.value(observedTotal);
+    if (window < 0) throw ArgumentError.value(window);
     final digest = _digest(identifier);
+    final adopted = origin == MonitoredBackupOrigin.adopted;
     await database.transaction(() async {
       await database
           .into(database.recoverbullMonitoredBackup)
           .insert(
             RecoverbullMonitoredBackupCompanion.insert(
               digest: digest,
-              expectedServerDistinctCandidateTotal: const Value(0),
-              currentWindow: const Value(0),
+              expectedServerDistinctCandidateTotal: Value(
+                adopted ? observedTotal : 0,
+              ),
+              currentWindow: Value(adopted ? window : 0),
+              lastWarningWindow: adopted ? Value(window) : const Value(null),
             ),
             mode: InsertMode.insertOrIgnore,
           );

--- a/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
+++ b/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
@@ -123,7 +123,7 @@ final class RecoverBullAttemptMonitoringStore {
       await _row(_digest(identifier)) != null;
 
   Future<void> removeBackup(String backupIdHex) async {
-    final digest = Uint8List.fromList(_decodeHash(backupIdHex));
+    final digest = _digest(_decodeHash(backupIdHex));
     await (database.delete(
       database.recoverbullMonitoredBackup,
     )..where((row) => row.digest.equals(digest))).go();

--- a/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
+++ b/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
@@ -24,6 +24,7 @@ final class RecoverBullAttemptsSnapshot {
   final bool notModified;
   final int? totalEntries;
   final int? maxAttemptIdentifiers;
+  final List<List<int>> targetedLockouts;
 
   const RecoverBullAttemptsSnapshot({
     required this.collectionStartedAt,
@@ -34,6 +35,7 @@ final class RecoverBullAttemptsSnapshot {
     this.notModified = false,
     this.totalEntries,
     this.maxAttemptIdentifiers,
+    this.targetedLockouts = const [],
   });
 }
 

--- a/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
+++ b/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
@@ -138,6 +138,10 @@ final class RecoverBullAttemptMonitoringStore {
     MonitoredBackupOrigin origin = MonitoredBackupOrigin.created,
     int observedTotal = 0,
     int window = 0,
+    String? driveAccount,
+    String? driveFileId,
+    DateTime? driveFileCreatedAt,
+    DateTime? driveFileModifiedAt,
   }) async {
     if (observedTotal < 0) throw ArgumentError.value(observedTotal);
     if (window < 0) throw ArgumentError.value(window);
@@ -154,9 +158,148 @@ final class RecoverBullAttemptMonitoringStore {
               ),
               currentWindow: Value(adopted ? window : 0),
               lastWarningWindow: adopted ? Value(window) : const Value(null),
+              origin: Value(
+                adopted
+                    ? (driveAccount != null ? 'drive' : 'adopted')
+                    : 'created',
+              ),
+              driveAccount: Value(driveAccount),
+              driveFileId: Value(driveFileId),
+              driveFileCreatedAt: Value(driveFileCreatedAt),
+              driveFileModifiedAt: Value(driveFileModifiedAt),
             ),
             mode: InsertMode.insertOrIgnore,
           );
+    });
+  }
+
+  Future<void> purgeDriveAccount(String account) async {
+    await (database.delete(
+      database.recoverbullMonitoredBackup,
+    )..where((row) => row.driveAccount.equals(account))).go();
+    await (database.delete(
+      database.recoverbullDriveBackupCache,
+    )..where((row) => row.account.equals(account))).go();
+  }
+
+  Future<List<RecoverbullMonitoredBackupData>> driveBackups(String account) =>
+      (database.select(
+        database.recoverbullMonitoredBackup,
+      )..where((row) => row.driveAccount.equals(account))).get();
+
+  Future<List<RecoverbullDriveBackupCacheData>> driveCache(String account) =>
+      (database.select(
+        database.recoverbullDriveBackupCache,
+      )..where((row) => row.account.equals(account))).get();
+
+  Future<void> saveDriveCache({
+    required String account,
+    required String driveFileId,
+    required List<int> backupDigest,
+    required DateTime createdAt,
+    DateTime? modifiedAt,
+  }) async {
+    await database
+        .into(database.recoverbullDriveBackupCache)
+        .insertOnConflictUpdate(
+          RecoverbullDriveBackupCacheCompanion.insert(
+            account: account,
+            driveFileId: driveFileId,
+            backupDigest: Uint8List.fromList(backupDigest),
+            driveFileCreatedAt: createdAt,
+            driveFileModifiedAt: Value(modifiedAt),
+          ),
+        );
+  }
+
+  /// Reconciles the complete Drive view in one transaction. A local row is
+  /// never converted into a Drive row, but a Drive row can be re-adopted after
+  /// monitoring was disabled because its cache entry is not authoritative.
+  Future<bool> reconcileDriveBackups(
+    String account,
+    List<DriveBackupObservation> observations,
+  ) async {
+    return database.transaction<bool>(() async {
+      final enabled =
+          await (database.select(database.recoverbullState)
+                ..where((row) => row.id.equals(1)))
+              .getSingle()
+              .then((row) => row.attemptMonitoringEnabled);
+      if (!enabled) return false;
+      await (database.delete(database.recoverbullMonitoredBackup)..where(
+            (row) =>
+                row.driveAccount.isNotNull() &
+                row.driveAccount.isNotValue(account),
+          ))
+          .go();
+      await (database.delete(
+        database.recoverbullDriveBackupCache,
+      )..where((row) => row.account.isNotValue(account))).go();
+      final desired = {for (final item in observations) item.digestKey};
+      final rows = await driveBackups(account);
+      for (final row in rows) {
+        if (!desired.contains(_hex(row.digest))) {
+          await (database.delete(
+            database.recoverbullMonitoredBackup,
+          )..where((t) => t.digest.equals(row.digest))).go();
+        }
+      }
+      final caches = await driveCache(account);
+      final currentFiles = {for (final item in observations) item.fileId};
+      for (final cache in caches) {
+        if (!currentFiles.contains(cache.driveFileId)) {
+          await (database.delete(database.recoverbullDriveBackupCache)..where(
+                (t) =>
+                    t.account.equals(account) &
+                    t.driveFileId.equals(cache.driveFileId),
+              ))
+              .go();
+        }
+      }
+      for (final item in observations) {
+        final digest = Uint8List.fromList(item.digest);
+        final existing = await (database.select(
+          database.recoverbullMonitoredBackup,
+        )..where((t) => t.digest.equals(digest))).getSingleOrNull();
+        if (existing == null) {
+          await database
+              .into(database.recoverbullMonitoredBackup)
+              .insert(
+                RecoverbullMonitoredBackupCompanion.insert(
+                  digest: digest,
+                  lastWarningWindow: const Value(0),
+                  origin: const Value('drive'),
+                  driveAccount: Value(account),
+                  driveFileId: Value(item.fileId),
+                  driveFileCreatedAt: Value(item.createdAt),
+                  driveFileModifiedAt: Value(item.modifiedAt),
+                ),
+              );
+        } else if (existing.origin == 'drive') {
+          await (database.update(
+            database.recoverbullMonitoredBackup,
+          )..where((t) => t.digest.equals(digest))).write(
+            RecoverbullMonitoredBackupCompanion(
+              driveAccount: Value(account),
+              driveFileId: Value(item.fileId),
+              driveFileCreatedAt: Value(item.createdAt),
+              driveFileModifiedAt: Value(item.modifiedAt),
+            ),
+          );
+        }
+        await database
+            .into(database.recoverbullDriveBackupCache)
+            .insertOnConflictUpdate(
+              RecoverbullDriveBackupCacheCompanion.insert(
+                account: account,
+                driveFileId: item.fileId,
+                backupDigest: digest,
+                driveFileCreatedAt: item.createdAt,
+                driveFileModifiedAt: Value(item.modifiedAt),
+              ),
+            );
+      }
+      return true;
     });
   }
 
@@ -547,10 +690,30 @@ final class RecoverBullAttemptMonitoringStore {
         1000;
   }
 
+  static String _hex(List<int> bytes) =>
+      bytes.map((value) => value.toRadixString(16).padLeft(2, '0')).join();
+
   static int collectionSecond(DateTime value) =>
       value.toUtc().millisecondsSinceEpoch ~/ 1000;
 
   static bool _same(List<int> a, List<int> b) =>
       a.length == b.length &&
       Iterable<int>.generate(a.length).every((i) => a[i] == b[i]);
+}
+
+final class DriveBackupObservation {
+  final String fileId;
+  final List<int> digest;
+  final DateTime createdAt;
+  final DateTime? modifiedAt;
+
+  const DriveBackupObservation({
+    required this.fileId,
+    required this.digest,
+    required this.createdAt,
+    required this.modifiedAt,
+  });
+
+  String get digestKey =>
+      digest.map((value) => value.toRadixString(16).padLeft(2, '0')).join();
 }

--- a/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
+++ b/features/recoverbull/lib/src/attempt_monitoring/recoverbull_attempt_monitoring.dart
@@ -303,6 +303,22 @@ final class RecoverBullAttemptMonitoringStore {
                   .firstOrNull ??
               snapshot.collectionStartedAt,
         );
+        if (row.currentWindow == 0 && row.lastWarningWindow == 0) {
+          await (database.update(database.recoverbullMonitoredBackup)..where(
+                (t) =>
+                    t.digest.equals(row.digest) &
+                    t.rowRevision.equals(row.rowRevision),
+              ))
+              .write(
+                RecoverbullMonitoredBackupCompanion(
+                  expectedServerDistinctCandidateTotal: Value(observed),
+                  currentWindow: Value(observedWindow),
+                  lastWarningWindow: const Value(null),
+                  rowRevision: Value(row.rowRevision + 1),
+                ),
+              );
+          continue;
+        }
         if (row.currentWindow != 0 && row.currentWindow != observedWindow) {
           await (database.update(database.recoverbullMonitoredBackup)..where(
                 (t) =>

--- a/features/recoverbull/lib/src/composition/recoverbull_composition.dart
+++ b/features/recoverbull/lib/src/composition/recoverbull_composition.dart
@@ -42,6 +42,7 @@ import '../router/recoverbull_flow.dart';
 import '../google_drive/ui/screens/drive_vaults_list_page.dart';
 import '../ui/screens/server_confirmation_page.dart';
 import '../ui/screens/settings_page.dart';
+import '../ui/screens/recoverbull_settings_cubit.dart';
 import '../google_drive/presentation/state.dart';
 import '../attempt_monitoring/recoverbull_attempt_monitoring.dart';
 import 'package:bull_logger/bull_logger.dart' show LogSink;
@@ -397,11 +398,15 @@ final class RecoverBullFeature {
               ),
               settingsPageBuilder: (context) => SettingsPage(
                 log: log,
-                fetchUrlUsecase: FetchRecoverbullUrlUsecase(
-                  recoverBullRepository: _repository,
-                ),
-                storeUrlUsecase: StoreRecoverbullUrlUsecase(
-                  recoverBullRepository: _repository,
+                cubit: RecoverBullSettingsCubit(
+                  log: log,
+                  fetchUrl: FetchRecoverbullUrlUsecase(
+                    recoverBullRepository: _repository,
+                  ),
+                  storeUrl: StoreRecoverbullUrlUsecase(
+                    recoverBullRepository: _repository,
+                  ),
+                  monitoring: _attemptMonitoring,
                 ),
               ),
               requestPermissionPageBuilder: (context) => RequestPermissionPage(
@@ -424,11 +429,15 @@ final class RecoverBullFeature {
               ),
               settingsPageBuilder: (context) => SettingsPage(
                 log: log,
-                fetchUrlUsecase: FetchRecoverbullUrlUsecase(
-                  recoverBullRepository: _repository,
-                ),
-                storeUrlUsecase: StoreRecoverbullUrlUsecase(
-                  recoverBullRepository: _repository,
+                cubit: RecoverBullSettingsCubit(
+                  log: log,
+                  fetchUrl: FetchRecoverbullUrlUsecase(
+                    recoverBullRepository: _repository,
+                  ),
+                  storeUrl: StoreRecoverbullUrlUsecase(
+                    recoverBullRepository: _repository,
+                  ),
+                  monitoring: _attemptMonitoring,
                 ),
               ),
               requestPermissionPageBuilder: (context) => RequestPermissionPage(

--- a/features/recoverbull/lib/src/composition/recoverbull_composition.dart
+++ b/features/recoverbull/lib/src/composition/recoverbull_composition.dart
@@ -170,7 +170,10 @@ final class RecoverBullFeature {
     final fetchVaultKey = FetchVaultKeyFromServerUsecase(
       repository: repository,
       ensureTor: ensureTor,
-      recordAttempt: RecordLocalAttemptUsecase(attemptMonitoringStore),
+      recordAttempt: RecordLocalAttemptUsecase(
+        attemptMonitoringStore,
+        remote: productionAttemptMonitoringRemote,
+      ),
       alertPort: attemptMonitoring,
       log: log,
     );

--- a/features/recoverbull/lib/src/composition/recoverbull_composition.dart
+++ b/features/recoverbull/lib/src/composition/recoverbull_composition.dart
@@ -5,6 +5,7 @@ import '../data/datasources/recoverbull_settings_datasource.dart';
 import '../data/recoverbull_repository_impl.dart';
 import '../data/file_system_repository.dart';
 import '../data/google_drive_repository.dart';
+import '../data/debug_google_drive_repository.dart';
 import '../domain/entities/encrypted_vault.dart';
 import '../domain/usecases/check_server_connection_usecase.dart';
 import '../domain/usecases/allow_permission_usecase.dart';
@@ -30,6 +31,8 @@ import '../domain/usecases/save_file_to_system_usecase.dart';
 import '../domain/usecases/store_recoverbull_url_usecase.dart';
 import '../domain/usecases/store_vault_key_into_server_usecase.dart';
 import '../domain/usecases/verify_decrypted_vault_usecase.dart';
+import '../domain/usecases/discover_drive_backups_usecase.dart';
+import '../data/google_drive_backup_discovery_adapter.dart';
 import '../google_drive/presentation/bloc.dart';
 import '../google_drive/recoverbull_google_drive_router.dart';
 import '../presentation/bloc.dart';
@@ -127,9 +130,17 @@ final class RecoverBullFeature {
       log: log,
       datasource: FileStorageDatasource(),
     );
-    final drive = GoogleDriveRepository(
+    final productionDrive = GoogleDriveRepositoryImpl(
       log: log,
       datasource: GoogleDriveAppDatasource(log: log),
+    );
+    final drive = selectGoogleDriveRepository(production: productionDrive);
+    unawaited(
+      DiscoverDriveBackupsUsecase(
+        drive: GoogleDriveBackupDiscoveryAdapter(drive),
+        store: attemptMonitoringStore,
+        log: log,
+      ).execute(),
     );
     final ensureTor = EnsureRecoverBullTorSessionUsecase(
       tor.embedded,

--- a/features/recoverbull/lib/src/data/datasources/google_drive_datasource.dart
+++ b/features/recoverbull/lib/src/data/datasources/google_drive_datasource.dart
@@ -8,14 +8,18 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:googleapis/drive/v3.dart' as drive;
 
 class GoogleDriveAppDatasource {
+  static const metadataFields =
+      'nextPageToken,files(id, name, createdTime, modifiedTime)';
+  static const metadataPageSize = 1000;
   final LogSink log;
+  final Future<GoogleDriveMetadataPage> Function(String? pageToken)? pageLister;
   static final _google = GoogleSignIn(
     scopes: ['https://www.googleapis.com/auth/drive.appdata'],
   );
 
   drive.DriveApi? _driveApi;
 
-  GoogleDriveAppDatasource({required this.log});
+  GoogleDriveAppDatasource({required this.log, this.pageLister});
 
   void _checkConnection() {
     if (_driveApi == null) throw 'unauthenticated';
@@ -37,23 +41,64 @@ class GoogleDriveAppDatasource {
     }
   }
 
+  Future<String?> connectSilently() async {
+    try {
+      final account = await _google.signInSilently();
+      if (account == null) return null;
+      final client = await _google.authenticatedClient();
+      if (client == null) return null;
+      _driveApi = drive.DriveApi(client);
+      return account.email;
+    } catch (error, stackTrace) {
+      log.warning(
+        'Google silent sign-in unavailable',
+        error: error,
+        trace: stackTrace,
+      );
+      await disconnect();
+      return null;
+    }
+  }
+
   Future<void> disconnect() async {
     await _google.disconnect();
     _driveApi = null;
   }
 
   Future<List<DriveFileMetadataModel>> fetchAllMetadata() async {
-    _checkConnection();
+    if (pageLister == null) _checkConnection();
+    final result = <DriveFileMetadataModel>[];
+    final seenTokens = <String>{};
+    String? token;
+    while (true) {
+      final page = pageLister == null
+          ? await _listPageFromApi(token)
+          : await pageLister!(token);
+      result.addAll(page.files);
+      final next = page.nextPageToken;
+      if (next == null || next.isEmpty) return result;
+      if (!seenTokens.add(next)) {
+        throw StateError('Drive pagination repeated a page token');
+      }
+      token = next;
+    }
+  }
+
+  Future<GoogleDriveMetadataPage> _listPageFromApi(String? pageToken) async {
     final response = await _driveApi!.files.list(
       spaces: 'appDataFolder',
       q: "mimeType='application/json' and trashed=false",
-      $fields: 'files(id, name, createdTime)',
+      $fields: metadataFields,
       orderBy: 'createdTime desc',
+      pageToken: pageToken,
+      pageSize: metadataPageSize,
     );
-    return response.files
-            ?.map((file) => DriveFileMetadataModel.fromDriveFile(file))
-            .toList() ??
-        [];
+    return GoogleDriveMetadataPage(
+      files:
+          response.files?.map(DriveFileMetadataModel.fromDriveFile).toList() ??
+          const [],
+      nextPageToken: response.nextPageToken,
+    );
   }
 
   Future<List<int>> fetchFileContent(String fileId) async {
@@ -96,4 +141,11 @@ class GoogleDriveAppDatasource {
       ),
     );
   }
+}
+
+final class GoogleDriveMetadataPage {
+  final List<DriveFileMetadataModel> files;
+  final String? nextPageToken;
+
+  const GoogleDriveMetadataPage({required this.files, this.nextPageToken});
 }

--- a/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
+++ b/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
@@ -279,6 +279,18 @@ final class RecoverBullAttemptMonitoringRemoteAdapter
           serviceBusy: true,
         );
       }
+      if (error.code == 429) {
+        return RecoverBullAttemptsSnapshot(
+          collectionStartedAt: DateTime.fromMillisecondsSinceEpoch(
+            0,
+            isUtc: true,
+          ),
+          totalAttempts: const {},
+          targetedLockouts: [
+            for (final digest in backupDigests) _decodeDigest(digest),
+          ],
+        );
+      }
       rethrow;
     } finally {
       await route.closeQuietly();

--- a/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
+++ b/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
@@ -217,7 +217,8 @@ class RecoverBullRemoteDatasource {
 
 /// Production bridge for the pinned client. It filters before returning so a
 /// complete public `/attempts` map never enters package state.
-final class RecoverBullAttemptMonitoringRemoteAdapter {
+final class RecoverBullAttemptMonitoringRemoteAdapter
+    implements RecoverBullAttemptMonitoringRemotePort {
   final RecoverBullRemoteDatasource datasource;
   final Future<RecoverBullTorRoute> Function() routeFactory;
 
@@ -226,6 +227,7 @@ final class RecoverBullAttemptMonitoringRemoteAdapter {
     required this.routeFactory,
   });
 
+  @override
   Future<RecoverBullAttemptsSnapshot?> poll({
     required String? etag,
     required List<String> backupDigests,
@@ -267,7 +269,7 @@ final class RecoverBullAttemptMonitoringRemoteAdapter {
           ),
       };
     } on KeyServerException catch (error) {
-      if (error.code == 503) {
+      if (error.code == 404 || error.code == 503) {
         return RecoverBullAttemptsSnapshot(
           collectionStartedAt: DateTime.fromMillisecondsSinceEpoch(
             0,

--- a/features/recoverbull/lib/src/data/datasources/recoverbull_settings_datasource.dart
+++ b/features/recoverbull/lib/src/data/datasources/recoverbull_settings_datasource.dart
@@ -21,7 +21,17 @@ class RecoverbullSettingsDatasource {
         state.serverUrlOverride ?? _defaultServer.toString(),
       );
       if (oldEffective == url) return;
-      await _database.delete(_database.recoverbullMonitoredBackup).go();
+      await (_database.update(_database.recoverbullMonitoredBackup)).write(
+        const RecoverbullMonitoredBackupCompanion(
+          expectedServerDistinctCandidateTotal: Value(0),
+          currentWindow: Value(0),
+          // Zero is a private marker for a row awaiting its first observation
+          // on the new server. A newly created row keeps null and still alerts
+          // on its first server-side attempt.
+          lastWarningWindow: Value(0),
+          rowRevision: Value(0),
+        ),
+      );
       await _database
           .update(_database.recoverbullState)
           .write(

--- a/features/recoverbull/lib/src/data/debug_google_drive_repository.dart
+++ b/features/recoverbull/lib/src/data/debug_google_drive_repository.dart
@@ -1,0 +1,230 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:primitives/primitives.dart';
+
+import '../domain/entities/drive_file_metadata.dart';
+import '../domain/entities/encrypted_vault.dart';
+import '../domain/recoverbull_failure.dart';
+import '../domain/repositories/google_drive_repository.dart';
+
+/// An in-memory Drive containing deterministic, non-secret vault fixtures.
+/// This class is intentionally usable only from debug composition.
+final class DebugGoogleDriveRepository implements GoogleDriveRepository {
+  final String accountEmail;
+  final Map<String, _DebugDriveFile> _files = {};
+  int _nextId = 0;
+  bool _connected = false;
+  Future<void> _queue = Future<void>.value();
+
+  DebugGoogleDriveRepository({
+    this.accountEmail = 'recoverbull.debug@example.invalid',
+  }) {
+    for (var i = 0; i < 3; i++) {
+      final vault = _fixture(i);
+      final id = 'debug-file-$i';
+      _files[id] = _DebugDriveFile(
+        content: vault.toFile(),
+        createdAt: vault.createdAt.toUtc(),
+      );
+    }
+    _nextId = _files.length;
+  }
+
+  @override
+  Future<Result<Null, RecoverBullFailure>> connect() => _serialized(() async {
+    _connected = true;
+    return const Ok(null);
+  });
+
+  @override
+  Future<String?> connectSilently() => _serialized(() async {
+    _connected = true;
+    return accountEmail;
+  });
+
+  @override
+  Future<void> disconnect() => _serialized(() async => _connected = false);
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(GoogleDriveDiscoverySession? session) action,
+  ) => _serialized(() async {
+    _connected = true;
+    return action(_DebugSession(this, accountEmail));
+  });
+
+  @override
+  Future<Result<List<DriveFileMetadata>, RecoverBullFailure>>
+  fetchAllMetadata() => _serialized(_fetchAllMetadataUnlocked);
+
+  Future<Result<List<DriveFileMetadata>, RecoverBullFailure>>
+  _fetchAllMetadataUnlocked() async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    return Ok([
+      for (final entry in _files.entries)
+        DriveFileMetadata(
+          id: entry.key,
+          name: EncryptedVault(file: entry.value.content).filename,
+          createdTime: entry.value.createdAt,
+          modifiedTime: null,
+        ),
+    ]);
+  }
+
+  @override
+  Future<Result<EncryptedVault, RecoverBullFailure>> fetchVault(
+    String fileId,
+  ) => _serialized(() => _fetchVaultUnlocked(fileId));
+
+  Future<Result<EncryptedVault, RecoverBullFailure>> _fetchVaultUnlocked(
+    String fileId,
+  ) async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    final content = _files[fileId]?.content;
+    if (content == null) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    return Ok(EncryptedVault(file: content));
+  }
+
+  @override
+  Future<Result<String, RecoverBullFailure>> fetchRawFile(String fileId) =>
+      _serialized(() => _fetchRawFileUnlocked(fileId));
+
+  Future<Result<String, RecoverBullFailure>> _fetchRawFileUnlocked(
+    String fileId,
+  ) async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    final content = _files[fileId]?.content;
+    return content == null
+        ? const Err(RecoverBullUnexpectedFailure('Drive operation failed'))
+        : Ok(content);
+  }
+
+  @override
+  Future<Result<EncryptedVault, RecoverBullFailure>> fetchLatestVault() =>
+      _serialized(_fetchLatestVaultUnlocked);
+
+  Future<Result<EncryptedVault, RecoverBullFailure>>
+  _fetchLatestVaultUnlocked() async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    if (_files.isEmpty) {
+      return const Err(RecoverBullUnexpectedFailure('no drive backups'));
+    }
+    final file = _files.values.reduce(
+      (a, b) => a.createdAt.isAfter(b.createdAt) ? a : b,
+    );
+    return Ok(EncryptedVault(file: file.content));
+  }
+
+  @override
+  Future<Result<Null, RecoverBullFailure>> store(String content) =>
+      _serialized(() => _storeUnlocked(content));
+
+  Future<Result<Null, RecoverBullFailure>> _storeUnlocked(
+    String content,
+  ) async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    try {
+      final vault = EncryptedVault(file: content);
+      _files['debug-file-${_nextId++}'] = _DebugDriveFile(
+        content: vault.toFile(),
+        createdAt: vault.createdAt.toUtc(),
+      );
+      return const Ok(null);
+    } catch (_) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+  }
+
+  @override
+  Future<Result<Null, RecoverBullFailure>> trash(String fileId) =>
+      _serialized(() => _trashUnlocked(fileId));
+
+  Future<Result<Null, RecoverBullFailure>> _trashUnlocked(String fileId) async {
+    if (!_connected) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    if (_files.remove(fileId) == null) {
+      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
+    }
+    return const Ok(null);
+  }
+
+  Future<T> _serialized<T>(Future<T> Function() action) {
+    final start = _queue;
+    final result = start.then((_) => action(), onError: (_, _) => action());
+    _queue = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  static EncryptedVault _fixture(int index) {
+    final id = List<int>.generate(32, (i) => (i + index) & 0xff);
+    final salt = List<int>.generate(16, (i) => (i * 3 + index) & 0xff);
+    final bytes = List<int>.generate(64, (i) => (i + index * 7) & 0xff);
+    final raw = jsonEncode({
+      'version': 1,
+      'created_at': DateTime.utc(2026, 1, index + 1).millisecondsSinceEpoch,
+      'id': id.map((v) => v.toRadixString(16).padLeft(2, '0')).join(),
+      'salt': salt.map((v) => v.toRadixString(16).padLeft(2, '0')).join(),
+      'ciphertext': base64Encode(bytes),
+      'path': "m/83696968'/0'/0'",
+    });
+    return EncryptedVault(file: raw);
+  }
+}
+
+final class _DebugSession implements GoogleDriveDiscoverySession {
+  final DebugGoogleDriveRepository repository;
+  @override
+  final String account;
+
+  const _DebugSession(this.repository, this.account);
+
+  @override
+  Future<List<DriveFileMetadata>> fetchAllMetadata() async {
+    final result = await repository._fetchAllMetadataUnlocked();
+    return switch (result) {
+      Ok(:final value) => value,
+      Err() => throw StateError('Drive metadata unavailable'),
+    };
+  }
+
+  @override
+  Future<String> fetchRawFile(String fileId) async {
+    final result = await repository._fetchRawFileUnlocked(fileId);
+    return switch (result) {
+      Ok(:final value) => value,
+      Err() => throw StateError('Drive content unavailable'),
+    };
+  }
+}
+
+final class _DebugDriveFile {
+  final String content;
+  final DateTime createdAt;
+
+  const _DebugDriveFile({required this.content, required this.createdAt});
+}
+
+GoogleDriveRepository selectGoogleDriveRepository({
+  required GoogleDriveRepository production,
+  bool fakeEnabled = const bool.fromEnvironment('RECOVERBULL_FAKE_DRIVE'),
+  bool debugMode = kDebugMode,
+}) {
+  if (fakeEnabled && !debugMode) {
+    throw StateError('RECOVERBULL_FAKE_DRIVE is debug-only');
+  }
+  return fakeEnabled ? DebugGoogleDriveRepository() : production;
+}

--- a/features/recoverbull/lib/src/data/google_drive_backup_discovery_adapter.dart
+++ b/features/recoverbull/lib/src/data/google_drive_backup_discovery_adapter.dart
@@ -1,0 +1,41 @@
+import '../domain/recoverbull_drive_discovery_port.dart';
+import '../domain/repositories/google_drive_repository.dart';
+
+final class GoogleDriveBackupDiscoveryAdapter
+    implements RecoverBullDriveDiscoveryPort {
+  final GoogleDriveRepository repository;
+
+  const GoogleDriveBackupDiscoveryAdapter(this.repository);
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(RecoverBullDriveDiscoverySession? session) action,
+  ) {
+    return repository.withDiscoverySession((session) {
+      if (session == null) return action(null);
+      return action(_AdapterSession(session));
+    });
+  }
+}
+
+final class _AdapterSession implements RecoverBullDriveDiscoverySession {
+  final GoogleDriveDiscoverySession _session;
+
+  const _AdapterSession(this._session);
+
+  @override
+  String get account => _session.account;
+
+  @override
+  Future<List<RecoverBullDriveFile>> files() async => [
+    for (final file in await _session.fetchAllMetadata())
+      RecoverBullDriveFile(
+        id: file.id,
+        createdTime: file.createdTime,
+        modifiedTime: file.modifiedTime,
+      ),
+  ];
+
+  @override
+  Future<String> content(String fileId) => _session.fetchRawFile(fileId);
+}

--- a/features/recoverbull/lib/src/data/google_drive_repository.dart
+++ b/features/recoverbull/lib/src/data/google_drive_repository.dart
@@ -4,101 +4,151 @@ import './datasources/google_drive_datasource.dart';
 import '../domain/entities/drive_file_metadata.dart';
 import '../domain/entities/encrypted_vault.dart';
 import '../domain/recoverbull_failure.dart';
+import '../domain/repositories/google_drive_repository.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:primitives/primitives.dart';
 
 /// Data boundary for Google Drive vault storage. Catches Drive/auth/IO
 /// exceptions, logs the raw reason, and returns a [RecoverBullFailure].
-class GoogleDriveRepository {
+final class GoogleDriveRepositoryImpl implements GoogleDriveRepository {
   final LogSink log;
   final GoogleDriveAppDatasource _dataSource;
+  Future<void> _queue = Future<void>.value();
 
-  GoogleDriveRepository({
+  GoogleDriveRepositoryImpl({
     required this.log,
     required GoogleDriveAppDatasource datasource,
   }) : _dataSource = datasource;
 
+  @override
   Future<Result<Null, RecoverBullFailure>> connect() async {
-    try {
-      await _dataSource.connect();
-      return const Ok(null);
-    } catch (e, st) {
-      log.error('drive connect failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        await _dataSource.connect();
+        return const Ok(null);
+      } catch (e, st) {
+        log.error('drive connect failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
-  Future<void> disconnect() => _dataSource.disconnect();
+  @override
+  Future<String?> connectSilently() => _serialized(_dataSource.connectSilently);
 
+  @override
+  Future<void> disconnect() => _serialized(_dataSource.disconnect);
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(GoogleDriveDiscoverySession? session) action,
+  ) => _serialized(() async {
+    final account = await _dataSource.connectSilently();
+    if (account == null) return action(null);
+    return action(_Session(this, account));
+  });
+
+  @override
   Future<Result<List<DriveFileMetadata>, RecoverBullFailure>>
   fetchAllMetadata() async {
-    try {
-      return Ok(await _fetchAllMetadata());
-    } catch (e, st) {
-      log.error('drive fetchAllMetadata failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        return Ok(await _fetchAllMetadata());
+      } catch (e, st) {
+        log.error('drive fetchAllMetadata failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
+  @override
   Future<Result<EncryptedVault, RecoverBullFailure>> fetchVault(
     String fileId,
   ) async {
-    try {
-      return Ok(EncryptedVault(file: await _fetchContent(fileId)));
-    } catch (e, st) {
-      log.error('drive fetchVault failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        return Ok(EncryptedVault(file: await _fetchContent(fileId)));
+      } catch (e, st) {
+        log.error('drive fetchVault failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
   /// Raw file content (not parsed as a vault) — used when exporting a backup
   /// file verbatim to local storage.
+  @override
   Future<Result<String, RecoverBullFailure>> fetchRawFile(String fileId) async {
-    try {
-      return Ok(await _fetchContent(fileId));
-    } catch (e, st) {
-      log.error('drive fetchRawFile failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        return Ok(await _fetchContent(fileId));
+      } catch (e, st) {
+        log.error('drive fetchRawFile failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
   /// Fetches the most recently created vault. (The "pick latest" shaping lives
   /// here, not in the use-case, and an empty Drive surfaces as a failure rather
   /// than the `StateError` `reduce` would throw.)
+  @override
   Future<Result<EncryptedVault, RecoverBullFailure>> fetchLatestVault() async {
-    try {
-      final backups = await _fetchAllMetadata();
-      if (backups.isEmpty) {
-        return const Err(RecoverBullUnexpectedFailure('no drive backups'));
+    return _serialized(() async {
+      try {
+        final backups = await _fetchAllMetadata();
+        if (backups.isEmpty) {
+          return const Err(RecoverBullUnexpectedFailure('no drive backups'));
+        }
+        final latest = backups.reduce(
+          (a, b) => a.createdTime.compareTo(b.createdTime) > 0 ? a : b,
+        );
+        return Ok(EncryptedVault(file: await _fetchContent(latest.id)));
+      } catch (e, st) {
+        log.error('drive fetchLatestVault failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
       }
-      final latest = backups.reduce(
-        (a, b) => a.createdTime.compareTo(b.createdTime) > 0 ? a : b,
-      );
-      return Ok(EncryptedVault(file: await _fetchContent(latest.id)));
-    } catch (e, st) {
-      log.error('drive fetchLatestVault failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    });
   }
 
+  @override
   Future<Result<Null, RecoverBullFailure>> store(String content) async {
-    try {
-      await _dataSource.store(content);
-      return const Ok(null);
-    } catch (e, st) {
-      log.error('drive store failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        await _dataSource.store(content);
+        return const Ok(null);
+      } catch (e, st) {
+        log.error('drive store failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
+  @override
   Future<Result<Null, RecoverBullFailure>> trash(String fileId) async {
-    try {
-      await _dataSource.trash(fileId);
-      return const Ok(null);
-    } catch (e, st) {
-      log.error('drive trash failed', error: e, trace: st);
-      return const Err(RecoverBullUnexpectedFailure('Drive operation failed'));
-    }
+    return _serialized(() async {
+      try {
+        await _dataSource.trash(fileId);
+        return const Ok(null);
+      } catch (e, st) {
+        log.error('drive trash failed', error: e, trace: st);
+        return const Err(
+          RecoverBullUnexpectedFailure('Drive operation failed'),
+        );
+      }
+    });
   }
 
   Future<List<DriveFileMetadata>> _fetchAllMetadata() async {
@@ -110,4 +160,29 @@ class GoogleDriveRepository {
     final bytes = await _dataSource.fetchFileContent(fileId);
     return utf8.decode(bytes);
   }
+
+  Future<T> _serialized<T>(Future<T> Function() action) {
+    final start = _queue;
+    final result = start.then((_) => action(), onError: (_, _) => action());
+    _queue = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+
+  Future<List<DriveFileMetadata>> _sessionMetadata() => _fetchAllMetadata();
+}
+
+final class _Session implements GoogleDriveDiscoverySession {
+  final GoogleDriveRepositoryImpl _repository;
+  @override
+  final String account;
+
+  const _Session(this._repository, this.account);
+
+  @override
+  Future<List<DriveFileMetadata>> fetchAllMetadata() =>
+      _repository._sessionMetadata();
+
+  @override
+  Future<String> fetchRawFile(String fileId) =>
+      _repository._fetchContent(fileId);
 }

--- a/features/recoverbull/lib/src/data/models/drive_file_metadata_model.dart
+++ b/features/recoverbull/lib/src/data/models/drive_file_metadata_model.dart
@@ -7,11 +7,13 @@ class DriveFileMetadataModel {
   final String id;
   final String name;
   final DateTime createdTime;
+  final DateTime? modifiedTime;
 
   DriveFileMetadataModel({
     required this.id,
     required this.name,
     required this.createdTime,
+    this.modifiedTime,
   });
 
   factory DriveFileMetadataModel.fromDriveFile(drive.File file) {
@@ -23,11 +25,17 @@ class DriveFileMetadataModel {
       id: file.id!,
       name: file.name!,
       createdTime: file.createdTime!,
+      modifiedTime: file.modifiedTime,
     );
   }
 
   DriveFileMetadata toEntity() {
-    return DriveFileMetadata(id: id, name: name, createdTime: createdTime);
+    return DriveFileMetadata(
+      id: id,
+      name: name,
+      createdTime: createdTime,
+      modifiedTime: modifiedTime,
+    );
   }
 }
 

--- a/features/recoverbull/lib/src/database/recoverbull_database.dart
+++ b/features/recoverbull/lib/src/database/recoverbull_database.dart
@@ -43,6 +43,11 @@ class RecoverbullMonitoredBackup extends Table {
   IntColumn get currentWindow => integer().withDefault(const Constant(0))();
   IntColumn get lastWarningWindow => integer().nullable()();
   IntColumn get rowRevision => integer().withDefault(const Constant(0))();
+  TextColumn get origin => text().withDefault(const Constant('created'))();
+  TextColumn get driveAccount => text().nullable()();
+  TextColumn get driveFileId => text().nullable()();
+  DateTimeColumn get driveFileCreatedAt => dateTime().nullable()();
+  DateTimeColumn get driveFileModifiedAt => dateTime().nullable()();
 
   @override
   Set<Column<Object>> get primaryKey => {digest};
@@ -56,7 +61,24 @@ class RecoverbullMonitoredBackup extends Table {
   ];
 }
 
-@DriftDatabase(tables: [RecoverbullState, RecoverbullMonitoredBackup])
+class RecoverbullDriveBackupCache extends Table {
+  TextColumn get account => text()();
+  TextColumn get driveFileId => text()();
+  BlobColumn get backupDigest => blob()();
+  DateTimeColumn get driveFileCreatedAt => dateTime()();
+  DateTimeColumn get driveFileModifiedAt => dateTime().nullable()();
+
+  @override
+  Set<Column<Object>> get primaryKey => {account, driveFileId};
+}
+
+@DriftDatabase(
+  tables: [
+    RecoverbullState,
+    RecoverbullMonitoredBackup,
+    RecoverbullDriveBackupCache,
+  ],
+)
 final class RecoverBullDatabase extends _$RecoverBullDatabase {
   static const schema = 1;
   final bool initialPermissionGranted;

--- a/features/recoverbull/lib/src/database/schemas/recoverbull_database/drift_schema_v1.json
+++ b/features/recoverbull/lib/src/database/schemas/recoverbull_database/drift_schema_v1.json
@@ -224,6 +224,56 @@
             "default_dart": "const CustomExpression('0')",
             "default_client_dart": null,
             "dsl_features": []
+          },
+          {
+            "name": "origin",
+            "getter_name": "origin",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'created\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_account",
+            "getter_name": "driveAccount",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_id",
+            "getter_name": "driveFileId",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_created_at",
+            "getter_name": "driveFileCreatedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_modified_at",
+            "getter_name": "driveFileModifiedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
           }
         ],
         "is_virtual": false,
@@ -236,6 +286,74 @@
         ],
         "explicit_pk": [
           "digest"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "recoverbull_drive_backup_cache",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "account",
+            "getter_name": "account",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_id",
+            "getter_name": "driveFileId",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "backup_digest",
+            "getter_name": "backupDigest",
+            "moor_type": "blob",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_created_at",
+            "getter_name": "driveFileCreatedAt",
+            "moor_type": "dateTime",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "drive_file_modified_at",
+            "getter_name": "driveFileModifiedAt",
+            "moor_type": "dateTime",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": [],
+        "explicit_pk": [
+          "account",
+          "drive_file_id"
         ]
       }
     }
@@ -255,7 +373,16 @@
       "sql": [
         {
           "dialect": "sqlite",
-          "sql": "CREATE TABLE IF NOT EXISTS \"recoverbull_monitored_backup\" (\"digest\" BLOB NOT NULL CHECK (length(digest) = 32), \"expected_server_distinct_candidate_total\" INTEGER NOT NULL DEFAULT 0, \"current_window\" INTEGER NOT NULL DEFAULT 0, \"last_warning_window\" INTEGER NULL, \"row_revision\" INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (\"digest\"), CHECK (expected_server_distinct_candidate_total >= 0), CHECK (current_window >= 0), CHECK (last_warning_window IS NULL OR last_warning_window >= 0), CHECK (row_revision >= 0));"
+          "sql": "CREATE TABLE IF NOT EXISTS \"recoverbull_monitored_backup\" (\"digest\" BLOB NOT NULL CHECK (length(digest) = 32), \"expected_server_distinct_candidate_total\" INTEGER NOT NULL DEFAULT 0, \"current_window\" INTEGER NOT NULL DEFAULT 0, \"last_warning_window\" INTEGER NULL, \"row_revision\" INTEGER NOT NULL DEFAULT 0, \"origin\" TEXT NOT NULL DEFAULT 'created', \"drive_account\" TEXT NULL, \"drive_file_id\" TEXT NULL, \"drive_file_created_at\" TEXT NULL, \"drive_file_modified_at\" TEXT NULL, PRIMARY KEY (\"digest\"), CHECK (expected_server_distinct_candidate_total >= 0), CHECK (current_window >= 0), CHECK (last_warning_window IS NULL OR last_warning_window >= 0), CHECK (row_revision >= 0));"
+        }
+      ]
+    },
+    {
+      "name": "recoverbull_drive_backup_cache",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"recoverbull_drive_backup_cache\" (\"account\" TEXT NOT NULL, \"drive_file_id\" TEXT NOT NULL, \"backup_digest\" BLOB NOT NULL, \"drive_file_created_at\" TEXT NOT NULL, \"drive_file_modified_at\" TEXT NULL, PRIMARY KEY (\"account\", \"drive_file_id\"));"
         }
       ]
     }

--- a/features/recoverbull/lib/src/domain/entities/drive_file_metadata.dart
+++ b/features/recoverbull/lib/src/domain/entities/drive_file_metadata.dart
@@ -2,10 +2,12 @@ class DriveFileMetadata {
   final String id;
   final String name;
   final DateTime createdTime;
+  final DateTime? modifiedTime;
 
   DriveFileMetadata({
     required this.id,
     required this.name,
     required this.createdTime,
+    this.modifiedTime,
   });
 }

--- a/features/recoverbull/lib/src/domain/recoverbull_drive_discovery_port.dart
+++ b/features/recoverbull/lib/src/domain/recoverbull_drive_discovery_port.dart
@@ -1,0 +1,23 @@
+abstract interface class RecoverBullDriveDiscoveryPort {
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(RecoverBullDriveDiscoverySession? session) action,
+  );
+}
+
+abstract interface class RecoverBullDriveDiscoverySession {
+  String get account;
+  Future<List<RecoverBullDriveFile>> files();
+  Future<String> content(String fileId);
+}
+
+final class RecoverBullDriveFile {
+  final String id;
+  final DateTime createdTime;
+  final DateTime? modifiedTime;
+
+  const RecoverBullDriveFile({
+    required this.id,
+    required this.createdTime,
+    this.modifiedTime,
+  });
+}

--- a/features/recoverbull/lib/src/domain/repositories/google_drive_repository.dart
+++ b/features/recoverbull/lib/src/domain/repositories/google_drive_repository.dart
@@ -1,0 +1,27 @@
+import 'package:primitives/primitives.dart';
+
+import '../entities/drive_file_metadata.dart';
+import '../entities/encrypted_vault.dart';
+import '../recoverbull_failure.dart';
+
+abstract interface class GoogleDriveRepository {
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(GoogleDriveDiscoverySession? session) action,
+  );
+  Future<Result<Null, RecoverBullFailure>> connect();
+  Future<String?> connectSilently();
+  Future<void> disconnect();
+  Future<Result<List<DriveFileMetadata>, RecoverBullFailure>>
+  fetchAllMetadata();
+  Future<Result<EncryptedVault, RecoverBullFailure>> fetchVault(String fileId);
+  Future<Result<String, RecoverBullFailure>> fetchRawFile(String fileId);
+  Future<Result<EncryptedVault, RecoverBullFailure>> fetchLatestVault();
+  Future<Result<Null, RecoverBullFailure>> store(String content);
+  Future<Result<Null, RecoverBullFailure>> trash(String fileId);
+}
+
+abstract interface class GoogleDriveDiscoverySession {
+  String get account;
+  Future<List<DriveFileMetadata>> fetchAllMetadata();
+  Future<String> fetchRawFile(String fileId);
+}

--- a/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
@@ -101,6 +101,7 @@ final class CheckBackupAttemptMonitoringUsecase {
         _hex(entry.key): entry.value,
     };
     for (final row in rows) {
+      if (row.currentWindow == 0 && row.lastWarningWindow == 0) continue;
       final hash = _hex(row.digest);
       final observed = entries[hash];
       if (observed == null ||

--- a/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
@@ -1,5 +1,4 @@
 import '../../attempt_monitoring/recoverbull_attempt_monitoring.dart';
-import '../entities/key_server_attempts.dart';
 import '../entities/attempt_alert.dart';
 
 final class CheckBackupAttemptMonitoringUsecase {
@@ -102,10 +101,6 @@ final class CheckBackupAttemptMonitoringUsecase {
       for (final entry in snapshot.totalAttempts.entries)
         _hex(entry.key): entry.value,
     };
-    final windows = {
-      for (final entry in snapshot.windowStartedAt.entries)
-        _hex(entry.key): entry.value,
-    };
     for (final row in rows) {
       if (row.currentWindow == 0 && row.lastWarningWindow == 0) continue;
       final hash = _hex(row.digest);
@@ -114,28 +109,14 @@ final class CheckBackupAttemptMonitoringUsecase {
           observed <= row.expectedServerDistinctCandidateTotal) {
         continue;
       }
-      final window = attemptWindowIdentity(
-        windows[hash] ?? snapshot.collectionStartedAt,
+      alerts.add(
+        SuspiciousActivityAlert(
+          backupIdHash: hash,
+          observedTotal: observed,
+          expectedTotal: row.expectedServerDistinctCandidateTotal,
+          windowStartedAt: snapshot.collectionStartedAt,
+        ),
       );
-      if (row.lastWarningWindow != window) {
-        alerts.add(
-          SuspiciousActivityAlert(
-            backupIdHash: hash,
-            observedTotal: observed,
-            expectedTotal: row.expectedServerDistinctCandidateTotal,
-            windowStartedAt: snapshot.collectionStartedAt,
-          ),
-        );
-        await store.replaceBackup(
-          AttemptMonitoringBackupState(
-            serverUrl: '',
-            backupIdHash: hash,
-            expectedTotalAttempts: row.expectedServerDistinctCandidateTotal,
-            currentWindow: row.currentWindow,
-            lastWarningWindow: window,
-          ),
-        );
-      }
     }
     return alerts;
   }

--- a/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
@@ -62,6 +62,12 @@ final class CheckBackupAttemptMonitoringUsecase {
         if (unavailable) const AttemptMonitoringUnavailableAlert(since: null),
       ];
     }
+    if (snapshot.targetedLockouts.isNotEmpty) {
+      return [
+        for (final digest in snapshot.targetedLockouts)
+          TargetedLockoutAlert(backupIdHash: _hex(digest)),
+      ];
+    }
     final alerts = <AttemptAlert>[];
     final collection = await store.state();
     var wiped = false;

--- a/features/recoverbull/lib/src/domain/usecases/discover_drive_backups_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/discover_drive_backups_usecase.dart
@@ -1,0 +1,207 @@
+import 'package:bull_logger/bull_logger.dart';
+
+import '../../attempt_monitoring/recoverbull_attempt_monitoring.dart';
+import '../entities/encrypted_vault.dart';
+import '../recoverbull_drive_discovery_port.dart';
+
+enum DriveDiscoveryStatus {
+  unauthenticated,
+  disabled,
+  empty,
+  complete,
+  partial,
+  failed,
+}
+
+final class DriveDiscoveryResult {
+  final DriveDiscoveryStatus status;
+  final int listed;
+  final int monitored;
+  final int invalid;
+  final int failed;
+
+  const DriveDiscoveryResult({
+    required this.status,
+    required this.listed,
+    required this.monitored,
+    required this.invalid,
+    required this.failed,
+  });
+
+  bool get isPartial => status == DriveDiscoveryStatus.partial;
+}
+
+final class DiscoverDriveBackupsUsecase {
+  final RecoverBullDriveDiscoveryPort drive;
+  final RecoverBullAttemptMonitoringStore store;
+  final LogSink? log;
+
+  const DiscoverDriveBackupsUsecase({
+    required this.drive,
+    required this.store,
+    this.log,
+  });
+
+  Future<DriveDiscoveryResult> execute() async {
+    try {
+      return await _execute();
+    } catch (_) {
+      log?.warning('recoverbull.drive.discovery.failed');
+      return const DriveDiscoveryResult(
+        status: DriveDiscoveryStatus.failed,
+        listed: 0,
+        monitored: 0,
+        invalid: 0,
+        failed: 1,
+      );
+    }
+  }
+
+  Future<DriveDiscoveryResult> _execute() async {
+    if (!(await store.state()).attemptMonitoringEnabled) {
+      return const DriveDiscoveryResult(
+        status: DriveDiscoveryStatus.disabled,
+        listed: 0,
+        monitored: 0,
+        invalid: 0,
+        failed: 0,
+      );
+    }
+    return drive.withDiscoverySession((session) async {
+      if (session == null) {
+        return const DriveDiscoveryResult(
+          status: DriveDiscoveryStatus.unauthenticated,
+          listed: 0,
+          monitored: 0,
+          invalid: 0,
+          failed: 0,
+        );
+      }
+      final account = session.account;
+      final List<RecoverBullDriveFile> files;
+      try {
+        files = await session.files();
+      } catch (_) {
+        log?.warning('recoverbull.drive.discovery.failed');
+        return const DriveDiscoveryResult(
+          status: DriveDiscoveryStatus.failed,
+          listed: 0,
+          monitored: 0,
+          invalid: 0,
+          failed: 1,
+        );
+      }
+      if (files.isEmpty) {
+        final applied = await store.reconcileDriveBackups(account, const []);
+        if (!applied) return _disabledResult;
+        return const DriveDiscoveryResult(
+          status: DriveDiscoveryStatus.empty,
+          listed: 0,
+          monitored: 0,
+          invalid: 0,
+          failed: 0,
+        );
+      }
+
+      final cache = await store.driveCache(account);
+      final monitored = await store.monitoredBackups();
+      final monitoredDigests = {for (final row in monitored) _key(row.digest)};
+      final observations = <DriveBackupObservation>[];
+      var invalid = 0;
+      var failed = 0;
+      for (final file in files) {
+        final old = cache
+            .where((row) => row.driveFileId == file.id)
+            .firstOrNull;
+        if (old != null &&
+            old.driveFileModifiedAt == file.modifiedTime &&
+            monitoredDigests.contains(_key(old.backupDigest))) {
+          observations.add(
+            DriveBackupObservation(
+              fileId: file.id,
+              digest: old.backupDigest,
+              createdAt: file.createdTime,
+              modifiedAt: file.modifiedTime,
+            ),
+          );
+          continue;
+        }
+        final String content;
+        try {
+          content = await session.content(file.id);
+        } catch (_) {
+          failed++;
+          if (old != null) {
+            observations.add(
+              DriveBackupObservation(
+                fileId: file.id,
+                digest: old.backupDigest,
+                createdAt: old.driveFileCreatedAt,
+                modifiedAt: old.driveFileModifiedAt,
+              ),
+            );
+          }
+          continue;
+        }
+        try {
+          final vault = EncryptedVault(file: content);
+          observations.add(
+            DriveBackupObservation(
+              fileId: file.id,
+              digest: store.digestFor(_decode(vault.id)),
+              createdAt: file.createdTime,
+              modifiedAt: file.modifiedTime,
+            ),
+          );
+        } catch (_) {
+          invalid++;
+          if (old != null) {
+            observations.add(
+              DriveBackupObservation(
+                fileId: file.id,
+                digest: old.backupDigest,
+                createdAt: old.driveFileCreatedAt,
+                modifiedAt: old.driveFileModifiedAt,
+              ),
+            );
+          }
+        }
+      }
+      final applied = await store.reconcileDriveBackups(account, observations);
+      if (!applied) return _disabledResult;
+      final status = failed > 0 || invalid > 0
+          ? DriveDiscoveryStatus.partial
+          : DriveDiscoveryStatus.complete;
+      if (status == DriveDiscoveryStatus.partial) {
+        log?.warning(
+          'recoverbull.drive.discovery.partial listed=${files.length} '
+          'monitored=${{for (final item in observations) item.digestKey}.length} '
+          'invalid=$invalid failed=$failed',
+        );
+      }
+      return DriveDiscoveryResult(
+        status: status,
+        listed: files.length,
+        monitored: {for (final item in observations) item.digestKey}.length,
+        invalid: invalid,
+        failed: failed,
+      );
+    });
+  }
+
+  static const _disabledResult = DriveDiscoveryResult(
+    status: DriveDiscoveryStatus.disabled,
+    listed: 0,
+    monitored: 0,
+    invalid: 0,
+    failed: 0,
+  );
+
+  static String _key(List<int> value) =>
+      value.map((item) => item.toRadixString(16).padLeft(2, '0')).join();
+
+  static List<int> _decode(String value) => [
+    for (var i = 0; i < value.length; i += 2)
+      int.parse(value.substring(i, i + 2), radix: 16),
+  ];
+}

--- a/features/recoverbull/lib/src/domain/usecases/fetch_vault_key_from_server_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/fetch_vault_key_from_server_usecase.dart
@@ -75,14 +75,18 @@ class FetchVaultKeyFromServerUsecase {
     EncryptedVault vault,
     VaultKeyFetchResult value,
   ) async {
-    if (value.attemptStatus != null) {
-      try {
-        final alert = await _recordAttempt?.execute(
-          backupIdHex: vault.id,
-          attemptStatus: value.attemptStatus,
-        );
-        if (alert != null) _alertPort?.publish(alert);
-      } catch (_) {}
+    try {
+      final alert = await _recordAttempt?.execute(
+        backupIdHex: vault.id,
+        attemptStatus: value.attemptStatus,
+      );
+      if (alert != null) _alertPort?.publish(alert);
+    } catch (error, stackTrace) {
+      log.warning(
+        'attempt monitoring update failed',
+        error: error,
+        trace: stackTrace,
+      );
     }
     return Ok(value.vaultKey);
   }

--- a/features/recoverbull/lib/src/domain/usecases/fetch_vault_key_with_status_from_server_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/fetch_vault_key_with_status_from_server_usecase.dart
@@ -47,14 +47,20 @@ final class FetchVaultKeyWithStatusFromServerUsecase {
         vault.salt,
         route,
       );
-      if (result case Ok(:final value) when value.attemptStatus != null) {
+      if (result case Ok(:final value)) {
         try {
           final alert = await recordAttempt?.execute(
             backupIdHex: vault.id,
             attemptStatus: value.attemptStatus,
           );
           if (alert != null) alertPort?.publish(alert);
-        } catch (_) {}
+        } catch (error, stackTrace) {
+          log.warning(
+            'attempt monitoring update failed',
+            error: error,
+            trace: stackTrace,
+          );
+        }
       }
       return result;
     } finally {

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/connect_google_drive_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/connect_google_drive_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';
 

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/delete_drive_file_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/delete_drive_file_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';
 

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/export_drive_file_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/export_drive_file_usecase.dart
@@ -1,5 +1,5 @@
 import '../../../data/file_system_repository.dart';
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../entities/drive_file_metadata.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_all_drive_file_metadata_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_all_drive_file_metadata_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../entities/drive_file_metadata.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_latest_google_drive_backup_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_latest_google_drive_backup_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../entities/encrypted_vault.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_vault_from_drive_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/fetch_vault_from_drive_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../entities/drive_file_metadata.dart';
 import '../../entities/encrypted_vault.dart';
 import '../../recoverbull_failure.dart';

--- a/features/recoverbull/lib/src/domain/usecases/google_drive/save_to_google_drive_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/google_drive/save_to_google_drive_usecase.dart
@@ -1,4 +1,4 @@
-import '../../../data/google_drive_repository.dart';
+import '../../repositories/google_drive_repository.dart';
 import '../../entities/encrypted_vault.dart';
 import '../../recoverbull_failure.dart';
 import 'package:primitives/primitives.dart';

--- a/features/recoverbull/lib/src/domain/usecases/record_local_attempt_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/record_local_attempt_usecase.dart
@@ -5,24 +5,83 @@ import '../../attempt_monitoring/recoverbull_attempt_monitoring.dart';
 
 final class RecordLocalAttemptUsecase {
   final RecoverBullAttemptMonitoringStore store;
-  const RecordLocalAttemptUsecase(this.store);
+  final RecoverBullAttemptMonitoringRemotePort? remote;
+
+  const RecordLocalAttemptUsecase(this.store, {this.remote});
 
   Future<SuspiciousActivityAlert?> execute({
     required String backupIdHex,
     KeyServerAttemptStatus? attemptStatus,
   }) async {
-    if (attemptStatus == null) return null;
     final identifier = convert.hex.decode(
       backupIdHex.replaceAll(RegExp(r'\s'), ''),
     );
+    if (attemptStatus == null) {
+      if (remote == null) return null;
+      final digest = store.digestFor(identifier);
+      RecoverBullAttemptsSnapshot? snapshot;
+      try {
+        snapshot = await remote!.poll(
+          etag: null,
+          backupDigests: [_hex(digest)],
+        );
+      } catch (_) {
+        await _registerPendingAdoption(identifier);
+        rethrow;
+      }
+      if (snapshot == null || snapshot.serviceBusy) {
+        await _registerPendingAdoption(identifier);
+        return null;
+      }
+      final observed = snapshot.totalAttempts.entries
+          .where((entry) => _same(entry.key, digest))
+          .map((entry) => entry.value)
+          .firstOrNull;
+      if (observed == null) return null;
+      final window =
+          snapshot.windowStartedAt.entries
+              .where((entry) => _same(entry.key, digest))
+              .map((entry) => entry.value)
+              .firstOrNull ??
+          snapshot.collectionStartedAt;
+      final windowIdentity = attemptWindowIdentity(window);
+      final existing = (await store.monitoredBackups())
+          .where((candidate) => _same(candidate.digest, digest))
+          .firstOrNull;
+      if (existing == null) {
+        await store.registerBackup(
+          identifier,
+          origin: MonitoredBackupOrigin.adopted,
+          observedTotal: observed,
+          window: windowIdentity,
+        );
+      } else {
+        await store.replaceBackup(
+          AttemptMonitoringBackupState(
+            serverUrl: '',
+            backupIdHash: _hex(digest),
+            expectedTotalAttempts: observed,
+            currentWindow: windowIdentity,
+            lastWarningWindow: windowIdentity,
+          ),
+        );
+      }
+      return null;
+    }
     final digest = store.digestFor(identifier);
     final row = (await store.monitoredBackups())
         .where((candidate) => _same(candidate.digest, digest))
         .firstOrNull;
-    await store.recordStatus(identifier, attemptStatus);
     if (row == null) {
+      await store.registerBackup(
+        identifier,
+        origin: MonitoredBackupOrigin.adopted,
+        observedTotal: attemptStatus.totalAttempts,
+        window: attemptWindowIdentity(attemptStatus.windowStartedAt),
+      );
       return null;
     }
+    await store.recordStatus(identifier, attemptStatus);
     final window = attemptWindowIdentity(attemptStatus.windowStartedAt);
     final anchor = row.currentWindow == window
         ? row.expectedServerDistinctCandidateTotal
@@ -50,6 +109,10 @@ final class RecordLocalAttemptUsecase {
 
   static String _hex(List<int> bytes) =>
       bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+  Future<void> _registerPendingAdoption(List<int> identifier) =>
+      store.registerBackup(identifier, origin: MonitoredBackupOrigin.adopted);
+
   static bool _same(List<int> a, List<int> b) =>
       a.length == b.length &&
       List<int>.generate(a.length, (i) => i).every((i) => a[i] == b[i]);

--- a/features/recoverbull/lib/src/domain/usecases/trash_vault_key_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/trash_vault_key_usecase.dart
@@ -59,6 +59,9 @@ final class TrashVaultKeyUsecase {
           if (alert != null) alertPort?.publish(alert);
         } catch (_) {}
       }
+      if (result case Ok()) {
+        await recordAttempt?.store.removeBackup(vault.id);
+      }
       return result;
     } finally {
       if (ownsRoute) {

--- a/features/recoverbull/lib/src/presentation/bloc.dart
+++ b/features/recoverbull/lib/src/presentation/bloc.dart
@@ -598,8 +598,13 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
 
     try {
       await _registerMonitoredBackupUsecase?.execute(backupIdHex: vault.id);
-    } catch (_) {
+    } catch (error, stackTrace) {
       // Local attempt monitoring is advisory after the external provider succeeded.
+      log.error(
+        'attempt monitoring registration failed',
+        error: error,
+        trace: stackTrace,
+      );
     }
     if (isClosed || _closingBloc || emit.isDone) {
       _pendingProviderVault = null;

--- a/features/recoverbull/lib/src/public/recoverbull.dart
+++ b/features/recoverbull/lib/src/public/recoverbull.dart
@@ -425,7 +425,24 @@ final class RecoverBullCore {
         state.serverUrlOverride ?? config.effectiveDefaultServer.toString(),
       );
       if (oldEffective == server) return;
-      await db.delete(db.recoverbullMonitoredBackup).go();
+      final monitoredBackups = await db
+          .select(db.recoverbullMonitoredBackup)
+          .get();
+      for (final backup in monitoredBackups) {
+        await (db.update(db.recoverbullMonitoredBackup)..where(
+              (row) =>
+                  row.digest.equals(backup.digest) &
+                  row.rowRevision.equals(backup.rowRevision),
+            ))
+            .write(
+              RecoverbullMonitoredBackupCompanion(
+                expectedServerDistinctCandidateTotal: const Value(0),
+                currentWindow: const Value(0),
+                lastWarningWindow: const Value(null),
+                rowRevision: Value(backup.rowRevision + 1),
+              ),
+            );
+      }
       await db
           .update(db.recoverbullState)
           .write(

--- a/features/recoverbull/lib/src/public/recoverbull.dart
+++ b/features/recoverbull/lib/src/public/recoverbull.dart
@@ -84,6 +84,21 @@ final class RecoverBullServerSettings {
   });
 }
 
+@immutable
+final class RecoverBullMonitoringStatus {
+  final bool enabled;
+  final int monitoredCount;
+  final DateTime? lastSuccessfulCheck;
+
+  const RecoverBullMonitoringStatus({
+    required this.enabled,
+    required this.monitoredCount,
+    required this.lastSuccessfulCheck,
+  });
+
+  bool get isUncovered => monitoredCount == 0;
+}
+
 enum RecoverBullAttemptAlertKind {
   suspiciousActivity,
   targetedLockout,
@@ -94,24 +109,27 @@ enum RecoverBullAttemptAlertKind {
 
 final class RecoverBullAttemptAlert {
   final RecoverBullAttemptAlertKind kind;
-  final Object _handle;
+  final String? backupReference;
+  final int? observedTotal;
+  final int? expectedTotal;
+  final DateTime? windowStartedAt;
+  final String _identity;
 
-  RecoverBullAttemptAlert(this.kind) : _handle = Object();
+  RecoverBullAttemptAlert(this.kind)
+    : backupReference = null,
+      observedTotal = null,
+      expectedTotal = null,
+      windowStartedAt = null,
+      _identity = kind.name;
 
-  const RecoverBullAttemptAlert._(this.kind, this._handle);
-}
-
-final class _AlertIdentity {
-  final String _value;
-
-  const _AlertIdentity(this._value);
-
-  @override
-  bool operator ==(Object other) =>
-      other is _AlertIdentity && other._value == _value;
-
-  @override
-  int get hashCode => _value.hashCode;
+  const RecoverBullAttemptAlert._(
+    this.kind,
+    this._identity, {
+    this.backupReference,
+    this.observedTotal,
+    this.expectedTotal,
+    this.windowStartedAt,
+  });
 }
 
 abstract interface class RecoverBullAttemptMonitoringController {
@@ -121,6 +139,7 @@ abstract interface class RecoverBullAttemptMonitoringController {
   Future<void> acknowledge(RecoverBullAttemptAlert alert);
   bool get enabled;
   Stream<List<RecoverBullAttemptAlert>> get alerts;
+  Future<RecoverBullMonitoringStatus> status();
 }
 
 final class RecoverBullAttemptMonitoring
@@ -148,6 +167,16 @@ final class RecoverBullAttemptMonitoring
   bool get enabled => _enabled;
 
   @override
+  Future<RecoverBullMonitoringStatus> status() async {
+    final state = await _store.state();
+    return RecoverBullMonitoringStatus(
+      enabled: state.attemptMonitoringEnabled,
+      monitoredCount: (await _store.monitoredBackups()).length,
+      lastSuccessfulCheck: state.lastSuccessfulCheckAt,
+    );
+  }
+
+  @override
   Stream<List<RecoverBullAttemptAlert>> get alerts async* {
     yield List.unmodifiable(_visibleAlerts);
     yield* _alertUpdates.stream;
@@ -170,7 +199,8 @@ final class RecoverBullAttemptMonitoring
       for (final alert in alerts) {
         final alreadyVisible = _visibleAlerts.any(
           (visible) =>
-              visible.kind == alert.kind && visible._handle == alert._handle,
+              visible.kind == alert.kind &&
+              visible._identity == alert._identity,
         );
         if (!alreadyVisible) _visibleAlerts.add(alert);
       }
@@ -189,7 +219,7 @@ final class RecoverBullAttemptMonitoring
     final alreadyVisible = _visibleAlerts.any(
       (visible) =>
           visible.kind == publicAlert.kind &&
-          visible._handle == publicAlert._handle,
+          visible._identity == publicAlert._identity,
     );
     if (alreadyVisible) return;
     _visibleAlerts.add(publicAlert);
@@ -202,33 +232,35 @@ final class RecoverBullAttemptMonitoring
     return switch (alert) {
       domain_alert.SuspiciousActivityAlert(
         :final backupIdHash,
+        :final observedTotal,
+        :final expectedTotal,
         :final windowStartedAt,
       ) =>
         RecoverBullAttemptAlert._(
           RecoverBullAttemptAlertKind.suspiciousActivity,
-          _AlertIdentity(
-            's:$backupIdHash:${windowStartedAt.toUtc().microsecondsSinceEpoch}',
-          ),
+          's:$backupIdHash:${windowStartedAt.toUtc().microsecondsSinceEpoch}',
+          backupReference: _safeReference(backupIdHash),
+          observedTotal: observedTotal,
+          expectedTotal: expectedTotal,
+          windowStartedAt: windowStartedAt,
         ),
       domain_alert.TargetedLockoutAlert(:final backupIdHash) =>
         RecoverBullAttemptAlert._(
           RecoverBullAttemptAlertKind.targetedLockout,
-          _AlertIdentity('l:$backupIdHash'),
+          'l:$backupIdHash',
+          backupReference: _safeReference(backupIdHash),
         ),
       domain_alert.ServicePressureAlert(:final kind) =>
         RecoverBullAttemptAlert._(
           RecoverBullAttemptAlertKind.servicePressure,
-          _AlertIdentity('p:$kind'),
+          'p:$kind',
         ),
       domain_alert.AttemptMonitoringUnavailableAlert() =>
-        RecoverBullAttemptAlert._(
-          RecoverBullAttemptAlertKind.unavailable,
-          const _AlertIdentity('u'),
-        ),
+        RecoverBullAttemptAlert._(RecoverBullAttemptAlertKind.unavailable, 'u'),
       domain_alert.CountersWipedAlert(:final wipedAt) =>
         RecoverBullAttemptAlert._(
           RecoverBullAttemptAlertKind.countersWiped,
-          _AlertIdentity('c:${wipedAt.toUtc().microsecondsSinceEpoch}'),
+          'c:${wipedAt.toUtc().microsecondsSinceEpoch}',
         ),
     };
   }
@@ -239,12 +271,15 @@ final class RecoverBullAttemptMonitoring
   @override
   Future<void> acknowledge(RecoverBullAttemptAlert alert) async {
     _visibleAlerts.removeWhere(
-      (candidate) => candidate._handle == alert._handle,
+      (candidate) => candidate._identity == alert._identity,
     );
     if (!_alertUpdates.isClosed) {
       _alertUpdates.add(List.unmodifiable(_visibleAlerts));
     }
   }
+
+  static String _safeReference(String value) =>
+      value.length <= 8 ? value : value.substring(0, 8);
 }
 
 final class _CallbackAttemptMonitoringRemote

--- a/features/recoverbull/lib/src/ui/screens/attempt_alert_detail_page.dart
+++ b/features/recoverbull/lib/src/ui/screens/attempt_alert_detail_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../generated/l10n/recoverbull_localizations.dart';
+import '../../public/recoverbull.dart';
+
+class RecoverBullAttemptAlertDetailPage extends StatelessWidget {
+  final RecoverBullAttemptAlert alert;
+
+  const RecoverBullAttemptAlertDetailPage({super.key, required this.alert});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = RecoverBullLocalizations.of(context);
+    final security =
+        alert.kind == RecoverBullAttemptAlertKind.targetedLockout ||
+        alert.kind == RecoverBullAttemptAlertKind.suspiciousActivity;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.recoverbullAttemptAlertDetailsTitle)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (alert.backupReference case final reference?)
+              Text(l10n.recoverbullAttemptAlertReference(reference)),
+            if (alert.observedTotal case final observed?)
+              Text(
+                l10n.recoverbullAttemptAlertAttempts(
+                  observed,
+                  alert.expectedTotal ?? 0,
+                ),
+              ),
+            if (alert.windowStartedAt case final window?)
+              Text(
+                l10n.recoverbullAttemptAlertWindow(
+                  MaterialLocalizations.of(
+                    context,
+                  ).formatMediumDate(window.toLocal()),
+                ),
+              ),
+            if (security) ...[
+              const SizedBox(height: 16),
+              Text(l10n.recoverbullAttemptAlertAction),
+            ],
+            if (alert.kind == RecoverBullAttemptAlertKind.targetedLockout) ...[
+              const SizedBox(height: 8),
+              Text(l10n.recoverbullAttemptAlertLockoutGuidance),
+            ],
+            if (!security) ...[
+              const SizedBox(height: 16),
+              Text(l10n.recoverbullAttemptAlertInformational),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/features/recoverbull/lib/src/ui/screens/fetch_vault_key_page.dart
+++ b/features/recoverbull/lib/src/ui/screens/fetch_vault_key_page.dart
@@ -115,9 +115,9 @@ class _FetchVaultKeyPageState extends State<FetchVaultKeyPage> {
           }
           if (state.decryptedVault != null && state.vaultKey != null) {
             if (_hasNavigatedAway) return;
-            _hasNavigatedAway = true;
             switch (state.flow) {
               case RecoverBullFlow.viewVaultKey:
+                _hasNavigatedAway = true;
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) =>

--- a/features/recoverbull/lib/src/ui/screens/recoverbull_settings_cubit.dart
+++ b/features/recoverbull/lib/src/ui/screens/recoverbull_settings_cubit.dart
@@ -1,0 +1,91 @@
+import 'package:bull_logger/bull_logger.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/usecases/fetch_recoverbull_url_usecase.dart';
+import '../../domain/usecases/store_recoverbull_url_usecase.dart';
+import '../../public/recoverbull.dart';
+
+final class RecoverBullSettingsState {
+  final bool loading;
+  final bool saving;
+  final String url;
+  final RecoverBullMonitoringStatus? monitoring;
+
+  const RecoverBullSettingsState({
+    this.loading = true,
+    this.saving = false,
+    this.url = '',
+    this.monitoring,
+  });
+
+  RecoverBullSettingsState copyWith({
+    bool? loading,
+    bool? saving,
+    String? url,
+    RecoverBullMonitoringStatus? monitoring,
+  }) => RecoverBullSettingsState(
+    loading: loading ?? this.loading,
+    saving: saving ?? this.saving,
+    url: url ?? this.url,
+    monitoring: monitoring ?? this.monitoring,
+  );
+}
+
+final class RecoverBullSettingsCubit extends Cubit<RecoverBullSettingsState> {
+  final LogSink log;
+  final FetchRecoverbullUrlUsecase fetchUrl;
+  final StoreRecoverbullUrlUsecase storeUrl;
+  final RecoverBullAttemptMonitoringController? monitoring;
+
+  RecoverBullSettingsCubit({
+    required this.log,
+    required this.fetchUrl,
+    required this.storeUrl,
+    this.monitoring,
+  }) : super(const RecoverBullSettingsState());
+
+  Future<void> load() async {
+    try {
+      final url = await fetchUrl.execute();
+      emit(
+        state.copyWith(
+          loading: false,
+          url: url.toString(),
+          monitoring: await monitoring?.status(),
+        ),
+      );
+    } catch (error, trace) {
+      log.warning(
+        'recoverbull.settings.load_failed',
+        error: error,
+        trace: trace,
+      );
+      emit(state.copyWith(loading: false));
+    }
+  }
+
+  Future<bool> save(String value) async {
+    emit(state.copyWith(saving: true));
+    try {
+      final url = Uri.parse(value);
+      await storeUrl.execute(url);
+      emit(state.copyWith(saving: false, url: url.toString()));
+      return true;
+    } catch (error, trace) {
+      log.warning(
+        'recoverbull.settings.save_failed',
+        error: error,
+        trace: trace,
+      );
+      emit(state.copyWith(saving: false));
+      return false;
+    }
+  }
+
+  Future<void> setMonitoringEnabled(bool enabled) async {
+    final controller = monitoring;
+    if (controller == null) return;
+    await controller.setEnabled(enabled);
+    emit(state.copyWith(monitoring: await controller.status()));
+  }
+}

--- a/features/recoverbull/lib/src/ui/screens/settings_page.dart
+++ b/features/recoverbull/lib/src/ui/screens/settings_page.dart
@@ -1,23 +1,34 @@
-import '../../domain/usecases/fetch_recoverbull_url_usecase.dart';
-import '../../domain/usecases/store_recoverbull_url_usecase.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../l10n/context_localizations.dart';
 import '../support.dart';
-import 'package:bull_ui/bull_ui.dart' show Gap;
+import 'recoverbull_settings_cubit.dart';
+import '../../domain/usecases/fetch_recoverbull_url_usecase.dart';
+import '../../domain/usecases/store_recoverbull_url_usecase.dart';
+import '../../public/recoverbull.dart';
+import 'package:bull_ui/bull_ui.dart' show BullSwitch, Gap;
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SettingsPage extends StatefulWidget {
   final LogSink log;
-  final FetchRecoverbullUrlUsecase fetchUrlUsecase;
-  final StoreRecoverbullUrlUsecase storeUrlUsecase;
-  const SettingsPage({
+  final RecoverBullSettingsCubit cubit;
+  SettingsPage({
     super.key,
     required this.log,
-    required this.fetchUrlUsecase,
-    required this.storeUrlUsecase,
-  });
+    RecoverBullSettingsCubit? cubit,
+    FetchRecoverbullUrlUsecase? fetchUrlUsecase,
+    StoreRecoverbullUrlUsecase? storeUrlUsecase,
+    RecoverBullAttemptMonitoringController? monitoring,
+  }) : cubit =
+           cubit ??
+           RecoverBullSettingsCubit(
+             log: log,
+             fetchUrl: fetchUrlUsecase!,
+             storeUrl: storeUrlUsecase!,
+             monitoring: monitoring,
+           );
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -26,15 +37,13 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   final _urlController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
-  bool _isLoading = false;
-  bool _isSaving = false;
   bool _isEditing = false;
   String _originalUrl = '';
 
   @override
   void initState() {
     super.initState();
-    _loadUrl();
+    widget.cubit.load();
   }
 
   @override
@@ -43,39 +52,18 @@ class _SettingsPageState extends State<SettingsPage> {
     super.dispose();
   }
 
-  Future<void> _loadUrl() async {
-    setState(() => _isLoading = true);
-    try {
-      final url = await widget.fetchUrlUsecase.execute();
-      _originalUrl = url.toString();
-    } catch (e) {
-      widget.log.warning('recoverbull.settings.load_failed');
-    } finally {
-      if (mounted) setState(() => _isLoading = false);
-    }
-  }
-
   Future<void> _saveUrl() async {
     if (!_formKey.currentState!.validate()) return;
 
-    setState(() => _isSaving = true);
-    try {
-      final url = Uri.parse(_urlController.text);
-      await widget.storeUrlUsecase.execute(url);
-      _originalUrl = url.toString();
-      if (mounted) {
-        setState(() => _isEditing = false);
-      }
-    } catch (e) {
-      widget.log.warning('recoverbull.settings.save_failed');
-      if (mounted) {
-        SnackBarUtils.showSnackBar(
-          context,
-          context.loc.recoverbullErrorUnexpected,
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _isSaving = false);
+    final saved = await widget.cubit.save(_urlController.text);
+    if (saved && mounted) {
+      _originalUrl = widget.cubit.state.url;
+      setState(() => _isEditing = false);
+    } else if (mounted) {
+      SnackBarUtils.showSnackBar(
+        context,
+        context.loc.recoverbullErrorUnexpected,
+      );
     }
   }
 
@@ -105,6 +93,9 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (_originalUrl.isEmpty && widget.cubit.state.url.isNotEmpty) {
+      _originalUrl = widget.cubit.state.url;
+    }
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -117,116 +108,164 @@ class _SettingsPageState extends State<SettingsPage> {
           color: context.appColors.onSurface,
         ),
       ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  crossAxisAlignment: .stretch,
-                  children: [
-                    const Gap(16),
-                    Row(
-                      mainAxisAlignment: .spaceBetween,
-                      children: [
+      body: BlocBuilder<RecoverBullSettingsCubit, RecoverBullSettingsState>(
+        bloc: widget.cubit,
+        builder: (context, settings) => settings.loading
+            ? const Center(child: CircularProgressIndicator())
+            : Padding(
+                padding: const EdgeInsets.all(16),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: .stretch,
+                    children: [
+                      const Gap(16),
+                      Row(
+                        mainAxisAlignment: .spaceBetween,
+                        children: [
+                          BBText(
+                            context.loc.recoverbullSettingsKeyServerUrl,
+                            style: context.font.titleMedium,
+                            color: context.appColors.onSurface,
+                          ),
+                          if (!_isEditing)
+                            TextButton.icon(
+                              onPressed: () {
+                                _urlController.text = _originalUrl;
+                                setState(() => _isEditing = true);
+                              },
+                              icon: const Icon(Icons.edit, size: 18),
+                              label: Text(context.loc.recoverbullSettingsEdit),
+                            ),
+                        ],
+                      ),
+                      const Gap(12),
+                      if (_isEditing) ...[
+                        TextFormField(
+                          controller: _urlController,
+                          validator: _validateUrl,
+                          maxLines: null,
+                          autofocus: true,
+                          style: context.font.bodyMedium,
+                          decoration: InputDecoration(
+                            hintText: context.loc.recoverbullSettingsUrlHint,
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            contentPadding: const EdgeInsets.all(16),
+                          ),
+                        ),
+                      ] else ...[
+                        Container(
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: context.appColors.cardBackground,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: context.appColors.border),
+                          ),
+                          child: BBText(
+                            _originalUrl,
+                            style: context.font.bodyMedium,
+                            color: context.appColors.onSurface,
+                          ),
+                        ),
+                      ],
+                      if (settings.monitoring case final monitoring?) ...[
+                        const Gap(24),
                         BBText(
-                          context.loc.recoverbullSettingsKeyServerUrl,
+                          context.loc.recoverbullMonitoringTitle,
                           style: context.font.titleMedium,
                           color: context.appColors.onSurface,
                         ),
-                        if (!_isEditing)
-                          TextButton.icon(
-                            onPressed: () {
-                              _urlController.text = _originalUrl;
-                              setState(() => _isEditing = true);
-                            },
-                            icon: const Icon(Icons.edit, size: 18),
-                            label: Text(context.loc.recoverbullSettingsEdit),
-                          ),
-                      ],
-                    ),
-                    const Gap(12),
-                    if (_isEditing) ...[
-                      TextFormField(
-                        controller: _urlController,
-                        validator: _validateUrl,
-                        maxLines: null,
-                        autofocus: true,
-                        style: context.font.bodyMedium,
-                        decoration: InputDecoration(
-                          hintText: context.loc.recoverbullSettingsUrlHint,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          contentPadding: const EdgeInsets.all(16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: BBText(
+                                context.loc.recoverbullMonitoringEnabled,
+                                style: context.font.bodyMedium,
+                                color: context.appColors.onSurface,
+                              ),
+                            ),
+                            BullSwitch(
+                              value: monitoring.enabled,
+                              onChanged: widget.cubit.setMonitoringEnabled,
+                            ),
+                          ],
                         ),
-                      ),
-                    ] else ...[
-                      Container(
-                        padding: const EdgeInsets.all(16),
-                        decoration: BoxDecoration(
-                          color: context.appColors.cardBackground,
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(color: context.appColors.border),
-                        ),
-                        child: BBText(
-                          _originalUrl,
+                        Text(
+                          monitoring.isUncovered
+                              ? context.loc.recoverbullMonitoringUncovered
+                              : context.loc.recoverbullMonitoringCount(
+                                  monitoring.monitoredCount,
+                                ),
                           style: context.font.bodyMedium,
-                          color: context.appColors.onSurface,
+                        ),
+                        if (monitoring.lastSuccessfulCheck case final date?)
+                          Text(
+                            context.loc.recoverbullMonitoringLastCheck(
+                              MaterialLocalizations.of(
+                                context,
+                              ).formatMediumDate(date.toLocal()),
+                            ),
+                            style: context.font.bodySmall,
+                          ),
+                        const Gap(8),
+                        Text(
+                          context.loc.recoverbullMonitoringExplanation,
+                          style: context.font.bodySmall,
+                        ),
+                      ],
+                      const Spacer(),
+                      if (_isEditing) ...[
+                        Row(
+                          children: [
+                            Expanded(
+                              child: BBButton.big(
+                                label: context.loc.recoverbullSettingsCancel,
+                                onPressed: _cancelEdit,
+                                bgColor: context.appColors.cardBackground,
+                                textColor: context.appColors.onSurface,
+                              ),
+                            ),
+                            const Gap(8),
+                            Expanded(
+                              child: BBButton.big(
+                                label: context.loc.recoverbullSettingsSave,
+                                onPressed: _saveUrl,
+                                bgColor: context.appColors.onSurface,
+                                textColor: context.appColors.surface,
+                                disabled: settings.saving,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const Gap(16),
+                      ],
+                      GestureDetector(
+                        onTap: _openRecoverBullWebsite,
+                        child: Row(
+                          mainAxisAlignment: .center,
+                          children: [
+                            Icon(
+                              Icons.info_outline,
+                              size: 20,
+                              color: context.appColors.primary,
+                            ),
+                            const Gap(8),
+                            BBText(
+                              context.loc.recoverbullLearnMore,
+                              style: context.font.bodyMedium,
+                              color: context.appColors.primary,
+                            ),
+                          ],
                         ),
                       ),
+                      const Gap(24),
                     ],
-                    const Spacer(),
-                    if (_isEditing) ...[
-                      Row(
-                        children: [
-                          Expanded(
-                            child: BBButton.big(
-                              label: context.loc.recoverbullSettingsCancel,
-                              onPressed: _cancelEdit,
-                              bgColor: context.appColors.cardBackground,
-                              textColor: context.appColors.onSurface,
-                            ),
-                          ),
-                          const Gap(8),
-                          Expanded(
-                            child: BBButton.big(
-                              label: context.loc.recoverbullSettingsSave,
-                              onPressed: _saveUrl,
-                              bgColor: context.appColors.onSurface,
-                              textColor: context.appColors.surface,
-                              disabled: _isSaving,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const Gap(16),
-                    ],
-                    GestureDetector(
-                      onTap: _openRecoverBullWebsite,
-                      child: Row(
-                        mainAxisAlignment: .center,
-                        children: [
-                          Icon(
-                            Icons.info_outline,
-                            size: 20,
-                            color: context.appColors.primary,
-                          ),
-                          const Gap(8),
-                          BBText(
-                            context.loc.recoverbullLearnMore,
-                            style: context.font.bodyMedium,
-                            color: context.appColors.primary,
-                          ),
-                        ],
-                      ),
-                    ),
-                    const Gap(24),
-                  ],
+                  ),
                 ),
               ),
-            ),
+      ),
     );
   }
 }

--- a/features/recoverbull/lib/src/ui/widgets/attempt_alert_warnings.dart
+++ b/features/recoverbull/lib/src/ui/widgets/attempt_alert_warnings.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../generated/l10n/recoverbull_localizations.dart';
 import '../../public/recoverbull.dart';
+import '../support.dart';
 
 /// Opaque attempt monitoring advisory for shell placement. It accepts only public alert
 /// types and never renders identifiers, hashes, or URLs.
@@ -19,20 +20,56 @@ class RecoverBullAttemptAlertWarnings extends StatelessWidget {
           return Column(
             children: [
               for (final alert in alerts)
-                Card(
-                  child: ListTile(
-                    title: Text(_title(l10n, alert)),
-                    subtitle: _subtitle(l10n, alert),
-                    trailing: TextButton(
-                      onPressed: () => controller.acknowledge(alert),
-                      child: Text(l10n.recoverbullAttemptMonitoringDismiss),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Material(
+                      color: context.appColors.surface,
+                      child: InfoCard(
+                        title: _title(l10n, alert),
+                        description: _description(l10n, alert),
+                        tagColor: _isSecurityAlert(alert)
+                            ? context.appColors.error
+                            : context.appColors.primary,
+                        bgColor: _isSecurityAlert(alert)
+                            ? context.appColors.errorContainer
+                            : context.appColors.cardBackground,
+                        onTap: () {},
+                      ),
                     ),
-                  ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        onPressed: () => controller.acknowledge(alert),
+                        child: Text(l10n.recoverbullAttemptMonitoringDismiss),
+                      ),
+                    ),
+                  ],
                 ),
             ],
           );
         },
       );
+
+  bool _isSecurityAlert(RecoverBullAttemptAlert alert) =>
+      alert.kind == RecoverBullAttemptAlertKind.suspiciousActivity ||
+      alert.kind == RecoverBullAttemptAlertKind.targetedLockout;
+
+  String _description(
+    RecoverBullLocalizations l10n,
+    RecoverBullAttemptAlert alert,
+  ) => switch (alert.kind) {
+    RecoverBullAttemptAlertKind.suspiciousActivity =>
+      l10n.recoverbullAttemptMonitoringSuspiciousActivityBody,
+    RecoverBullAttemptAlertKind.targetedLockout =>
+      l10n.recoverbullAttemptMonitoringLockoutBody,
+    RecoverBullAttemptAlertKind.servicePressure =>
+      l10n.recoverbullAttemptMonitoringServicePressure,
+    RecoverBullAttemptAlertKind.unavailable =>
+      l10n.recoverbullAttemptMonitoringUnavailableUnknownDuration,
+    RecoverBullAttemptAlertKind.countersWiped =>
+      l10n.recoverbullAttemptMonitoringCountersWiped,
+  };
 
   String _title(RecoverBullLocalizations l10n, RecoverBullAttemptAlert alert) =>
       switch (alert.kind) {
@@ -47,17 +84,4 @@ class RecoverBullAttemptAlertWarnings extends StatelessWidget {
         RecoverBullAttemptAlertKind.countersWiped =>
           l10n.recoverbullAttemptMonitoringCountersWiped,
       };
-
-  Widget? _subtitle(
-    RecoverBullLocalizations l10n,
-    RecoverBullAttemptAlert alert,
-  ) => switch (alert.kind) {
-    RecoverBullAttemptAlertKind.suspiciousActivity => Text(
-      l10n.recoverbullAttemptMonitoringSuspiciousActivityBody,
-    ),
-    RecoverBullAttemptAlertKind.targetedLockout => Text(
-      l10n.recoverbullAttemptMonitoringLockoutBody,
-    ),
-    _ => null,
-  };
 }

--- a/features/recoverbull/lib/src/ui/widgets/attempt_alert_warnings.dart
+++ b/features/recoverbull/lib/src/ui/widgets/attempt_alert_warnings.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import '../../../generated/l10n/recoverbull_localizations.dart';
 import '../../public/recoverbull.dart';
 import '../support.dart';
+import '../screens/attempt_alert_detail_page.dart';
 
-/// Opaque attempt monitoring advisory for shell placement. It accepts only public alert
-/// types and never renders identifiers, hashes, or URLs.
+/// Opaque attempt monitoring advisory for shell placement. It accepts only public alert types and never renders identifiers, hashes, or URLs.
 class RecoverBullAttemptAlertWarnings extends StatelessWidget {
   final RecoverBullAttemptMonitoringController controller;
   const RecoverBullAttemptAlertWarnings({super.key, required this.controller});
@@ -34,7 +34,12 @@ class RecoverBullAttemptAlertWarnings extends StatelessWidget {
                         bgColor: _isSecurityAlert(alert)
                             ? context.appColors.errorContainer
                             : context.appColors.cardBackground,
-                        onTap: () {},
+                        onTap: () => Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) =>
+                                RecoverBullAttemptAlertDetailPage(alert: alert),
+                          ),
+                        ),
                       ),
                     ),
                     Align(

--- a/features/recoverbull/test/data/google_drive_development_test.dart
+++ b/features/recoverbull/test/data/google_drive_development_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_recoverbull/src/data/datasources/google_drive_datasource.dart';
+import 'package:bull_recoverbull/src/data/models/drive_file_metadata_model.dart';
+import 'package:bull_recoverbull/src/data/debug_google_drive_repository.dart';
+import 'package:bull_logger/bull_logger.dart';
+import 'package:primitives/primitives.dart';
+
+void main() {
+  test(
+    'production listing contract requests pagination fields and page size',
+    () {
+      expect(
+        GoogleDriveAppDatasource.metadataFields,
+        contains('nextPageToken'),
+      );
+      expect(GoogleDriveAppDatasource.metadataPageSize, 1000);
+    },
+  );
+
+  test('metadata listing follows pages and rejects a repeated token', () async {
+    final pages = <String?, GoogleDriveMetadataPage>{
+      null: GoogleDriveMetadataPage(
+        files: [_file('one')],
+        nextPageToken: 'second',
+      ),
+      'second': GoogleDriveMetadataPage(
+        files: [_file('two')],
+        nextPageToken: 'final',
+      ),
+      'final': GoogleDriveMetadataPage(files: [_file('three')]),
+    };
+    final datasource = GoogleDriveAppDatasource(
+      log: _Log(),
+      pageLister: (token) async => pages[token]!,
+    );
+    expect(await datasource.fetchAllMetadata(), hasLength(3));
+    expect(
+      (await datasource.fetchAllMetadata()).map((file) => file.id),
+      orderedEquals(['one', 'two', 'three']),
+    );
+
+    final repeated = GoogleDriveAppDatasource(
+      log: _Log(),
+      pageLister: (token) async => GoogleDriveMetadataPage(
+        files: [_file('page')],
+        nextPageToken: 'same',
+      ),
+    );
+    await expectLater(repeated.fetchAllMetadata(), throwsStateError);
+  });
+
+  test(
+    'debug selection has an explicit release guard and fake operations',
+    () async {
+      final production = DebugGoogleDriveRepository();
+      expect(
+        () => selectGoogleDriveRepository(
+          production: production,
+          fakeEnabled: true,
+          debugMode: false,
+        ),
+        throwsStateError,
+      );
+      final fake = selectGoogleDriveRepository(
+        production: production,
+        fakeEnabled: true,
+        debugMode: true,
+      );
+      await fake.connect();
+      final files = switch (await fake.fetchAllMetadata()) {
+        Ok(:final value) => value,
+        Err() => throw StateError('fake metadata failed'),
+      };
+      expect(files, hasLength(3));
+      expect(files.map((file) => file.createdTime.year), everyElement(2026));
+      final firstId = files.first.id;
+      expect(await fake.fetchVault(firstId), isA<Ok>());
+      final firstContent = switch (await fake.fetchRawFile(firstId)) {
+        Ok(:final value) => value,
+        Err() => throw StateError('fake content failed'),
+      };
+      expect(await fake.fetchLatestVault(), isA<Ok>());
+      expect(await fake.store(firstContent), isA<Ok>());
+      final afterStore = await fake.fetchAllMetadata();
+      expect(switch (afterStore) {
+        Ok(:final value) => value.length,
+        Err() => -1,
+      }, 4);
+      expect(await fake.trash(firstId), isA<Ok>());
+      final afterTrash = await fake.fetchAllMetadata();
+      expect(switch (afterTrash) {
+        Ok(:final value) => value.length,
+        Err() => -1,
+      }, 3);
+      expect(await fake.fetchRawFile(firstId), isA<Err>());
+      expect(await fake.trash('missing'), isA<Err>());
+      await fake.disconnect();
+      expect(await fake.fetchAllMetadata(), isA<Err>());
+      expect(await fake.fetchLatestVault(), isA<Err>());
+      expect(await fake.store(firstContent), isA<Err>());
+      expect(await fake.trash(files.last.id), isA<Err>());
+      expect(await fake.connectSilently(), 'recoverbull.debug@example.invalid');
+      expect(await fake.fetchAllMetadata(), isA<Ok>());
+    },
+  );
+
+  test(
+    'debug discovery session serializes disconnect until the action completes',
+    () async {
+      final fake = DebugGoogleDriveRepository();
+      Future<void>? pendingDisconnect;
+      Future<dynamic>? pendingRead;
+      var readCompleted = false;
+      var disconnectCompleted = false;
+      final sessionDone = fake.withDiscoverySession((session) async {
+        expect(session, isNotNull);
+        pendingDisconnect = fake.disconnect();
+        pendingRead = fake.fetchAllMetadata();
+        pendingDisconnect!.whenComplete(() => disconnectCompleted = true);
+        pendingRead!.whenComplete(() => readCompleted = true);
+        expect(disconnectCompleted, isFalse);
+        expect(readCompleted, isFalse);
+        return null;
+      });
+      await sessionDone;
+      await pendingDisconnect;
+      await pendingRead;
+      expect(disconnectCompleted, isTrue);
+      expect(readCompleted, isTrue);
+      await fake.disconnect();
+    },
+  );
+
+  test('debug discovery queue continues after a thrown callback', () async {
+    final fake = DebugGoogleDriveRepository();
+    await expectLater(
+      fake.withDiscoverySession<void>((_) async => throw StateError('test')),
+      throwsStateError,
+    );
+    expect(await fake.connect(), isA<Ok>());
+  });
+}
+
+DriveFileMetadataModel _file(String id) => DriveFileMetadataModel(
+  id: id,
+  name: '$id.json',
+  createdTime: DateTime.utc(2026),
+);
+
+final class _Log implements LogSink {
+  @override
+  void fine(String message, {Object? error, StackTrace? trace}) {}
+
+  @override
+  void error(String message, {Object? error, StackTrace? trace}) {}
+
+  @override
+  void info(String message, {Object? error, StackTrace? trace}) {}
+
+  @override
+  void warning(String message, {Object? error, StackTrace? trace}) {}
+
+  @override
+  LogSink scoped(String scope) => this;
+}

--- a/features/recoverbull/test/database/recoverbull_database_test.dart
+++ b/features/recoverbull/test/database/recoverbull_database_test.dart
@@ -1,13 +1,25 @@
-import 'package:bull_recoverbull/bull_recoverbull.dart';
 import 'package:bull_recoverbull/src/database/recoverbull_database.dart';
 import 'package:bull_recoverbull/src/attempt_monitoring/recoverbull_attempt_monitoring.dart';
 import 'package:bull_recoverbull/src/data/datasources/recoverbull_settings_datasource.dart';
+import 'package:bull_recoverbull/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart';
+import 'package:bull_recoverbull/src/public/recoverbull.dart';
 import 'package:drift/native.dart';
 import 'package:drift/drift.dart' hide isNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'dart:io';
 import 'package:path/path.dart' as p;
+
+final class _DatabaseTestRemote
+    implements RecoverBullAttemptMonitoringRemotePort {
+  RecoverBullAttemptsSnapshot? response;
+
+  @override
+  Future<RecoverBullAttemptsSnapshot?> poll({
+    required String? etag,
+    required List<String> backupDigests,
+  }) async => response;
+}
 
 void main() {
   test('new state starts without imported backup status', () async {
@@ -153,7 +165,7 @@ void main() {
   });
 
   test(
-    'storing a changed server atomically invalidates attempt monitoring state',
+    'storing a changed server preserves identifiers and resets monitoring state',
     () async {
       final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
       await database.ensureState();
@@ -188,33 +200,90 @@ void main() {
       expect(state.lastUnavailabilityWarningAt, isNull);
       expect(state.generation, 1);
       expect(state.revision, 1);
-      expect(await store.monitoredBackups(), isEmpty);
+      expect(await store.monitoredBackups(), hasLength(1));
+      final remote = _DatabaseTestRemote()
+        ..response = RecoverBullAttemptsSnapshot(
+          collectionStartedAt: DateTime.utc(2026, 1, 2),
+          totalAttempts: {(await store.monitoredBackups()).single.digest: 1},
+        );
+      expect(
+        await CheckBackupAttemptMonitoringUsecase(
+          store: store,
+          remote: remote,
+          clock: () => DateTime.utc(2026, 1, 2, 1),
+        ).execute(),
+        isEmpty,
+      );
       await database.close();
     },
   );
 
   test(
-    'schema has exactly the two logical tables and bundled sqlite is usable',
+    'public setServer preserves monitored backups while resetting state',
     () async {
-      final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
-      final tables = await database
-          .customSelect(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
-          )
-          .get();
-      expect(tables.map((row) => row.read<String>('name')).toSet(), {
-        'recoverbull_state',
-        'recoverbull_monitored_backup',
-      });
-      expect(
-        (await database.customSelect('SELECT sqlite_version()').getSingle())
-            .read<String>('sqlite_version()'),
-        isNotEmpty,
+      final directory = await Directory.systemTemp.createTemp(
+        'recoverbull-server-',
       );
-      expect(sqlite.sqlite3.version.toString(), isNotEmpty);
-      await database.close();
+      final path = p.join(directory.path, 'state.sqlite');
+      final lifecycle = RecoverBullLifecycle();
+      final database = await lifecycle.openDatabase(path);
+      final store = RecoverBullAttemptMonitoringStore(database);
+      await store.registerBackup(List<int>.filled(32, 1));
+      await store.recordOwnAttempt(
+        List<int>.filled(32, 1),
+        serverTotalAttempts: 4,
+        window: DateTime.utc(2026),
+      );
+      await database
+          .update(database.recoverbullState)
+          .write(
+            RecoverbullStateCompanion(
+              etag: const Value('etag'),
+              collectionStartedAt: Value(DateTime.utc(2026)),
+              lastSuccessfulCheckAt: Value(DateTime.utc(2026)),
+            ),
+          );
+
+      final core = RecoverBullCore(
+        config: RecoverBullConfig(databasePath: path),
+        dependencies: const RecoverBullDependencies(),
+        lifecycle: lifecycle,
+      );
+      await core.setServer(Uri.parse('http://newexample.onion'));
+
+      final row = (await store.monitoredBackups()).single;
+      expect(row.expectedServerDistinctCandidateTotal, 0);
+      expect(row.currentWindow, 0);
+      expect(row.lastWarningWindow, isNull);
+      final state = await store.state();
+      expect(state.etag, isNull);
+      expect(state.collectionStartedAt, isNull);
+      expect(state.lastSuccessfulCheckAt, isNull);
+      await lifecycle.dispose();
+      await directory.delete(recursive: true);
     },
   );
+
+  test('schema has the monitoring tables and bundled sqlite is usable', () async {
+    final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
+    final tables = await database
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+        )
+        .get();
+    expect(tables.map((row) => row.read<String>('name')).toSet(), {
+      'recoverbull_state',
+      'recoverbull_monitored_backup',
+      'recoverbull_drive_backup_cache',
+    });
+    expect(
+      (await database.customSelect('SELECT sqlite_version()').getSingle())
+          .read<String>('sqlite_version()'),
+      isNotEmpty,
+    );
+    expect(sqlite.sqlite3.version.toString(), isNotEmpty);
+    await database.close();
+  });
 
   test(
     'attempt monitoring polling cannot overwrite the own-attempt baseline',

--- a/features/recoverbull/test/database/recoverbull_database_test.dart
+++ b/features/recoverbull/test/database/recoverbull_database_test.dart
@@ -263,7 +263,6 @@ void main() {
       await directory.delete(recursive: true);
     },
   );
-
   test('schema has the monitoring tables and bundled sqlite is usable', () async {
     final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
     final tables = await database

--- a/features/recoverbull/test/database/schema_v1_test.dart
+++ b/features/recoverbull/test/database/schema_v1_test.dart
@@ -24,7 +24,11 @@ void main() {
           (entity['data']! as Map<String, Object?>)['name']! as String:
               entity['data']! as Map<String, Object?>,
     };
-    expect(tables.keys, {'recoverbull_state', 'recoverbull_monitored_backup'});
+    expect(tables.keys, {
+      'recoverbull_state',
+      'recoverbull_monitored_backup',
+      'recoverbull_drive_backup_cache',
+    });
 
     final stateColumns = (tables['recoverbull_state']!['columns']! as List)
         .cast<Map<String, Object?>>();

--- a/features/recoverbull/test/domain/usecases/attempt_alert_integration_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_alert_integration_usecases_test.dart
@@ -26,6 +26,19 @@ class _Repository extends Mock implements RecoverBullRepository {}
 
 class _Ensure extends Mock implements EnsureRecoverBullTorSessionUsecase {}
 
+final class _ServiceBusyRemote
+    implements RecoverBullAttemptMonitoringRemotePort {
+  @override
+  Future<RecoverBullAttemptsSnapshot?> poll({
+    required String? etag,
+    required List<String> backupDigests,
+  }) async => RecoverBullAttemptsSnapshot(
+    collectionStartedAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    totalAttempts: const {},
+    serviceBusy: true,
+  );
+}
+
 RecoverBullTorRoute _route({Future<void> Function()? onClose}) =>
     RecoverBullTorRoute(
       TorRoute(
@@ -134,6 +147,46 @@ void main() {
     expect(await monitoring.alerts.first, isEmpty);
     await database.close();
   });
+
+  test(
+    'successful fetch enrolls a pending adoption when attempts are unavailable',
+    () async {
+      final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
+      await database.ensureState();
+      final store = RecoverBullAttemptMonitoringStore(database);
+      final backup = sdk.RecoverBull.createBackup(
+        secret: [1, 2, 3],
+        backupKey: List<int>.filled(32, 9),
+      );
+      final vault = EncryptedVault(file: backup.toJson());
+      final repository = _Repository();
+      when(
+        () => repository.fetchVaultKeyWithStatus(any(), any(), any(), any()),
+      ).thenAnswer(
+        (_) async => const Ok(
+          VaultKeyFetchResult(vaultKey: 'aabb', attemptStatus: null),
+        ),
+      );
+
+      final result = await FetchVaultKeyFromServerUsecase(
+        repository: repository,
+        ensureTor: _Ensure(),
+        recordAttempt: RecordLocalAttemptUsecase(
+          store,
+          remote: _ServiceBusyRemote(),
+        ),
+        log: const TestLogSink(),
+      ).execute(vault: vault, password: 'password', route: _route());
+
+      expect(result, isA<Ok>());
+      final row = (await store.monitoredBackups()).single;
+      expect(row.origin, 'adopted');
+      expect(row.expectedServerDistinctCandidateTotal, 0);
+      expect(row.currentWindow, 0);
+      expect(row.lastWarningWindow, 0);
+      await database.close();
+    },
+  );
 
   test(
     'distinct suspicious alerts remain independently acknowledgeable',

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -8,9 +8,12 @@ import 'package:bull_recoverbull/src/domain/usecases/is_recoverbull_attempt_moni
 import 'package:bull_recoverbull/src/domain/usecases/record_local_attempt_usecase.dart';
 import 'package:bull_recoverbull/src/domain/usecases/register_monitored_backup_usecase.dart';
 import 'package:bull_recoverbull/src/domain/usecases/set_recoverbull_attempt_monitoring_enabled_usecase.dart';
+import 'package:bull_recoverbull/src/domain/usecases/discover_drive_backups_usecase.dart';
+import 'package:bull_recoverbull/src/domain/recoverbull_drive_discovery_port.dart';
 import 'package:bull_recoverbull/src/attempt_monitoring/recoverbull_attempt_monitoring.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:convert';
 
 class _Remote implements RecoverBullAttemptMonitoringRemotePort {
   RecoverBullAttemptsSnapshot? response;
@@ -26,6 +29,76 @@ class _Remote implements RecoverBullAttemptMonitoringRemotePort {
     lastEtag = etag;
     return response;
   }
+}
+
+final class _DriveDiscovery implements RecoverBullDriveDiscoveryPort {
+  const _DriveDiscovery();
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(RecoverBullDriveDiscoverySession? session) action,
+  ) => action(
+    _TestDiscoverySession(account: 'account', files: files, content: content),
+  );
+
+  Future<String> account() async => 'account';
+
+  Future<List<RecoverBullDriveFile>> files() async => [
+    RecoverBullDriveFile(id: 'file', createdTime: DateTime.utc(2026)),
+  ];
+
+  Future<String> content(String fileId) async =>
+      _validVault('000102030405060708090a0b0c0d0e0f');
+}
+
+final class _CountingDrive implements RecoverBullDriveDiscoveryPort {
+  int contentCalls = 0;
+  final String currentAccount;
+  final String fileId;
+  final String backupId;
+
+  _CountingDrive(this.currentAccount, this.fileId, this.backupId);
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(RecoverBullDriveDiscoverySession? session) action,
+  ) => action(
+    _TestDiscoverySession(
+      account: currentAccount,
+      files: files,
+      content: content,
+    ),
+  );
+
+  Future<String> account() async => currentAccount;
+
+  Future<List<RecoverBullDriveFile>> files() async => [
+    RecoverBullDriveFile(id: fileId, createdTime: DateTime.utc(2026)),
+  ];
+
+  Future<String> content(String fileId) async {
+    contentCalls++;
+    return _validVault(backupId);
+  }
+}
+
+final class _TestDiscoverySession implements RecoverBullDriveDiscoverySession {
+  @override
+  final String account;
+  final Future<List<RecoverBullDriveFile>> Function() _files;
+  final Future<String> Function(String) _content;
+
+  const _TestDiscoverySession({
+    required this.account,
+    required this._files,
+    required this._content,
+  });
+
+  @override
+  Future<List<RecoverBullDriveFile>> files() => _files();
+
+  @override
+  Future<String> content(String fileId) => _content(fileId);
 }
 
 void main() {
@@ -52,6 +125,49 @@ void main() {
     );
     await db.close();
   });
+
+  test('startup drive discovery adopts each returned backup', () async {
+    final (db, store) = await build();
+    await DiscoverDriveBackupsUsecase(
+      drive: const _DriveDiscovery(),
+      store: store,
+    ).execute();
+    final row = (await store.monitoredBackups()).single;
+    expect(row.expectedServerDistinctCandidateTotal, 0);
+    expect(row.lastWarningWindow, 0);
+    await db.close();
+  });
+
+  test(
+    'drive discovery caches file content and purges only old drive rows',
+    () async {
+      final (db, store) = await build();
+      final drive = _CountingDrive(
+        'old-account',
+        'file',
+        '101112131415161718191a1b1c1d1e1f',
+      );
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      await discovery.execute();
+      expect(drive.contentCalls, 1);
+      await store.registerBackup(
+        List<int>.filled(16, 7),
+        origin: MonitoredBackupOrigin.adopted,
+      );
+      final next = _CountingDrive(
+        'new-account',
+        'new-file',
+        '202122232425262728292a2b2c2d2e2f',
+      );
+      await DiscoverDriveBackupsUsecase(drive: next, store: store).execute();
+      final rows = await store.monitoredBackups();
+      expect(rows, hasLength(2));
+      expect(rows.where((row) => row.driveAccount == 'old-account'), isEmpty);
+      expect(rows.where((row) => row.driveAccount == null), hasLength(1));
+      await db.close();
+    },
+  );
 
   test('adopting a backup seeds its observed baseline and window', () async {
     final (db, store) = await build();
@@ -884,6 +1000,15 @@ void main() {
 
 String _hex(List<int> bytes) =>
     bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+String _validVault(String seed) => jsonEncode({
+  'version': 1,
+  'created_at': 1780000000000,
+  'id': (seed + seed).substring(0, 64),
+  'salt': '000102030405060708090a0b0c0d0e0f',
+  'ciphertext': base64Encode(List<int>.generate(64, (i) => i)),
+  'path': "m/83696968'/0'/0'",
+});
 
 KeyServerAttemptStatus _status(int total, {DateTime? at}) =>
     KeyServerAttemptStatus(

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -430,6 +430,26 @@ void main() {
     await db.close();
   });
 
+  test(
+    'a rate-limited monitored backup emits a targeted lockout alert',
+    () async {
+      final (db, store) = await build();
+      await store.registerBackup(id);
+      final digest = (await store.monitoredBackups()).single.digest;
+      final alerts = await CheckBackupAttemptMonitoringUsecase(
+        store: store,
+        remote: _Remote()
+          ..response = RecoverBullAttemptsSnapshot(
+            collectionStartedAt: window,
+            totalAttempts: const {},
+            targetedLockouts: [digest],
+          ),
+      ).execute();
+      expect(alerts.single, isA<TargetedLockoutAlert>());
+      await db.close();
+    },
+  );
+
   test('disable wipes monitored identifiers and resets generation', () async {
     final (db, store) = await build();
     await store.registerBackup(id);

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -457,6 +457,47 @@ void main() {
     await db.close();
   });
 
+  test(
+    'successful fetch without status adopts from the global snapshot',
+    () async {
+      final (db, store) = await build();
+      final remote = _Remote()
+        ..response = RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: {store.digestFor(id): 4},
+          windowStartedAt: {store.digestFor(id): window},
+        );
+
+      await RecordLocalAttemptUsecase(
+        store,
+        remote: remote,
+      ).execute(backupIdHex: _hex(id));
+
+      final row = (await store.monitoredBackups()).single;
+      expect(row.expectedServerDistinctCandidateTotal, 4);
+      expect(row.currentWindow, attemptWindowIdentity(window));
+      expect(row.lastWarningWindow, attemptWindowIdentity(window));
+      await db.close();
+    },
+  );
+
+  test('missing digest in the global snapshot is not adopted', () async {
+    final (db, store) = await build();
+    final remote = _Remote()
+      ..response = RecoverBullAttemptsSnapshot(
+        collectionStartedAt: window,
+        totalAttempts: {store.digestFor(List<int>.filled(16, 9)): 4},
+      );
+
+    await RecordLocalAttemptUsecase(
+      store,
+      remote: remote,
+    ).execute(backupIdHex: _hex(id));
+
+    expect(await store.monitoredBackups(), isEmpty);
+    await db.close();
+  });
+
   test('opaque alert handle is not its digest or URL', () {
     final alert = public.RecoverBullAttemptAlert(
       public.RecoverBullAttemptAlertKind.suspiciousActivity,

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -53,6 +53,69 @@ void main() {
     await db.close();
   });
 
+  test('adopting a backup seeds its observed baseline and window', () async {
+    final (db, store) = await build();
+    await store.registerBackup(
+      id,
+      origin: MonitoredBackupOrigin.adopted,
+      observedTotal: 3,
+      window: attemptWindowIdentity(window),
+    );
+    final row = (await store.monitoredBackups()).single;
+    expect(row.expectedServerDistinctCandidateTotal, 3);
+    expect(row.currentWindow, attemptWindowIdentity(window));
+    expect(row.lastWarningWindow, attemptWindowIdentity(window));
+    await db.close();
+  });
+
+  test('adopted baseline stays silent until the next server attempt', () async {
+    final (db, store) = await build();
+    await store.registerBackup(
+      id,
+      origin: MonitoredBackupOrigin.adopted,
+      observedTotal: 3,
+      window: attemptWindowIdentity(window),
+    );
+    final digest = (await store.monitoredBackups()).single.digest;
+    var now = window;
+    final check = CheckBackupAttemptMonitoringUsecase(
+      store: store,
+      remote: _Remote()
+        ..response = RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: {digest: 3},
+          windowStartedAt: {digest: window},
+        ),
+      clock: () => now,
+    );
+    expect(await check.execute(), isEmpty);
+    (check.remote as _Remote).response = RecoverBullAttemptsSnapshot(
+      collectionStartedAt: window,
+      totalAttempts: {digest: 4},
+      windowStartedAt: {digest: window},
+    );
+    now = now.add(const Duration(minutes: 2));
+    expect((await check.execute()).single, isA<SuspiciousActivityAlert>());
+    await db.close();
+  });
+
+  test('created baseline alerts on its first server attempt', () async {
+    final (db, store) = await build();
+    await store.registerBackup(id, origin: MonitoredBackupOrigin.created);
+    final digest = (await store.monitoredBackups()).single.digest;
+    final alerts = await CheckBackupAttemptMonitoringUsecase(
+      store: store,
+      remote: _Remote()
+        ..response = RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: {digest: 1},
+          windowStartedAt: {digest: window},
+        ),
+    ).execute();
+    expect(alerts.single, isA<SuspiciousActivityAlert>());
+    await db.close();
+  });
+
   test('status recording uses the server total as the baseline', () async {
     final (db, store) = await build();
     await store.registerBackup(id);

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -193,7 +193,7 @@ void main() {
       window: attemptWindowIdentity(window),
     );
     final digest = (await store.monitoredBackups()).single.digest;
-    var now = window;
+    var now = DateTime.now().toUtc();
     final check = CheckBackupAttemptMonitoringUsecase(
       store: store,
       remote: _Remote()
@@ -210,7 +210,7 @@ void main() {
       totalAttempts: {digest: 4},
       windowStartedAt: {digest: window},
     );
-    now = now.add(const Duration(minutes: 2));
+    now = now.add(const Duration(hours: 2));
     expect((await check.execute()).single, isA<SuspiciousActivityAlert>());
     await db.close();
   });
@@ -964,7 +964,7 @@ void main() {
     },
   );
 
-  test('the same window does not re-raise on a second recovery', () async {
+  test('the same window re-raises after a later check', () async {
     final (db, store) = await build();
     await store.registerBackup(id);
     final digest = (await store.monitoredBackups()).single.digest;
@@ -974,15 +974,21 @@ void main() {
         totalAttempts: {digest: 2},
         windowStartedAt: {digest: window},
       );
+    var now = DateTime.now().toUtc();
     final check = CheckBackupAttemptMonitoringUsecase(
       store: store,
       remote: remote,
+      clock: () => now,
     );
     expect(
       (await check.execute()).whereType<SuspiciousActivityAlert>(),
       hasLength(1),
     );
-    expect(await check.execute(), isEmpty);
+    now = now.add(const Duration(hours: 2));
+    expect(
+      (await check.execute()).whereType<SuspiciousActivityAlert>(),
+      hasLength(1),
+    );
     await db.close();
   });
 

--- a/features/recoverbull/test/domain/usecases/discovery_reconciliation_test.dart
+++ b/features/recoverbull/test/domain/usecases/discovery_reconciliation_test.dart
@@ -1,0 +1,445 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_logger/bull_logger.dart';
+import 'package:bull_recoverbull/src/attempt_monitoring/recoverbull_attempt_monitoring.dart';
+import 'package:bull_recoverbull/src/database/recoverbull_database.dart';
+import 'package:bull_recoverbull/src/domain/recoverbull_drive_discovery_port.dart';
+import 'package:bull_recoverbull/src/domain/entities/encrypted_vault.dart';
+import 'package:bull_recoverbull/src/domain/entities/drive_file_metadata.dart';
+import 'package:bull_recoverbull/src/domain/usecases/discover_drive_backups_usecase.dart';
+import 'package:bull_recoverbull/src/data/google_drive_backup_discovery_adapter.dart';
+import 'package:bull_recoverbull/src/domain/repositories/google_drive_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+void main() {
+  Future<(RecoverBullDatabase, RecoverBullAttemptMonitoringStore)>
+  build() async {
+    final db = RecoverBullDatabase.forTesting(NativeDatabase.memory());
+    await db.ensureState();
+    return (db, RecoverBullAttemptMonitoringStore(db));
+  }
+
+  test(
+    'discovers unique and duplicate vaults, and reports invalid files',
+    () async {
+      expect(EncryptedVault.isValid(_valid('01')), isTrue);
+      final (db, store) = await build();
+      final drive = _FakeDrive({
+        'a': _valid('01'),
+        'b': _valid('02'),
+        'duplicate': _valid('01'),
+        'invalid': '{"not":"a vault"}',
+      });
+      final log = _CaptureLog();
+      final result = await DiscoverDriveBackupsUsecase(
+        drive: drive,
+        store: store,
+        log: log,
+      ).execute();
+      expect(result.status, DriveDiscoveryStatus.partial);
+      expect(result.listed, 4);
+      expect(result.invalid, 1);
+      expect(result.monitored, 2);
+      expect(
+        log.messages,
+        contains(
+          'recoverbull.drive.discovery.partial listed=4 monitored=2 invalid=1 failed=0',
+        ),
+      );
+      expect(log.messages.join(), isNot(contains('duplicate')));
+      expect(log.messages.join(), isNot(contains('01')));
+      expect((await store.driveBackups('old-account')), hasLength(2));
+      expect((await store.driveCache('old-account')), hasLength(3));
+      await db.close();
+    },
+  );
+
+  test(
+    'unchanged files avoid downloads and are re-adopted after disable',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('03')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      await discovery.execute();
+      expect(drive.contentCalls, 1);
+      await store.setEnabled(false);
+      await store.setEnabled(true);
+      await discovery.execute();
+      expect(drive.contentCalls, 2);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      await db.close();
+    },
+  );
+
+  test('disabled discovery performs no Drive work', () async {
+    final (db, store) = await build();
+    await store.setEnabled(false);
+    final drive = _FakeDrive({'a': _valid('0d')});
+    final result = await DiscoverDriveBackupsUsecase(
+      drive: drive,
+      store: store,
+    ).execute();
+    expect(result.status, DriveDiscoveryStatus.disabled);
+    expect(drive.accountCalls, 0);
+    expect(drive.filesCalls, 0);
+    expect(drive.contentCalls, 0);
+    expect(await store.monitoredBackups(), isEmpty);
+    await db.close();
+  });
+
+  test('disable during an in-flight fetch prevents reconciliation', () async {
+    final (db, store) = await build();
+    final drive = _FakeDrive({'a': _valid('0e')});
+    final gate = Completer<String>();
+    drive.blockedContent = gate;
+    final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+    final pending = discovery.execute();
+    await drive.fetchStarted.future;
+    await store.setEnabled(false);
+    gate.complete(_valid('0e'));
+    final result = await pending;
+    expect(result.status, DriveDiscoveryStatus.disabled);
+    expect(await store.monitoredBackups(), isEmpty);
+    expect(await store.driveCache('old-account'), isEmpty);
+    await db.close();
+  });
+
+  test('closed store is converted to a safe failed result', () async {
+    final (db, store) = await build();
+    await db.close();
+    final log = _CaptureLog();
+    final result = await DiscoverDriveBackupsUsecase(
+      drive: _FakeDrive({'secret-id': _valid('12')}),
+      store: store,
+      log: log,
+    ).execute();
+    expect(result.status, DriveDiscoveryStatus.failed);
+    expect(log.messages, ['recoverbull.drive.discovery.failed']);
+    expect(log.messages.join(), isNot(contains('secret-id')));
+    expect(log.messages.join(), isNot(contains('12')));
+  });
+
+  test(
+    'modified and deleted files reconcile mappings and preserve duplicates',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('04'), 'b': _valid('04')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.filesById['a'] = _valid('05');
+      drive.modified['a'] = DateTime.utc(2026, 2);
+      await discovery.execute();
+      expect((await store.driveBackups('old-account')), hasLength(2));
+      drive.filesById.remove('a');
+      await discovery.execute();
+      expect((await store.driveBackups('old-account')), hasLength(1));
+      expect((await store.driveCache('old-account')), hasLength(1));
+      drive.filesById.remove('b');
+      await discovery.execute();
+      expect(await store.driveBackups('old-account'), isEmpty);
+      expect(await store.driveCache('old-account'), isEmpty);
+      await db.close();
+    },
+  );
+
+  test('transient content failure preserves the cached mapping', () async {
+    final (db, store) = await build();
+    final drive = _FakeDrive({'a': _valid('06')});
+    final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+    await discovery.execute();
+    final historicalDigest = (await store.driveBackups(
+      'old-account',
+    )).single.digest;
+    final oldDigest = (await store.driveCache(
+      'old-account',
+    )).single.backupDigest;
+    drive.filesById['a'] = _valid('11');
+    drive.failContent = true;
+    drive.modified['a'] = DateTime.utc(2026, 3);
+    final result = await discovery.execute();
+    expect(result.status, DriveDiscoveryStatus.partial);
+    expect(result.failed, 1);
+    expect(await store.driveBackups('old-account'), hasLength(1));
+    expect(
+      (await store.driveBackups('old-account')).single.digest,
+      historicalDigest,
+    );
+    expect(await store.driveCache('old-account'), hasLength(1));
+    expect(
+      (await store.driveCache('old-account')).single.driveFileModifiedAt,
+      isNull,
+    );
+    drive.failContent = false;
+    final retried = await discovery.execute();
+    final retriedCache = (await store.driveCache('old-account')).single;
+    expect(retried.status, DriveDiscoveryStatus.complete);
+    expect(drive.contentCalls, 3);
+    expect(retriedCache.driveFileModifiedAt, DateTime.utc(2026, 3));
+    expect(retriedCache.backupDigest, isNot(orderedEquals(oldDigest)));
+    await db.close();
+  });
+
+  test(
+    'invalid modified content preserves old metadata until a retry succeeds',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('0f')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.filesById['a'] = '{"invalid":true}';
+      drive.modified['a'] = DateTime.utc(2026, 4);
+      final partial = await discovery.execute();
+      expect(partial.status, DriveDiscoveryStatus.partial);
+      expect(partial.invalid, 1);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      expect(
+        (await store.driveCache('old-account')).single.driveFileModifiedAt,
+        isNull,
+      );
+      drive.filesById['a'] = _valid('10');
+      final complete = await discovery.execute();
+      expect(complete.status, DriveDiscoveryStatus.complete);
+      expect(drive.contentCalls, 3);
+      expect(
+        (await store.driveCache('old-account')).single.driveFileModifiedAt,
+        DateTime.utc(2026, 4),
+      );
+      await db.close();
+    },
+  );
+
+  test(
+    'account and listing failures are failed and preserve existing state',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('09')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.failListing = true;
+      expect((await discovery.execute()).status, DriveDiscoveryStatus.failed);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      expect(await store.driveCache('old-account'), hasLength(1));
+      drive.failListing = false;
+      drive.failAccount = true;
+      expect((await discovery.execute()).status, DriveDiscoveryStatus.failed);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      drive.failAccount = false;
+      drive.filesById.clear();
+      expect((await discovery.execute()).status, DriveDiscoveryStatus.empty);
+      expect(await store.driveBackups('old-account'), isEmpty);
+      expect(await store.driveCache('old-account'), isEmpty);
+      await db.close();
+    },
+  );
+
+  test(
+    'missing silent account is unauthenticated without reconciliation',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('0c')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.accountName = null;
+
+      final result = await discovery.execute();
+
+      expect(result.status, DriveDiscoveryStatus.unauthenticated);
+      expect(result.listed, 0);
+      expect(result.monitored, 0);
+      expect(result.invalid, 0);
+      expect(result.failed, 0);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      expect(await store.driveCache('old-account'), hasLength(1));
+      await db.close();
+    },
+  );
+
+  test(
+    'repository metadata failure is failed and does not reconcile',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('0b')});
+      await DiscoverDriveBackupsUsecase(drive: drive, store: store).execute();
+      final repository = _MockGoogleDriveRepository();
+      var entered = false;
+      when(
+        () => repository.withDiscoverySession<DriveDiscoveryResult>(any()),
+      ).thenAnswer((invocation) {
+        entered = true;
+        final action =
+            invocation.positionalArguments.single
+                as Future<DriveDiscoveryResult> Function(
+                  GoogleDriveDiscoverySession? session,
+                );
+        return action(_FailingDiscoverySession());
+      });
+      final result = await DiscoverDriveBackupsUsecase(
+        drive: GoogleDriveBackupDiscoveryAdapter(repository),
+        store: store,
+      ).execute();
+      expect(result.status, DriveDiscoveryStatus.failed);
+      expect(entered, isTrue);
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      expect(await store.driveCache('old-account'), hasLength(1));
+      await db.close();
+    },
+  );
+
+  test(
+    'deleting one unchanged duplicate preserves the monitored digest',
+    () async {
+      final (db, store) = await build();
+      final drive = _FakeDrive({'a': _valid('0a'), 'b': _valid('0a')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.filesById.remove('a');
+      await discovery.execute();
+      expect(await store.driveBackups('old-account'), hasLength(1));
+      expect(await store.driveCache('old-account'), hasLength(1));
+      expect(drive.contentCalls, 2);
+      await db.close();
+    },
+  );
+
+  test(
+    'account switch purges Drive rows but preserves local monitoring',
+    () async {
+      final (db, store) = await build();
+      await store.registerBackup(List<int>.filled(32, 7));
+      final drive = _FakeDrive({'a': _valid('07')});
+      final discovery = DiscoverDriveBackupsUsecase(drive: drive, store: store);
+      await discovery.execute();
+      drive.accountName = 'new-account';
+      drive.filesById['b'] = _valid('08');
+      await discovery.execute();
+      final rows = await store.monitoredBackups();
+      expect(rows.where((row) => row.driveAccount == 'old-account'), isEmpty);
+      expect(
+        rows.where((row) => row.driveAccount == 'new-account'),
+        hasLength(1),
+      );
+      expect(rows.where((row) => row.driveAccount == null), hasLength(1));
+      expect(await store.driveCache('old-account'), isEmpty);
+      expect(await store.driveCache('new-account'), hasLength(2));
+      await db.close();
+    },
+  );
+}
+
+String _valid(String byte) => jsonEncode({
+  'version': 1,
+  'created_at': 1780000000000,
+  'id': List.filled(32, byte).join(),
+  'salt': '000102030405060708090a0b0c0d0e0f',
+  'ciphertext': base64Encode(List<int>.generate(64, (i) => i)),
+  'path': "m/83696968'/0'/0'",
+});
+
+final class _FakeDrive implements RecoverBullDriveDiscoveryPort {
+  final Map<String, String> filesById;
+  final Map<String, DateTime> modified = {};
+  String? accountName = 'old-account';
+  bool failContent = false;
+  bool failListing = false;
+  bool failAccount = false;
+  int contentCalls = 0;
+  int accountCalls = 0;
+  int filesCalls = 0;
+  Completer<String>? blockedContent;
+  final fetchStarted = Completer<void>();
+
+  _FakeDrive(this.filesById);
+
+  @override
+  Future<T> withDiscoverySession<T>(
+    Future<T> Function(RecoverBullDriveDiscoverySession? session) action,
+  ) async {
+    if (failAccount) throw StateError('account unavailable');
+    if (accountName == null) return action(null);
+    return action(_FakeDiscoverySession(this));
+  }
+
+  Future<String?> account() async {
+    accountCalls++;
+    if (failAccount) throw StateError('account unavailable');
+    return accountName;
+  }
+
+  Future<List<RecoverBullDriveFile>> files() async {
+    filesCalls++;
+    if (failListing) throw StateError('listing unavailable');
+    return [
+      for (final id in filesById.keys)
+        RecoverBullDriveFile(
+          id: id,
+          createdTime: DateTime.utc(2026),
+          modifiedTime: modified[id],
+        ),
+    ];
+  }
+
+  Future<String> content(String fileId) async {
+    contentCalls++;
+    if (!fetchStarted.isCompleted) fetchStarted.complete();
+    if (blockedContent != null) return blockedContent!.future;
+    if (failContent) throw StateError('transient');
+    return filesById[fileId]!;
+  }
+}
+
+final class _FakeDiscoverySession implements RecoverBullDriveDiscoverySession {
+  final _FakeDrive drive;
+  const _FakeDiscoverySession(this.drive);
+
+  @override
+  String get account => drive.accountName!;
+
+  @override
+  Future<List<RecoverBullDriveFile>> files() => drive.files();
+
+  @override
+  Future<String> content(String fileId) => drive.content(fileId);
+}
+
+final class _CaptureLog implements LogSink {
+  final messages = <String>[];
+
+  @override
+  void fine(String message, {Object? error, StackTrace? trace}) =>
+      messages.add(message);
+
+  @override
+  void info(String message, {Object? error, StackTrace? trace}) =>
+      messages.add(message);
+
+  @override
+  void warning(String message, {Object? error, StackTrace? trace}) =>
+      messages.add(message);
+
+  @override
+  void error(String message, {Object? error, StackTrace? trace}) =>
+      messages.add(message);
+
+  @override
+  LogSink scoped(String scope) => this;
+}
+
+final class _MockGoogleDriveRepository extends Mock
+    implements GoogleDriveRepository {}
+
+final class _FailingDiscoverySession implements GoogleDriveDiscoverySession {
+  @override
+  String get account => 'old-account';
+
+  @override
+  Future<List<DriveFileMetadata>> fetchAllMetadata() =>
+      Future.error(StateError('metadata unavailable'));
+
+  @override
+  Future<String> fetchRawFile(String fileId) =>
+      Future.error(StateError('content unavailable'));
+}

--- a/features/recoverbull/test/domain/usecases/fetch_vault_key_with_status_usecase_test.dart
+++ b/features/recoverbull/test/domain/usecases/fetch_vault_key_with_status_usecase_test.dart
@@ -7,6 +7,10 @@ import 'package:bull_recoverbull/src/domain/recoverbull_tor_route.dart';
 import 'package:bull_recoverbull/src/domain/repositories/recoverbull_repository.dart';
 import 'package:bull_recoverbull/src/domain/usecases/ensure_recoverbull_tor_session_usecase.dart';
 import 'package:bull_recoverbull/src/domain/usecases/fetch_vault_key_with_status_from_server_usecase.dart';
+import 'package:bull_recoverbull/src/domain/usecases/record_local_attempt_usecase.dart';
+import 'package:bull_recoverbull/src/attempt_monitoring/recoverbull_attempt_monitoring.dart';
+import 'package:bull_recoverbull/src/database/recoverbull_database.dart';
+import 'package:drift/native.dart';
 import 'package:bull_tor/tor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -19,6 +23,19 @@ final class _Ensure extends Mock
     implements EnsureRecoverBullTorSessionUsecase {}
 
 final class _Vault extends Mock implements EncryptedVault {}
+
+final class _MonitoringRemote
+    implements RecoverBullAttemptMonitoringRemotePort {
+  final RecoverBullAttemptsSnapshot snapshot;
+
+  const _MonitoringRemote(this.snapshot);
+
+  @override
+  Future<RecoverBullAttemptsSnapshot?> poll({
+    required String? etag,
+    required List<String> backupDigests,
+  }) async => snapshot;
+}
 
 RecoverBullTorRoute _route(void Function() onClose) => RecoverBullTorRoute(
   TorRoute(
@@ -84,4 +101,50 @@ void main() {
     expect(result, isA<Err<VaultKeyFetchResult, RecoverBullFailure>>());
     expect(closeCount, 1);
   });
+
+  test(
+    'records a successful fetch when the server omits attempt status',
+    () async {
+      final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
+      await database.ensureState();
+      final store = RecoverBullAttemptMonitoringStore(database);
+      final identifier = [0];
+      await store.registerBackup(identifier);
+      final digest = store.digestFor(identifier);
+      final window = DateTime.utc(2026, 8, 5, 14);
+      final record = RecordLocalAttemptUsecase(
+        store,
+        remote: _MonitoringRemote(
+          RecoverBullAttemptsSnapshot(
+            collectionStartedAt: window,
+            totalAttempts: {digest: 4},
+            windowStartedAt: {digest: window},
+          ),
+        ),
+      );
+      when(
+        () => repository.fetchVaultKeyWithStatus(any(), any(), any(), any()),
+      ).thenAnswer(
+        (_) async => const Ok(
+          VaultKeyFetchResult(vaultKey: 'aabb', attemptStatus: null),
+        ),
+      );
+
+      final result = await FetchVaultKeyWithStatusFromServerUsecase(
+        repository: repository,
+        ensureSession: ensure,
+        recordAttempt: record,
+        log: const TestLogSink(),
+      ).execute(vault: vault, password: 'password');
+
+      expect(result, isA<Ok<VaultKeyFetchResult, RecoverBullFailure>>());
+      expect(
+        (await store.monitoredBackups())
+            .single
+            .expectedServerDistinctCandidateTotal,
+        4,
+      );
+      await database.close();
+    },
+  );
 }

--- a/features/recoverbull/test/domain/usecases/monitoring_status_usecase_test.dart
+++ b/features/recoverbull/test/domain/usecases/monitoring_status_usecase_test.dart
@@ -1,0 +1,24 @@
+import 'package:bull_recoverbull/src/attempt_monitoring/recoverbull_attempt_monitoring.dart';
+import 'package:bull_recoverbull/src/database/recoverbull_database.dart';
+import 'package:bull_recoverbull/src/public/recoverbull.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('public monitoring status reports empty and active coverage', () async {
+    final database = RecoverBullDatabase.forTesting(NativeDatabase.memory());
+    await database.ensureState();
+    final store = RecoverBullAttemptMonitoringStore(database);
+    final controller = RecoverBullAttemptMonitoring(store, enabled: true);
+
+    final empty = await controller.status();
+    expect(empty.enabled, isTrue);
+    expect(empty.monitoredCount, 0);
+    expect(empty.isUncovered, isTrue);
+    await store.registerBackup(List<int>.generate(16, (index) => index));
+    final active = await controller.status();
+    expect(active.monitoredCount, 1);
+    expect(active.isUncovered, isFalse);
+    await database.close();
+  });
+}

--- a/features/recoverbull/test/domain/usecases/status_attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/status_attempt_monitoring_usecases_test.dart
@@ -11,7 +11,6 @@ import 'package:bull_recoverbull/src/database/recoverbull_database.dart';
 import 'dart:io';
 
 import 'package:bull_tor/tor.dart';
-import 'package:convert/convert.dart' as convert;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -48,7 +47,6 @@ void main() {
       backupKey: List<int>.filled(32, 9),
     );
     final vault = EncryptedVault(file: backup.toJson());
-    await store.registerBackup(convert.hex.decode(vault.id));
     final repository = _Repository();
     final session = _Session();
     final route = RecoverBullTorRoute(
@@ -90,6 +88,7 @@ void main() {
       recordAttempt: record,
       log: const TestLogSink(),
     ).execute(vault: vault, password: 'password');
+    expect(await store.monitoredBackups(), hasLength(1));
     await TrashVaultKeyUsecase(
       repository: repository,
       ensureSession: session,
@@ -97,12 +96,7 @@ void main() {
       log: const TestLogSink(),
     ).execute(vault: vault, password: 'password');
 
-    expect(
-      (await store.monitoredBackups())
-          .single
-          .expectedServerDistinctCandidateTotal,
-      1,
-    );
+    expect(await store.monitoredBackups(), isEmpty);
     await database.close();
   });
 }

--- a/features/recoverbull/test/public/recoverbull_public_api_contract_test.dart
+++ b/features/recoverbull/test/public/recoverbull_public_api_contract_test.dart
@@ -59,6 +59,14 @@ final class _Monitoring implements RecoverBullAttemptMonitoringController {
 
   @override
   Future<void> setEnabled(bool enabled) async {}
+
+  @override
+  Future<RecoverBullMonitoringStatus> status() async =>
+      const RecoverBullMonitoringStatus(
+        enabled: false,
+        monitoredCount: 0,
+        lastSuccessfulCheck: null,
+      );
 }
 
 void main() {

--- a/features/recoverbull/test/ui/attempt_alert_warnings_test.dart
+++ b/features/recoverbull/test/ui/attempt_alert_warnings_test.dart
@@ -24,6 +24,13 @@ class _Controller implements RecoverBullAttemptMonitoringController {
   @override
   bool get enabled => true;
   @override
+  Future<RecoverBullMonitoringStatus> status() async =>
+      const RecoverBullMonitoringStatus(
+        enabled: true,
+        monitoredCount: 0,
+        lastSuccessfulCheck: null,
+      );
+  @override
   Future<List<RecoverBullAttemptAlert>> check() async => visible;
   @override
   Future<List<RecoverBullAttemptAlert>> checkOnColdLaunch() async => visible;

--- a/features/recoverbull/test/ui/attempt_alert_warnings_test.dart
+++ b/features/recoverbull/test/ui/attempt_alert_warnings_test.dart
@@ -8,6 +8,7 @@ import 'package:bull_recoverbull/src/ui/widgets/attempt_alert_warnings.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:bull_ui/bull_ui.dart' show BullInfoCard;
 
 class _Controller implements RecoverBullAttemptMonitoringController {
   final List<RecoverBullAttemptAlert> visible;
@@ -67,12 +68,12 @@ void main() {
         ),
       );
       await tester.pump();
-      expect(find.byType(ListTile), findsOneWidget);
+      expect(find.byType(BullInfoCard), findsOneWidget);
       expect(find.text('RecoverBull security notice'), findsNothing);
 
       await tester.tap(find.byType(TextButton));
       await tester.pump();
-      expect(find.byType(ListTile), findsNothing);
+      expect(find.byType(BullInfoCard), findsNothing);
       await database.close();
     },
   );
@@ -105,7 +106,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.byType(ListTile), findsOneWidget);
+    expect(find.byType(BullInfoCard), findsOneWidget);
     await database.close();
   });
 
@@ -138,7 +139,7 @@ void main() {
         RecoverBullAttemptAlertKind.countersWiped =>
           l10n.recoverbullAttemptMonitoringCountersWiped,
       };
-      expect(find.text(expected), findsOneWidget);
+      expect(find.text(expected), findsAtLeastNWidgets(1));
       if (kind != RecoverBullAttemptAlertKind.suspiciousActivity) {
         expect(
           find.text(l10n.recoverbullAttemptMonitoringSuspiciousActivityTitle),
@@ -147,7 +148,7 @@ void main() {
       }
       await tester.tap(find.byType(TextButton));
       await tester.pump();
-      expect(find.byType(ListTile), findsNothing);
+      expect(find.byType(BullInfoCard), findsNothing);
       await controller.dispose();
     }
   });

--- a/features/recoverbull/test/ui/fetch_vault_key_page_test.dart
+++ b/features/recoverbull/test/ui/fetch_vault_key_page_test.dart
@@ -238,6 +238,57 @@ void main() {
     },
   );
 
+  testWidgets(
+    'test flow reaches completion after the intermediate decrypted-vault '
+    'emission the bloc really produces',
+    (tester) async {
+      final bloc = _MutableRecoverBullBloc(
+        const RecoverBullState(flow: RecoverBullFlow.testVault),
+      );
+      addTearDown(bloc.close);
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates:
+              RecoverBullLocalizations.localizationsDelegates,
+          supportedLocales: RecoverBullLocalizations.supportedLocales,
+          home: BlocProvider<RecoverBullBloc>.value(
+            value: bloc,
+            child: const FetchVaultKeyPage(
+              input: 'redacted',
+              inputType: InputType.vaultKey,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      bloc.emitState(
+        const RecoverBullState(
+          flow: RecoverBullFlow.testVault,
+          vaultKey: 'fetched-key',
+        ),
+      );
+      await tester.pumpAndSettle();
+      bloc.emitState(
+        const RecoverBullState(
+          flow: RecoverBullFlow.testVault,
+          vaultKey: 'fetched-key',
+          decryptedVault: DecryptedVault(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      bloc.emitState(
+        const RecoverBullState(
+          flow: RecoverBullFlow.testVault,
+          isFlowFinished: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TestCompletedPage), findsOneWidget);
+    },
+  );
+
   testWidgets('pending provider save keeps the user on provider selection', (
     tester,
   ) async {


### PR DESCRIPTION
## Linked issue

No issue needed: stacked follow-up to #2751.

## Problem

RecoverBull backup recovery had no durable monitoring of key-server attempts and provider backups, so users could not see stale, missing, or unexpectedly locked-out backup states.

This PR is stacked on #2751 and must merge into `feat/recoverbull-package` after that PR lands. Review #2751 first.

## Changes

- Monitor backup attempts across creation, testing, use, adoption, server-key changes, and targeted lockout flows.
- Surface attempt alerts, alert details, monitoring settings, and aggregate monitored-backup totals in the UI.
- Exhaustively paginate Google Drive metadata and reconcile discovered files with persisted monitoring state.
- Add a debug-only fake Google Drive backend covering three fake Drive vaults, three Drive rows/cache entries, and UI reconciliation with the existing Custom Location.
- Keep logs security-safe by recording aggregate monitoring information without secrets, vault contents, backup identifiers, or raw provider data.

## Non-goals

- The debug fake does not validate real Google OAuth, Drive permissions, or production provider behavior.
- The fake is explicitly rejected outside debug builds.
- This PR does not change the real Google authentication flow or mutate production backup data.
- This PR does not edit or replace the stacked package extraction in #2751.

## Risk and security

Monitoring is advisory and does not expose recovery keys or vault contents. Aggregate logging is sanitized and contains no secrets or synthetic backup IDs. The debug fake is unavailable outside debug mode, so it cannot be selected in production builds.

## Architecture and dependencies

Monitoring remains behind RecoverBull domain use cases, repository contracts, and the package public API. Google Drive pagination and reconciliation are implemented in the RecoverBull data boundary; presentation consumes typed monitoring state. No new dependency is introduced.

## Database and generated files

The RecoverBull package database schema and tracked generated/localization inputs are included as part of the already-committed package extraction and monitoring state. No released schema is rewritten.

## Verification

- `make checks` — analyze reported no issues; dart fix reported nothing to fix; format check made zero changes; all unit/member tests passed, including 232 RecoverBull tests.
- Linux integration — 19 passed, 10 skipped; funded fixtures were intentionally absent for this develop-based run.
- Samsung S10e debug validation — three fake Google Drive vaults reconciled to three Drive rows/cache entries, and the UI reported four monitored backups including the existing Custom Location.
- The debug fake was verified as unavailable outside debug mode.
- Device verification used the debug fake only; no real Google OAuth or production Drive account was used.
