### PR TITLE
fix(recoverbull): surface shared key-server pressure

### DIFF
--- a/features/recoverbull/lib/l10n/recoverbull_en.arb
+++ b/features/recoverbull/lib/l10n/recoverbull_en.arb
@@ -524,8 +524,19 @@
       }
     }
   },
+  "recoverbullErrorServiceBusy": "The service is busy. Please try again later.",
+  "recoverbullErrorServiceBusyRetryIn": "The service is busy. Please try again in {retryIn}.",
+  "@recoverbullErrorServiceBusyRetryIn": {
+    "description": "Error message when the service is under shared pressure and provides a retry delay.",
+    "placeholders": {
+      "retryIn": {
+        "type": "String"
+      }
+    }
+  },
   "recoverbullAttemptMonitoringSuspiciousActivityBody": "This may indicate a potential attack. Do you recognize these attempts? Open the details for recommended next steps.",
   "recoverbullAttemptMonitoringSuspiciousActivityAnnouncement": "The server reports more backup attempts than this phone or app expected. Reinstallation, another phone or device, or your own recovery elsewhere can explain this. If you recognize it, no urgent action is needed; otherwise, treat it as a possible compromise and open the details.",
+  "recoverbullAttemptMonitoringIdentifierSaturation": "The backup service is nearing its identifier capacity. Please try again later.",
   "recoverbullEnterVaultKeyInstead": "Enter a vault key instead",
   "@recoverbullEnterVaultKeyInstead": {
     "description": "Button text to switch to manual vault key entry"

--- a/features/recoverbull/lib/l10n/recoverbull_fr.arb
+++ b/features/recoverbull/lib/l10n/recoverbull_fr.arb
@@ -189,8 +189,11 @@
       }
     }
   },
+  "recoverbullErrorServiceBusy": "Le service est occupé. Veuillez réessayer plus tard.",
+  "recoverbullErrorServiceBusyRetryIn": "Le service est occupé. Veuillez réessayer dans {retryIn}.",
   "recoverbullAttemptMonitoringSuspiciousActivityBody": "Cela peut indiquer une attaque potentielle. Reconnaissez-vous ces tentatives ? Consultez les détails pour connaître les mesures recommandées.",
   "recoverbullAttemptMonitoringSuspiciousActivityAnnouncement": "Le serveur rapporte plus de tentatives de sauvegarde que ce téléphone ou cette app n’en attendait. Une réinstallation, un autre téléphone ou appareil, ou votre propre récupération ailleurs peuvent l’expliquer. Si vous les reconnaissez, aucune action urgente n’est nécessaire ; sinon, considérez une compromission possible et consultez les détails.",
+  "recoverbullAttemptMonitoringIdentifierSaturation": "Le service de sauvegarde approche de sa capacité d’identifiants. Veuillez réessayer plus tard.",
   "recoverbullEnterVaultKeyInstead": "Entrer une clé de coffre-fort",
   "recoverbullSettingsUrlHint": "http://exemple.onion",
   "recoverbullLearnMore": "En savoir plus sur Recoverbull",

--- a/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
+++ b/features/recoverbull/lib/src/data/datasources/recoverbull_remote_datasource.dart
@@ -14,6 +14,7 @@ class RecoverBullRemoteDatasource {
   final LogSink log;
   final RecoverbullSettingsDatasource _recoverbullSettingsDatasource;
   final Future<void> Function(Uri, HttpClient)? infoRequest;
+  final Future<Info> Function(Uri, HttpClient)? infoDetailsRequest;
   final Future<FetchBackupKeyResult> Function(
     Uri,
     HttpClient,
@@ -50,6 +51,7 @@ class RecoverBullRemoteDatasource {
     required this.log,
     this.timing,
     this.infoRequest,
+    this.infoDetailsRequest,
     this.fetchRequest,
     this.storeRequest,
     this.trashRequest,
@@ -97,6 +99,19 @@ class RecoverBullRemoteDatasource {
       );
       rethrow;
     }
+  }
+
+  Future<Info> infoDetails(RecoverBullTorRoute route) async {
+    final url = validateRecoverBullServerUrl(
+      await _recoverbullSettingsDatasource.fetch(),
+    );
+    final request = infoDetailsRequest;
+    return _timed(
+      'server_info',
+      () => request != null
+          ? request(url, route.client)
+          : KeyServer(address: url, client: route.client).infos(),
+    );
   }
 
   Future<void> store(
@@ -238,9 +253,16 @@ class RecoverBullRemoteDatasource {
     } on KeyServerException catch (e) {
       final code = e.code;
       if (code == 429) {
+        // Defensive compatibility branch: the 2026-09 contract reserves 429
+        // for targeted operations, not proof of a targeted lockout here.
         log.warning(
           'recoverbull.attempts.poll.rate_limited code=429 '
           'attempts=${e.attempts ?? 'unknown'} '
+          'retry_after_seconds=${e.retryAfter?.inSeconds ?? 'unknown'}',
+        );
+      } else if (code == 503) {
+        log.warning(
+          'recoverbull.attempts.poll.unavailable code=503 '
           'retry_after_seconds=${e.retryAfter?.inSeconds ?? 'unknown'}',
         );
       } else {
@@ -286,6 +308,7 @@ final class RecoverBullAttemptMonitoringRemoteAdapter
         etag: etag,
         backupIdHashes: backupDigests,
       );
+      final info = await datasource.infoDetails(route);
       return switch (result) {
         AttemptsNotModified() => RecoverBullAttemptsSnapshot(
           collectionStartedAt: DateTime.fromMillisecondsSinceEpoch(
@@ -294,6 +317,7 @@ final class RecoverBullAttemptMonitoringRemoteAdapter
           ),
           totalAttempts: {},
           notModified: true,
+          maxAttemptIdentifiers: info.maxAttemptIdentifiers,
         ),
         AttemptsModified(
           :final etag,
@@ -305,6 +329,7 @@ final class RecoverBullAttemptMonitoringRemoteAdapter
             etag: etag,
             collectionStartedAt: collectionStartedAt,
             totalEntries: totalEntries,
+            maxAttemptIdentifiers: info.maxAttemptIdentifiers,
             totalAttempts: {
               for (final entry in matchingEntries)
                 _decodeDigest(entry.idHash): entry.totalAttempts,

--- a/features/recoverbull/lib/src/data/recoverbull_repository_impl.dart
+++ b/features/recoverbull/lib/src/data/recoverbull_repository_impl.dart
@@ -315,7 +315,9 @@ class RecoverBullRepositoryImpl implements RecoverBullRepository {
       }
       return Err(
         error.code == 503
-            ? const RecoverBullTemporarilyUnavailableFailure()
+            ? RecoverBullTemporarilyUnavailableFailure(
+                retryIn: error.retryAfter,
+              )
             : const KeyServerUnavailableFailure(),
       );
     } catch (error, trace) {
@@ -345,7 +347,10 @@ class RecoverBullRepositoryImpl implements RecoverBullRepository {
     } else if (code != null && code >= 400 && code < 500) {
       log.warning('$prefix.rejected code=$code');
     } else if (code != null && code >= 500) {
-      log.warning('$prefix.unavailable code=$code');
+      log.warning(
+        '$prefix.unavailable code=$code '
+        'retry_after_seconds=${code == 503 ? error.retryAfter?.inSeconds ?? 'unknown' : 'unknown'}',
+      );
     } else if (code == null) {
       log.warning('$prefix.unavailable code=unknown');
     } else {
@@ -403,6 +408,12 @@ class RecoverBullRepositoryImpl implements RecoverBullRepository {
       return KeyServerRateLimitedFailure(
         retryIn: retryIn,
         logMessage: 'Key server rate limit reached',
+      );
+    }
+    if (code == 503) {
+      return KeyServerBusyFailure(
+        retryIn: e.retryAfter,
+        logMessage: 'Key server temporarily busy',
       );
     }
     if (code != null && code >= 400 && code < 500) {

--- a/features/recoverbull/lib/src/domain/entities/attempt_alert.dart
+++ b/features/recoverbull/lib/src/domain/entities/attempt_alert.dart
@@ -21,7 +21,7 @@ final class TargetedLockoutAlert extends AttemptAlert {
   const TargetedLockoutAlert({required this.backupIdHash});
 }
 
-enum ServicePressureKind { serviceBusy }
+enum ServicePressureKind { serviceBusy, identifierSaturation }
 
 final class ServicePressureAlert extends AttemptAlert {
   final ServicePressureKind kind;

--- a/features/recoverbull/lib/src/domain/recoverbull_failure.dart
+++ b/features/recoverbull/lib/src/domain/recoverbull_failure.dart
@@ -69,6 +69,11 @@ final class VaultRateLimitedFailure extends RecoverBullFailure {
   const VaultRateLimitedFailure({required this.retryIn});
 }
 
+final class VaultServiceBusyFailure extends RecoverBullFailure {
+  final Duration? retryIn;
+  const VaultServiceBusyFailure({this.retryIn});
+}
+
 final class ExternalTorProxyUnavailableFailure extends RecoverBullFailure {
   const ExternalTorProxyUnavailableFailure([super.logMessage]);
 }
@@ -80,6 +85,12 @@ final class KeyServerInvalidCredentialsFailure extends RecoverBullFailure {
 final class KeyServerRateLimitedFailure extends RecoverBullFailure {
   final Duration? retryIn;
   const KeyServerRateLimitedFailure({this.retryIn, String? logMessage})
+    : super(logMessage);
+}
+
+final class KeyServerBusyFailure extends RecoverBullFailure {
+  final Duration? retryIn;
+  const KeyServerBusyFailure({this.retryIn, String? logMessage})
     : super(logMessage);
 }
 
@@ -99,7 +110,11 @@ final class KeyServerHealthCheckTimeoutFailure extends RecoverBullFailure {
 /// The key server is reachable but temporarily unable to serve health checks.
 final class RecoverBullTemporarilyUnavailableFailure
     extends RecoverBullFailure {
-  const RecoverBullTemporarilyUnavailableFailure([super.logMessage]);
+  final Duration? retryIn;
+  const RecoverBullTemporarilyUnavailableFailure({
+    this.retryIn,
+    String? logMessage,
+  }) : super(logMessage);
 }
 
 final class InvalidVaultFileFailure extends RecoverBullFailure {

--- a/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/check_backup_attempt_monitoring_usecase.dart
@@ -3,6 +3,7 @@ import '../entities/attempt_alert.dart';
 
 final class CheckBackupAttemptMonitoringUsecase {
   static const snapshotFreshness = Duration(seconds: 60);
+  static const identifierSaturationThreshold = 0.9;
   static const unavailabilityThreshold = Duration(days: 3);
   static const unavailabilityWarnCooldown = Duration(days: 1);
   static const minFailuresWithoutSuccess = 3;
@@ -58,6 +59,8 @@ final class CheckBackupAttemptMonitoringUsecase {
       final unavailable = await store.recordPollFailure(now: current);
       return [
         const ServicePressureAlert(ServicePressureKind.serviceBusy),
+        if (_isIdentifierSaturated(snapshot))
+          const ServicePressureAlert(ServicePressureKind.identifierSaturation),
         if (unavailable) const AttemptMonitoringUnavailableAlert(since: null),
       ];
     }
@@ -77,6 +80,11 @@ final class CheckBackupAttemptMonitoringUsecase {
     final applied = await store.applySnapshot(snapshot, token);
     if (!applied.accepted) return const [];
     if (snapshot.notModified) return const [];
+    if (_isIdentifierSaturated(snapshot)) {
+      alerts.add(
+        const ServicePressureAlert(ServicePressureKind.identifierSaturation),
+      );
+    }
     final entries = {
       for (final entry in snapshot.totalAttempts.entries)
         _hex(entry.key): entry.value,
@@ -103,4 +111,13 @@ final class CheckBackupAttemptMonitoringUsecase {
 
   static String _hex(List<int> bytes) =>
       bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+  static bool _isIdentifierSaturated(RecoverBullAttemptsSnapshot snapshot) {
+    final total = snapshot.totalEntries;
+    final capacity = snapshot.maxAttemptIdentifiers;
+    return total != null &&
+        capacity != null &&
+        capacity > 0 &&
+        total >= capacity * identifierSaturationThreshold;
+  }
 }

--- a/features/recoverbull/lib/src/domain/usecases/connect_to_key_server_usecase.dart
+++ b/features/recoverbull/lib/src/domain/usecases/connect_to_key_server_usecase.dart
@@ -71,6 +71,11 @@ class ConnectToKeyServerUsecase {
           case Err(:final failure)
               when failure is KeyServerHealthCheckTimeoutFailure:
             return Err(failure);
+          case Err(:final failure) when failure is KeyServerBusyFailure:
+            return Err(failure);
+          case Err(:final failure)
+              when failure is RecoverBullTemporarilyUnavailableFailure:
+            return Err(failure);
           case Err():
             break;
         }

--- a/features/recoverbull/lib/src/presentation/bloc.dart
+++ b/features/recoverbull/lib/src/presentation/bloc.dart
@@ -818,6 +818,11 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
           const InvalidVaultCredentialsFailure(),
         core.KeyServerRateLimitedFailure(:final retryIn) =>
           VaultRateLimitedFailure(retryIn: retryIn ?? Duration.zero),
+        core.KeyServerBusyFailure(:final retryIn) => VaultServiceBusyFailure(
+          retryIn: retryIn,
+        ),
+        core.RecoverBullTemporarilyUnavailableFailure(:final retryIn) =>
+          VaultServiceBusyFailure(retryIn: retryIn),
         core.KeyServerUnavailableFailure() => const VaultKeyFetchFailure(),
         core.ExternalTorProxyUnavailableFailure() =>
           const ExternalTorProxyUnavailableFailure(),
@@ -837,6 +842,11 @@ class RecoverBullBloc extends Bloc<RecoverBullEvent, RecoverBullState> {
     core.KeyServerRateLimitedFailure(:final retryIn) => VaultRateLimitedFailure(
       retryIn: retryIn ?? Duration.zero,
     ),
+    core.KeyServerBusyFailure(:final retryIn) => VaultServiceBusyFailure(
+      retryIn: retryIn,
+    ),
+    core.RecoverBullTemporarilyUnavailableFailure(:final retryIn) =>
+      VaultServiceBusyFailure(retryIn: retryIn),
     core.KeyServerUnavailableFailure() => const KeyServerConnectionFailure(),
     core.ExternalTorProxyUnavailableFailure() =>
       const ExternalTorProxyUnavailableFailure(),

--- a/features/recoverbull/lib/src/presentation/recoverbull_failure_l10n.dart
+++ b/features/recoverbull/lib/src/presentation/recoverbull_failure_l10n.dart
@@ -26,15 +26,31 @@ extension RecoverBullFailureL10n on RecoverBullFailure {
       context.loc.recoverbullSelectBackupFileNotValidError,
     VaultRateLimitedFailure(:final retryIn) =>
       context.loc.recoverbullErrorRateLimited(_cooldown(context, retryIn)),
+    VaultServiceBusyFailure(:final retryIn) =>
+      retryIn == null
+          ? context.loc.recoverbullErrorServiceBusy
+          : context.loc.recoverbullErrorServiceBusyRetryIn(
+              _cooldown(context, retryIn),
+            ),
     KeyServerInvalidCredentialsFailure() =>
       context.loc.recoverbullErrorUnexpected,
     KeyServerRateLimitedFailure() => context.loc.recoverbullErrorUnexpected,
+    KeyServerBusyFailure(:final retryIn) =>
+      retryIn == null
+          ? context.loc.recoverbullErrorServiceBusy
+          : context.loc.recoverbullErrorServiceBusyRetryIn(
+              _cooldown(context, retryIn),
+            ),
     KeyServerRejectedFailure() => context.loc.recoverbullErrorUnexpected,
     KeyServerUnavailableFailure() => context.loc.recoverbullErrorUnexpected,
     KeyServerHealthCheckTimeoutFailure() =>
       context.loc.recoverbullErrorUnexpected,
-    RecoverBullTemporarilyUnavailableFailure() =>
-      context.loc.recoverbullErrorUnexpected,
+    RecoverBullTemporarilyUnavailableFailure(:final retryIn) =>
+      retryIn == null
+          ? context.loc.recoverbullErrorServiceBusy
+          : context.loc.recoverbullErrorServiceBusyRetryIn(
+              _cooldown(context, retryIn),
+            ),
     InvalidVaultFileFailure() => context.loc.recoverbullErrorUnexpected,
     RecoverBullGoogleDriveFetchFailure() =>
       context.loc.recoverbullGoogleDriveErrorFetchFailed,
@@ -50,7 +66,7 @@ extension RecoverBullFailureL10n on RecoverBullFailure {
     // remaining duration) to 1s so the UI never shows "0 seconds" or a
     // negative value.
     final seconds = retryIn.inSeconds < 1 ? 1 : retryIn.inSeconds;
-    if (seconds < 60) {
+    if (seconds < 60 || seconds % 60 != 0) {
       return context.loc.durationSeconds(seconds.toString());
     }
     final minutes = seconds ~/ 60;

--- a/features/recoverbull/lib/src/public/recoverbull.dart
+++ b/features/recoverbull/lib/src/public/recoverbull.dart
@@ -104,6 +104,7 @@ enum RecoverBullAttemptAlertKind {
   suspiciousActivity,
   targetedLockout,
   servicePressure,
+  identifierSaturation,
   unavailable,
 }
 
@@ -337,7 +338,9 @@ final class RecoverBullAttemptMonitoring
         ),
       domain_alert.ServicePressureAlert(:final kind) =>
         RecoverBullAttemptAlert._(
-          RecoverBullAttemptAlertKind.servicePressure,
+          kind == domain_alert.ServicePressureKind.identifierSaturation
+              ? RecoverBullAttemptAlertKind.identifierSaturation
+              : RecoverBullAttemptAlertKind.servicePressure,
           'service:${kind.name}',
           'p:$kind',
         ),

--- a/features/recoverbull/test/data/recoverbull_remote_datasource_test.dart
+++ b/features/recoverbull/test/data/recoverbull_remote_datasource_test.dart
@@ -32,6 +32,10 @@ final class _AttemptsDatasource extends RecoverBullRemoteDatasource {
     String? etag,
     List<String> backupIdHashes = const [],
   }) async => AttemptsNotModified();
+
+  @override
+  Future<Info> infoDetails(RecoverBullTorRoute route) async =>
+      Info(cooldown: 1, maxAttempts: 3, secretMaxLength: 1, canary: '🐦');
 }
 
 void main() {
@@ -193,6 +197,43 @@ void main() {
   });
 
   test(
+    'monitoring adapter carries capacity from info to the snapshot',
+    () async {
+      final settings = _Settings();
+      when(
+        () => settings.fetch(),
+      ).thenAnswer((_) async => Uri.parse('http://key.onion'));
+      final datasource = RecoverBullRemoteDatasource(
+        log: const TestLogSink(),
+        recoverbullSettingsDatasource: settings,
+        attemptsRequest: (_, _, _, _) async => AttemptsModified(
+          etag: 'etag',
+          maxAgeSeconds: 1,
+          version: 1,
+          collectionStartedAt: DateTime.utc(2026),
+          totalEntries: 9,
+          matchingEntries: const [],
+        ),
+        infoDetailsRequest: (_, _) async => Info(
+          cooldown: 1,
+          maxAttempts: 3,
+          secretMaxLength: 1,
+          canary: '🐦',
+          maxAttemptIdentifiers: 10,
+        ),
+      );
+      final adapter = RecoverBullAttemptMonitoringRemoteAdapter(
+        datasource: datasource,
+        routeFactory: () async => routeFor(_Client()),
+      );
+
+      final snapshot = await adapter.poll(etag: null, backupDigests: const []);
+
+      expect(snapshot!.maxAttemptIdentifiers, 10);
+    },
+  );
+
+  test(
     'attempts logs modified and not-modified outcomes without identifiers',
     () async {
       final settings = _Settings();
@@ -247,6 +288,38 @@ void main() {
       expect(
         notModifiedLog.entries.single.message,
         contains('outcome=not_modified matching_count=0'),
+      );
+    },
+  );
+
+  test(
+    'monitoring adapter does not publish a snapshot when info fails',
+    () async {
+      final settings = _Settings();
+      when(
+        () => settings.fetch(),
+      ).thenAnswer((_) async => Uri.parse('http://key.onion'));
+      final datasource = RecoverBullRemoteDatasource(
+        log: const TestLogSink(),
+        recoverbullSettingsDatasource: settings,
+        attemptsRequest: (_, _, _, _) async => AttemptsModified(
+          etag: 'etag',
+          maxAgeSeconds: 1,
+          version: 1,
+          collectionStartedAt: DateTime.utc(2026),
+          totalEntries: 9,
+          matchingEntries: const [],
+        ),
+        infoDetailsRequest: (_, _) async => throw StateError('info failed'),
+      );
+      final adapter = RecoverBullAttemptMonitoringRemoteAdapter(
+        datasource: datasource,
+        routeFactory: () async => routeFor(_Client()),
+      );
+
+      await expectLater(
+        adapter.poll(etag: null, backupDigests: const []),
+        throwsA(isA<StateError>()),
       );
     },
   );
@@ -324,6 +397,34 @@ void main() {
     );
     expect(log.entries.single.message, isNot(contains('sentinel')));
     expect(log.entries.single.error, isNull);
+  });
+
+  test('attempts logs Retry-After for shared 503 pressure', () async {
+    final settings = _Settings();
+    when(
+      () => settings.fetch(),
+    ).thenAnswer((_) async => Uri.parse('http://sentinel.onion'));
+    final log = TestLogSink.recording();
+    final datasource = RecoverBullRemoteDatasource(
+      log: log,
+      recoverbullSettingsDatasource: settings,
+      attemptsRequest: (_, _, _, _) async => throw KeyServerException(
+        code: 503,
+        retryAfter: const Duration(seconds: 47),
+        message: 'server payload',
+      ),
+    );
+
+    await expectLater(
+      datasource.attempts(route: routeFor(_Client())),
+      throwsA(isA<KeyServerException>()),
+    );
+
+    expect(
+      log.entries.single.message,
+      'recoverbull.attempts.poll.unavailable code=503 retry_after_seconds=47',
+    );
+    expect(log.entries.single.message, isNot(contains('payload')));
   });
 
   test('reports timings for every remote phase and terminal outcome', () async {

--- a/features/recoverbull/test/data/recoverbull_repository_test.dart
+++ b/features/recoverbull/test/data/recoverbull_repository_test.dart
@@ -89,6 +89,56 @@ void main() {
       repository.fetchVaultKey('00', 'password', '00', route);
 
   group('RecoverBullRepository.fetchVaultKey maps KeyServerException', () {
+    test('503 preserves Retry-After as a busy failure', () async {
+      stubFetchThrows(
+        recoverbull.KeyServerException(
+          code: 503,
+          retryAfter: const Duration(seconds: 30),
+          message: 'server text must not classify the response',
+        ),
+      );
+
+      final result = await fetch();
+
+      final failure = (result as Err<String, RecoverBullFailure>).failure;
+      expect(failure, isA<KeyServerBusyFailure>());
+      expect(
+        (failure as KeyServerBusyFailure).retryIn,
+        const Duration(seconds: 30),
+      );
+    });
+
+    test('500 remains unavailable regardless of response text', () async {
+      stubFetchThrows(
+        recoverbull.KeyServerException(code: 500, message: 'busy'),
+      );
+
+      final result = await fetch();
+
+      expect(
+        (result as Err<String, RecoverBullFailure>).failure,
+        isA<KeyServerUnavailableFailure>(),
+      );
+    });
+
+    test('server failure logs only status and retry metadata', () async {
+      stubFetchThrows(
+        recoverbull.KeyServerException(
+          code: 503,
+          retryAfter: const Duration(seconds: 47),
+          message: 'server payload',
+        ),
+      );
+
+      await fetch();
+
+      expect(
+        logSink.entries.single.message,
+        'recoverbull.key.fetch.unavailable code=503 retry_after_seconds=47',
+      );
+      expect(logSink.entries.single.message, isNot(contains('payload')));
+    });
+
     test('401 -> KeyServerInvalidCredentialsFailure (no raw leak)', () async {
       stubFetchThrows(
         recoverbull.KeyServerException(code: 401, message: 'unauthorized xyz'),
@@ -171,18 +221,18 @@ void main() {
       );
     });
 
-    test('5xx -> KeyServerUnavailableFailure', () async {
+    test('503 -> KeyServerBusyFailure', () async {
       stubFetchThrows(recoverbull.KeyServerException(code: 503));
 
       final result = await fetch();
 
       expect(
         (result as Err<String, RecoverBullFailure>).failure,
-        isA<KeyServerUnavailableFailure>(),
+        isA<KeyServerBusyFailure>(),
       );
       expect(
         logSink.entries.single.message,
-        'recoverbull.key.fetch.unavailable code=503',
+        'recoverbull.key.fetch.unavailable code=503 retry_after_seconds=unknown',
       );
     });
 
@@ -357,8 +407,8 @@ void main() {
       ),
       (
         code: 503,
-        failure: isA<KeyServerUnavailableFailure>(),
-        event: 'unavailable code=503',
+        failure: isA<KeyServerBusyFailure>(),
+        event: 'unavailable code=503 retry_after_seconds=unknown',
       ),
       (
         code: null,
@@ -603,17 +653,21 @@ void main() {
 
   group('RecoverBullRepository.checkConnection', () {
     test('maps HTTP 503 to temporary unavailability', () async {
-      when(
-        () => remote.checkConnection(any()),
-      ).thenThrow(recoverbull.KeyServerException(code: 503));
+      when(() => remote.checkConnection(any())).thenThrow(
+        recoverbull.KeyServerException(
+          code: 503,
+          retryAfter: const Duration(seconds: 30),
+        ),
+      );
 
       final result = await repository.checkConnection(route);
 
       expect(result, isA<Err<Null, RecoverBullFailure>>());
-      expect(
-        (result as Err<Null, RecoverBullFailure>).failure,
-        isA<RecoverBullTemporarilyUnavailableFailure>(),
-      );
+      final failure =
+          (result as Err<Null, RecoverBullFailure>).failure
+              as RecoverBullTemporarilyUnavailableFailure;
+      expect(failure, isA<RecoverBullTemporarilyUnavailableFailure>());
+      expect(failure.retryIn, const Duration(seconds: 30));
     });
 
     test('maps timeout to health check timeout', () async {

--- a/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
+++ b/features/recoverbull/test/domain/usecases/attempt_monitoring_usecases_test.dart
@@ -112,6 +112,91 @@ void main() {
     return (db, RecoverBullAttemptMonitoringStore(db));
   }
 
+  test('identifier saturation alerts without a matching user hash', () async {
+    final (db, store) = await build();
+    await store.registerBackup(id, origin: MonitoredBackupOrigin.adopted);
+    final remote = _Remote()
+      ..response = RecoverBullAttemptsSnapshot(
+        collectionStartedAt: window,
+        totalAttempts: const {},
+        totalEntries: 9,
+        maxAttemptIdentifiers: 10,
+      );
+
+    final alerts = await CheckBackupAttemptMonitoringUsecase(
+      store: store,
+      remote: remote,
+      clock: () => DateTime.utc(2026, 8, 5, 16),
+    ).execute(forceRefresh: true);
+
+    expect(
+      alerts,
+      contains(
+        const ServicePressureAlert(ServicePressureKind.identifierSaturation),
+      ),
+    );
+    await db.close();
+  });
+
+  test(
+    'identifier saturation is silent below or without a positive capacity',
+    () async {
+      for (final snapshot in [
+        RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: const {},
+          totalEntries: 8,
+          maxAttemptIdentifiers: 10,
+        ),
+        RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: const {},
+          maxAttemptIdentifiers: 10,
+        ),
+        RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: const {},
+          totalEntries: 9,
+        ),
+        RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: const {},
+          totalEntries: 9,
+          maxAttemptIdentifiers: 0,
+        ),
+      ]) {
+        final (db, store) = await build();
+        await store.registerBackup(id, origin: MonitoredBackupOrigin.adopted);
+        final alerts = await CheckBackupAttemptMonitoringUsecase(
+          store: store,
+          remote: _Remote()..response = snapshot,
+          clock: () => DateTime.utc(2026, 8, 5, 16),
+        ).execute(forceRefresh: true);
+        expect(alerts.whereType<ServicePressureAlert>(), isEmpty);
+        await db.close();
+      }
+    },
+  );
+
+  test('service busy and saturation produce one alert of each kind', () async {
+    final (db, store) = await build();
+    await store.registerBackup(id, origin: MonitoredBackupOrigin.adopted);
+    final alerts = await CheckBackupAttemptMonitoringUsecase(
+      store: store,
+      remote: _Remote()
+        ..response = RecoverBullAttemptsSnapshot(
+          collectionStartedAt: window,
+          totalAttempts: const {},
+          serviceBusy: true,
+          totalEntries: 9,
+          maxAttemptIdentifiers: 10,
+        ),
+      clock: () => DateTime.utc(2026, 8, 5, 16),
+    ).execute(forceRefresh: true);
+    expect(alerts.whereType<ServicePressureAlert>(), hasLength(2));
+    await db.close();
+  });
+
   test('registering a backup does not count an attempt', () async {
     final (db, store) = await build();
     await RegisterMonitoredBackupUsecase(store).execute(

--- a/features/recoverbull/test/domain/usecases/connect_to_key_server_usecase_test.dart
+++ b/features/recoverbull/test/domain/usecases/connect_to_key_server_usecase_test.dart
@@ -68,6 +68,25 @@ void main() {
   Future<Result<bool, RecoverBullFailure>> run() =>
       usecase.execute(onAttempt: attempts.add);
 
+  test('temporary server pressure is preserved for the caller', () async {
+    when(() => checkConnection.execute(route: route)).thenAnswer(
+      (_) async => const Err(
+        RecoverBullTemporarilyUnavailableFailure(
+          retryIn: Duration(seconds: 30),
+        ),
+      ),
+    );
+
+    final result = await run();
+
+    final failure = (result as Err<bool, RecoverBullFailure>).failure;
+    expect(failure, isA<RecoverBullTemporarilyUnavailableFailure>());
+    expect(
+      (failure as RecoverBullTemporarilyUnavailableFailure).retryIn,
+      const Duration(seconds: 30),
+    );
+  });
+
   test('stops at the first answer instead of exhausting the budget', () async {
     when(
       () => checkConnection.execute(route: route),

--- a/features/recoverbull/test/presentation/recoverbull_backup_bloc_test.dart
+++ b/features/recoverbull/test/presentation/recoverbull_backup_bloc_test.dart
@@ -248,7 +248,7 @@ void main() {
     );
 
     test(
-      'rate-limited storeVaultKey -> VaultRateLimitedFailure (cooldown kept)',
+      'busy storeVaultKey -> VaultServiceBusyFailure (cooldown kept)',
       () async {
         const cooldown = Duration(minutes: 5);
         final vault = MockEncryptedVault();
@@ -275,8 +275,7 @@ void main() {
             vaultKey: any(named: 'vaultKey'),
           ),
         ).thenAnswer(
-          (_) async =>
-              Err(const core.KeyServerRateLimitedFailure(retryIn: cooldown)),
+          (_) async => Err(const core.KeyServerBusyFailure(retryIn: cooldown)),
         );
 
         final bloc = buildBloc(flow: RecoverBullFlow.secureVault);
@@ -292,11 +291,11 @@ void main() {
         );
         await pumpEventQueue();
 
-        // The 429 cooldown must survive the create path instead of collapsing
+        // The 503 cooldown must survive the create path instead of collapsing
         // into the generic VaultCreationFailure.
-        expect(bloc.state.failure, isA<VaultRateLimitedFailure>());
+        expect(bloc.state.failure, isA<VaultServiceBusyFailure>());
         expect(
-          (bloc.state.failure as VaultRateLimitedFailure).retryIn,
+          (bloc.state.failure as VaultServiceBusyFailure).retryIn,
           cooldown,
         );
         verifyNever(() => lifecycle.markStored());

--- a/features/recoverbull/test/presentation/recoverbull_failure_l10n_test.dart
+++ b/features/recoverbull/test/presentation/recoverbull_failure_l10n_test.dart
@@ -1,6 +1,6 @@
 import 'package:bull_recoverbull/generated/l10n/recoverbull_localizations.dart';
-import 'package:bull_recoverbull/src/domain/recoverbull_failure.dart';
 import 'package:bull_recoverbull/src/presentation/recoverbull_failure_l10n.dart';
+import 'package:bull_recoverbull/src/domain/recoverbull_failure.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -26,8 +26,16 @@ void main() {
       const VaultRateLimitedFailure(retryIn: Duration.zero),
       const KeyServerInvalidCredentialsFailure(diagnostic),
       const KeyServerRateLimitedFailure(logMessage: diagnostic),
+      const KeyServerBusyFailure(
+        retryIn: Duration(seconds: 30),
+        logMessage: diagnostic,
+      ),
       const KeyServerRejectedFailure(diagnostic),
       const KeyServerUnavailableFailure(diagnostic),
+      const RecoverBullTemporarilyUnavailableFailure(
+        retryIn: Duration(seconds: 30),
+        logMessage: diagnostic,
+      ),
       const InvalidVaultFileFailure(diagnostic),
       const RecoverBullGoogleDriveFetchFailure(diagnostic),
       const RecoverBullGoogleDriveDeleteFailure(diagnostic),
@@ -54,5 +62,55 @@ void main() {
     expect(messages, hasLength(failures.length));
     expect(messages, everyElement(isNot(contains(diagnostic))));
     expect(messages, everyElement(isNotEmpty));
+  });
+
+  testWidgets('503 failures say service busy with optional retry delay', (
+    tester,
+  ) async {
+    late List<String> messages;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: RecoverBullLocalizations.localizationsDelegates,
+        supportedLocales: RecoverBullLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            messages = [
+              const KeyServerBusyFailure(
+                retryIn: Duration(seconds: 30),
+              ).toTranslated(context),
+              const RecoverBullTemporarilyUnavailableFailure(
+                retryIn: Duration(seconds: 30),
+              ).toTranslated(context),
+              const KeyServerBusyFailure().toTranslated(context),
+              const RecoverBullTemporarilyUnavailableFailure().toTranslated(
+                context,
+              ),
+              const KeyServerBusyFailure(
+                retryIn: Duration(seconds: 61),
+              ).toTranslated(context),
+              const KeyServerBusyFailure(
+                retryIn: Duration(seconds: 90),
+              ).toTranslated(context),
+            ];
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(messages[0], contains('service is busy'));
+    expect(messages[0], contains('30 seconds'));
+    expect(messages[0], isNot(contains('Rate limited')));
+    expect(messages[1], contains('service is busy'));
+    expect(messages[1], contains('30 seconds'));
+    expect(messages[1], isNot(contains('Rate limited')));
+    expect(messages[2], contains('service is busy'));
+    expect(messages[2], contains('later'));
+    expect(messages[2], isNot(contains('second')));
+    expect(messages[3], contains('service is busy'));
+    expect(messages[3], contains('later'));
+    expect(messages[3], isNot(contains('second')));
+    expect(messages[4], contains('61 seconds'));
+    expect(messages[5], contains('90 seconds'));
   });
 }

--- a/lib/features/announcements/domain/entities/recoverbull_announcement.dart
+++ b/lib/features/announcements/domain/entities/recoverbull_announcement.dart
@@ -25,6 +25,8 @@ AnnouncementId _idFor(RecoverBullAttemptAlertKind kind) => switch (kind) {
     AnnouncementId.recoverBullTargetedActivity,
   RecoverBullAttemptAlertKind.servicePressure =>
     AnnouncementId.recoverBullServicePressure,
+  RecoverBullAttemptAlertKind.identifierSaturation =>
+    AnnouncementId.recoverBullServicePressure,
   RecoverBullAttemptAlertKind.unavailable =>
     AnnouncementId.recoverBullUnavailable,
 };

--- a/lib/features/announcements/presentation/announcement_l10n.dart
+++ b/lib/features/announcements/presentation/announcement_l10n.dart
@@ -17,9 +17,7 @@ extension AnnouncementL10n on Announcement {
       context,
       this,
     ),
-    AnnouncementId.recoverBullServicePressure => RecoverBullLocalizations.of(
-      context,
-    ).recoverbullAttemptMonitoringServicePressure,
+    AnnouncementId.recoverBullServicePressure => _servicePressureText(context),
     AnnouncementId.recoverBullUnavailable => RecoverBullLocalizations.of(
       context,
     ).recoverbullAttemptMonitoringUnavailableUnknownDuration,
@@ -33,9 +31,7 @@ extension AnnouncementL10n on Announcement {
       context,
       this,
     ),
-    AnnouncementId.recoverBullServicePressure => RecoverBullLocalizations.of(
-      context,
-    ).recoverbullAttemptMonitoringServicePressure,
+    AnnouncementId.recoverBullServicePressure => _servicePressureText(context),
     AnnouncementId.recoverBullUnavailable => RecoverBullLocalizations.of(
       context,
     ).recoverbullAttemptMonitoringUnavailableUnknownDuration,
@@ -49,6 +45,17 @@ extension AnnouncementL10n on Announcement {
         )
         ? l10n.recoverbullAttemptMonitoringLockoutTitle
         : l10n.recoverbullAttemptMonitoringSuspiciousActivityTitle;
+  }
+
+  String _servicePressureText(BuildContext context) {
+    final announcement = this as RecoverBullAnnouncement;
+    final l10n = RecoverBullLocalizations.of(context);
+    return announcement.sourceAlerts.any(
+          (alert) =>
+              alert.kind == RecoverBullAttemptAlertKind.identifierSaturation,
+        )
+        ? l10n.recoverbullAttemptMonitoringIdentifierSaturation
+        : l10n.recoverbullAttemptMonitoringServicePressure;
   }
 
   String _targetedActivityDescription(

--- a/test/features/announcements/domain/recoverbull_announcements_test.dart
+++ b/test/features/announcements/domain/recoverbull_announcements_test.dart
@@ -92,7 +92,7 @@ void main() {
       ]),
     ).execute().first;
 
-    expect(announcements, hasLength(4));
+    expect(announcements, hasLength(5));
     expect(
       announcements.map((announcement) => announcement.primaryAlert.kind),
       containsAll(RecoverBullAttemptAlertKind.values),


### PR DESCRIPTION
Linked issue: No issue needed: security-audit follow-up to #2751 and #2800.

Stacking: targets feat/recoverbull-package; merge into that branch before #2751 lands.

Problem: 2026-09 contract distinguishes targeted 429, shared-pressure 503 with Retry-After, and genuine 500; monitoring was blind when global identifier capacity filled without victim hash.

Changes: 90% global saturation alert using /attempts totalEntries + /info maxAttemptIdentifiers; unknown/missing invalid capacity silent; 503 distinct busy failure preserving optional delay through health/fetch/store/UI; no invented delay; exact non-minute durations; 500 generic; safe retry-after logs; defensive attempts 429 retained.

Security/invariants: backup/recovery and key-server paths touched; no raw identifiers/secrets/endpoints/payloads; no trash retry; hex, store-before-upload, ETag/hashes/staleness unchanged.

No deps, schema, migration, generated output or default endpoint changes.

Red-Green evidence and verification exactly as above.

Review order: single commit 53266631f.