### PR TITLE
perf(seed): move mnemonic derivation off the UI isolate

### DIFF
--- a/lib/core/seed/data/repository/seed_repository.dart
+++ b/lib/core/seed/data/repository/seed_repository.dart
@@ -17,12 +17,15 @@ class SeedRepository {
     String? passphrase,
   }) async {
     try {
+      // The model retains its input list across the async isolate boundary.
       final model = SeedModel.mnemonic(
-        mnemonicWords: mnemonicWords,
+        mnemonicWords: List<String>.unmodifiable(mnemonicWords),
         passphrase: passphrase,
       );
-      await _source.store(fingerprint: model.masterFingerprint, seed: model);
-      return model.toEntity() as MnemonicSeed;
+      // PBKDF2 is CPU-bound; derive once, off the calling isolate.
+      final seed = await compute(_toEntityInIsolate, model) as MnemonicSeed;
+      await _source.store(fingerprint: seed.masterFingerprint, seed: model);
+      return seed;
     } catch (e, stackTrace) {
       log.severe(
         message: 'Failed to create seed from mnemonic',

--- a/test/core_test/seed/seed_repository_test.dart
+++ b/test/core_test/seed/seed_repository_test.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:bb_mobile/core/seed/data/datasources/seed_datasource.dart';
+import 'package:bb_mobile/core/seed/data/models/seed_model.dart';
+import 'package:bb_mobile/core/seed/data/repository/seed_repository.dart';
+import 'package:bip39_mnemonic/bip39_mnemonic.dart' as bip39;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSeedDatasource extends Mock implements SeedDatasource {}
+
+void main() {
+  // The first English BIP39 vector. The expected seed is not hardcoded here: it
+  // comes from `bip39_mnemonic`, whose own suite already checks that API against
+  // the official vectors. These tests cover our use of it, not BIP39 itself.
+  const words = [
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'abandon',
+    'about',
+  ];
+  const passphrase = 'TREZOR';
+
+  late _MockSeedDatasource datasource;
+  late SeedRepository repository;
+  late List<int> expectedSeedBytes;
+  late List<MnemonicSeedModel> storedSeeds;
+  late List<String> storedFingerprints;
+
+  setUpAll(() {
+    registerFallbackValue(const SeedModel.mnemonic(mnemonicWords: <String>[]));
+  });
+
+  setUp(() {
+    datasource = _MockSeedDatasource();
+    repository = SeedRepository(source: datasource);
+    expectedSeedBytes = bip39.Mnemonic.fromWords(
+      words: words,
+      passphrase: passphrase,
+    ).seed;
+    storedSeeds = [];
+    storedFingerprints = [];
+  });
+
+  /// Records what reached the datasource, and whether the event loop got a turn
+  /// before it did.
+  void stubStore({void Function()? onStore}) {
+    when(
+      () => datasource.store(
+        fingerprint: any(named: 'fingerprint'),
+        seed: any(named: 'seed'),
+      ),
+    ).thenAnswer((invocation) async {
+      onStore?.call();
+      storedFingerprints.add(
+        invocation.namedArguments[const Symbol('fingerprint')] as String,
+      );
+      storedSeeds.add(
+        invocation.namedArguments[const Symbol('seed')] as MnemonicSeedModel,
+      );
+    });
+  }
+
+  test('derives the seed without blocking the calling isolate', () async {
+    var yielded = false;
+    var yieldedBeforeStore = false;
+    stubStore(onStore: () => yieldedBeforeStore = yielded);
+    // Fires on the next event-loop turn, so it can only have run if the
+    // derivation actually suspended instead of hogging the isolate.
+    Timer.run(() => yielded = true);
+
+    final seed = await repository.createFromMnemonic(
+      mnemonicWords: words,
+      passphrase: passphrase,
+    );
+
+    expect(yieldedBeforeStore, isTrue);
+    expect(seed.bytes, equals(expectedSeedBytes));
+    expect(seed.mnemonicWords, equals(words));
+    expect(seed.passphrase, passphrase);
+    expect(storedFingerprints, equals([seed.masterFingerprint]));
+    expect(storedSeeds.single.mnemonicWords, equals(words));
+    expect(storedSeeds.single.passphrase, passphrase);
+  });
+
+  test('persists the mnemonic the returned seed was derived from', () async {
+    stubStore();
+    final callerWords = List<String>.of(words);
+
+    final pending = repository.createFromMnemonic(
+      mnemonicWords: callerWords,
+      passphrase: passphrase,
+    );
+    // The caller's list is its own; mutating it while the derivation runs must
+    // not change what is persisted under the returned fingerprint.
+    callerWords[0] = 'zoo';
+    final seed = await pending;
+
+    expect(seed.bytes, equals(expectedSeedBytes));
+    expect(seed.mnemonicWords, equals(words));
+    expect(storedSeeds.single.mnemonicWords, equals(words));
+    expect(storedFingerprints, equals([seed.masterFingerprint]));
+  });
+}


### PR DESCRIPTION
## Linked issue

None — measured wallet-creation performance correction requesting the `no-issue-needed` exemption.

## Problem

Creating or recovering a wallet derived the same BIP39 seed twice on the UI isolate: once through `masterFingerprint` and again through `toEntity`. On a Pixel 6a production-profile build, this consumed about one second of main-isolate CPU and produced 37–38 skipped frames in two of three unprofiled creation runs.

## Changes

- Snapshot the caller's mnemonic words before crossing the asynchronous isolate boundary.
- Derive the seed entity once with `compute`, then reuse its fingerprint for persistence.
- Add regression coverage for event-loop yielding, BIP39 seed equivalence, passphrase preservation, and caller-list mutation during derivation.

## Non-goals

- No change to BIP39 derivation semantics, wallet descriptors, synchronization, storage format, dependencies, or generated files.
- No attempt to move the shorter account-xpub derivation or native wallet initialization off the UI isolate.

## Risk and security

This change touches mnemonic and seed handling and requires security review. `compute` transiently copies the immutable seed model to a short-lived native isolate; it does not log, expose, or cache mnemonic, seed, passphrase, or private-key material. The exact model used for derivation is also persisted, preventing a caller mutation from associating different mnemonic contents with the derived fingerprint. On Flutter Web, `compute` uses the current event loop; this application and the measured correction target Android and iOS.

## Performance

Pixel 6a, production-profile arm64 APK, fresh app data for each run. CPU samples use a 1 ms period and target the main isolate only.

| Path | Main-isolate seed derivation before | After |
| --- | ---: | ---: |
| Create wallet | 1,012 ms | 0 ms |
| Recover wallet | 1,007 ms | 0 ms |

Unprofiled creation runs reported 38, 0, and 37 skipped frames before the fix, versus 0, 0, and 0 after it. All post-fix creation runs and the recovery run reached wallet home. VM service enumeration observed the `_toEntityInIsolate` worker during derivation. The measured profile APK SHA-256 was `40b29a302c99ed825b89c22c6f3af8e65f7b3b7966d0b628ef30955bb6f3cdd9`.

## Verification

- Red A: the original implementation failed the event-loop-yield test and allowed caller mutation to invalidate the second derivation.
- Red B: `compute` without the list snapshot passed the yield test but persisted the mutated mnemonic.
- Green: both regression tests pass with the final implementation.
- `make checks` — passed with Flutter 3.44.9 / Dart 3.12.2 via FVM.
- CI-equivalent Linux integration command under Xvfb, D-Bus, and GNOME Keyring — 21 passed, 10 expected skips; funded testnet fixtures were intentionally absent for this `develop` PR.
- Production-profile arm64 APK — built, installed, and measured on a Pixel 6a.
- Independent post-fix security review — no confirmed findings.

## Review order

Single commit: `a6151279d`.
