### PR TITLE
feat(coins): enable Liquid coin selection

### DIFF
--- a/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
+++ b/lib/core/wallet/data/datasources/lwk_wallet_datasource.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
 import 'package:bull_logger/bull_logger.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_facade.dart';
 import 'package:bb_mobile/core/wallet/data/models/balance_model.dart';
@@ -13,7 +14,9 @@ import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
 import 'package:bb_mobile/core/electrum/domain/value_objects/electrum_connection.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:flutter/material.dart';
 import 'package:bull_sdk/lwk.dart' as lwk;
 
@@ -23,11 +26,14 @@ class LwkWalletDatasource {
   final Map<String, Future<void>> _activeSyncs;
   final StreamController<String> _walletSyncStartedController;
   final StreamController<String> _walletSyncFinishedController;
+  final Future<lwk.Wallet> Function(WalletModel) _createPublicWallet;
 
-  LwkWalletDatasource()
-    : _activeSyncs = {},
-      _walletSyncStartedController = StreamController<String>.broadcast(),
-      _walletSyncFinishedController = StreamController<String>.broadcast();
+  LwkWalletDatasource({
+    Future<lwk.Wallet> Function(WalletModel)? createPublicWallet,
+  }) : _createPublicWallet = createPublicWallet ?? LwkFacade.createPublicWallet,
+       _activeSyncs = {},
+       _walletSyncStartedController = StreamController<String>.broadcast(),
+       _walletSyncFinishedController = StreamController<String>.broadcast();
 
   Stream<String> get walletSyncStartedStream =>
       _walletSyncStartedController.stream;
@@ -114,19 +120,25 @@ class LwkWalletDatasource {
 
   Future<List<WalletUtxoModel>> getUtxos({required WalletModel wallet}) async {
     try {
-      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
+      final lwkWallet = await _createPublicWallet(wallet);
       final utxos = await lwkWallet.utxos();
 
-      final unspent = utxos.map((utxo) {
-        return WalletUtxoModel.liquid(
-          txId: utxo.outpoint.txid,
-          vout: utxo.outpoint.vout,
-          amountSat: utxo.unblinded.value,
-          scriptPubkey: utxo.scriptPubkey,
-          standardAddress: utxo.address.standard,
-          confidentialAddress: utxo.address.confidential,
-        );
-      });
+      final assetId = _lBtcAssetId(
+        wallet.isTestnet ? Network.liquidTestnet : Network.liquidMainnet,
+      );
+      final unspent = utxos
+          .where((utxo) => utxo.unblinded.asset == assetId)
+          .map((utxo) {
+            return WalletUtxoModel.liquid(
+              txId: utxo.outpoint.txid,
+              vout: utxo.outpoint.vout,
+              amountSat: utxo.unblinded.value,
+              scriptPubkey: utxo.scriptPubkey,
+              standardAddress: utxo.address.standard,
+              confidentialAddress: utxo.address.confidential,
+              blockHeight: utxo.height,
+            );
+          });
 
       return unspent.toList();
     } catch (e) {
@@ -264,8 +276,8 @@ class LwkWalletDatasource {
 
   String _lBtcAssetId(Network network) {
     return network == Network.liquidTestnet
-        ? lwk.getLtestAssetId()
-        : lwk.getLbtcAssetId();
+        ? AssetConstants.lbtcTestnet
+        : AssetConstants.lbtcMainnet;
   }
 
   Future<List<WalletTransactionModel>> getTransactions({
@@ -385,18 +397,35 @@ class LwkWalletDatasource {
     int? amountSat,
     bool drain = false,
     required WalletModel wallet,
+    Set<Outpoint>? selectedInputs,
   }) async {
     try {
-      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
+      final lwkWallet = await _createPublicWallet(wallet);
       // LWK accepts sat/kvByte as a double. Our RelativeFee stores sat/kwu,
       // and 1 sat/kwu = 4 sat/kvByte, so the conversion is exact integer
       // arithmetic promoted to double — no precision loss at the SDK boundary.
-      final pset = await lwkWallet.buildLbtcTx(
-        sats: BigInt.from(amountSat ?? 0),
-        outAddress: address,
-        feeRate: feeRate.satPerKvbyte,
-        drain: drain,
-      );
+      final pset = selectedInputs == null
+          ? await lwkWallet.buildLbtcTx(
+              sats: BigInt.from(amountSat ?? 0),
+              outAddress: address,
+              feeRate: feeRate.satPerKvbyte,
+              drain: drain,
+            )
+          : await lwkWallet.buildCustomTx(
+              utxos: [
+                for (final input in selectedInputs)
+                  lwk.OutPoint(txid: input.txId, vout: input.vout),
+              ],
+              outputs: [
+                if (!drain)
+                  lwk.TxOutputSpec(
+                    address: address,
+                    satoshi: BigInt.from(amountSat!),
+                  ),
+              ],
+              drainTo: drain ? address : null,
+              feeRate: feeRate.satPerKvbyte,
+            );
       final decoded = await lwkWallet.decodeTx(pset: pset);
       log.info(decoded.absoluteFees.toString());
       return pset;
@@ -408,7 +437,9 @@ class LwkWalletDatasource {
         // A build failure on a wallet whose confirmed L-BTC UTXO count exceeds
         // the Liquid confidential-tx input limit is almost certainly the
         // ">256 inputs" case.
-        if (await _exceedsLiquidInputLimit(wallet)) {
+        if (selectedInputs != null
+            ? selectedInputs.length > maxLiquidTxInputs
+            : await _exceedsLiquidInputLimit(wallet)) {
           throw ConsolidationRequiredException(e.msg);
         }
         throw e.msg;
@@ -479,9 +510,64 @@ class LwkWalletDatasource {
     required RelativeFee feeRate,
     required int highUtxoThreshold,
     required int maximumInputs,
+    Set<Outpoint> unspendable = const {},
   }) async {
     try {
-      final lwkWallet = await LwkFacade.createPublicWallet(wallet);
+      final lwkWallet = await _createPublicWallet(wallet);
+      // LWK's consolidation helper cannot exclude frozen coins. Build the
+      // same balanced batches with explicit inputs when exclusions exist.
+      if (unspendable.isNotEmpty) {
+        if (maximumInputs <= 0) {
+          throw ArgumentError.value(maximumInputs, 'maximumInputs');
+        }
+        final assetId = _lBtcAssetId(
+          wallet.isTestnet ? Network.liquidTestnet : Network.liquidMainnet,
+        );
+        final coins = (await lwkWallet.utxos())
+            .where(
+              (coin) =>
+                  coin.unblinded.asset == assetId &&
+                  coin.height != null &&
+                  !unspendable.contains((
+                    txId: coin.outpoint.txid,
+                    vout: coin.outpoint.vout,
+                  )),
+            )
+            .toList();
+        if (coins.length <= highUtxoThreshold) return [];
+        final limit = maximumInputs.clamp(1, 250);
+        final batches = (coins.length / limit).ceil();
+        final batchSize = (coins.length / batches).ceil();
+        final start = (await lwkWallet.addressLastUnused()).index!;
+        final psets = <String>[];
+        for (var offset = 0; offset < coins.length; offset += batchSize) {
+          final address = await lwkWallet.address(
+            index: start + offset ~/ batchSize,
+          );
+          try {
+            psets.add(
+              await lwkWallet.buildCustomTx(
+                utxos: coins
+                    .skip(offset)
+                    .take(batchSize)
+                    .map((coin) => coin.outpoint)
+                    .toList(),
+                outputs: [],
+                drainTo: address.confidential,
+                feeRate: feeRate.satPerKvbyte,
+              ),
+            );
+          } on lwk.LwkError catch (error) {
+            if (!error.msg.contains(_lwkInsufficientFundsMarker)) rethrow;
+          }
+        }
+        if (psets.isEmpty) {
+          throw NoSpendableUtxoException(
+            'Consolidation inputs cannot cover the fee',
+          );
+        }
+        return psets;
+      }
       final psets = await lwkWallet.consolidate(
         feeRate: feeRate.satPerKvbyte,
         highUtxoThreshold: highUtxoThreshold,
@@ -496,6 +582,13 @@ class LwkWalletDatasource {
       }
     }
   }
+
+  Set<Outpoint> getPsetInputs(String pset) => {
+    for (final input in lwk.PartiallySignedElementsTransaction.fromString(
+      psetString: pset,
+    ).extractTx().getInputs())
+      (txId: input.txid, vout: input.vout),
+  };
 
   Future<String> signPset(
     String pset, {

--- a/lib/core/wallet/data/mappers/wallet_utxo_mapper.dart
+++ b/lib/core/wallet/data/mappers/wallet_utxo_mapper.dart
@@ -44,6 +44,7 @@ class WalletUtxoMapper {
           addressLabels: addressLabels,
           isFrozen: isFrozen,
           confirmations: model.confirmations,
+          blockHeight: model.blockHeight,
         );
     }
   }
@@ -69,6 +70,7 @@ class WalletUtxoMapper {
           scriptPubkey: entity.scriptPubkey,
           standardAddress: entity.standardAddress,
           confidentialAddress: entity.confidentialAddress,
+          blockHeight: entity.blockHeight,
         );
     }
   }

--- a/lib/core/wallet/data/models/wallet_utxo_model.dart
+++ b/lib/core/wallet/data/models/wallet_utxo_model.dart
@@ -24,6 +24,7 @@ sealed class WalletUtxoModel with _$WalletUtxoModel {
     required String standardAddress,
     required String confidentialAddress,
     @Default(0) int confirmations,
+    int? blockHeight,
   }) = LiquidWalletUtxoModel;
 
   const WalletUtxoModel._();

--- a/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
@@ -1,21 +1,27 @@
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
 import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 import 'package:bb_mobile/core/wallet/domain/liquid_send_port.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/selected_inputs_unavailable_exception.dart';
 
 class LiquidWalletRepository implements LiquidSendPort {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final SeedDatasource _seed;
   final LwkWalletDatasource _lwkWallet;
+  final FrozenWalletUtxoDatasource _frozenWalletUtxoDatasource;
 
   LiquidWalletRepository({
     required this._walletMetadataDatasource,
     required SeedDatasource seedDatasource,
     required LwkWalletDatasource lwkWalletDatasource,
+    required this._frozenWalletUtxoDatasource,
   }) : _seed = seedDatasource,
        _lwkWallet = lwkWalletDatasource;
 
@@ -26,6 +32,7 @@ class LiquidWalletRepository implements LiquidSendPort {
     int? amountSat,
     required RelativeFee feeRate,
     bool? drain,
+    Set<Outpoint>? selectedInputs,
   }) async {
     final metadata = await _walletMetadataDatasource.fetch(walletId);
 
@@ -42,12 +49,32 @@ class LiquidWalletRepository implements LiquidSendPort {
       isTestnet: metadata.isTestnet,
       id: metadata.id,
     );
+    final frozen = await _frozenOutpoints();
+    Set<Outpoint>? inputs = selectedInputs;
+    if (selectedInputs != null || frozen.isNotEmpty) {
+      final available = {
+        for (final utxo in await _lwkWallet.getUtxos(wallet: wallet))
+          if (!frozen.contains((txId: utxo.txId, vout: utxo.vout)))
+            (txId: utxo.txId, vout: utxo.vout),
+      };
+      if (selectedInputs != null &&
+          (selectedInputs.isEmpty || !available.containsAll(selectedInputs))) {
+        throw SelectedInputsUnavailableException(
+          'Selected Liquid coins are unavailable',
+        );
+      }
+      inputs ??= available;
+      if (inputs.isEmpty) {
+        throw NoSpendableUtxoException('No spendable Liquid coins');
+      }
+    }
     final pset = await _lwkWallet.buildPset(
       wallet: wallet,
       address: address,
       amountSat: amountSat,
       feeRate: feeRate,
       drain: drain ?? false,
+      selectedInputs: inputs,
     );
 
     return pset;
@@ -97,6 +124,7 @@ class LiquidWalletRepository implements LiquidSendPort {
       feeRate: feeRate,
       highUtxoThreshold: highUtxoThreshold,
       maximumInputs: maximumInputs,
+      unspendable: await _frozenOutpoints(),
     );
   }
 
@@ -104,6 +132,13 @@ class LiquidWalletRepository implements LiquidSendPort {
     required String pset,
     required String walletId,
   }) async {
+    final frozen = await _frozenOutpoints();
+    if (frozen.isNotEmpty &&
+        _lwkWallet.getPsetInputs(pset).any(frozen.contains)) {
+      throw NoSpendableUtxoException(
+        'The transaction spends a frozen Liquid coin',
+      );
+    }
     final metadata = await _walletMetadataDatasource.fetch(walletId);
 
     if (metadata == null) {
@@ -129,6 +164,11 @@ class LiquidWalletRepository implements LiquidSendPort {
 
     return signedPsbt;
   }
+
+  Future<Set<Outpoint>> _frozenOutpoints() async => {
+    for (final utxo in await _frozenWalletUtxoDatasource.getAllFrozen())
+      (txId: utxo.txId, vout: utxo.vout),
+  };
 
   Future<int> getAmountSentToAddress({
     required String pset,

--- a/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
+++ b/lib/core/wallet/data/repositories/liquid_wallet_repository.dart
@@ -5,8 +5,9 @@ import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dar
 import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
 import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/domain/liquid_send_port.dart';
 
-class LiquidWalletRepository {
+class LiquidWalletRepository implements LiquidSendPort {
   final WalletMetadataDatasource _walletMetadataDatasource;
   final SeedDatasource _seed;
   final LwkWalletDatasource _lwkWallet;
@@ -18,6 +19,7 @@ class LiquidWalletRepository {
   }) : _seed = seedDatasource,
        _lwkWallet = lwkWalletDatasource;
 
+  @override
   Future<String> buildPset({
     required String walletId,
     required String address,

--- a/lib/core/wallet/domain/entities/wallet_utxo.dart
+++ b/lib/core/wallet/domain/entities/wallet_utxo.dart
@@ -40,6 +40,7 @@ sealed class WalletUtxo with _$WalletUtxo {
     @Default([]) List<Label> addressLabels,
     @Default(false) bool isFrozen,
     @Default(0) int confirmations,
+    int? blockHeight,
   }) = LiquidWalletUtxo;
 
   const WalletUtxo._();
@@ -54,5 +55,9 @@ sealed class WalletUtxo with _$WalletUtxo {
   };
 
   /// Whether the UTXO has at least one confirmation (threshold 1).
-  bool get isConfirmed => confirmations > 0;
+  bool get isConfirmed => switch (this) {
+    LiquidWalletUtxo(:final blockHeight) =>
+      blockHeight != null && blockHeight > 0,
+    BitcoinWalletUtxo(:final confirmations) => confirmations > 0,
+  };
 }

--- a/lib/core/wallet/domain/liquid_send_port.dart
+++ b/lib/core/wallet/domain/liquid_send_port.dart
@@ -1,0 +1,11 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+
+abstract interface class LiquidSendPort {
+  Future<String> buildPset({
+    required String walletId,
+    required String address,
+    int? amountSat,
+    required RelativeFee feeRate,
+    bool? drain,
+  });
+}

--- a/lib/core/wallet/domain/liquid_send_port.dart
+++ b/lib/core/wallet/domain/liquid_send_port.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
 
 abstract interface class LiquidSendPort {
   Future<String> buildPset({
@@ -7,5 +8,6 @@ abstract interface class LiquidSendPort {
     int? amountSat,
     required RelativeFee feeRate,
     bool? drain,
+    Set<Outpoint>? selectedInputs,
   });
 }

--- a/lib/core/wallet/wallet_locator.dart
+++ b/lib/core/wallet/wallet_locator.dart
@@ -74,6 +74,7 @@ class WalletLocator {
         walletMetadataDatasource: locator<WalletMetadataDatasource>(),
         seedDatasource: locator<SeedDatasource>(),
         lwkWalletDatasource: locator<LwkWalletDatasource>(),
+        frozenWalletUtxoDatasource: locator<FrozenWalletUtxoDatasource>(),
       ),
     );
 

--- a/lib/features/coins/domain/utxo_sort_filter.dart
+++ b/lib/features/coins/domain/utxo_sort_filter.dart
@@ -165,11 +165,20 @@ int _primaryCompare(WalletUtxo a, WalletUtxo b, CoinsSort sort) {
     case CoinsSort.amountAsc:
       return a.amountSat.compareTo(b.amountSat);
     case CoinsSort.dateNewest:
-      // Fewer confirmations = newer; pending (0) is newest.
-      return a.confirmations.compareTo(b.confirmations);
+      return -_compareAge(a, b);
     case CoinsSort.dateOldest:
-      return b.confirmations.compareTo(a.confirmations);
+      return _compareAge(a, b);
   }
+}
+
+int _compareAge(WalletUtxo a, WalletUtxo b) {
+  if (a is LiquidWalletUtxo && b is LiquidWalletUtxo) {
+    if (!a.isConfirmed || !b.isConfirmed) {
+      return (a.isConfirmed ? 0 : 1).compareTo(b.isConfirmed ? 0 : 1);
+    }
+    return a.blockHeight!.compareTo(b.blockHeight!);
+  }
+  return b.confirmations.compareTo(a.confirmations);
 }
 
 /// Deterministic tie-break: amount descending, then outpoint key.

--- a/lib/features/coins/ui/screens/coins_screen.dart
+++ b/lib/features/coins/ui/screens/coins_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bb_mobile/core/utils/build_context_x.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/features/coins/domain/utxo_sort_filter.dart';
 import 'package:bb_mobile/features/coins/presentation/coins_cubit.dart';
 import 'package:bb_mobile/features/coins/presentation/coins_failure_l10n.dart';
@@ -178,6 +179,7 @@ void openSortFilterSheet(BuildContext context, CoinsState state) {
   BullBottomSheet.show<void>(
     context: context,
     child: CoinsSortFilterSheet(
+      showKeychain: !state.utxos.any((utxo) => utxo is LiquidWalletUtxo),
       filter: state.filter,
       allLabels: state.allLabels,
       onApply: (filter) {

--- a/lib/features/coins/ui/widgets/coins_sort_filter_sheet.dart
+++ b/lib/features/coins/ui/widgets/coins_sort_filter_sheet.dart
@@ -12,12 +12,14 @@ class CoinsSortFilterSheet extends StatefulWidget {
     required this.allLabels,
     required this.onApply,
     required this.onReset,
+    this.showKeychain = true,
   });
 
   final CoinsFilter filter;
   final Set<String> allLabels;
   final ValueChanged<CoinsFilter> onApply;
   final VoidCallback onReset;
+  final bool showKeychain;
 
   @override
   State<CoinsSortFilterSheet> createState() => _CoinsSortFilterSheetState();
@@ -64,32 +66,33 @@ class _CoinsSortFilterSheetState extends State<CoinsSortFilterSheet> {
           _sortGrid(context),
           const SizedBox(height: 20),
 
-          _sectionLabel(context, loc.coinsKeychain),
-          BullSegmented(
-            items: {
-              loc.coinsKeychainAll,
-              loc.coinsKeychainReceive,
-              loc.coinsKeychainChange,
-            },
-            initialValue: switch (_keychain) {
-              KeychainFilter.all => loc.coinsKeychainAll,
-              KeychainFilter.receive => loc.coinsKeychainReceive,
-              KeychainFilter.change => loc.coinsKeychainChange,
-            },
-            onSelected: (v) {
-              setState(() {
-                if (v == loc.coinsKeychainReceive) {
-                  _keychain = KeychainFilter.receive;
-                } else if (v == loc.coinsKeychainChange) {
-                  _keychain = KeychainFilter.change;
-                } else {
-                  _keychain = KeychainFilter.all;
-                }
-              });
-            },
-          ),
-          const SizedBox(height: 20),
-
+          if (widget.showKeychain) ...[
+            _sectionLabel(context, loc.coinsKeychain),
+            BullSegmented(
+              items: {
+                loc.coinsKeychainAll,
+                loc.coinsKeychainReceive,
+                loc.coinsKeychainChange,
+              },
+              initialValue: switch (_keychain) {
+                KeychainFilter.all => loc.coinsKeychainAll,
+                KeychainFilter.receive => loc.coinsKeychainReceive,
+                KeychainFilter.change => loc.coinsKeychainChange,
+              },
+              onSelected: (v) {
+                setState(() {
+                  if (v == loc.coinsKeychainReceive) {
+                    _keychain = KeychainFilter.receive;
+                  } else if (v == loc.coinsKeychainChange) {
+                    _keychain = KeychainFilter.change;
+                  } else {
+                    _keychain = KeychainFilter.all;
+                  }
+                });
+              },
+            ),
+            const SizedBox(height: 20),
+          ],
           _sectionLabel(context, loc.coinsFrozenStatus),
           BullSegmented(
             items: {

--- a/lib/features/coins/ui/widgets/utxo_tile.dart
+++ b/lib/features/coins/ui/widgets/utxo_tile.dart
@@ -177,8 +177,10 @@ class UtxoTile extends StatelessWidget {
             ),
           ),
         ),
-        const SizedBox(width: 8),
-        _keychainBadge(context),
+        if (utxo is BitcoinWalletUtxo) ...[
+          const SizedBox(width: 8),
+          _keychainBadge(context),
+        ],
       ],
     );
   }
@@ -213,7 +215,7 @@ class UtxoTile extends StatelessWidget {
 
   Widget _confPill(BuildContext context) {
     final colors = context.bull;
-    final pending = utxo.confirmations == 0;
+    final pending = !utxo.isConfirmed;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -226,6 +228,8 @@ class UtxoTile extends StatelessWidget {
         Text(
           pending
               ? context.loc.coinsPending
+              : utxo is LiquidWalletUtxo
+              ? context.loc.coreWalletTransactionStatusConfirmed
               : context.loc.coinsConfsCount(utxo.confirmations),
           style: context.bullText.labelLarge?.copyWith(
             fontSize: 11,

--- a/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
@@ -1,12 +1,12 @@
 import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
-import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/liquid_send_port.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 
 class PrepareLiquidSendUsecase {
-  final LiquidWalletRepository _liquidWalletRepository;
+  final LiquidSendPort _liquidWalletRepository;
 
   PrepareLiquidSendUsecase({required this._liquidWalletRepository});
 

--- a/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
+++ b/lib/features/send/domain/usecases/prepare_liquid_send_usecase.dart
@@ -2,6 +2,8 @@ import 'package:bb_mobile/core/errors/bull_exception.dart';
 import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
 import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/liquid_send_port.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/selected_inputs_unavailable_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/consolidation_required_exception.dart';
 import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
 
@@ -16,6 +18,7 @@ class PrepareLiquidSendUsecase {
     required RelativeFee feeRate,
     int? amountSat,
     bool drain = false,
+    Set<Outpoint>? selectedInputs,
   }) async {
     try {
       if (amountSat == null && drain == false) {
@@ -28,8 +31,11 @@ class PrepareLiquidSendUsecase {
         amountSat: drain ? null : amountSat,
         feeRate: feeRate,
         drain: drain,
+        selectedInputs: selectedInputs,
       );
       return psbt;
+    } on SelectedInputsUnavailableException {
+      rethrow;
     } on NoSpendableUtxoException {
       rethrow;
     } on ConsolidationRequiredException {

--- a/lib/features/send/domain/usecases/resolve_selected_inputs_usecase.dart
+++ b/lib/features/send/domain/usecases/resolve_selected_inputs_usecase.dart
@@ -18,7 +18,10 @@ class ResolveSelectedInputsUsecase {
     if (outpoints.isEmpty) {
       return const Err(SendSelectedCoinsUnavailableFailure());
     }
-    final reservedResult = await _payjoinSessions.reservedOutpoints();
+    final reservedResult =
+        availableUtxos.every((utxo) => utxo is LiquidWalletUtxo)
+        ? const Ok<Set<Outpoint>, PayjoinFailure>({})
+        : await _payjoinSessions.reservedOutpoints();
     final Set<Outpoint> reservedOutpoints;
     switch (reservedResult) {
       case Ok(:final value):

--- a/lib/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart
+++ b/lib/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart
@@ -3,18 +3,19 @@ import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/send/domain/send_failure.dart';
 
-class ValidateSweepPaymentRequestUsecase {
+class ValidateCoinControlPaymentRequestUsecase {
   Result<void, SendFailure> execute({
     required Wallet wallet,
     required PaymentRequest paymentRequest,
+    bool isSweep = true,
   }) {
-    final isBitcoinDestination =
-        paymentRequest is BitcoinPaymentRequest ||
+    final isMatchingDestination =
+        (wallet.isBitcoin && paymentRequest is BitcoinPaymentRequest) ||
+        (wallet.isLiquid && paymentRequest is LiquidPaymentRequest) ||
         (paymentRequest is Bip21PaymentRequest &&
-            paymentRequest.network.isBitcoin &&
-            paymentRequest.amountSat == null);
-    if (!wallet.isBitcoin ||
-        !isBitcoinDestination ||
+            paymentRequest.network == wallet.network &&
+            (!isSweep || paymentRequest.amountSat == null));
+    if (!isMatchingDestination ||
         wallet.isTestnet != paymentRequest.isTestnet) {
       return const Err(SendInvalidPaymentRequestFailure());
     }

--- a/lib/features/send/presentation/bloc/send_cubit.dart
+++ b/lib/features/send/presentation/bloc/send_cubit.dart
@@ -58,7 +58,7 @@ import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_us
 import 'package:bb_mobile/features/send/domain/usecases/verify_send_signed_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_send_swap_payin_usecase.dart';
-import 'package:bb_mobile/features/send/domain/usecases/validate_sweep_payment_request_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/domain/send_failure.dart';
 import 'package:bb_mobile/features/send/domain/bitcoin_recipient_list_policy.dart';
@@ -117,7 +117,7 @@ class SendCubit extends Cubit<SendState>
     required this._getSendPayjoinEnabledUsecase,
     required this._verifySignedTxUsecase,
     required this._resolveSelectedInputsUsecase,
-    required this._validateSweepPaymentRequestUsecase,
+    required this._validateCoinControlPaymentRequestUsecase,
     Future<PaymentRequest> Function(String)? parsePaymentRequest,
   }) : _parsePaymentRequest = parsePaymentRequest ?? PaymentRequest.parse,
        super(
@@ -127,6 +127,8 @@ class SendCubit extends Cubit<SendState>
            sendType:
                initialSweepOutpoints.isEmpty && initialSelectedOutpoints.isEmpty
                ? SendType.lightning
+               : _wallet?.isLiquid == true
+               ? SendType.liquid
                : SendType.bitcoin,
            sendMax: initialSweepOutpoints.isNotEmpty,
            loadingBestWallet:
@@ -187,7 +189,8 @@ class SendCubit extends Cubit<SendState>
   final CheckLiquidConsolidationUsecase _checkLiquidConsolidationUsecase;
   final VerifySendSignedTxUsecase _verifySignedTxUsecase;
   final ResolveSelectedInputsUsecase _resolveSelectedInputsUsecase;
-  final ValidateSweepPaymentRequestUsecase _validateSweepPaymentRequestUsecase;
+  final ValidateCoinControlPaymentRequestUsecase
+  _validateCoinControlPaymentRequestUsecase;
   final Future<PaymentRequest> Function(String) _parsePaymentRequest;
 
   StreamSubscription<Result<OrderSwapRecord, SendFailure>>?
@@ -236,6 +239,7 @@ class SendCubit extends Cubit<SendState>
     required String address,
     required int? amountSat,
     required bool drain,
+    Set<Outpoint>? selectedInputs,
   }) async {
     if (fee is RelativeFee) return Ok(fee);
     if (fee is! AbsoluteFee) {
@@ -249,6 +253,7 @@ class SendCubit extends Cubit<SendState>
       amountSat: amountSat,
       feeRate: const RelativeFee(25),
       drain: drain,
+      selectedInputs: selectedInputs,
     );
     final vsize = await _calculateLiquidPsetSizeUsecase.execute(
       pset: placeholderPset,
@@ -335,7 +340,7 @@ class SendCubit extends Cubit<SendState>
 
   Future<void> _initializeSweep(Set<Outpoint> outpoints) async {
     final wallet = _wallet;
-    if (wallet == null || !wallet.isBitcoin) {
+    if (wallet == null) {
       emit(
         state.copyWith(
           sweepOutpoints: outpoints,
@@ -364,7 +369,7 @@ class SendCubit extends Cubit<SendState>
 
   Future<void> _initializeSelectedInputs() async {
     final wallet = _wallet;
-    if (wallet == null || !wallet.isBitcoin) {
+    if (wallet == null) {
       emit(
         state.copyWith(
           sendType: SendType.bitcoin,
@@ -617,7 +622,11 @@ class SendCubit extends Cubit<SendState>
 
   Future<bool> addRecipient() async {
     final inputGeneration = _paymentRequestInputGeneration;
-    if (state.selectedInputsUnavailable) return false;
+    if (state.selectedInputsUnavailable ||
+        (state.usesSelectedInputsOnly &&
+            state.selectedWallet?.isLiquid == true)) {
+      return false;
+    }
     emit(state.copyWith(loadingBestWallet: true, failure: null));
     final paymentRequest = await _resolvePrimaryPaymentRequest(inputGeneration);
     if (paymentRequest == null) return false;
@@ -983,6 +992,19 @@ class SendCubit extends Cubit<SendState>
         return;
       }
       confirmedRequest = paymentRequest;
+      if (state.usesSelectedInputsOnly &&
+          !state.isSweep &&
+          state.selectedWallet?.isLiquid == true) {
+        final validation = _validateCoinControlPaymentRequestUsecase.execute(
+          wallet: state.selectedWallet!,
+          paymentRequest: paymentRequest,
+          isSweep: state.isSweep,
+        );
+        if (validation case Err(:final failure)) {
+          emit(state.copyWith(loadingBestWallet: false, failure: failure));
+          return;
+        }
+      }
       if (state.supportsRecipientList &&
           state.recipientDrafts.any((recipient) => !recipient.isValid)) {
         emit(
@@ -1005,7 +1027,7 @@ class SendCubit extends Cubit<SendState>
           );
           return;
         }
-        switch (_validateSweepPaymentRequestUsecase.execute(
+        switch (_validateCoinControlPaymentRequestUsecase.execute(
           wallet: wallet,
           paymentRequest: paymentRequest,
         )) {
@@ -1018,7 +1040,10 @@ class SendCubit extends Cubit<SendState>
         await _setSelectedWallet(wallet, manual: true);
         if (isStale()) return;
         emit(
-          state.copyWith(sendType: SendType.bitcoin, loadingBestWallet: false),
+          state.copyWith(
+            sendType: wallet.isLiquid ? SendType.liquid : SendType.bitcoin,
+            loadingBestWallet: false,
+          ),
         );
         await loadFees(inputGeneration: inputGeneration);
         if (isStale()) return;
@@ -1358,10 +1383,7 @@ class SendCubit extends Cubit<SendState>
       return false;
     }
     final paymentRequest = state.paymentRequest!;
-    // D7: frozen coins are never spendable, so every balance check compares
-    // against the spendable balance (wallet balance − frozen total), not the
-    // raw wallet balance. Degrades to the full balance on Liquid / before
-    // utxos load (nothing frozen there).
+    // Balance checks exclude frozen coins once UTXOs have loaded.
     final spendableSat = state.spendableBalanceSat;
     switch (paymentRequest) {
       case Bolt11PaymentRequest _:
@@ -1849,6 +1871,7 @@ class SendCubit extends Cubit<SendState>
       // consolidating.
       final consolidationRequired =
           wallet.isLiquid &&
+          !state.usesSelectedInputsOnly &&
           await _checkLiquidConsolidationUsecase.execute(walletId: wallet.id);
       if (isStale()) return;
       // Resolve the persisted intent against fresh wallet data. On failure the
@@ -2344,6 +2367,7 @@ class SendCubit extends Cubit<SendState>
         state.copyWith(
           buildingTransaction: true,
           bitcoinAbsoluteFeesSat: null,
+          liquidAbsoluteFees: null,
           recipientAmountsSat: state.usesRecipientList
               ? const []
               : state.recipientAmountsSat,
@@ -2385,6 +2409,9 @@ class SendCubit extends Cubit<SendState>
           address: address,
           amountSat: amount,
           drain: drain,
+          selectedInputs: state.usesSelectedInputsOnly
+              ? state.requiredInputOutpoints
+              : null,
         );
         if (isStale()) return false;
         final RelativeFee liquidFeeRate;
@@ -2401,6 +2428,9 @@ class SendCubit extends Cubit<SendState>
           feeRate: liquidFeeRate,
           amountSat: amount,
           drain: drain,
+          selectedInputs: state.usesSelectedInputsOnly
+              ? state.requiredInputOutpoints
+              : null,
         );
         if (isStale()) return false;
         if (state.lightningOrder case final order?) {
@@ -2936,7 +2966,7 @@ class SendCubit extends Cubit<SendState>
       // label, swap update and wallet sync would be lost to a null-check
       // crash instead.
       final wallet = state.selectedWallet!;
-      if (!await _validateSelectedBitcoinInputsForBroadcast(wallet)) return;
+      if (!await _validateSelectedInputsForBroadcast(wallet)) return;
       final label = state.label;
       final chainSwap = state.chainSwap;
 
@@ -3093,8 +3123,8 @@ class SendCubit extends Cubit<SendState>
     }
   }
 
-  Future<bool> _validateSelectedBitcoinInputsForBroadcast(Wallet wallet) async {
-    if (wallet.isLiquid || !state.usesSelectedInputsOnly) return true;
+  Future<bool> _validateSelectedInputsForBroadcast(Wallet wallet) async {
+    if (!state.usesSelectedInputsOnly) return true;
     if (state.selectedInputsUnavailable) {
       emit(
         state.copyWith(
@@ -3107,6 +3137,24 @@ class SendCubit extends Cubit<SendState>
       return false;
     }
     try {
+      if (wallet.isLiquid) {
+        final availableUtxos = await _getWalletUtxosUsecase.execute(
+          walletId: wallet.id,
+        );
+        final result = await _resolveSelectedInputsUsecase.execute(
+          outpoints: state.requiredInputOutpoints,
+          availableUtxos: availableUtxos,
+        );
+        if (result is Ok) return true;
+        _invalidateSignedTransaction();
+        emit(
+          state.copyWith(
+            failure: const SendSelectedCoinsUnavailableFailure(),
+            broadcastingTransaction: false,
+          ),
+        );
+        return false;
+      }
       await _validateBitcoinSelectionUsecase.execute(
         walletId: wallet.id,
         selectedInputs: state.selectedUtxos,

--- a/lib/features/send/presentation/bloc/send_state.dart
+++ b/lib/features/send/presentation/bloc/send_state.dart
@@ -280,6 +280,7 @@ abstract class SendState with _$SendState {
 
   bool get canAddRecipient =>
       !selectedInputsUnavailable &&
+      !(usesSelectedInputsOnly && selectedWallet?.isLiquid == true) &&
       (supportsRecipientList ||
           (paymentRequest == null &&
               copiedRawPaymentRequest.trim().isNotEmpty));
@@ -521,14 +522,10 @@ abstract class SendState with _$SendState {
   }
 
   /// Amount (sats) locked in user-frozen coins ([WalletUtxo.isFrozen], which is
-  /// scoped to `origin = 'user'`). Zero until [utxos] are loaded, and zero in
-  /// practice for Liquid because freeze isn't surfaced there (the Coins entry is
-  /// Bitcoin-only) — not because the network is intrinsically exempt.
+  /// scoped to `origin = 'user'`). Zero until [utxos] are loaded.
   ///
-  /// Note: this intentionally excludes payjoin-derived locks, which the spend
-  /// path also treats as unspendable. So with an active payjoin the real drain
-  /// may produce slightly less than [spendableBalanceSat] reports — it never
-  /// over-spends (the build re-excludes both sets), only fails closed.
+  /// Payjoin reservations are also excluded when building, so the final drain
+  /// amount can be lower than [spendableBalanceSat].
   int get frozenBalanceSat => utxos
       .where((u) => u.isFrozen)
       .fold(0, (sum, u) => sum + u.amountSat.toInt());
@@ -641,6 +638,7 @@ abstract class SendState with _$SendState {
       failure is SendTransactionBuildFailure ||
       failure is SendInsufficientBalanceFailure ||
       failure is SendInsufficientFundsForFeesFailure ||
+      failure is SendSelectedCoinsInsufficientFailure ||
       failure is SendSelectedCoinsUnavailableFailure;
 
   bool get blocksSwapDueToHardwareWallet {

--- a/lib/features/send/public/send_route_args.dart
+++ b/lib/features/send/public/send_route_args.dart
@@ -21,13 +21,6 @@ final class SendRouteArgs {
   }
 
   void _validate() {
-    if (!wallet.isBitcoin) {
-      throw ArgumentError.value(
-        wallet.id,
-        'wallet',
-        'must be a Bitcoin wallet',
-      );
-    }
     if (selectedOutpoints.isEmpty) {
       throw ArgumentError.value(
         selectedOutpoints,

--- a/lib/features/send/send_locator.dart
+++ b/lib/features/send/send_locator.dart
@@ -46,7 +46,7 @@ import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_us
 import 'package:bb_mobile/features/send/domain/usecases/verify_send_signed_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_payjoin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_send_swap_payin_usecase.dart';
-import 'package:bb_mobile/features/send/domain/usecases/validate_sweep_payment_request_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/presentation/bloc/send_cubit.dart';
 import 'package:bb_mobile/features/send/public/send_route_args.dart';
@@ -182,8 +182,8 @@ class SendLocator {
     locator.registerFactory<ResolveSelectedInputsUsecase>(
       () => ResolveSelectedInputsUsecase(locator<PayjoinSessions>()),
     );
-    locator.registerFactory<ValidateSweepPaymentRequestUsecase>(
-      ValidateSweepPaymentRequestUsecase.new,
+    locator.registerFactory<ValidateCoinControlPaymentRequestUsecase>(
+      ValidateCoinControlPaymentRequestUsecase.new,
     );
   }
 
@@ -250,8 +250,8 @@ class SendLocator {
         getSendPayjoinEnabledUsecase: locator<GetSendPayjoinEnabledUsecase>(),
         verifySignedTxUsecase: locator<VerifySendSignedTxUsecase>(),
         resolveSelectedInputsUsecase: locator<ResolveSelectedInputsUsecase>(),
-        validateSweepPaymentRequestUsecase:
-            locator<ValidateSweepPaymentRequestUsecase>(),
+        validateCoinControlPaymentRequestUsecase:
+            locator<ValidateCoinControlPaymentRequestUsecase>(),
       ),
     );
   }

--- a/lib/features/send/ui/screens/send_screen.dart
+++ b/lib/features/send/ui/screens/send_screen.dart
@@ -1007,6 +1007,10 @@ class _BottomButtons extends StatelessWidget {
     final isBitcoinWallet = context.select(
       (SendCubit cubit) => !cubit.state.selectedWallet!.isLiquid,
     );
+    final isOnchainSend = context.select(
+      (SendCubit cubit) => !cubit.state.isLightning && !cubit.state.isChainSwap,
+    );
+    final isSweep = context.select((SendCubit cubit) => cubit.state.isSweep);
     final wallet = context.select(
       (SendCubit cubit) => cubit.state.selectedWallet,
     );
@@ -1019,7 +1023,8 @@ class _BottomButtons extends StatelessWidget {
       child: Column(
         crossAxisAlignment: .stretch,
         children: [
-          if (isBitcoinWallet && !hasFinalizedTx) ...[
+          if ((isBitcoinWallet || (isOnchainSend && !isSweep)) &&
+              !hasFinalizedTx) ...[
             BBButton.big(
               label: context.loc.sendAdvancedSettings,
               onPressed: () {
@@ -1274,6 +1279,12 @@ class _LiquidOnchainSendInfoSection extends StatelessWidget {
     final formattedAbsoluteFees = context.select(
       (SendCubit cubit) => cubit.state.formattedAbsoluteFees,
     );
+    final selectedCoins = context.select(
+      (SendCubit cubit) => (
+        count: cubit.state.selectedUtxos.length,
+        totalSat: cubit.state.selectedSpendableBalanceSat,
+      ),
+    );
 
     final label = context.select((SendCubit cubit) => cubit.state.label);
     return CommonOnchainSendInfoSection(
@@ -1283,6 +1294,12 @@ class _LiquidOnchainSendInfoSection extends StatelessWidget {
       formattedFiatEquivalent: '~$formattedFiatEquivalent',
       absoluteFees: formattedAbsoluteFees,
       selectedFeeOptionTitle: '',
+      selectedCoinsDetails: selectedCoins.count == 0
+          ? null
+          : _SelectedCoinsDetails(
+              count: selectedCoins.count,
+              totalSat: selectedCoins.totalSat,
+            ),
       note: label,
       // Liquid has fixed fees — no fee priority selector
       onFeePriorityTap: null,

--- a/lib/features/send/ui/widgets/advanced_options_bottom_sheet.dart
+++ b/lib/features/send/ui/widgets/advanced_options_bottom_sheet.dart
@@ -19,6 +19,9 @@ class AdvancedOptionsBottomSheet extends StatelessWidget {
       (SendCubit cubit) => cubit.state.replaceByFee,
     );
     final isSweep = context.select((SendCubit cubit) => cubit.state.isSweep);
+    final isLiquid = context.select(
+      (SendCubit cubit) => cubit.state.selectedWallet!.isLiquid,
+    );
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
@@ -49,22 +52,24 @@ class AdvancedOptionsBottomSheet extends StatelessWidget {
             ],
           ),
           const Gap(32),
-          Row(
-            mainAxisAlignment: .spaceBetween,
-            children: [
-              BBText(
-                context.loc.sendReplaceByFeeActivated,
-                style: context.font.headlineMedium,
-                color: context.appColors.secondary,
-              ),
-              Switch(
-                value: isRBFEnabled,
-                onChanged: (val) async =>
-                    await context.read<SendCubit>().replaceByFeeChanged(val),
-              ),
-            ],
-          ),
-          const Gap(24),
+          if (!isLiquid) ...[
+            Row(
+              mainAxisAlignment: .spaceBetween,
+              children: [
+                BBText(
+                  context.loc.sendReplaceByFeeActivated,
+                  style: context.font.headlineMedium,
+                  color: context.appColors.secondary,
+                ),
+                Switch(
+                  value: isRBFEnabled,
+                  onChanged: (val) async =>
+                      await context.read<SendCubit>().replaceByFeeChanged(val),
+                ),
+              ],
+            ),
+            const Gap(24),
+          ],
           if (!isSweep) ...[
             ListTile(
               title: BBText(

--- a/lib/features/send/ui/widgets/coin_select_tile.dart
+++ b/lib/features/send/ui/widgets/coin_select_tile.dart
@@ -45,8 +45,10 @@ class CoinSelectTile extends StatelessWidget {
         ? context.loc.sendReceive
         : context.loc.sendChange;
     final label = utxo.labels.join(', ');
-    final confirmations = utxo.confirmations == 0
+    final confirmations = !utxo.isConfirmed
         ? context.loc.sendUnconfirmed
+        : utxo is LiquidWalletUtxo
+        ? context.loc.coreWalletTransactionStatusConfirmed
         : context.loc.sendCoinConfirmations(utxo.confirmations);
 
     return GestureDetector(
@@ -129,18 +131,20 @@ class CoinSelectTile extends StatelessWidget {
                           color: context.appColors.onSurface,
                         ),
                       ),
-                      BBText(
-                        context.loc.sendType,
-                        style: context.font.labelMedium?.copyWith(
-                          color: context.appColors.onSurfaceVariant,
+                      if (utxo is BitcoinWalletUtxo) ...[
+                        BBText(
+                          context.loc.sendType,
+                          style: context.font.labelMedium?.copyWith(
+                            color: context.appColors.onSurfaceVariant,
+                          ),
                         ),
-                      ),
-                      BBText(
-                        addressType,
-                        style: context.font.labelLarge?.copyWith(
-                          color: context.appColors.onSurface,
+                        BBText(
+                          addressType,
+                          style: context.font.labelLarge?.copyWith(
+                            color: context.appColors.onSurface,
+                          ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                   const SizedBox(height: 8),

--- a/lib/features/wallet/ui/screens/wallet_detail_screen.dart
+++ b/lib/features/wallet/ui/screens/wallet_detail_screen.dart
@@ -88,12 +88,8 @@ class WalletDetailScreen extends StatelessWidget {
                       SliverToBoxAdapter(
                         child: ConsolidationBanner(wallet: wallet),
                       ),
-                    if (wallet.isBitcoin) ...[
-                      const SliverToBoxAdapter(child: Gap(8)),
-                      SliverToBoxAdapter(
-                        child: _CoinsEntryTile(wallet: wallet),
-                      ),
-                    ],
+                    const SliverToBoxAdapter(child: Gap(8)),
+                    SliverToBoxAdapter(child: _CoinsEntryTile(wallet: wallet)),
                     if (wallet.isLiquid)
                       SliverToBoxAdapter(
                         child: Padding(

--- a/test/core_test/wallet/liquid_wallet_repository_test.dart
+++ b/test/core_test/wallet/liquid_wallet_repository_test.dart
@@ -1,0 +1,188 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/storage/tables/wallet_metadata_table.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/frozen_wallet_utxo_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/wallet_metadata_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_metadata_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/data/repositories/liquid_wallet_repository.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/outpoint.dart';
+import 'package:bb_mobile/core/wallet/domain/no_spendable_utxo_exception.dart';
+import 'package:bb_mobile/core/wallet/domain/selected_inputs_unavailable_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMetadataDatasource extends Mock
+    implements WalletMetadataDatasource {}
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+class _MockLwkDatasource extends Mock implements LwkWalletDatasource {}
+
+class _MockFrozenDatasource extends Mock
+    implements FrozenWalletUtxoDatasource {}
+
+void main() {
+  const walletId = 'elwpkh([73c5da0a/84h/1h/0h])';
+  const first = (txId: 'first', vout: 0);
+  const second = (txId: 'second', vout: 1);
+  const fee = RelativeFee(25);
+  late _MockLwkDatasource lwk;
+  late _MockFrozenDatasource frozen;
+  late LiquidWalletRepository repository;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const WalletModel.publicLwk(
+        id: walletId,
+        isTestnet: true,
+        combinedCtDescriptor: 'descriptor',
+      ),
+    );
+    registerFallbackValue(fee);
+  });
+
+  setUp(() {
+    final metadata = _MockMetadataDatasource();
+    lwk = _MockLwkDatasource();
+    frozen = _MockFrozenDatasource();
+    repository = LiquidWalletRepository(
+      walletMetadataDatasource: metadata,
+      seedDatasource: _MockSeedDatasource(),
+      lwkWalletDatasource: lwk,
+      frozenWalletUtxoDatasource: frozen,
+    );
+    when(() => metadata.fetch(walletId)).thenAnswer(
+      (_) async => const WalletMetadataModel(
+        id: walletId,
+        masterFingerprint: '73c5da0a',
+        xpubFingerprint: 'deadbeef',
+        isEncryptedVaultTested: false,
+        isPhysicalBackupTested: false,
+        xpub: '',
+        externalPublicDescriptor: 'descriptor',
+        internalPublicDescriptor: '',
+        signer: Signer.local,
+        isDefault: false,
+      ),
+    );
+    when(() => frozen.getAllFrozen()).thenAnswer((_) async => []);
+    when(() => lwk.getUtxos(wallet: any(named: 'wallet'))).thenAnswer(
+      (_) async => [
+        for (final coin in [first, second])
+          WalletUtxoModel.liquid(
+            txId: coin.txId,
+            vout: coin.vout,
+            amountSat: BigInt.from(50000),
+            scriptPubkey: '',
+            standardAddress: 'tex1address',
+            confidentialAddress: 'tlq1address',
+          ),
+      ],
+    );
+    when(
+      () => lwk.buildPset(
+        wallet: any(named: 'wallet'),
+        address: any(named: 'address'),
+        feeRate: any(named: 'feeRate'),
+        amountSat: any(named: 'amountSat'),
+        drain: any(named: 'drain'),
+        selectedInputs: any(named: 'selectedInputs'),
+      ),
+    ).thenAnswer((_) async => 'pset');
+  });
+
+  Future<String> build({Set<Outpoint>? selected}) => repository.buildPset(
+    walletId: walletId,
+    address: 'recipient',
+    amountSat: 10000,
+    feeRate: fee,
+    selectedInputs: selected,
+  );
+
+  Set<Outpoint>? builtInputs() =>
+      verify(
+            () => lwk.buildPset(
+              wallet: any(named: 'wallet'),
+              address: 'recipient',
+              feeRate: fee,
+              amountSat: 10000,
+              drain: false,
+              selectedInputs: captureAny(named: 'selectedInputs'),
+            ),
+          ).captured.single
+          as Set<Outpoint>?;
+
+  test('passes exactly the selected outpoints to the builder', () async {
+    await build(selected: {second});
+    expect(builtInputs(), {second});
+  });
+
+  test('preserves automatic selection when no coins are frozen', () async {
+    await build();
+    expect(builtInputs(), isNull);
+  });
+
+  test('excludes frozen coins from automatic sends', () async {
+    when(() => frozen.getAllFrozen()).thenAnswer(
+      (_) async => [(walletId: walletId, txId: first.txId, vout: first.vout)],
+    );
+    await build();
+    expect(builtInputs(), {second});
+  });
+
+  for (final selection in <Set<Outpoint>>[
+    {},
+    {first, (txId: 'missing', vout: 0)},
+  ]) {
+    test('rejects an unavailable selection $selection', () async {
+      await expectLater(
+        build(selected: selection),
+        throwsA(isA<SelectedInputsUnavailableException>()),
+      );
+      verifyNever(
+        () => lwk.buildPset(
+          wallet: any(named: 'wallet'),
+          address: any(named: 'address'),
+          feeRate: any(named: 'feeRate'),
+          amountSat: any(named: 'amountSat'),
+          drain: any(named: 'drain'),
+          selectedInputs: any(named: 'selectedInputs'),
+        ),
+      );
+    });
+  }
+
+  test('rejects a selected coin frozen after it was selected', () async {
+    when(() => frozen.getAllFrozen()).thenAnswer(
+      (_) async => [(walletId: walletId, txId: first.txId, vout: first.vout)],
+    );
+    await expectLater(
+      build(selected: {first, second}),
+      throwsA(isA<SelectedInputsUnavailableException>()),
+    );
+  });
+
+  test('does not sign a PSET that spends a newly frozen coin', () async {
+    when(() => frozen.getAllFrozen()).thenAnswer(
+      (_) async => [(walletId: walletId, txId: first.txId, vout: first.vout)],
+    );
+    when(() => lwk.getPsetInputs('pset')).thenReturn({first});
+    await expectLater(
+      repository.signPset(pset: 'pset', walletId: walletId),
+      throwsA(isA<NoSpendableUtxoException>()),
+    );
+  });
+
+  test('rejects automatic sends when all coins are frozen', () async {
+    when(() => frozen.getAllFrozen()).thenAnswer(
+      (_) async => [
+        for (final coin in [first, second])
+          (walletId: walletId, txId: coin.txId, vout: coin.vout),
+      ],
+    );
+    await expectLater(build(), throwsA(isA<NoSpendableUtxoException>()));
+  });
+}

--- a/test/core_test/wallet/lwk_wallet_datasource_test.dart
+++ b/test/core_test/wallet/lwk_wallet_datasource_test.dart
@@ -1,0 +1,234 @@
+import 'package:bb_mobile/core/fees/domain/fees_entity.dart';
+import 'package:bb_mobile/core/utils/constants.dart';
+import 'package:bb_mobile/core/wallet/data/datasources/lwk_wallet_datasource.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_model.dart';
+import 'package:bb_mobile/core/wallet/data/models/wallet_utxo_model.dart';
+import 'package:bb_mobile/core/wallet/domain/insufficient_funds_exception.dart';
+import 'package:bull_sdk/lwk.dart' as lwk;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLwkWallet extends Mock implements lwk.Wallet {}
+
+void main() {
+  const wallet = WalletModel.publicLwk(
+    id: 'liquid-wallet',
+    combinedCtDescriptor: 'descriptor',
+    isTestnet: true,
+  );
+  const selection = {(txId: 'selected', vout: 1)};
+  const fee = RelativeFee(25);
+  late _MockLwkWallet lwkWallet;
+  late LwkWalletDatasource datasource;
+
+  lwk.TxOut coin(
+    String txid, {
+    String asset = AssetConstants.lbtcTestnet,
+    int? height = 100,
+  }) => lwk.TxOut(
+    scriptPubkey: 'script',
+    outpoint: lwk.OutPoint(txid: txid, vout: 0),
+    height: height,
+    unblinded: lwk.TxOutSecrets(
+      value: BigInt.from(20000),
+      valueBf: '',
+      asset: asset,
+      assetBf: '',
+    ),
+    isSpent: false,
+    address: const lwk.Address(
+      standard: 'tex1address',
+      confidential: 'tlq1address',
+    ),
+  );
+
+  setUpAll(() => registerFallbackValue(BigInt.zero));
+
+  setUp(() {
+    lwkWallet = _MockLwkWallet();
+    datasource = LwkWalletDatasource(
+      createPublicWallet: (_) async => lwkWallet,
+    );
+    when(
+      () => lwkWallet.buildCustomTx(
+        utxos: any(named: 'utxos'),
+        outputs: any(named: 'outputs'),
+        drainTo: any(named: 'drainTo'),
+        feeRate: any(named: 'feeRate'),
+      ),
+    ).thenAnswer((_) async => 'pset');
+    when(
+      () => lwkWallet.buildLbtcTx(
+        sats: any(named: 'sats'),
+        outAddress: any(named: 'outAddress'),
+        feeRate: any(named: 'feeRate'),
+        drain: any(named: 'drain'),
+      ),
+    ).thenAnswer((_) async => 'pset');
+    when(() => lwkWallet.decodeTx(pset: 'pset')).thenAnswer(
+      (_) async => lwk.PsetAmounts(absoluteFees: BigInt.from(50), balances: []),
+    );
+  });
+
+  test('builds a fixed output using only the specified inputs', () async {
+    await datasource.buildPset(
+      wallet: wallet,
+      address: 'recipient',
+      amountSat: 20000,
+      feeRate: fee,
+      selectedInputs: selection,
+    );
+
+    verify(
+      () => lwkWallet.buildCustomTx(
+        utxos: [const lwk.OutPoint(txid: 'selected', vout: 1)],
+        outputs: [
+          lwk.TxOutputSpec(address: 'recipient', satoshi: BigInt.from(20000)),
+        ],
+        feeRate: 100,
+      ),
+    ).called(1);
+    verifyNever(
+      () => lwkWallet.buildLbtcTx(
+        sats: any(named: 'sats'),
+        outAddress: any(named: 'outAddress'),
+        feeRate: any(named: 'feeRate'),
+        drain: any(named: 'drain'),
+      ),
+    );
+  });
+
+  test(
+    'drains selected coins to the recipient without a fixed output',
+    () async {
+      await datasource.buildPset(
+        wallet: wallet,
+        address: 'recipient',
+        drain: true,
+        feeRate: fee,
+        selectedInputs: selection,
+      );
+
+      verify(
+        () => lwkWallet.buildCustomTx(
+          utxos: [const lwk.OutPoint(txid: 'selected', vout: 1)],
+          outputs: [],
+          drainTo: 'recipient',
+          feeRate: 100,
+        ),
+      ).called(1);
+    },
+  );
+
+  test('preserves automatic selection when no inputs are specified', () async {
+    await datasource.buildPset(
+      wallet: wallet,
+      address: 'recipient',
+      amountSat: 20000,
+      feeRate: fee,
+    );
+
+    verify(
+      () => lwkWallet.buildLbtcTx(
+        sats: BigInt.from(20000),
+        outAddress: 'recipient',
+        feeRate: 100,
+        drain: false,
+      ),
+    ).called(1);
+  });
+
+  test(
+    'reports insufficient selected funds without retrying automatic selection',
+    () async {
+      when(
+        () => lwkWallet.buildCustomTx(
+          utxos: any(named: 'utxos'),
+          outputs: any(named: 'outputs'),
+          drainTo: any(named: 'drainTo'),
+          feeRate: any(named: 'feeRate'),
+        ),
+      ).thenThrow(const lwk.LwkError(msg: 'InsufficientFunds'));
+
+      await expectLater(
+        datasource.buildPset(
+          wallet: wallet,
+          address: 'recipient',
+          amountSat: 20000,
+          feeRate: fee,
+          selectedInputs: selection,
+        ),
+        throwsA(isA<InsufficientFundsException>()),
+      );
+      verifyNever(
+        () => lwkWallet.buildLbtcTx(
+          sats: any(named: 'sats'),
+          outAddress: any(named: 'outAddress'),
+          feeRate: any(named: 'feeRate'),
+          drain: any(named: 'drain'),
+        ),
+      );
+    },
+  );
+
+  test('lists only L-BTC coins for the wallet network', () async {
+    when(() => lwkWallet.utxos()).thenAnswer(
+      (_) async => [coin('lbtc'), coin('other-asset', asset: 'other')],
+    );
+
+    final coins = await datasource.getUtxos(wallet: wallet);
+
+    expect(coins.map((coin) => coin.txId), ['lbtc']);
+    expect((coins.single as LiquidWalletUtxoModel).blockHeight, 100);
+  });
+
+  test(
+    'consolidates only confirmed unfrozen L-BTC coins in bounded batches',
+    () async {
+      when(() => lwkWallet.utxos()).thenAnswer(
+        (_) async => [
+          for (final id in ['first', 'second', 'third', 'frozen']) coin(id),
+          coin('pending', height: null),
+          coin('other-asset', asset: 'other'),
+        ],
+      );
+      when(() => lwkWallet.addressLastUnused()).thenAnswer(
+        (_) async =>
+            const lwk.Address(standard: '', confidential: '', index: 4),
+      );
+      when(() => lwkWallet.address(index: any(named: 'index'))).thenAnswer(
+        (invocation) async => lwk.Address(
+          standard: '',
+          confidential: 'recipient-${invocation.namedArguments[#index]}',
+        ),
+      );
+
+      final psets = await datasource.consolidate(
+        wallet: wallet,
+        feeRate: fee,
+        highUtxoThreshold: 0,
+        maximumInputs: 2,
+        unspendable: {(txId: 'frozen', vout: 0)},
+      );
+
+      expect(psets, hasLength(2));
+      final calls = verify(
+        () => lwkWallet.buildCustomTx(
+          utxos: captureAny(named: 'utxos'),
+          outputs: [],
+          drainTo: captureAny(named: 'drainTo'),
+          feeRate: 100,
+        ),
+      ).captured;
+      expect(calls, [
+        [
+          const lwk.OutPoint(txid: 'first', vout: 0),
+          const lwk.OutPoint(txid: 'second', vout: 0),
+        ],
+        'recipient-4',
+        [const lwk.OutPoint(txid: 'third', vout: 0)],
+        'recipient-5',
+      ]);
+    },
+  );
+}

--- a/test/features/coins/domain/utxo_sort_filter_test.dart
+++ b/test/features/coins/domain/utxo_sort_filter_test.dart
@@ -1,4 +1,5 @@
 import 'package:bb_mobile/core/wallet/domain/entities/wallet_address.dart';
+import 'package:bb_mobile/core/wallet/domain/entities/wallet_utxo.dart';
 import 'package:bb_mobile/features/coins/domain/utxo_sort_filter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,6 +7,33 @@ import '../wallet_utxo_fixture.dart';
 
 void main() {
   group('sortAndFilterUtxos — sorting', () {
+    test('orders Liquid coins by confirmation height with pending newest', () {
+      WalletUtxo coin(int? height) => WalletUtxo.liquid(
+        walletId: 'liquid',
+        txId: '$height',
+        vout: 0,
+        amountSat: BigInt.from(10000),
+        scriptPubkey: '',
+        standardAddress: '',
+        confidentialAddress: '',
+        blockHeight: height,
+      );
+      final coins = [coin(100), coin(null), coin(200)];
+      expect(
+        sortAndFilterUtxos(
+          coins,
+          const CoinsFilter(sort: CoinsSort.dateNewest),
+        ).map((coin) => coin.txId),
+        ['null', '200', '100'],
+      );
+      expect(
+        sortAndFilterUtxos(
+          coins,
+          const CoinsFilter(sort: CoinsSort.dateOldest),
+        ).map((coin) => coin.txId),
+        ['100', '200', 'null'],
+      );
+    });
     test('amountDesc orders largest first', () {
       final utxos = [
         walletUtxoFixture(sats: 100, vout: 0),

--- a/test/features/send/domain/usecases/validate_coin_control_payment_request_usecase_test.dart
+++ b/test/features/send/domain/usecases/validate_coin_control_payment_request_usecase_test.dart
@@ -3,7 +3,7 @@ import 'package:bb_mobile/core/utils/payment_request.dart';
 import 'package:bb_mobile/core/utils/result.dart';
 import 'package:bb_mobile/core/wallet/domain/entities/wallet.dart';
 import 'package:bb_mobile/features/send/domain/send_failure.dart';
-import 'package:bb_mobile/features/send/domain/usecases/validate_sweep_payment_request_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 final _wallet = Wallet(
@@ -20,7 +20,38 @@ final _wallet = Wallet(
 );
 
 void main() {
-  final usecase = ValidateSweepPaymentRequestUsecase();
+  final usecase = ValidateCoinControlPaymentRequestUsecase();
+
+  test('accepts a Liquid destination on the selected wallet network', () {
+    expect(
+      usecase.execute(
+        wallet: _wallet.copyWith(network: Network.liquidMainnet),
+        paymentRequest: const PaymentRequest.liquid(
+          address: 'lq1recipient',
+          isTestnet: false,
+        ),
+      ),
+      isA<Ok<void, SendFailure>>(),
+    );
+  });
+
+  test('allows an embedded Liquid amount for Send but not Sweep', () {
+    final wallet = _wallet.copyWith(network: Network.liquidMainnet);
+    const request = PaymentRequest.bip21(
+      network: Network.liquidMainnet,
+      uri: 'liquidnetwork:lq1recipient?amount=0.0005',
+      address: 'lq1recipient',
+      amountSat: 50000,
+    );
+    expect(
+      usecase.execute(wallet: wallet, paymentRequest: request, isSweep: false),
+      isA<Ok<void, SendFailure>>(),
+    );
+    expect(
+      usecase.execute(wallet: wallet, paymentRequest: request),
+      isA<Err<void, SendFailure>>(),
+    );
+  });
 
   test('accepts a Bitcoin address on the wallet network', () {
     final result = usecase.execute(

--- a/test/features/send/presentation/bloc/send_cubit_test.dart
+++ b/test/features/send/presentation/bloc/send_cubit_test.dart
@@ -54,7 +54,7 @@ import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_us
 import 'package:bb_mobile/features/send/domain/usecases/verify_exchange_payin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_send_swap_payin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/verify_send_signed_tx_usecase.dart';
-import 'package:bb_mobile/features/send/domain/usecases/validate_sweep_payment_request_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_send_swap_usecase.dart';
 import 'package:bb_mobile/core/utils/payment_request.dart';
 import 'package:bb_mobile/core/utils/result.dart';
@@ -238,7 +238,7 @@ class _TestableSendCubit extends SendCubit {
     required super.getSendPayjoinEnabledUsecase,
     required super.verifySignedTxUsecase,
     required super.resolveSelectedInputsUsecase,
-    required super.validateSweepPaymentRequestUsecase,
+    required super.validateCoinControlPaymentRequestUsecase,
     super.parsePaymentRequest,
   });
 
@@ -460,7 +460,8 @@ void main() {
     getSendPayjoinEnabledUsecase: getSendPayjoinEnabledUsecase,
     verifySignedTxUsecase: verifySignedTxUsecase,
     resolveSelectedInputsUsecase: ResolveSelectedInputsUsecase(payjoinSessions),
-    validateSweepPaymentRequestUsecase: ValidateSweepPaymentRequestUsecase(),
+    validateCoinControlPaymentRequestUsecase:
+        ValidateCoinControlPaymentRequestUsecase(),
     parsePaymentRequest: parsePaymentRequest,
   );
 
@@ -641,6 +642,215 @@ void main() {
       () => getNetworkFeesUsecase.execute(isLiquid: any(named: 'isLiquid')),
     ).thenAnswer((_) async => _sweepFeeOptions);
   }
+
+  group('SendCubit Liquid coin control', () {
+    const outpoint = (txId: 'liquid-selected', vout: 0);
+    const request = PaymentRequest.liquid(
+      address: 'lq1recipient',
+      isTestnet: false,
+    );
+    late Wallet wallet;
+    late WalletUtxo selected;
+
+    setUp(() {
+      wallet = _liquidWallet(balanceSat: 300000);
+      selected = WalletUtxo.liquid(
+        walletId: wallet.id,
+        txId: outpoint.txId,
+        vout: outpoint.vout,
+        scriptPubkey: '',
+        amountSat: BigInt.from(75000),
+        standardAddress: 'ex1own',
+        confidentialAddress: 'lq1own',
+      );
+      stubSweepLoad(wallet: wallet, utxos: [selected]);
+      when(
+        () => checkLiquidConsolidationUsecase.execute(walletId: wallet.id),
+      ).thenAnswer((_) async => false);
+      when(
+        () => prepareLiquidSendUsecase.execute(
+          walletId: wallet.id,
+          address: any(named: 'address'),
+          feeRate: any(named: 'feeRate'),
+          amountSat: any(named: 'amountSat'),
+          drain: any(named: 'drain'),
+          selectedInputs: {outpoint},
+        ),
+      ).thenAnswer((_) async => 'liquid-pset');
+      when(
+        () => calculateLiquidAbsoluteFeesUsecase.execute(pset: 'liquid-pset'),
+      ).thenAnswer((_) async => 100);
+      when(
+        () => signLiquidTxUsecase.execute(
+          pset: 'liquid-pset',
+          walletId: wallet.id,
+        ),
+      ).thenAnswer((_) async => 'signed-liquid-pset');
+    });
+
+    Future<_TestableSendCubit> start({bool sweep = false}) async {
+      final cubit = buildCubit(
+        wallet: wallet,
+        initialSweepOutpoints: sweep ? {outpoint} : {},
+        initialSelectedOutpoints: sweep ? {} : {outpoint},
+      );
+      addTearDown(cubit.close);
+      await cubit.loadWalletWithRatesAndFees();
+      await cubit.onScannedPaymentRequest('lq1recipient', request);
+      return cubit;
+    }
+
+    test(
+      'opens selected Send at amount entry and preserves the fixed output',
+      () async {
+        final cubit = await start();
+        expect(cubit.state.step, SendStep.amount);
+        expect(cubit.state.sendType, SendType.liquid);
+        expect(cubit.state.maxAvailableBalanceSat, 75000);
+        expect(cubit.state.canAddRecipient, isFalse);
+        await cubit.amountChanged(amount: '20000');
+        await cubit.onAmountConfirmed();
+        expect(cubit.state.failure, isNull);
+        expect(cubit.state.confirmedAmountSat, 20000);
+        expect(cubit.state.unsignedPsbt, 'liquid-pset');
+        verify(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: wallet.id,
+            address: 'lq1recipient',
+            amountSat: 20000,
+            feeRate: any(named: 'feeRate'),
+            drain: false,
+            selectedInputs: {outpoint},
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'sweeps selected balance minus the built fee and signs the PSET',
+      () async {
+        final cubit = await start(sweep: true);
+        expect(cubit.state.failure, isNull);
+        expect(cubit.state.step, SendStep.confirm);
+        expect(cubit.state.confirmedAmountSat, 74900);
+        expect(cubit.state.isPayjoinAvailable, isFalse);
+        await cubit.signTransaction();
+        expect(cubit.state.signedLiquidTx, 'signed-liquid-pset');
+        verify(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: wallet.id,
+            address: 'lq1recipient',
+            amountSat: any(named: 'amountSat'),
+            feeRate: any(named: 'feeRate'),
+            drain: true,
+            selectedInputs: {outpoint},
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'keeps selected inputs in the absolute-fee estimate and final build',
+      () async {
+        final cubit = await start(sweep: true);
+        when(
+          () => calculateLiquidPsetSizeUsecase.execute(pset: 'liquid-pset'),
+        ).thenAnswer((_) async => const Ok(1000));
+        when(
+          () => calculateLiquidAbsoluteFeesUsecase.execute(pset: 'liquid-pset'),
+        ).thenAnswer((_) async => 200);
+        cubit.setStateForTest(
+          cubit.state.copyWith(
+            selectedFeeOption: FeeSelection.custom,
+            customFee: const AbsoluteFee(200),
+          ),
+        );
+
+        await cubit.createTransaction();
+
+        expect(cubit.state.failure, isNull);
+        expect(cubit.state.confirmedAmountSat, 74800);
+        expect(cubit.state.requiredInputOutpoints, {outpoint});
+        verify(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: wallet.id,
+            address: 'lq1recipient',
+            amountSat: any(named: 'amountSat'),
+            feeRate: const RelativeFee(25),
+            drain: true,
+            selectedInputs: {outpoint},
+          ),
+        ).called(1);
+        verify(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: wallet.id,
+            address: 'lq1recipient',
+            amountSat: any(named: 'amountSat'),
+            feeRate: const RelativeFee(50),
+            drain: true,
+            selectedInputs: {outpoint},
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'clears the previous fee when selected funds cannot cover a rebuild',
+      () async {
+        final cubit = await start(sweep: true);
+        when(
+          () => prepareLiquidSendUsecase.execute(
+            walletId: wallet.id,
+            address: any(named: 'address'),
+            amountSat: any(named: 'amountSat'),
+            feeRate: any(named: 'feeRate'),
+            drain: true,
+            selectedInputs: {outpoint},
+          ),
+        ).thenThrow(InsufficientFundsException('InsufficientFunds'));
+
+        expect(await cubit.createTransaction(), isFalse);
+        expect(
+          cubit.state.failure,
+          isA<SendSelectedCoinsInsufficientFailure>(),
+        );
+        expect(cubit.state.absoluteFees, isNull);
+        expect(cubit.state.unsignedPsbt, isNull);
+        expect(cubit.state.disableConfirmSend, isTrue);
+      },
+    );
+
+    test('rejects a newly frozen Liquid coin before broadcasting', () async {
+      final cubit = await start(sweep: true);
+      await cubit.signTransaction();
+      when(
+        () => getWalletUtxosUsecase.execute(walletId: wallet.id),
+      ).thenAnswer((_) async => [selected.copyWith(isFrozen: true)]);
+
+      await cubit.broadcastTransaction();
+
+      expect(cubit.state.failure, isA<SendSelectedCoinsUnavailableFailure>());
+      expect(cubit.state.signedLiquidTx, isNull);
+      verifyNever(() => broadcastLiquidTxUsecase.execute(any()));
+    });
+
+    test(
+      'rejects cross-chain destinations while Liquid coins are selected',
+      () async {
+        final cubit = await start();
+        await cubit.onScannedPaymentRequest(
+          'bc1qrecipient',
+          const PaymentRequest.bitcoin(
+            address: 'bc1qrecipient',
+            isTestnet: false,
+          ),
+        );
+        expect(cubit.state.failure, isA<SendInvalidPaymentRequestFailure>());
+        expect(cubit.state.selectedWallet, wallet);
+        expect(await cubit.addRecipient(), isFalse);
+      },
+    );
+  });
 
   group('SendCubit initial selected coins', () {
     for (final isSweep in [false, true]) {

--- a/test/features/send/ui/widgets/coin_select_tile_test.dart
+++ b/test/features/send/ui/widgets/coin_select_tile_test.dart
@@ -107,4 +107,29 @@ void main() {
 
     expect(find.text('6 confirmations'), findsOneWidget);
   });
+
+  testWidgets('shows Liquid confirmation status without a keychain label', (
+    tester,
+  ) async {
+    final liquid = LiquidWalletUtxo(
+      walletId: 'liquid',
+      txId: 'tx',
+      vout: 0,
+      scriptPubkey: '',
+      amountSat: BigInt.from(10000),
+      standardAddress: 'tex1own',
+      confidentialAddress: 'tlq1own',
+      blockHeight: 100,
+    );
+    await pumpTile(tester, selected: true, onTap: () {}, coin: liquid);
+    expect(find.text('Confirmed'), findsOneWidget);
+    expect(find.text('Receive'), findsNothing);
+    await pumpTile(
+      tester,
+      selected: true,
+      onTap: () {},
+      coin: liquid.copyWith(blockHeight: null),
+    );
+    expect(find.text('Unconfirmed'), findsOneWidget);
+  });
 }

--- a/test/security_audit/behavior/send_signed_transaction_lifecycle_test.dart
+++ b/test/security_audit/behavior/send_signed_transaction_lifecycle_test.dart
@@ -50,7 +50,7 @@ import 'package:bb_mobile/features/send/domain/usecases/sign_bitcoin_tx_usecase.
 import 'package:bb_mobile/features/send/domain/usecases/sign_liquid_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_paid_send_swap_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/update_send_swap_payin_usecase.dart';
-import 'package:bb_mobile/features/send/domain/usecases/validate_sweep_payment_request_usecase.dart';
+import 'package:bb_mobile/features/send/domain/usecases/validate_coin_control_payment_request_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/verify_exchange_payin_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/verify_send_signed_tx_usecase.dart';
 import 'package:bb_mobile/features/send/domain/usecases/watch_payjoin_usecase.dart';
@@ -215,7 +215,7 @@ class _TestSendCubit extends SendCubit {
     required super.getSendPayjoinEnabledUsecase,
     required super.verifySignedTxUsecase,
     required super.resolveSelectedInputsUsecase,
-    required super.validateSweepPaymentRequestUsecase,
+    required super.validateCoinControlPaymentRequestUsecase,
   });
 
   void seed(SendState state) => emit(state);
@@ -319,7 +319,8 @@ void main() {
       resolveSelectedInputsUsecase: ResolveSelectedInputsUsecase(
         _MockPayjoinSessions(),
       ),
-      validateSweepPaymentRequestUsecase: ValidateSweepPaymentRequestUsecase(),
+      validateCoinControlPaymentRequestUsecase:
+          ValidateCoinControlPaymentRequestUsecase(),
     );
   });
 


### PR DESCRIPTION
Depends on #2797.

Part of #1060.

## Summary

- Enables **Manage coins** for Liquid L-BTC wallets, including freeze/unfreeze and **Send**/**Sweep** actions for selected coins.
- Uses only the selected inputs for Liquid transaction construction and fee recalculation. Fixed-amount sends return unused value as wallet change; MAX and Sweep send the selected balance minus fees.
- Allows coin reselection from Advanced Settings in ordinary Liquid sends and shows the selected count and total on confirmation.
- Excludes frozen coins from automatic sends, manually selected sends, and consolidation.
- Shows Liquid coins as Confirmed or Pending and sorts them by confirmation height. Exact confirmation counts remain deferred.

## Risk and security

Changes Liquid PSET input selection and frozen-coin checks before local signing. Selected-coin availability is checked again before broadcast. No changes to key storage or key handling.

Reuses the existing Send and Coins flows. Liquid multi-recipient sends and a broader UI redesign are outside this change. No SDK dependency or database schema changes.
