### PR TITLE
ci: batch dart format invocations to stay below ARG_MAX

### DIFF
--- a/makefile
+++ b/makefile
@@ -56,10 +56,10 @@ fix-check:
 	@echo "🧹 dart fix should have nothing to suggest"
 	@bash -c 'set -o pipefail; fvm dart fix --dry-run | tee /dev/stderr | grep -q "Nothing to fix!"'
 
-# Formatting gate scoped to existing git-tracked source via git ls-files: untracked generated code never trips it, deleted files are skipped, and tracked generated files are filtered by suffix and by /generated/ path segment because `dart format` does not read analysis_options.yaml `exclude:`. Keep the regex in sync with the staged-files variant in .git_hooks/pre-commit. pipefail so a git/grep failure cannot silently pass the gate (xargs -r would no-op and exit 0).
+# Formatting gate scoped to existing git-tracked source via git ls-files: untracked generated code never trips it, deleted files are skipped, and tracked generated files are filtered by suffix and by /generated/ path segment because `dart format` does not read analysis_options.yaml `exclude:`. Keep the regex in sync with the staged-files variant in .git_hooks/pre-commit. pipefail so a git/grep failure cannot silently pass the gate (xargs -r would no-op and exit 0), and bounded batches keep the formatter below ARG_MAX as the workspace grows.
 format-check:
 	@echo "🎨 dart format should have nothing to change"
-	@bash -c 'set -o pipefail; git ls-files "*.dart" | grep -vE "\.(g|freezed|gr|config|mocks|steps)\.dart$$|/generated/" | while IFS= read -r file; do if [ -f "$$file" ]; then printf "%s\n" "$$file"; fi; done | xargs -r fvm dart format --output=none --set-exit-if-changed'
+	@bash -c 'set -o pipefail; git ls-files "*.dart" | grep -vE "\.(g|freezed|gr|config|mocks|steps)\.dart$$|/generated/" | while IFS= read -r file; do if [ -f "$$file" ]; then printf "%s\n" "$$file"; fi; done | xargs -r -n 100 fvm dart format --output=none --set-exit-if-changed'
 
 bull-ui-check:
 	@echo "🧱 bull_ui import boundary (coins/ui imports only package:bull_ui)"


### PR DESCRIPTION
## Linked issue

None — CI tooling fix, requesting the `no-issue-needed` exemption.

## Problem

`make format-check` passes every tracked Dart file to a single `dart format` invocation. The workspace has grown past the Linux argument-size limit, so the formatter fails with `ProcessException: Argument list too long` (`make: *** [makefile:62: format-check] Error 123`). Because `format-check` runs before `unit-test` in the `checks` job, unit tests never execute on affected heads.

## Changes

`makefile` `format-check`: feed `xargs` bounded batches (`-r -n 100`) instead of one argument list. The set of checked files, the generated-file filter, `pipefail`, and the exit semantics are unchanged: any unformatted file in any batch still fails the gate. Comment updated accordingly.

## Non-goals

- Reordering the `checks` job so a formatting failure no longer hides test results.
- Touching `.git_hooks/pre-commit`, which only formats staged files and is not exposed to this limit.

## Risk and security

None. Build tooling only; no application code, keys, signing, or backup paths involved.

## Architecture and dependencies

No changes.

## Database and generated files

No changes.

## Verification

Local, Flutter 3.44.9 via fvm 4.1.2, on this branch:

- `make deps` — `Got dependencies!`
- `make build-runner translations` — 4003 + 83 outputs
- `make analyze bull-ui-check fix-check format-check` — exit 0; `Nothing to fix!`; format-check ran 21 batches over 2097 files, 0 changed
- `make unit-test` — exit 0; `All tests passed!` for the root app and all 7 workspace packages

The same batching change has been running on `feat/recoverbull-package` (PR #2751) since 2026-08-26 with a green `checks` job.
