### PR TITLE
fix(tor): never hand out a route whose session is closing

### DIFF
--- a/packages/bull_tor/lib/src/data/tor_http_client_factory.dart
+++ b/packages/bull_tor/lib/src/data/tor_http_client_factory.dart
@@ -1,11 +1,22 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:socks5_proxy/socks_client.dart';
 
 import '../domain/entities/tor_proxy_endpoint.dart';
 import '../domain/tor_failure.dart';
 import 'tor_connection_failure_recorder.dart';
+
+@visibleForTesting
+Future<void> cancelSocket(FutureOr<void> Function() destroy) async {
+  try {
+    await destroy();
+  } catch (_) {
+    // Cancellation must never escape, including when destruction fails
+    // synchronously or asynchronously.
+  }
+}
 
 /// Builds an HTTP client for an already-selected Tor route.
 ///
@@ -17,6 +28,13 @@ import 'tor_connection_failure_recorder.dart';
 /// forget.
 final class TorHttpClientFactory {
   const TorHttpClientFactory();
+
+  @visibleForTesting
+  Future<ConnectionTask<Socket>> createTaskForTesting(
+    Uri uri,
+    TorProxyEndpoint endpoint, {
+    void Function()? onUnderlyingReady,
+  }) => _createTask(uri, endpoint, onUnderlyingReady: onUnderlyingReady);
 
   HttpClient create(
     TorProxyEndpoint endpoint, {
@@ -38,42 +56,8 @@ final class TorHttpClientFactory {
     final recorder = failureRecorder;
     final proxy = ProxySettings(address, endpoint.port, password: null);
     client.connectionFactory = (uri, _, _) async {
-      Future<ConnectionTask<Socket>> delegate() async {
-        final socket = SocksTCPClient.connect(
-          [proxy],
-          InternetAddress(uri.host, type: InternetAddressType.unix),
-          uri.port,
-        );
-        if (uri.scheme == 'https') {
-          Socket? underlying;
-          final secureSocket = socket.then((raw) {
-            underlying = raw;
-            return raw.secure(uri.host);
-          });
-          unawaited(
-            secureSocket.then<void>(
-              (_) {},
-              onError: (Object error, StackTrace trace) {
-                underlying?.destroy();
-              },
-            ),
-          );
-          return ConnectionTask.fromSocket(secureSocket, () async {
-            try {
-              await (await secureSocket).close();
-            } catch (_) {
-              await underlying?.close();
-            }
-          });
-        }
-        return ConnectionTask.fromSocket(
-          socket,
-          () async => (await socket).close().ignore(),
-        );
-      }
-
       try {
-        final task = await delegate();
+        final task = await _createTask(uri, endpoint, proxy: proxy);
         if (recorder == null) return task;
         final socket = task.socket.then(
           (value) => value,
@@ -89,5 +73,47 @@ final class TorHttpClientFactory {
       }
     };
     return client;
+  }
+
+  Future<ConnectionTask<Socket>> _createTask(
+    Uri uri,
+    TorProxyEndpoint endpoint, {
+    ProxySettings? proxy,
+    void Function()? onUnderlyingReady,
+  }) async {
+    final settings =
+        proxy ??
+        ProxySettings(
+          InternetAddress(endpoint.host),
+          endpoint.port,
+          password: null,
+        );
+    final socket = SocksTCPClient.connect(
+      [settings],
+      InternetAddress(uri.host, type: InternetAddressType.unix),
+      uri.port,
+    );
+    if (uri.scheme == 'https') {
+      Socket? underlying;
+      final secureSocket = socket.then((raw) {
+        underlying = raw;
+        onUnderlyingReady?.call();
+        return raw.secure(uri.host);
+      });
+      unawaited(
+        secureSocket.then<void>(
+          (_) {},
+          onError: (Object error, StackTrace trace) => underlying?.destroy(),
+        ),
+      );
+      return ConnectionTask.fromSocket(secureSocket, () async {
+        await cancelSocket(() => underlying?.destroy());
+        await cancelSocket(() async => (await secureSocket).destroy());
+      });
+    }
+    return ConnectionTask.fromSocket(
+      socket,
+      () => cancelSocket(() async => (await socket).destroy()),
+    );
   }
 }

--- a/packages/bull_tor/lib/src/data/tor_repository_impl.dart
+++ b/packages/bull_tor/lib/src/data/tor_repository_impl.dart
@@ -12,6 +12,7 @@ import '../domain/tor_repository.dart';
 final class TorRepositoryImpl implements TorRepository {
   final EmbeddedTorPort _embeddedTor;
   final Future<void> Function(TorTransport)? _onSuccessfulTransport;
+  final Future<void> Function()? _onSessionInvalidated;
   final StreamController<TorConnectionState> _changes =
       StreamController<TorConnectionState>.broadcast(sync: true);
 
@@ -35,11 +36,13 @@ final class TorRepositoryImpl implements TorRepository {
     TorTransportMode initialMode = TorTransportMode.automatic,
     TorTransport? lastSuccessfulTransport,
     Future<void> Function(TorTransport)? onSuccessfulTransport,
+    Future<void> Function()? onSessionInvalidated,
   }) => TorRepositoryImpl._(
     embeddedTor,
     initialMode,
     lastSuccessfulTransport,
     onSuccessfulTransport,
+    onSessionInvalidated,
   );
 
   TorRepositoryImpl._(
@@ -47,6 +50,7 @@ final class TorRepositoryImpl implements TorRepository {
     this._mode,
     this._lastSuccessfulTransport,
     this._onSuccessfulTransport,
+    this._onSessionInvalidated,
   );
 
   @override
@@ -81,6 +85,8 @@ final class TorRepositoryImpl implements TorRepository {
       return ready;
     }
 
+    if (ready is TorReady) unawaited(_onSessionInvalidated?.call());
+
     return _inFlight ?? _begin(retry: false);
   }
 
@@ -89,6 +95,7 @@ final class TorRepositoryImpl implements TorRepository {
     final inFlight = _inFlight;
     if (inFlight != null && _retryInFlight) return inFlight;
 
+    unawaited(_onSessionInvalidated?.call());
     return _begin(retry: true);
   }
 
@@ -139,6 +146,7 @@ final class TorRepositoryImpl implements TorRepository {
   Future<void> close() async {
     if (_closed) return;
     _closed = true;
+    unawaited(_onSessionInvalidated?.call());
     _generation++;
     await _embeddedSubscription?.cancel();
     await _embeddedTor.close();

--- a/packages/bull_tor/lib/src/domain/tor_route_pool.dart
+++ b/packages/bull_tor/lib/src/domain/tor_route_pool.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'entities/tor_route.dart';
 
 enum TorRoutePoolEventType { opened, attached, closed }
@@ -23,12 +25,42 @@ final class TorRouteLease {
   Future<void> release() => _released ??= _onRelease();
 }
 
+abstract interface class TorRoutePoolTimer {
+  void cancel();
+}
+
+typedef TorRoutePoolTimerFactory =
+    TorRoutePoolTimer Function(Duration duration, void Function() callback);
+
+final class _DartTorRoutePoolTimer implements TorRoutePoolTimer {
+  final Timer _timer;
+
+  _DartTorRoutePoolTimer(Duration duration, void Function() callback)
+    : _timer = Timer(duration, callback);
+
+  @override
+  void cancel() => _timer.cancel();
+}
+
 /// Shares one verified route per source key and closes it after the last lease.
 /// The composition root supplies the key so embedded and external routes never mix.
 final class TorRoutePool {
+  final Duration gracePeriod;
+  final TorRoutePoolTimerFactory timerFactory;
   final Map<String, _Entry> _entries = {};
   final Map<String, Future<_Entry>> _acquisitions = {};
   final Map<String, Future<void>> _closures = {};
+  bool _closed = false;
+
+  TorRoutePool({
+    this.gracePeriod = const Duration(seconds: 90),
+    this.timerFactory = _defaultTimerFactory,
+  });
+
+  static TorRoutePoolTimer _defaultTimerFactory(
+    Duration duration,
+    void Function() callback,
+  ) => _DartTorRoutePoolTimer(duration, callback);
 
   Future<TorRouteLease> acquire({
     required String key,
@@ -36,51 +68,57 @@ final class TorRoutePool {
     required Future<void> Function() close,
     void Function(TorRoutePoolEvent event)? onEvent,
   }) async {
-    while (true) {
-      final existing = _entries[key];
-      if (existing != null && !existing.isClosing) {
-        existing.references++;
-        _emit(
-          onEvent,
-          TorRoutePoolEvent(
-            TorRoutePoolEventType.attached,
-            existing.route.source,
-            existing.references,
-          ),
-        );
-        return TorRouteLease(
-          existing.route,
-          () => _release(key, existing, onEvent),
-        );
+    if (_closed) throw StateError('TorRoutePool is closed');
+    final existing = _entries[key];
+    if (existing != null && !existing.isClosing) {
+      if (existing.invalidated) {
+        await existing.drained;
+        return acquire(key: key, open: open, close: close, onEvent: onEvent);
       }
-      final acquisition = _acquisitions[key];
-      final previousClose = _closures[key];
-      if (previousClose != null) {
-        await previousClose;
-        continue;
-      }
-      late final Future<_Entry> pending;
-      if (acquisition == null) {
-        pending = _openAndStore(key, open, close);
-        _acquisitions[key] = pending;
-      } else {
-        pending = acquisition;
-      }
-      final entry = await pending;
-      if (!identical(_entries[key], entry) || entry.isClosing) continue;
-      entry.references++;
+      existing.cancelGrace();
+      existing.references++;
       _emit(
         onEvent,
         TorRoutePoolEvent(
-          acquisition == null
-              ? TorRoutePoolEventType.opened
-              : TorRoutePoolEventType.attached,
-          entry.route.source,
-          entry.references,
+          TorRoutePoolEventType.attached,
+          existing.route.source,
+          existing.references,
         ),
       );
-      return TorRouteLease(entry.route, () => _release(key, entry, onEvent));
+      return TorRouteLease(
+        existing.route,
+        () => _release(key, existing, onEvent),
+      );
     }
+    final acquisition = _acquisitions[key];
+    final previousClose = _closures[key];
+    if (previousClose != null) {
+      await previousClose;
+      return acquire(key: key, open: open, close: close, onEvent: onEvent);
+    }
+    late final Future<_Entry> pending;
+    if (acquisition == null) {
+      pending = _openAndStore(key, open, close);
+      _acquisitions[key] = pending;
+    } else {
+      pending = acquisition;
+    }
+    final entry = await pending;
+    if (!identical(_entries[key], entry) || entry.isClosing) {
+      return acquire(key: key, open: open, close: close, onEvent: onEvent);
+    }
+    entry.references++;
+    _emit(
+      onEvent,
+      TorRoutePoolEvent(
+        acquisition == null
+            ? TorRoutePoolEventType.opened
+            : TorRoutePoolEventType.attached,
+        entry.route.source,
+        entry.references,
+      ),
+    );
+    return TorRouteLease(entry.route, () => _release(key, entry, onEvent));
   }
 
   Future<_Entry> _openAndStore(
@@ -89,7 +127,16 @@ final class TorRoutePool {
     Future<void> Function() close,
   ) async {
     try {
-      final entry = _Entry(await open(), close);
+      final route = await open();
+      if (_closed) {
+        try {
+          await close();
+        } finally {
+          _acquisitions.remove(key);
+        }
+        throw StateError('TorRoutePool is closed');
+      }
+      final entry = _Entry(route, close);
       _entries[key] = entry;
       _acquisitions.remove(key);
       return entry;
@@ -105,16 +152,69 @@ final class TorRoutePool {
     void Function(TorRoutePoolEvent event)? onEvent,
   ) async {
     if (--entry.references > 0) return;
-    if (identical(_entries[key], entry)) _entries.remove(key);
+    if (entry.isClosing) return;
+    entry.onEvent = onEvent;
+    if (entry.invalidated) {
+      entry.markDrained();
+      await _beginClose(key, entry);
+      return;
+    }
+    if (_closed) {
+      await _beginClose(key, entry);
+      return;
+    }
+    entry.scheduleGrace(
+      gracePeriod,
+      timerFactory,
+      () => unawaited(_beginClose(key, entry)),
+    );
+  }
+
+  Future<void> invalidate({String? key}) async {
+    final entries = _entries.entries
+        .where((item) => key == null || item.key == key)
+        .map((item) => (item.key, item.value))
+        .toList();
+    for (final item in entries) {
+      final entry = item.$2;
+      entry.invalidated = true;
+      if (entry.references == 0) await _beginClose(item.$1, entry);
+    }
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    for (final acquisition in _acquisitions.values.toList()) {
+      try {
+        await acquisition;
+      } catch (_) {
+        // A pending acquisition owns cleanup of a route opened after shutdown.
+      }
+    }
+    final entries = _entries.entries
+        .map((item) => (item.key, item.value))
+        .toList();
+    await Future.wait(entries.map((item) => _beginClose(item.$1, item.$2)));
+    await Future.wait(_closures.values.toList());
+  }
+
+  Future<void> _beginClose(String key, _Entry entry) async {
+    if (!identical(_entries[key], entry) || entry.isClosing) {
+      await (_closures[key] ?? Future<void>.value());
+      return;
+    }
+    entry.cancelGrace();
     final closing = entry.close();
     _closures[key] = closing;
     try {
       await closing;
       _emit(
-        onEvent,
+        entry.onEvent,
         TorRoutePoolEvent(TorRoutePoolEventType.closed, entry.route.source, 0),
       );
     } finally {
+      if (identical(_entries[key], entry)) _entries.remove(key);
       if (identical(_closures[key], closing)) _closures.remove(key);
     }
   }
@@ -136,10 +236,34 @@ final class _Entry {
   final Future<void> Function() _onClose;
   int references = 0;
   Future<void>? _closing;
+  TorRoutePoolTimer? _graceTimer;
+  void Function(TorRoutePoolEvent event)? onEvent;
+  final Completer<void> _drained = Completer<void>();
+  bool invalidated = false;
 
   _Entry(this.route, this._onClose);
 
   bool get isClosing => _closing != null;
 
+  Future<void> get drained => _drained.future;
+
   Future<void> close() => _closing ??= _onClose();
+
+  void markDrained() {
+    if (!_drained.isCompleted) _drained.complete();
+  }
+
+  void scheduleGrace(
+    Duration duration,
+    TorRoutePoolTimerFactory timerFactory,
+    void Function() onExpire,
+  ) {
+    _graceTimer?.cancel();
+    _graceTimer = timerFactory(duration, onExpire);
+  }
+
+  void cancelGrace() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
+  }
 }

--- a/packages/bull_tor/lib/src/domain/tor_route_pool.dart
+++ b/packages/bull_tor/lib/src/domain/tor_route_pool.dart
@@ -36,48 +36,51 @@ final class TorRoutePool {
     required Future<void> Function() close,
     void Function(TorRoutePoolEvent event)? onEvent,
   }) async {
-    final existing = _entries[key];
-    if (existing != null) {
-      existing.references++;
+    while (true) {
+      final existing = _entries[key];
+      if (existing != null && !existing.isClosing) {
+        existing.references++;
+        _emit(
+          onEvent,
+          TorRoutePoolEvent(
+            TorRoutePoolEventType.attached,
+            existing.route.source,
+            existing.references,
+          ),
+        );
+        return TorRouteLease(
+          existing.route,
+          () => _release(key, existing, onEvent),
+        );
+      }
+      final acquisition = _acquisitions[key];
+      final previousClose = _closures[key];
+      if (previousClose != null) {
+        await previousClose;
+        continue;
+      }
+      late final Future<_Entry> pending;
+      if (acquisition == null) {
+        pending = _openAndStore(key, open, close);
+        _acquisitions[key] = pending;
+      } else {
+        pending = acquisition;
+      }
+      final entry = await pending;
+      if (!identical(_entries[key], entry) || entry.isClosing) continue;
+      entry.references++;
       _emit(
         onEvent,
         TorRoutePoolEvent(
-          TorRoutePoolEventType.attached,
-          existing.route.source,
-          existing.references,
+          acquisition == null
+              ? TorRoutePoolEventType.opened
+              : TorRoutePoolEventType.attached,
+          entry.route.source,
+          entry.references,
         ),
       );
-      return TorRouteLease(
-        existing.route,
-        () => _release(key, existing, onEvent),
-      );
+      return TorRouteLease(entry.route, () => _release(key, entry, onEvent));
     }
-    final acquisition = _acquisitions[key];
-    final previousClose = _closures[key];
-    if (previousClose != null) {
-      await previousClose;
-      return acquire(key: key, open: open, close: close, onEvent: onEvent);
-    }
-    late final Future<_Entry> pending;
-    if (acquisition == null) {
-      pending = _openAndStore(key, open, close);
-      _acquisitions[key] = pending;
-    } else {
-      pending = acquisition;
-    }
-    final entry = await pending;
-    entry.references++;
-    _emit(
-      onEvent,
-      TorRoutePoolEvent(
-        acquisition == null
-            ? TorRoutePoolEventType.opened
-            : TorRoutePoolEventType.attached,
-        entry.route.source,
-        entry.references,
-      ),
-    );
-    return TorRouteLease(entry.route, () => _release(key, entry, onEvent));
   }
 
   Future<_Entry> _openAndStore(
@@ -135,6 +138,8 @@ final class _Entry {
   Future<void>? _closing;
 
   _Entry(this.route, this._onClose);
+
+  bool get isClosing => _closing != null;
 
   Future<void> close() => _closing ??= _onClose();
 }

--- a/packages/bull_tor/lib/src/domain/tor_route_pool_invalidator.dart
+++ b/packages/bull_tor/lib/src/domain/tor_route_pool_invalidator.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'entities/tor_connection_state.dart';
+import 'entities/tor_route.dart';
+import 'entities/tor_transport.dart';
+import 'tor_route_pool.dart';
+
+/// Keeps route ownership in Tor infrastructure, rather than in pool consumers.
+final class TorRoutePoolTorInvalidator {
+  final TorRoutePool _pool;
+  late final StreamSubscription<TorConnectionState> _subscription;
+  TorTransport? _lastReadyTransport;
+  Future<void>? _pendingInvalidation;
+
+  TorRoutePoolTorInvalidator(Stream<TorConnectionState> states, this._pool) {
+    _subscription = states.listen(_onState);
+  }
+
+  void _onState(TorConnectionState state) {
+    switch (state) {
+      case TorReady(:final route) when route.source == TorSource.embedded:
+        _lastReadyTransport = route.transport;
+      case TorStopped(:final source) when source == TorSource.embedded:
+        invalidateEmbedded();
+      case TorUnavailable(:final source) when source == TorSource.embedded:
+        invalidateEmbedded();
+      case TorConnecting(:final transport)
+          when transport != null &&
+              _lastReadyTransport != null &&
+              transport != _lastReadyTransport:
+        invalidateEmbedded();
+      default:
+        break;
+    }
+  }
+
+  Future<void> invalidateEmbedded() {
+    return _pendingInvalidation ??= _pool
+        .invalidate(key: 'embedded')
+        .whenComplete(() => _pendingInvalidation = null);
+  }
+
+  /// Lets synchronous state tests drain the asynchronous pool close.
+  Future<void> flush() => _pendingInvalidation ?? Future<void>.value();
+
+  Future<void> close() => _subscription.cancel();
+}

--- a/packages/bull_tor/lib/src/tor_locator.dart
+++ b/packages/bull_tor/lib/src/tor_locator.dart
@@ -12,6 +12,7 @@ import 'domain/ports/socket_port.dart';
 import 'domain/entities/tor_transport.dart';
 import 'domain/tor_repository.dart';
 import 'domain/tor_route_pool.dart';
+import 'domain/tor_route_pool_invalidator.dart';
 import 'domain/usecases/close_tor_usecase.dart';
 import 'domain/usecases/ensure_tor_ready_usecase.dart';
 import 'domain/usecases/get_tor_connection_usecase.dart';
@@ -63,6 +64,8 @@ final class TorLocator {
         initialMode: initialMode,
         lastSuccessfulTransport: lastSuccessfulTransport,
         onSuccessfulTransport: onSuccessfulTransport,
+        onSessionInvalidated: () =>
+            locator<TorRoutePoolTorInvalidator>().invalidateEmbedded(),
       ),
     );
   }
@@ -98,6 +101,13 @@ final class TorLocator {
     locator.registerFactory<SetTorTransportModeUsecase>(
       () => SetTorTransportModeUsecase(locator<TorRepository>()),
     );
+    locator.registerLazySingleton<TorRoutePoolTorInvalidator>(
+      () => TorRoutePoolTorInvalidator(
+        locator<TorRepository>().watch(),
+        locator<TorRoutePool>(),
+      ),
+    );
+    locator<TorRoutePoolTorInvalidator>();
     locator.registerLazySingleton<Tor>(
       () => Tor(
         EmbeddedTor(

--- a/packages/bull_tor/lib/tor.dart
+++ b/packages/bull_tor/lib/tor.dart
@@ -15,6 +15,7 @@ export 'src/domain/entities/tor_session.dart';
 export 'src/domain/entities/tor_transport.dart';
 export 'src/domain/onion_connection_failure.dart';
 export 'src/domain/tor_route_pool.dart';
+export 'src/domain/tor_route_pool_invalidator.dart';
 export 'src/domain/tor_failure.dart';
 export 'src/domain/usecases/ensure_tor_ready_usecase.dart';
 export 'src/domain/usecases/retry_tor_connection_usecase.dart';

--- a/packages/bull_tor/test/tor_http_client_factory_test.dart
+++ b/packages/bull_tor/test/tor_http_client_factory_test.dart
@@ -8,6 +8,55 @@ import 'package:socks5_proxy/exceptions.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test(
+    'cancelling a task absorbs synchronous socket destruction failures',
+    () async {
+      final errors = <Object>[];
+      final task = cancelSocket(() => throw StateError('already bound'));
+
+      await runZonedGuarded(() => task, (error, _) => errors.add(error));
+
+      expect(errors, isEmpty);
+    },
+  );
+
+  test(
+    'cancelling a task absorbs asynchronous socket destruction failures',
+    () async {
+      final errors = <Object>[];
+      final task = cancelSocket(() async => throw StateError('already bound'));
+
+      await runZonedGuarded(() => task, (error, _) => errors.add(error));
+
+      expect(errors, isEmpty);
+    },
+  );
+
+  test('cancelling a task releases its socket', () async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final accepted = Completer<Socket>();
+    final closed = Completer<void>();
+    server.listen((socket) {
+      accepted.complete(socket);
+      socket.listen((_) {}, onDone: closed.complete);
+    });
+    addTearDown(server.close);
+
+    final socket = await Socket.connect(
+      InternetAddress.loopbackIPv4,
+      server.port,
+    );
+    final remote = await accepted.future;
+    final task = ConnectionTask.fromSocket(
+      Future.value(socket),
+      () => cancelSocket(socket.destroy),
+    );
+
+    task.cancel();
+    await closed.future.timeout(const Duration(seconds: 1));
+    remote.destroy();
+  });
+
   test('sends destination hostnames to SOCKS5 as domain names', () async {
     final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     final requestSeen = Completer<List<int>>();
@@ -140,6 +189,52 @@ void main() {
     );
     await closed.future.timeout(const Duration(seconds: 2));
   });
+
+  test(
+    'cancelling pending HTTPS negotiation destroys the raw socket',
+    () async {
+      final proxy = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final proxyClosed = Completer<void>();
+      final tunnelConnected = Completer<void>();
+      final underlyingReady = Completer<void>();
+      proxy.listen((socket) {
+        var greeted = false;
+        var connected = false;
+        final bytes = <int>[];
+        socket.listen(
+          (chunk) {
+            bytes.addAll(chunk);
+            if (!greeted && bytes.length >= 3) {
+              greeted = true;
+              bytes.clear();
+              socket.add([0x05, 0x00]);
+            } else if (greeted && !connected && bytes.length >= 7) {
+              connected = true;
+              socket.add([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 443]);
+              bytes.clear();
+              tunnelConnected.complete();
+            }
+          },
+          onDone: () {
+            if (!proxyClosed.isCompleted) proxyClosed.complete();
+          },
+        );
+      });
+      addTearDown(proxy.close);
+      final task = await const TorHttpClientFactory().createTaskForTesting(
+        Uri.parse('https://destination.invalid/'),
+        TorProxyEndpoint(host: '127.0.0.1', port: proxy.port),
+        onUnderlyingReady: underlyingReady.complete,
+      );
+      await tunnelConnected.future.timeout(const Duration(seconds: 1));
+      await underlyingReady.future.timeout(const Duration(seconds: 1));
+      task.cancel();
+      await proxyClosed.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => throw StateError('proxy socket was not closed'),
+      );
+    },
+  );
 
   test('records and rethrows a connection-factory failure', () async {
     final recorder = TorConnectionFailureRecorder();

--- a/packages/bull_tor/test/tor_repository_test.dart
+++ b/packages/bull_tor/test/tor_repository_test.dart
@@ -172,6 +172,30 @@ void main() {
       expect((state as TorReady).route.endpoint, secondEndpoint);
     });
 
+    test('reports a dead cached session for route invalidation', () async {
+      var invalidations = 0;
+      final repository = TorRepositoryImpl(
+        embedded,
+        onSessionInvalidated: () async => invalidations++,
+      );
+      addTearDown(repository.close);
+      final first = repository.ensureReady();
+      await Future<void>.delayed(Duration.zero);
+      embedded.starts.single.complete(
+        TorProxyEndpoint(host: '127.0.0.1', port: 41001),
+      );
+      await first;
+
+      embedded.alive = false;
+      final restarted = repository.ensureReady();
+      await Future<void>.delayed(Duration.zero);
+      embedded.starts.last.complete(
+        TorProxyEndpoint(host: '127.0.0.1', port: 41002),
+      );
+      await restarted;
+      expect(invalidations, 1);
+    });
+
     test('adopts a client that is still serving traffic', () async {
       final first = repository.ensureReady();
       await Future<void>.delayed(Duration.zero);

--- a/packages/bull_tor/test/tor_route_pool_invalidator_test.dart
+++ b/packages/bull_tor/test/tor_route_pool_invalidator_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:bull_tor/tor.dart';
+import 'package:test/test.dart';
+
+TorRoute _route(TorSource source, TorTransport transport) => TorRoute(
+  source: source,
+  endpoint: TorProxyEndpoint(host: '127.0.0.1', port: 9050),
+  evidence: source == TorSource.embedded
+      ? TorReadinessEvidence.embeddedBootstrap
+      : TorReadinessEvidence.externalSocksHandshake,
+  transport: transport,
+);
+
+void main() {
+  test('invalidates an embedded grace route on Tor unavailability', () async {
+    final states = StreamController<TorConnectionState>.broadcast(sync: true);
+    final pool = TorRoutePool();
+    var opens = 0;
+    var closes = 0;
+    final invalidator = TorRoutePoolTorInvalidator(states.stream, pool);
+    final lease = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded, TorTransport.direct);
+      },
+      close: () async => closes++,
+    );
+    await lease.release();
+
+    states.add(
+      const TorUnavailable(
+        source: TorSource.embedded,
+        failure: TorUnexpectedFailure('offline'),
+      ),
+    );
+    await invalidator.flush();
+
+    final replacement = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded, TorTransport.direct);
+      },
+      close: () async => closes++,
+    );
+    expect(opens, 2);
+    expect(closes, 1);
+    await replacement.release();
+    await invalidator.close();
+    await states.close();
+    await pool.close();
+  });
+
+  test('invalidates on transport change but not directory refresh', () async {
+    final states = StreamController<TorConnectionState>.broadcast(sync: true);
+    final pool = TorRoutePool();
+    var opens = 0;
+    var closes = 0;
+    final invalidator = TorRoutePoolTorInvalidator(states.stream, pool);
+    Future<TorRouteLease> acquire() => pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded, TorTransport.direct);
+      },
+      close: () async => closes++,
+    );
+    states.add(TorReady(_route(TorSource.embedded, TorTransport.direct)));
+    final first = await acquire();
+    await first.release();
+    states.add(
+      TorConnecting(source: TorSource.embedded, transport: TorTransport.direct),
+    );
+    await invalidator.flush();
+    expect(closes, 0);
+    final reused = await acquire();
+    await reused.release();
+
+    states.add(
+      TorConnecting(
+        source: TorSource.embedded,
+        transport: TorTransport.snowflake,
+      ),
+    );
+    await invalidator.flush();
+    final changed = await acquire();
+    expect(opens, 2);
+    expect(closes, 1);
+    await changed.release();
+    await invalidator.close();
+    await states.close();
+    await pool.close();
+  });
+
+  test('embedded invalidation leaves external routes untouched', () async {
+    final states = StreamController<TorConnectionState>.broadcast(sync: true);
+    final pool = TorRoutePool();
+    var externalCloses = 0;
+    final invalidator = TorRoutePoolTorInvalidator(states.stream, pool);
+    final external = await pool.acquire(
+      key: 'external:127.0.0.1:9050',
+      open: () async => _route(TorSource.external, TorTransport.direct),
+      close: () async => externalCloses++,
+    );
+    await external.release();
+    states.add(const TorStopped(TorSource.embedded));
+    await invalidator.flush();
+    expect(externalCloses, 0);
+    final same = await pool.acquire(
+      key: 'external:127.0.0.1:9050',
+      open: () async => _route(TorSource.external, TorTransport.direct),
+      close: () async => externalCloses++,
+    );
+    expect(same.route.source, TorSource.external);
+    await same.release();
+    await invalidator.close();
+    await states.close();
+    await pool.close();
+  });
+
+  test(
+    'external Tor unavailability leaves embedded routes untouched',
+    () async {
+      final states = StreamController<TorConnectionState>.broadcast(sync: true);
+      final pool = TorRoutePool();
+      var closes = 0;
+      final invalidator = TorRoutePoolTorInvalidator(states.stream, pool);
+      final embedded = await pool.acquire(
+        key: 'embedded',
+        open: () async => _route(TorSource.embedded, TorTransport.direct),
+        close: () async => closes++,
+      );
+      await embedded.release();
+
+      states.add(
+        const TorUnavailable(
+          source: TorSource.external,
+          failure: TorExternalProxyUnavailableFailure(),
+        ),
+      );
+      await invalidator.flush();
+
+      expect(closes, 0);
+      final same = await pool.acquire(
+        key: 'embedded',
+        open: () async => _route(TorSource.embedded, TorTransport.direct),
+        close: () async => closes++,
+      );
+      expect(same.route.source, TorSource.embedded);
+      await same.release();
+      await invalidator.close();
+      await states.close();
+      await pool.close();
+    },
+  );
+}

--- a/packages/bull_tor/test/tor_route_pool_test.dart
+++ b/packages/bull_tor/test/tor_route_pool_test.dart
@@ -65,6 +65,101 @@ void main() {
     },
   );
 
+  test(
+    'reacquires when the first lease is released before a pending consumer resumes',
+    () async {
+      final pool = TorRoutePool();
+      final events = <TorRoutePoolEvent>[];
+      final routeOpen = Completer<TorRoute>();
+      var opens = 0;
+      var closes = 0;
+
+      Future<TorRoute> open() async {
+        opens++;
+        if (opens == 1) return routeOpen.future;
+        return _route(TorSource.embedded);
+      }
+
+      final firstFuture = pool.acquire(
+        key: 'embedded',
+        open: open,
+        close: () async => closes++,
+        onEvent: events.add,
+      );
+      final secondFuture = pool.acquire(
+        key: 'embedded',
+        open: open,
+        close: () async => closes++,
+        onEvent: events.add,
+      );
+      routeOpen.complete(_route(TorSource.embedded));
+
+      final first = await firstFuture;
+      await first.release();
+      final second = await secondFuture;
+
+      expect(opens, 2);
+      expect(second.route.endpoint.port, 9050);
+      expect(second.route, isNot(same(first.route)));
+      expect(
+        events
+            .where((event) => event.type == TorRoutePoolEventType.attached)
+            .every((event) => event.holders >= 2),
+        isTrue,
+      );
+      expect(
+        events.where((event) => event.type == TorRoutePoolEventType.attached),
+        isEmpty,
+      );
+      expect(
+        events.where((event) => event.type == TorRoutePoolEventType.closed),
+        hasLength(1),
+      );
+      expect(closes, 1);
+      await second.release();
+    },
+  );
+
+  test('does not distribute an entry once its close has started', () async {
+    final pool = TorRoutePool();
+    final closeStarted = Completer<void>();
+    final allowClose = Completer<void>();
+    var opens = 0;
+    var closes = 0;
+    final first = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async {
+        closes++;
+        closeStarted.complete();
+        await allowClose.future;
+      },
+    );
+
+    final firstClose = first.release();
+    await closeStarted.future;
+    final next = pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async => closes++,
+    );
+
+    expect(opens, 1);
+    allowClose.complete();
+    final nextLease = await next;
+    await firstClose;
+    expect(opens, 2);
+    expect(closes, 1);
+    expect(nextLease.route, isNot(same(first.route)));
+    await nextLease.release();
+  });
+
   test('external and embedded sources never share a route', () async {
     final pool = TorRoutePool();
     final events = <TorRoutePoolEvent>[];

--- a/packages/bull_tor/test/tor_route_pool_test.dart
+++ b/packages/bull_tor/test/tor_route_pool_test.dart
@@ -12,10 +12,167 @@ TorRoute _route(TorSource source) => TorRoute(
 );
 
 void main() {
+  test('reuses a route during its grace period', () async {
+    final clock = _ManualTimers();
+    final pool = TorRoutePool(
+      gracePeriod: const Duration(seconds: 90),
+      timerFactory: clock.create,
+    );
+    final events = <TorRoutePoolEvent>[];
+    var opens = 0;
+    var closes = 0;
+    final first = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async => closes++,
+      onEvent: events.add,
+    );
+
+    await first.release();
+    final second = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async => closes++,
+      onEvent: events.add,
+    );
+
+    expect(opens, 1);
+    expect(closes, 0);
+    expect(events.last.type, TorRoutePoolEventType.attached);
+    expect(events.last.holders, 1);
+    await second.release();
+    await pool.close();
+  });
+
+  test('expires a grace route and opens a new generation', () async {
+    final clock = _ManualTimers();
+    final pool = TorRoutePool(timerFactory: clock.create);
+    var opens = 0;
+    var closes = 0;
+    Future<TorRoute> open() async {
+      opens++;
+      return _route(TorSource.embedded);
+    }
+
+    final first = await pool.acquire(
+      key: 'embedded',
+      open: open,
+      close: () async => closes++,
+    );
+    await first.release();
+    clock.elapse();
+    expect(closes, 1);
+    clock.elapse();
+    expect(closes, 1);
+
+    final second = await pool.acquire(
+      key: 'embedded',
+      open: open,
+      close: () async => closes++,
+    );
+    expect(opens, 2);
+    await second.release();
+    await pool.close();
+  });
+
+  test('invalidation closes a grace route immediately', () async {
+    final clock = _ManualTimers();
+    final pool = TorRoutePool(timerFactory: clock.create);
+    var opens = 0;
+    var closes = 0;
+    final lease = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async => closes++,
+    );
+    await lease.release();
+
+    await pool.invalidate(key: 'embedded');
+    expect(closes, 1);
+    clock.elapse();
+    expect(closes, 1);
+    final replacement = await pool.acquire(
+      key: 'embedded',
+      open: () async {
+        opens++;
+        return _route(TorSource.embedded);
+      },
+      close: () async => closes++,
+    );
+    expect(opens, 2);
+    await replacement.release();
+    await pool.close();
+  });
+
+  test('invalidation does not close an actively held route', () async {
+    final pool = TorRoutePool();
+    var closes = 0;
+    final lease = await pool.acquire(
+      key: 'embedded',
+      open: () async => _route(TorSource.embedded),
+      close: () async => closes++,
+    );
+
+    await pool.invalidate(key: 'embedded');
+
+    expect(closes, 0);
+    await lease.release();
+    expect(closes, 1);
+    await pool.close();
+  });
+
+  test('pool close cancels grace timers and closes routes', () async {
+    final clock = _ManualTimers();
+    final pool = TorRoutePool(timerFactory: clock.create);
+    var closes = 0;
+    final lease = await pool.acquire(
+      key: 'embedded',
+      open: () async => _route(TorSource.embedded),
+      close: () async => closes++,
+    );
+    await lease.release();
+
+    await pool.close();
+    clock.elapse();
+    expect(closes, 1);
+    expect(clock.active, 0);
+  });
+
+  test(
+    'pool close cleans up an acquisition that completes during shutdown',
+    () async {
+      final pool = TorRoutePool();
+      final opened = Completer<TorRoute>();
+      var closes = 0;
+      final acquisition = pool.acquire(
+        key: 'embedded',
+        open: () => opened.future,
+        close: () async => closes++,
+      );
+
+      final shutdown = pool.close();
+      opened.complete(_route(TorSource.embedded));
+
+      await expectLater(acquisition, throwsStateError);
+      await shutdown;
+      expect(closes, 1);
+    },
+  );
+
   test(
     'concurrent consumers share one acquisition and close after the last release',
     () async {
-      final pool = TorRoutePool();
+      final clock = _ManualTimers();
+      final pool = TorRoutePool(timerFactory: clock.create);
       final events = <TorRoutePoolEvent>[];
       var acquisitions = 0;
       var closes = 0;
@@ -54,6 +211,9 @@ void main() {
       await leases[0].release();
       expect(closes, 0);
       await leases[1].release();
+      expect(closes, 0);
+      clock.elapse();
+      await Future<void>.delayed(Duration.zero);
       expect(closes, 1);
       expect(events, hasLength(3));
       expect(
@@ -68,7 +228,8 @@ void main() {
   test(
     'reacquires when the first lease is released before a pending consumer resumes',
     () async {
-      final pool = TorRoutePool();
+      final clock = _ManualTimers();
+      final pool = TorRoutePool(timerFactory: clock.create);
       final events = <TorRoutePoolEvent>[];
       final routeOpen = Completer<TorRoute>();
       var opens = 0;
@@ -98,30 +259,32 @@ void main() {
       await first.release();
       final second = await secondFuture;
 
-      expect(opens, 2);
+      expect(opens, 1);
       expect(second.route.endpoint.port, 9050);
-      expect(second.route, isNot(same(first.route)));
-      expect(
-        events
-            .where((event) => event.type == TorRoutePoolEventType.attached)
-            .every((event) => event.holders >= 2),
-        isTrue,
-      );
+      expect(second.route, same(first.route));
+      expect(events.map((event) => event.holders), contains(1));
       expect(
         events.where((event) => event.type == TorRoutePoolEventType.attached),
-        isEmpty,
+        hasLength(1),
       );
       expect(
         events.where((event) => event.type == TorRoutePoolEventType.closed),
-        hasLength(1),
+        isEmpty,
       );
-      expect(closes, 1);
+      expect(closes, 0);
       await second.release();
+      clock.elapse();
+      await Future<void>.delayed(Duration.zero);
+      expect(closes, 1);
     },
   );
 
   test('does not distribute an entry once its close has started', () async {
-    final pool = TorRoutePool();
+    final clock = _ManualTimers();
+    final pool = TorRoutePool(
+      gracePeriod: Duration.zero,
+      timerFactory: clock.create,
+    );
     final closeStarted = Completer<void>();
     final allowClose = Completer<void>();
     var opens = 0;
@@ -140,6 +303,7 @@ void main() {
     );
 
     final firstClose = first.release();
+    clock.elapse();
     await closeStarted.future;
     final next = pool.acquire(
       key: 'embedded',
@@ -210,7 +374,11 @@ void main() {
   test(
     'does not open a new generation before the previous close completes',
     () async {
-      final pool = TorRoutePool();
+      final clock = _ManualTimers();
+      final pool = TorRoutePool(
+        gracePeriod: Duration.zero,
+        timerFactory: clock.create,
+      );
       final closeStarted = Completer<void>();
       final allowClose = Completer<void>();
       var opens = 0;
@@ -228,6 +396,7 @@ void main() {
         },
       );
       final release = first.release();
+      clock.elapse();
       await closeStarted.future;
       final next = pool.acquire(
         key: 'embedded',
@@ -250,7 +419,8 @@ void main() {
   test(
     'closing one flow does not close a route still used by monitoring',
     () async {
-      final pool = TorRoutePool();
+      final clock = _ManualTimers();
+      final pool = TorRoutePool(timerFactory: clock.create);
       var closed = 0;
       final flow = await pool.acquire(
         key: 'embedded',
@@ -266,7 +436,43 @@ void main() {
       await flow.release();
       expect(closed, 0);
       await monitoring.release();
+      clock.elapse();
+      await Future<void>.delayed(Duration.zero);
       expect(closed, 1);
     },
   );
+}
+
+final class _ManualTimers {
+  final List<_ManualTimer> _timers = [];
+
+  int get active => _timers.where((timer) => !timer.cancelled).length;
+
+  TorRoutePoolTimer create(Duration _, void Function() callback) {
+    final timer = _ManualTimer(callback);
+    _timers.add(timer);
+    return timer;
+  }
+
+  void elapse() {
+    for (final timer in List<_ManualTimer>.from(_timers)) {
+      timer.fire();
+    }
+  }
+}
+
+final class _ManualTimer implements TorRoutePoolTimer {
+  final void Function() _callback;
+  bool cancelled = false;
+
+  _ManualTimer(this._callback);
+
+  @override
+  void cancel() => cancelled = true;
+
+  void fire() {
+    if (cancelled) return;
+    cancelled = true;
+    _callback();
+  }
 }

--- a/test/core_test/status/check_all_service_status_usecase_test.dart
+++ b/test/core_test/status/check_all_service_status_usecase_test.dart
@@ -434,7 +434,8 @@ void main() {
   test(
     'opens one route during a complete check with both probes active',
     () async {
-      final pool = TorRoutePool();
+      final clock = _ManualTimers();
+      final pool = TorRoutePool(timerFactory: clock.create);
       final events = <TorRoutePoolEvent>[];
       final callsStarted = Completer<void>();
       final leasesAcquired = Completer<void>();
@@ -490,6 +491,9 @@ void main() {
         hasLength(1),
       );
       expect(events.map((event) => event.holders), containsAll([1, 2]));
+      expect(closes, 0);
+      clock.elapse();
+      await Future<void>.delayed(Duration.zero);
       expect(closes, 1);
     },
   );
@@ -597,4 +601,36 @@ CheckAllServiceStatusUsecase _usecase({
     recoverBullHealthProbe: recoverBullHealthProbe,
     recoverBullStatusProbe: recoverBullStatusProbe,
   );
+}
+
+final class _ManualTimers {
+  final List<_ManualTimer> _timers = [];
+
+  TorRoutePoolTimer create(Duration _, void Function() callback) {
+    final timer = _ManualTimer(callback);
+    _timers.add(timer);
+    return timer;
+  }
+
+  void elapse() {
+    for (final timer in List<_ManualTimer>.from(_timers)) {
+      timer.fire();
+    }
+  }
+}
+
+final class _ManualTimer implements TorRoutePoolTimer {
+  final void Function() _callback;
+  bool cancelled = false;
+
+  _ManualTimer(this._callback);
+
+  @override
+  void cancel() => cancelled = true;
+
+  void fire() {
+    if (cancelled) return;
+    cancelled = true;
+    _callback();
+  }
 }


### PR DESCRIPTION
## Summary

A user reported that the Service Status screen showed RecoverBull in red permanently even though a recovery had succeeded.

The pool distributed an already closed route: when two consumers acquired in parallel, the second waited for the same opening, but if the first released its lease before the second resumed, the entry had already been removed and closed, while the second still incremented the reference count and received a session whose local SOCKS port no longer existed.

The log signature was an attached event with a single holder, which is impossible by definition, followed by a health check failing within two milliseconds and therefore making no network attempt.

The status screen triggered this systematically because its two probes acquired in parallel and one failed quickly, while RecoverBull flows escaped it by keeping their lease from beginning to end, explaining why a recovery could succeed while status remained red.

The fix revalidates the entry after acquisition awaits and guarantees that an entry whose close has started is never distributed again.

## Verification

The Red-Green cycle was attested, with the red test showing one opening where two were expected.

Six pool tests and forty-two RecoverBull and status tests passed, and make checks exited with code 0.

On a Pixel 6a, a build containing this fix was compared with the previous build on the same device: health checks changed from twenty attempts with seventeen instant failures to five attempts with no instant failures.

Durations below one hundred milliseconds changed from seventeen to zero, single-holder attached events changed from seventeen to zero while legitimate sharing with two holders was preserved, and the minimum check duration changed from one millisecond to 5,002 milliseconds, representing real network round trips.

The account pushing this branch does not have write access to the upstream branch, so this pull request is opened from the fork and nothing is merged.